### PR TITLE
fix: don't report multi-shard models installed until fully downloaded

### DIFF
--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -133,6 +133,27 @@ struct LocalModel: Identifiable, Equatable, Sendable {
     }
 }
 
+/// A model repository present in the cache that has not finished downloading —
+/// either currently in progress or a leftover partial from an interrupted run.
+struct IncompleteLocalModel: Identifiable, Equatable, Sendable {
+    var id: String { repoID }
+
+    let repoID: String
+    let provider: LocalModelProvider?
+    let downloadedBytes: Int64?
+    let snapshotURL: URL?
+    let modifiedAt: Date?
+}
+
+/// The outcome of a cache scan, split into fully installed models and partial
+/// downloads so the UI can surface and manage each independently.
+struct LocalModelScanResult: Equatable, Sendable {
+    let installed: [LocalModel]
+    let incomplete: [IncompleteLocalModel]
+
+    static let empty = LocalModelScanResult(installed: [], incomplete: [])
+}
+
 struct LocalModelMemoryEstimate: Equatable, Sendable {
     static let headroomFraction = 0.20
 
@@ -173,6 +194,10 @@ struct LocalModelConfigurationMetadata: Equatable, Sendable {
 
 enum LocalModelDiscovery {
     static func scan(path: String) async throws -> [LocalModel] {
+        try await scanAll(path: path).installed
+    }
+
+    static func scanAll(path: String) async throws -> LocalModelScanResult {
         let expandedPath = Self.expandedPath(path)
         return try await Task.detached(priority: .userInitiated) {
             try Self.scanSynchronously(path: expandedPath)
@@ -218,7 +243,7 @@ enum LocalModelDiscovery {
         return (effectivePath as NSString).expandingTildeInPath
     }
 
-    private static func scanSynchronously(path: String) throws -> [LocalModel] {
+    private static func scanSynchronously(path: String) throws -> LocalModelScanResult {
         let fileManager = FileManager.default
         let rootURL = URL(fileURLWithPath: path, isDirectory: true)
         var isDirectory: ObjCBool = false
@@ -236,53 +261,129 @@ enum LocalModelDiscovery {
             options: [.skipsHiddenFiles]
         )
 
-        let models = repoURLs.compactMap { repoURL -> LocalModel? in
+        var installed: [LocalModel] = []
+        var incomplete: [IncompleteLocalModel] = []
+
+        for repoURL in repoURLs {
             guard repoURL.lastPathComponent.hasPrefix("models--"),
                   isDirectoryURL(repoURL, fileManager: fileManager),
                   let repoID = repoID(fromCacheDirectoryName: repoURL.lastPathComponent)
             else {
-                return nil
+                continue
             }
 
-            guard let snapshotURL = preferredSnapshotURL(for: repoURL, fileManager: fileManager),
-                  isLikelyMLXModelSnapshot(snapshotURL, fileManager: fileManager)
-            else {
-                return nil
-            }
+            let snapshotURL = preferredSnapshotURL(for: repoURL, fileManager: fileManager)
 
-            let modifiedAt = (try? snapshotURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
-            let memoryMetadata = modelMemoryMetadata(
+            if let snapshotURL, isLikelyMLXModelSnapshot(snapshotURL, fileManager: fileManager) {
+                installed.append(
+                    makeLocalModel(repoID: repoID, snapshotURL: snapshotURL, fileManager: fileManager)
+                )
+            } else if isIncompleteDownload(snapshotURL: snapshotURL, repoURL: repoURL, fileManager: fileManager) {
+                incomplete.append(
+                    makeIncompleteModel(repoID: repoID, snapshotURL: snapshotURL, fileManager: fileManager)
+                )
+            }
+        }
+
+        return LocalModelScanResult(
+            installed: installed.sorted { orderedByRepoID($0.repoID, $1.repoID) },
+            incomplete: incomplete.sorted { orderedByRepoID($0.repoID, $1.repoID) }
+        )
+    }
+
+    private static func makeLocalModel(
+        repoID: String,
+        snapshotURL: URL,
+        fileManager: FileManager
+    ) -> LocalModel {
+        let modifiedAt = (try? snapshotURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        let memoryMetadata = modelMemoryMetadata(
+            repoID: repoID,
+            snapshotURL: snapshotURL,
+            fileManager: fileManager
+        )
+        return LocalModel(
+            repoID: repoID,
+            snapshotURL: snapshotURL,
+            modifiedAt: modifiedAt,
+            sizeBytes: snapshotSize(at: snapshotURL, fileManager: fileManager),
+            parameterCount: memoryMetadata.parameterCount,
+            quantizationBits: memoryMetadata.quantizationBits,
+            quantizationGroupSize: memoryMetadata.quantizationGroupSize,
+            contextSize: contextSize(at: snapshotURL, fileManager: fileManager),
+            provider: modelProvider(
                 repoID: repoID,
                 snapshotURL: snapshotURL,
                 fileManager: fileManager
-            )
-            return LocalModel(
-                repoID: repoID,
-                snapshotURL: snapshotURL,
-                modifiedAt: modifiedAt,
-                sizeBytes: snapshotSize(at: snapshotURL, fileManager: fileManager),
-                parameterCount: memoryMetadata.parameterCount,
-                quantizationBits: memoryMetadata.quantizationBits,
-                quantizationGroupSize: memoryMetadata.quantizationGroupSize,
-                contextSize: contextSize(at: snapshotURL, fileManager: fileManager),
-                provider: modelProvider(
-                    repoID: repoID,
-                    snapshotURL: snapshotURL,
-                    fileManager: fileManager
-                ),
-                capabilities: modelCapabilities(at: snapshotURL, fileManager: fileManager)
-            )
+            ),
+            capabilities: modelCapabilities(at: snapshotURL, fileManager: fileManager)
+        )
+    }
+
+    private static func makeIncompleteModel(
+        repoID: String,
+        snapshotURL: URL?,
+        fileManager: FileManager
+    ) -> IncompleteLocalModel {
+        let modifiedAt = snapshotURL.flatMap {
+            (try? $0.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        }
+        let provider = snapshotURL.flatMap {
+            modelProvider(repoID: repoID, snapshotURL: $0, fileManager: fileManager)
+        } ?? LocalModelProviderResolver.resolve(repoID: repoID, modelType: nil, architectures: [])
+        let downloadedBytes = snapshotURL.flatMap {
+            snapshotSize(at: $0, fileManager: fileManager)
+        }
+        return IncompleteLocalModel(
+            repoID: repoID,
+            provider: provider,
+            downloadedBytes: downloadedBytes,
+            snapshotURL: snapshotURL,
+            modifiedAt: modifiedAt
+        )
+    }
+
+    /// Determines whether a cached repository is a partial download rather than a
+    /// usable model. Used to surface interrupted or in-progress downloads so the
+    /// user can remove them.
+    private static func isIncompleteDownload(
+        snapshotURL: URL?,
+        repoURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        // A sharded model whose weight index is present but whose shards have not
+        // all arrived yet is, by definition, still downloading.
+        if let snapshotURL,
+           safetensorsShardIndexIsComplete(at: snapshotURL, fileManager: fileManager) == false {
+            return true
         }
 
-        return models.sorted { lhs, rhs in
-            switch lhs.repoID.localizedCaseInsensitiveCompare(rhs.repoID) {
-            case .orderedAscending:
-                return true
-            case .orderedDescending:
-                return false
-            case .orderedSame:
-                return lhs.repoID < rhs.repoID
-            }
+        // huggingface_hub streams each file into a "<etag>.incomplete" blob and
+        // only finalizes it once the transfer succeeds, so a leftover marks an
+        // interrupted download.
+        return hasIncompleteBlob(in: repoURL, fileManager: fileManager)
+    }
+
+    private static func hasIncompleteBlob(in repoURL: URL, fileManager: FileManager) -> Bool {
+        let blobsURL = repoURL.appendingPathComponent("blobs", isDirectory: true)
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: blobsURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+        return contents.contains { $0.pathExtension == "incomplete" }
+    }
+
+    private static func orderedByRepoID(_ lhs: String, _ rhs: String) -> Bool {
+        switch lhs.localizedCaseInsensitiveCompare(rhs) {
+        case .orderedAscending:
+            return true
+        case .orderedDescending:
+            return false
+        case .orderedSame:
+            return lhs < rhs
         }
     }
 
@@ -1081,6 +1182,7 @@ enum LocalModelDiscoveryError: LocalizedError, Equatable {
 @MainActor
 final class LocalModelLibrary: ObservableObject {
     @Published private(set) var models: [LocalModel] = []
+    @Published private(set) var incompleteModels: [IncompleteLocalModel] = []
     @Published private(set) var isScanning = false
     @Published private(set) var deletingModelIDs = Set<String>()
     @Published private(set) var error: String?
@@ -1098,11 +1200,12 @@ final class LocalModelLibrary: ObservableObject {
 
         scanTask = Task { [weak self] in
             do {
-                let models = try await LocalModelDiscovery.scan(path: path)
+                let result = try await LocalModelDiscovery.scanAll(path: path)
                 guard !Task.isCancelled else {
                     return
                 }
-                self?.models = models
+                self?.models = result.installed
+                self?.incompleteModels = result.incomplete
                 self?.error = nil
             } catch is CancellationError {
                 return
@@ -1111,6 +1214,7 @@ final class LocalModelLibrary: ObservableObject {
                     return
                 }
                 self?.models = []
+                self?.incompleteModels = []
                 self?.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
 
@@ -1132,19 +1236,28 @@ final class LocalModelLibrary: ObservableObject {
         path: String,
         onCompletion: @escaping () -> Void
     ) {
-        guard !deletingModelIDs.contains(model.repoID) else { return }
-        deletingModelIDs.insert(model.repoID)
+        delete(repoID: model.repoID, path: path, onCompletion: onCompletion)
+    }
+
+    func delete(
+        repoID: String,
+        path: String,
+        onCompletion: @escaping () -> Void
+    ) {
+        guard !deletingModelIDs.contains(repoID) else { return }
+        deletingModelIDs.insert(repoID)
         error = nil
 
         Task { [weak self] in
             do {
-                try await LocalModelDiscovery.delete(repoID: model.repoID, path: path)
-                self?.models.removeAll { $0.repoID == model.repoID }
-                self?.deletingModelIDs.remove(model.repoID)
+                try await LocalModelDiscovery.delete(repoID: repoID, path: path)
+                self?.models.removeAll { $0.repoID == repoID }
+                self?.incompleteModels.removeAll { $0.repoID == repoID }
+                self?.deletingModelIDs.remove(repoID)
                 onCompletion()
             } catch {
-                self?.deletingModelIDs.remove(model.repoID)
-                self?.error = "Couldn’t delete \(model.repoID): \(error.localizedDescription)"
+                self?.deletingModelIDs.remove(repoID)
+                self?.error = "Couldn’t delete \(repoID): \(error.localizedDescription)"
             }
         }
     }

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -380,9 +380,12 @@ enum LocalModelDiscovery {
             return false
         }
 
-        let indexURL = snapshotURL.appendingPathComponent("model.safetensors.index.json")
-        if fileManager.fileExists(atPath: indexURL.path) {
-            return true
+        // A sharded model advertises its weight files in an index. That index
+        // is tiny and downloads before the shards it points to, so its mere
+        // presence does not mean the model is fully downloaded. Require every
+        // referenced shard to exist before treating the snapshot as installed.
+        if let indexIsComplete = safetensorsShardIndexIsComplete(at: snapshotURL, fileManager: fileManager) {
+            return indexIsComplete
         }
 
         guard let contents = try? fileManager.contentsOfDirectory(
@@ -393,6 +396,39 @@ enum LocalModelDiscovery {
             return false
         }
         return contents.contains { $0.pathExtension == "safetensors" }
+    }
+
+    /// Validates a sharded-safetensors weight index against the files on disk.
+    ///
+    /// - Returns: `nil` when the snapshot has no `model.safetensors.index.json`
+    ///   to validate (single-file or non-safetensors layouts), otherwise `true`
+    ///   only when every shard listed in the index's `weight_map` is present.
+    private static func safetensorsShardIndexIsComplete(
+        at snapshotURL: URL,
+        fileManager: FileManager
+    ) -> Bool? {
+        let indexURL = snapshotURL.appendingPathComponent("model.safetensors.index.json")
+        guard fileManager.fileExists(atPath: indexURL.path) else {
+            return nil
+        }
+
+        guard let data = try? Data(contentsOf: indexURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let weightMap = json["weight_map"] as? [String: Any]
+        else {
+            // The index exists but cannot be read; treat as incomplete so a
+            // partially downloaded model is not reported as installed.
+            return false
+        }
+
+        let shardFilenames = Set(weightMap.values.compactMap { $0 as? String })
+        guard !shardFilenames.isEmpty else {
+            return false
+        }
+
+        return shardFilenames.allSatisfy { filename in
+            fileManager.fileExists(atPath: snapshotURL.appendingPathComponent(filename).path)
+        }
     }
 
     private static func snapshotSize(at snapshotURL: URL, fileManager: FileManager) -> Int64? {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -112,18 +112,35 @@ struct ModelsView: View {
                         )
                     }
 
-                    if localLibrary.isScanning && localLibrary.models.isEmpty {
+                    ForEach(filteredPendingModels) { pending in
+                        PendingModelRow(
+                            model: pending,
+                            isDeleting: localLibrary.deletingModelIDs.contains(pending.repoID),
+                            onPauseResume: {
+                                if downloadManager.isDownloadPaused {
+                                    downloadManager.resumeDownload()
+                                } else {
+                                    downloadManager.pauseDownload()
+                                }
+                            },
+                            onDelete: { deletePendingModel(pending) }
+                        )
+                    }
+
+                    if localLibrary.isScanning && localLibrary.models.isEmpty && filteredPendingModels.isEmpty {
                         ModelsLoadingState(title: "Scanning your Hugging Face cache…")
                     } else if filteredLocalModels.isEmpty {
-                        ModelsEmptyState(
-                            systemImage: localQuery.isEmpty ? "shippingbox" : "magnifyingglass",
-                            title: localQuery.isEmpty ? "No MLX models installed" : "No models match your filter",
-                            message: localQuery.isEmpty
-                                ? "Discover an MLX model on Hugging Face and download it to this cache."
-                                : "Try a different model name or provider.",
-                            actionTitle: localQuery.isEmpty ? "Discover models" : nil,
-                            action: { section = .discover }
-                        )
+                        if filteredPendingModels.isEmpty {
+                            ModelsEmptyState(
+                                systemImage: localQuery.isEmpty ? "shippingbox" : "magnifyingglass",
+                                title: localQuery.isEmpty ? "No MLX models installed" : "No models match your filter",
+                                message: localQuery.isEmpty
+                                    ? "Discover an MLX model on Hugging Face and download it to this cache."
+                                    : "Try a different model name or provider.",
+                                actionTitle: localQuery.isEmpty ? "Discover models" : nil,
+                                action: { section = .discover }
+                            )
+                        }
                     } else {
                         HStack {
                             Text("\(filteredLocalModels.count) \(filteredLocalModels.count == 1 ? "model" : "models")")
@@ -331,6 +348,70 @@ struct ModelsView: View {
 
     private var installedModelIDs: Set<String> {
         Set(localLibrary.models.map(\.repoID))
+    }
+
+    /// In-progress and interrupted downloads, surfaced on the Installed page so
+    /// they can be canceled or removed before they finish. The active download is
+    /// sourced from the download manager (live progress); leftover partials come
+    /// from the cache scan. Installed repos are excluded so nothing is duplicated.
+    private var pendingModels: [PendingModel] {
+        let installedIDs = installedModelIDs
+        let activeID = downloadManager.downloadingModelID
+        var result: [PendingModel] = []
+
+        if let activeID, !installedIDs.contains(activeID) {
+            result.append(
+                PendingModel(
+                    repoID: activeID,
+                    provider: LocalModelProviderResolver.resolve(
+                        repoID: activeID,
+                        modelType: nil,
+                        architectures: []
+                    ),
+                    downloadedBytes: nil,
+                    state: .downloading(
+                        progress: downloadManager.downloadProgress,
+                        isPaused: downloadManager.isDownloadPaused
+                    )
+                )
+            )
+        }
+
+        for incomplete in localLibrary.incompleteModels
+            where incomplete.repoID != activeID && !installedIDs.contains(incomplete.repoID) {
+            result.append(
+                PendingModel(
+                    repoID: incomplete.repoID,
+                    provider: incomplete.provider,
+                    downloadedBytes: incomplete.downloadedBytes,
+                    state: .incomplete
+                )
+            )
+        }
+        return result
+    }
+
+    private var filteredPendingModels: [PendingModel] {
+        let query = localQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return pendingModels }
+        return pendingModels.filter {
+            $0.repoID.localizedCaseInsensitiveContains(query)
+                || $0.provider?.displayName.localizedCaseInsensitiveContains(query) == true
+        }
+    }
+
+    private func deletePendingModel(_ pending: PendingModel) {
+        switch pending.state {
+        case .downloading:
+            downloadManager.removeDownload()
+        case .incomplete:
+            localLibrary.delete(
+                repoID: pending.repoID,
+                path: model.settings.modelSearchPath
+            ) {
+                NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
+            }
+        }
     }
 
     private var pageTitle: some View {
@@ -607,6 +688,132 @@ private struct ModelsSearchField: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
+    }
+}
+
+private struct PendingModel: Identifiable {
+    enum State: Equatable {
+        case downloading(progress: Double, isPaused: Bool)
+        case incomplete
+    }
+
+    let repoID: String
+    let provider: LocalModelProvider?
+    let downloadedBytes: Int64?
+    let state: State
+
+    var id: String { repoID }
+}
+
+private struct PendingModelRow: View {
+    let model: PendingModel
+    let isDeleting: Bool
+    let onPauseResume: () -> Void
+    let onDelete: () -> Void
+
+    @State private var isHovered = false
+    @State private var showsDeleteConfirmation = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ModelProviderBadge(provider: model.provider)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(modelName(model.repoID))
+                    .font(.body.weight(.semibold))
+                    .lineLimit(1)
+
+                Text(model.repoID)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                HStack(spacing: 6) {
+                    statusPill
+                    if let downloadedBytes = model.downloadedBytes {
+                        ModelPill(
+                            title: "\(ByteCountFormatter.string(fromByteCount: downloadedBytes, countStyle: .file)) on disk",
+                            systemImage: "internaldrive"
+                        )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer(minLength: 12)
+
+            if case let .downloading(_, isPaused) = model.state, !isDeleting {
+                ModelDownloadActionButton(
+                    title: isPaused ? "Resume download" : "Pause download",
+                    systemImage: isPaused ? "play.fill" : "pause.fill",
+                    tint: isPaused ? .green : .orange,
+                    action: onPauseResume
+                )
+            }
+
+            if isDeleting {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 30, height: 30)
+                    .help("Removing download")
+            } else {
+                ModelDownloadActionButton(
+                    title: deleteButtonTitle,
+                    systemImage: "trash",
+                    tint: .red
+                ) {
+                    showsDeleteConfirmation = true
+                }
+            }
+        }
+        .padding(14)
+        .contentShape(RoundedRectangle(cornerRadius: 12))
+        .onHover { isHovered = $0 }
+        .animation(.easeOut(duration: 0.14), value: isHovered)
+        .modelRowBackground(isHighlighted: false, isHovered: isHovered)
+        .alert(deleteConfirmationTitle, isPresented: $showsDeleteConfirmation) {
+            Button(deleteConfirmationButton, role: .destructive, action: onDelete)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the partially downloaded files for \(model.repoID) from the local Hugging Face cache.")
+        }
+    }
+
+    @ViewBuilder
+    private var statusPill: some View {
+        switch model.state {
+        case let .downloading(progress, isPaused):
+            let percent = Int((progress * 100).rounded())
+            ModelPill(
+                title: isPaused ? "Paused \(percent)%" : "Downloading \(percent)%",
+                systemImage: isPaused ? "pause.circle" : "arrow.down.circle",
+                color: .accentColor
+            )
+        case .incomplete:
+            ModelPill(
+                title: "Incomplete download",
+                systemImage: "exclamationmark.triangle.fill",
+                color: .orange
+            )
+        }
+    }
+
+    private var isDownloading: Bool {
+        if case .downloading = model.state { return true }
+        return false
+    }
+
+    private var deleteButtonTitle: String {
+        isDownloading ? "Cancel and remove download" : "Remove incomplete download"
+    }
+
+    private var deleteConfirmationTitle: String {
+        isDownloading ? "Cancel downloading \(modelName(model.repoID))?" : "Remove \(modelName(model.repoID))?"
+    }
+
+    private var deleteConfirmationButton: String {
+        isDownloading ? "Cancel Download" : "Remove Files"
     }
 }
 


### PR DESCRIPTION
## Problem

Clicking **Install** on a model, then trying to run it before the download finishes, showed the model as **Installed** but running it failed with **"can't connect to server."** And once a partial download was correctly hidden, there was no way to cancel or clean it up from the UI.

## Root cause

Installed-state is derived from a filesystem scan (`installedModelIDs` → `LocalModelDiscovery.scan`), which calls `isLikelyMLXModelSnapshot` to decide whether a cached repo counts as installed. That check short-circuited to `true` the moment `model.safetensors.index.json` existed:

```swift
let indexURL = snapshotURL.appendingPathComponent("model.safetensors.index.json")
if fileManager.fileExists(atPath: indexURL.path) {
    return true
}
```

The index is a tiny JSON file that `huggingface_hub`'s `snapshot_download` fetches **before** the weight shards it points to. So for any multi-shard model, the snapshot looked "installed" after just the config + index landed, while the actual weights were still downloading. Selecting it started `mlx-vlm-server` against missing weights; the server failed to load the model and never bound its port, surfacing to the client as "can't connect to server."

## Changes

**1. Fix the false "installed" state** (`fix:` commit)

Validate the index against the files on disk: parse `weight_map`, collect the referenced shard filenames, and only treat the snapshot as installed once **every** shard is present. Single-file and non-safetensors layouts are unaffected — the new helper returns `nil` and falls through to the existing presence logic.

**2. Let partial downloads be managed from the Installed page** (`feat:` commit)

Hiding partials fixed the bug but left them unmanageable, so this surfaces them where the user already looks:

- `LocalModelDiscovery.scanAll` classifies each cached repo as **installed**, **incomplete** (sharded index present but shards missing, or a leftover `*.incomplete` blob), or skipped. `scan()` still returns `[LocalModel]`, so existing callers (`AppDelegate`, `DashboardViewModel`) are unchanged.
- `LocalModelLibrary` publishes `incompleteModels` and gains a `repoID`-based `delete` (the model-based `delete` delegates to it).
- The Installed page renders a `PendingModelRow` for **active downloads** (live progress + pause/resume, from the download manager) and **incomplete leftovers** (from the cache scan), de-duplicated against installed models. The delete/cancel button is always enabled — cancel routes to `removeDownload` for active transfers and deletes the partial files for leftovers.

## Testing

- `make xcode-build` — succeeds.
- `make xcode-smoke` — passes.
- Manual: reproduced a multi-shard partial in the HF cache — it no longer shows as installed, appears on the Installed page as "Incomplete download," and its delete button removes it. A live download shows on the Installed page with progress and cancels cleanly.
- Verified the pure logic against synthetic snapshot dirs:

  | Case | Result |
  |---|---|
  | index only, no shards | not installed / incomplete |
  | index + shard 1 of 2 | not installed / incomplete |
  | index + all shards | installed |
  | single-file, `.incomplete` blob present | incomplete |
  | no index (single-file) | falls through to existing logic |

Note: the repo has no Swift test target, so I verified the logic standalone rather than adding a test. Happy to add a test target if you'd like one.
