### PR TITLE
fix: keep model downloads running when leaving the Models page

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -484,6 +484,8 @@ final class HuggingFaceModelLibrary: ObservableObject {
 
 @MainActor
 final class HuggingFaceDownloadManager: ObservableObject {
+    static let shared = HuggingFaceDownloadManager()
+
     @Published private(set) var downloadingModelID: String?
     @Published private(set) var downloadProgress = 0.0
     @Published private(set) var isDownloadPaused = false
@@ -535,12 +537,6 @@ final class HuggingFaceDownloadManager: ObservableObject {
                 HuggingFaceSnapshotDownloader.removeDownload(repoID: repoID, cachePath: cachePath)
             }.value
         }
-    }
-
-    func cancelDownload() {
-        downloadTask?.cancel()
-        downloadTask = nil
-        clearActiveDownload()
     }
 
     private func startActiveDownload() {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -21,7 +21,7 @@ struct ModelsView: View {
     @Binding var showsConfiguration: Bool
     @StateObject private var localLibrary = LocalModelLibrary()
     @StateObject private var hubLibrary = HuggingFaceModelLibrary()
-    @StateObject private var downloadManager = HuggingFaceDownloadManager()
+    @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
     @State private var section: ModelsPageSection = .installed
     @State private var localQuery = ""
     @State private var hubQuery = ""
@@ -59,7 +59,6 @@ struct ModelsView: View {
         .onDisappear {
             localLibrary.cancel()
             hubLibrary.cancel()
-            downloadManager.cancelDownload()
         }
     }
 


### PR DESCRIPTION
Fixes #17. The download manager was view-scoped and cancelled in `onDisappear`, so leaving the Models page killed active downloads. Share one app-scoped instance so downloads survive navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)