### PR TITLE
Detect Hugging Face hub cache from HF_HOME/HF_HUB_CACHE

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceCache.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceCache.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Locates the Hugging Face hub cache using the same environment variables
+/// as the `huggingface_hub` Python library: `HF_HUB_CACHE` takes precedence,
+/// then `HF_HOME` (with `/hub` appended), then a per-user default.
+enum HuggingFaceCache {
+    /// Cache location used when neither environment variable is set.
+    static let fallbackHubPath = "~/.cache/huggingface/hub"
+
+    /// The default hub cache path for the given environment.
+    static func defaultHubPath(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        if let cachePath = nonEmpty(environment["HF_HUB_CACHE"]) {
+            return cachePath
+        }
+        if let homePath = nonEmpty(environment["HF_HOME"]) {
+            return (homePath as NSString).appendingPathComponent("hub")
+        }
+        return fallbackHubPath
+    }
+
+    /// The effective model search path given a persisted setting.
+    ///
+    /// Installations that never customized the search path still have the
+    /// legacy hardcoded default persisted; re-resolve those against the
+    /// environment so `HF_HOME` and `HF_HUB_CACHE` are honored.
+    static func resolvedSearchPath(
+        stored: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        let defaultPath = defaultHubPath(environment: environment)
+        guard let stored, nonEmpty(stored) != nil else {
+            return defaultPath
+        }
+        let legacyPaths = [
+            fallbackHubPath,
+            (fallbackHubPath as NSString).expandingTildeInPath
+        ]
+        if legacyPaths.contains(stored), !legacyPaths.contains(defaultPath) {
+            return defaultPath
+        }
+        return stored
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Sources/Nativ/Features/Models/HuggingFaceCache.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceCache.swift
@@ -7,6 +7,16 @@ enum HuggingFaceCache {
     /// Cache location used when neither environment variable is set.
     static let fallbackHubPath = "~/.cache/huggingface/hub"
 
+    /// Environment variables that locate the hub cache, in priority order.
+    static let environmentVariableNames = ["HF_HUB_CACHE", "HF_HOME"]
+
+    /// Whether the given environment already configures the hub cache.
+    static func isConfigured(
+        in environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        environmentVariableNames.contains { nonEmpty(environment[$0]) != nil }
+    }
+
     /// The default hub cache path for the given environment.
     static func defaultHubPath(
         environment: [String: String] = ProcessInfo.processInfo.environment

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -52,6 +52,31 @@ final class NativModel: ObservableObject {
         allTimeStats = NativAllTimeStats.load(from: currentAnalyticsDatabaseURL())
         configureServerCallbacks()
         isRunning = server.isRunning
+        resolveHubCacheFromShellEnvironment()
+    }
+
+    /// GUI apps inherit launchd's environment, which excludes exports from
+    /// shell startup files. When the process environment doesn't configure
+    /// the Hugging Face cache, probe the user's login shell once and adopt
+    /// its HF_HOME/HF_HUB_CACHE if present. `resolvedSearchPath` only
+    /// migrates the legacy default, so user-customized paths are preserved.
+    private func resolveHubCacheFromShellEnvironment() {
+        guard !HuggingFaceCache.isConfigured() else { return }
+        Task.detached(priority: .utility) { [weak self] in
+            let shellEnvironment = ShellEnvironment.resolveFromLoginShell(
+                names: HuggingFaceCache.environmentVariableNames
+            )
+            guard !shellEnvironment.isEmpty else { return }
+            await MainActor.run {
+                guard let self else { return }
+                let resolved = HuggingFaceCache.resolvedSearchPath(
+                    stored: self.settings.modelSearchPath,
+                    environment: shellEnvironment
+                )
+                guard resolved != self.settings.modelSearchPath else { return }
+                self.settings.modelSearchPath = resolved
+            }
+        }
     }
 
     var metricsAreStale: Bool {

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -2,7 +2,11 @@ import Foundation
 import NativServerKit
 
 struct NativSettings: Codable, Equatable {
-    static let defaultModelSearchPath = "~/.cache/huggingface/hub"
+    /// Default hub cache location, resolved from the environment.
+    /// See `HuggingFaceCache.defaultHubPath`.
+    static var defaultModelSearchPath: String {
+        HuggingFaceCache.defaultHubPath()
+    }
 
     var modelSearchPath: String
     var languageModelID: String?
@@ -157,7 +161,8 @@ struct NativSettings: Codable, Equatable {
         let defaults = Self()
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let legacySelectedModelID = try container.decodeIfPresent(String.self, forKey: .selectedModelID)
-        modelSearchPath = try container.decodeIfPresent(String.self, forKey: .modelSearchPath) ?? defaults.modelSearchPath
+        let storedModelSearchPath = try container.decodeIfPresent(String.self, forKey: .modelSearchPath)
+        modelSearchPath = HuggingFaceCache.resolvedSearchPath(stored: storedModelSearchPath)
         languageModelID = try container.decodeIfPresent(String.self, forKey: .languageModelID) ?? legacySelectedModelID ?? defaults.languageModelID
         imageGenerationModelID = try container.decodeIfPresent(String.self, forKey: .imageGenerationModelID) ?? defaults.imageGenerationModelID
         textToSpeechModelID = try container.decodeIfPresent(String.self, forKey: .textToSpeechModelID) ?? defaults.textToSpeechModelID

--- a/Sources/Nativ/Utilities/ShellEnvironment.swift
+++ b/Sources/Nativ/Utilities/ShellEnvironment.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Reads environment variables from the user's login shell.
+///
+/// GUI apps on macOS inherit their environment from launchd, which knows
+/// nothing about exports in shell startup files (`.zshrc`, `.zprofile`, …).
+/// Spawning the shell as a login + interactive shell sources those files,
+/// letting the app discover variables users commonly export there. The same
+/// approach is used by VS Code and JetBrains IDEs.
+enum ShellEnvironment {
+    /// Segment separating shell-startup noise from the `env` output.
+    static let marker = "__NATIV_ENV__"
+
+    /// Resolves `names` by running the user's login shell once. Returns an
+    /// empty dictionary on any failure (missing shell, timeout, …).
+    static func resolveFromLoginShell(
+        names: [String],
+        timeout: TimeInterval = 3
+    ) -> [String: String] {
+        let shellPath = ProcessInfo.processInfo.environment["SHELL"].flatMap {
+            $0.isEmpty ? nil : $0
+        } ?? "/bin/zsh"
+        guard FileManager.default.isExecutableFile(atPath: shellPath) else {
+            return [:]
+        }
+        // NUL-separated output survives arbitrary values; the marker keeps
+        // shell-startup noise (prompts, banners) out of the parsed region.
+        return environment(
+            names: Set(names),
+            executablePath: shellPath,
+            arguments: ["-l", "-i", "-c", "printf '\\0\(marker)\\0'; /usr/bin/env -0"],
+            timeout: timeout
+        )
+    }
+
+    /// Runs an executable and parses NUL-separated `KEY=VALUE` entries from
+    /// its stdout, limited to `names`. Internal (not private) for testing.
+    static func environment(
+        names: Set<String>,
+        executablePath: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) -> [String: String] {
+        let process = Process()
+        let stdout = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdout
+        process.standardError = FileHandle.nullDevice
+
+        let output = NSMutableData()
+        let outputLock = NSLock()
+        stdout.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else { return }
+            outputLock.lock()
+            output.append(chunk)
+            outputLock.unlock()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            stdout.fileHandleForReading.readabilityHandler = nil
+            return [:]
+        }
+
+        let exited = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .utility).async {
+            process.waitUntilExit()
+            exited.signal()
+        }
+        if exited.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            process.waitUntilExit()
+        }
+
+        // Drain whatever remains in the pipe after the handler stops.
+        stdout.fileHandleForReading.readabilityHandler = nil
+        let remainder = stdout.fileHandleForReading.readDataToEndOfFile()
+        outputLock.lock()
+        output.append(remainder)
+        let data = output as Data
+        outputLock.unlock()
+
+        return parseEnvironment(String(decoding: data, as: UTF8.self), names: names)
+    }
+
+    /// Parses NUL-separated `KEY=VALUE` entries, ignoring everything before
+    /// `marker` and any segment without a key. Later entries win.
+    static func parseEnvironment(_ output: String, names: Set<String>) -> [String: String] {
+        var segments = output.components(separatedBy: "\0")
+        if let markerIndex = segments.firstIndex(of: marker) {
+            segments = Array(segments[(markerIndex + 1)...])
+        }
+        var result: [String: String] = [:]
+        for segment in segments {
+            guard let separator = segment.firstIndex(of: "=") else { continue }
+            let key = String(segment[..<separator])
+            guard names.contains(key) else { continue }
+            result[key] = String(segment[segment.index(after: separator)...])
+        }
+        return result
+    }
+}

--- a/Tests/NativTests/HuggingFaceCacheTests.swift
+++ b/Tests/NativTests/HuggingFaceCacheTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+final class HuggingFaceCacheTests: XCTestCase {
+    private let customCache = "/Volumes/models/cache"
+    private let customHome = "/Volumes/models/home"
+
+    // MARK: - defaultHubPath
+
+    func testDefaultHubPathFallsBackToUserCache() {
+        XCTAssertEqual(
+            HuggingFaceCache.defaultHubPath(environment: [:]),
+            HuggingFaceCache.fallbackHubPath
+        )
+    }
+
+    func testDefaultHubPathAppendsHubToHFHome() {
+        XCTAssertEqual(
+            HuggingFaceCache.defaultHubPath(environment: ["HF_HOME": customHome]),
+            "\(customHome)/hub"
+        )
+    }
+
+    func testDefaultHubPathToleratesHFHomeTrailingSlash() {
+        XCTAssertEqual(
+            HuggingFaceCache.defaultHubPath(environment: ["HF_HOME": "\(customHome)/"]),
+            "\(customHome)/hub"
+        )
+    }
+
+    func testDefaultHubPathPrefersHFHubCacheOverHFHome() {
+        XCTAssertEqual(
+            HuggingFaceCache.defaultHubPath(environment: [
+                "HF_HUB_CACHE": customCache,
+                "HF_HOME": customHome
+            ]),
+            customCache
+        )
+    }
+
+    func testDefaultHubPathIgnoresBlankValues() {
+        XCTAssertEqual(
+            HuggingFaceCache.defaultHubPath(environment: [
+                "HF_HUB_CACHE": "  ",
+                "HF_HOME": "\n"
+            ]),
+            HuggingFaceCache.fallbackHubPath
+        )
+    }
+
+    // MARK: - resolvedSearchPath
+
+    func testResolvedSearchPathUsesEnvironmentDefaultWhenUnset() {
+        XCTAssertEqual(
+            HuggingFaceCache.resolvedSearchPath(
+                stored: nil,
+                environment: ["HF_HOME": customHome]
+            ),
+            "\(customHome)/hub"
+        )
+        XCTAssertEqual(
+            HuggingFaceCache.resolvedSearchPath(
+                stored: "   ",
+                environment: ["HF_HOME": customHome]
+            ),
+            "\(customHome)/hub"
+        )
+    }
+
+    func testResolvedSearchPathMigratesLegacyDefault() {
+        XCTAssertEqual(
+            HuggingFaceCache.resolvedSearchPath(
+                stored: HuggingFaceCache.fallbackHubPath,
+                environment: ["HF_HOME": customHome]
+            ),
+            "\(customHome)/hub"
+        )
+    }
+
+    func testResolvedSearchPathMigratesExpandedLegacyDefault() {
+        let expanded = (HuggingFaceCache.fallbackHubPath as NSString).expandingTildeInPath
+        XCTAssertEqual(
+            HuggingFaceCache.resolvedSearchPath(
+                stored: expanded,
+                environment: ["HF_HUB_CACHE": customCache]
+            ),
+            customCache
+        )
+    }
+
+    func testResolvedSearchPathKeepsLegacyDefaultWithoutEnvironmentOverride() {
+        XCTAssertEqual(
+            HuggingFaceCache.resolvedSearchPath(
+                stored: HuggingFaceCache.fallbackHubPath,
+                environment: [:]
+            ),
+            HuggingFaceCache.fallbackHubPath
+        )
+    }
+
+    func testResolvedSearchPathKeepsCustomPath() {
+        XCTAssertEqual(
+            HuggingFaceCache.resolvedSearchPath(
+                stored: "/elsewhere/models",
+                environment: ["HF_HOME": customHome]
+            ),
+            "/elsewhere/models"
+        )
+    }
+}

--- a/Tests/NativTests/HuggingFaceCacheTests.swift
+++ b/Tests/NativTests/HuggingFaceCacheTests.swift
@@ -47,6 +47,18 @@ final class HuggingFaceCacheTests: XCTestCase {
         )
     }
 
+    // MARK: - isConfigured
+
+    func testIsConfiguredDetectsEitherVariable() {
+        XCTAssertTrue(HuggingFaceCache.isConfigured(in: ["HF_HOME": customHome]))
+        XCTAssertTrue(HuggingFaceCache.isConfigured(in: ["HF_HUB_CACHE": customCache]))
+    }
+
+    func testIsConfiguredIgnoresBlankAndMissingValues() {
+        XCTAssertFalse(HuggingFaceCache.isConfigured(in: [:]))
+        XCTAssertFalse(HuggingFaceCache.isConfigured(in: ["HF_HOME": "  ", "HF_HUB_CACHE": ""]))
+    }
+
     // MARK: - resolvedSearchPath
 
     func testResolvedSearchPathUsesEnvironmentDefaultWhenUnset() {

--- a/Tests/NativTests/ShellEnvironmentTests.swift
+++ b/Tests/NativTests/ShellEnvironmentTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+final class ShellEnvironmentTests: XCTestCase {
+    // MARK: - parseEnvironment
+
+    func testParseEnvironmentReadsEntriesAfterMarker() {
+        let output = "prompt junk\n\0\(ShellEnvironment.marker)\0HF_HOME=/Volumes/models\0PATH=/usr/bin\0"
+        XCTAssertEqual(
+            ShellEnvironment.parseEnvironment(output, names: ["HF_HOME"]),
+            ["HF_HOME": "/Volumes/models"]
+        )
+    }
+
+    func testParseEnvironmentIgnoresJunkBeforeMarker() {
+        // Junk containing "=" would parse as a bogus entry without the marker.
+        let output = "export FOO=bar\n\0\(ShellEnvironment.marker)\0HF_HOME=/x\0"
+        XCTAssertEqual(
+            ShellEnvironment.parseEnvironment(output, names: ["FOO", "HF_HOME"]),
+            ["HF_HOME": "/x"]
+        )
+    }
+
+    func testParseEnvironmentWithoutMarkerParsesEverything() {
+        let output = "HF_HOME=/x\0IGNORED=y\0"
+        XCTAssertEqual(
+            ShellEnvironment.parseEnvironment(output, names: ["HF_HOME"]),
+            ["HF_HOME": "/x"]
+        )
+    }
+
+    func testParseEnvironmentPreservesValuesContainingEqualsAndNewlines() {
+        let output = "TOKEN=abc=def\nghi\0"
+        XCTAssertEqual(
+            ShellEnvironment.parseEnvironment(output, names: ["TOKEN"]),
+            ["TOKEN": "abc=def\nghi"]
+        )
+    }
+
+    func testParseEnvironmentSkipsSegmentsWithoutSeparator() {
+        let output = "garbage\0HF_HOME=/x\0"
+        XCTAssertEqual(
+            ShellEnvironment.parseEnvironment(output, names: ["HF_HOME"]),
+            ["HF_HOME": "/x"]
+        )
+    }
+
+    func testParseEnvironmentEmptyOutput() {
+        XCTAssertEqual(ShellEnvironment.parseEnvironment("", names: ["HF_HOME"]), [:])
+    }
+
+    // MARK: - environment(executable:)
+
+    func testEnvironmentReadsProcessOutput() {
+        let result = ShellEnvironment.environment(
+            names: ["HOME", "NATIV_TEST_DEFINITELY_MISSING"],
+            executablePath: "/usr/bin/env",
+            arguments: ["-0"],
+            timeout: 5
+        )
+        XCTAssertNotNil(result["HOME"])
+        XCTAssertNil(result["NATIV_TEST_DEFINITELY_MISSING"])
+    }
+
+    func testEnvironmentReturnsEmptyOnTimeout() {
+        let start = Date()
+        let result = ShellEnvironment.environment(
+            names: ["HF_HOME"],
+            executablePath: "/bin/sleep",
+            arguments: ["30"],
+            timeout: 0.2
+        )
+        XCTAssertEqual(result, [:])
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+    }
+
+    func testEnvironmentReturnsEmptyForMissingExecutable() {
+        let result = ShellEnvironment.environment(
+            names: ["HF_HOME"],
+            executablePath: "/nonexistent/shell",
+            arguments: [],
+            timeout: 1
+        )
+        XCTAssertEqual(result, [:])
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -30,6 +30,10 @@ schemes:
       config: Debug
     archive:
       config: Release
+    test:
+      config: Debug
+      targets:
+        - NativTests
 targets:
   NativServerKit:
     type: framework
@@ -82,3 +86,13 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.utilities
         MARKETING_VERSION: 0.0.1
         CURRENT_PROJECT_VERSION: 1
+  NativTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: Tests/NativTests
+      - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: dev.local.NativTests
+        GENERATE_INFOPLIST_FILE: YES

--- a/project.yml
+++ b/project.yml
@@ -92,6 +92,7 @@ targets:
     sources:
       - path: Tests/NativTests
       - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
+      - path: Sources/Nativ/Utilities/ShellEnvironment.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.local.NativTests


### PR DESCRIPTION
Fixes #5 

## Summary

- Resolve the default model search path like the `huggingface_hub` Python library: `HF_HUB_CACHE` → `$HF_HOME/hub` → `~/.cache/huggingface/hub`.
- Existing installs that never customized the path have the legacy default persisted in Settings.plist; it is re-resolved against the environment on settings decode. Genuinely customized paths are always preserved.
- macOS GUI apps can't see shell rc-file exports, so when the process environment doesn't configure the cache, the app probes the user's login + interactive shell once at startup (async, 3s timeout — the same approach VS Code and JetBrains IDEs use) and adopts its `HF_HOME`/`HF_HUB_CACHE`. Parsing is
NUL-separated behind a marker segment, so noisy rc files (prompts, banners) can't corrupt values.
- Downloads and the embedded server already flow from this setting, so no other call sites change; views re-scan reactively when the path changes.

## Testing

- Adds a hostless `NativTests` XCTest target (the repo had none): 21 tests covering path-resolution precedence, legacy-default migration, `isConfigured`, env-output parsing (marker, junk segments, values with `=`/newlines), and process execution (output capture, timeout, missing executable). `xcodebuild
-scheme Nativ -configuration Debug test` — all pass.
- Manually verified on a machine with `HF_HOME` only in `~/.zshrc`, launching via `open` (i.e. launchd environment):
  - existing-user upgrade (persisted legacy default): Models view flips from `~/.cache/huggingface/hub` contents to the `HF_HOME` cache within ~1–3s, and the migrated path persists across relaunches;
  - fresh install (no plist): same result;
  - terminal launch with `HF_HOME` exported: detected instantly, probe skipped.
- Probe failures (missing shell, timeout, rc errors) degrade gracefully to current behavior.

## Notes for reviewers
- Run `xcodegen generate` after checkout to get the test target; the tracked `Nativ.xcodeproj` is intentionally unchanged to avoid xcodegen-version churn (CI regenerates it).

Note: this fix was generated by AI, verified by me.