### PR TITLE
feat: allow choosing the local server port

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */; };
 		E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41417C210BF817681A8C6D87 /* IntegrationsView.swift */; };
 		ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
+		F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		B0E2EE61C1652C49ECC69658 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B7C7712D68B2782589312766 /* ControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelView.swift; sourceTree = "<group>"; };
 		BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormatting.swift; sourceTree = "<group>"; };
+		330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerPortProbe.swift; sourceTree = "<group>"; };
 		D1651E057CC5D05857CF1595 /* NativServerKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativServerKit.swift; sourceTree = "<group>"; };
 		D97F637262DB138A253DEA6F /* ChatComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposer.swift; sourceTree = "<group>"; };
 		DB24BFEFF23914DA8BDB0E1C /* ModelProviderIcons */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ModelProviderIcons; path = Sources/Nativ/ModelProviderIcons; sourceTree = SOURCE_ROOT; };
@@ -124,6 +126,7 @@
 			children = (
 				7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */,
 				BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */,
+				330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				692EA024371CB249BE53DB86 /* NativAnalyticsStore.swift in Sources */,
 				4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */,
 				ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */,
+				F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */,
 				E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */,
 				8B4DF732A8A6AA5FFBE11982 /* StatsView.swift in Sources */,
 				23C7BE9CB287D87B15233E7B /* WelcomeView.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -29,6 +29,7 @@ struct ModelConfigurationLayout<Content: View>: View {
                 ModelConfigurationView(
                     settings: $model.settings,
                     settingsRequireRestart: model.settingsRequireRestart,
+                    activeServerPort: model.activeServerPort,
                     onReset: model.resetSettings
                 )
                 .frame(width: 320)
@@ -62,10 +63,12 @@ struct ModelConfigurationLayout<Content: View>: View {
 struct ModelConfigurationView: View {
     @Binding var settings: NativSettings
     let settingsRequireRestart: Bool
+    let activeServerPort: Int?
     let onReset: () -> Void
     @State private var modelConfiguration: LocalModelConfigurationMetadata?
     @State private var isLoadingModelConfiguration = false
     @State private var modelConfigurationRevision = 0
+    @State private var isSelectedPortAvailable = true
 
     var body: some View {
         VStack(spacing: 0) {
@@ -82,6 +85,7 @@ struct ModelConfigurationView: View {
                     speculativeDecodingSection
                     structuredOutputSection
                     prefixCachingSection
+                    serverSection
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 18)
@@ -123,6 +127,41 @@ struct ModelConfigurationView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 16)
+    }
+
+    private var serverSection: some View {
+        ChatConfigurationSection(title: "Server") {
+            ConfigurationIntegerField(
+                title: "Port",
+                value: $settings.serverPort,
+                range: 1...65_535,
+                usesGroupingSeparator: false
+            )
+
+            if showsPortInUseWarning {
+                Label(
+                    "Port \(String(settings.normalized().serverPort)) is already in use — that port can’t be used.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.footnote)
+                .foregroundStyle(.orange)
+            } else {
+                Text("The local server listens at 127.0.0.1 on this port.")
+                    .configurationHintStyle()
+            }
+        }
+        .task(id: settings.normalized().serverPort) {
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled else { return }
+            let port = settings.normalized().serverPort
+            let available = await Task.detached { ServerPortProbe.isAvailable(port) }.value
+            guard !Task.isCancelled else { return }
+            isSelectedPortAvailable = available
+        }
+    }
+
+    private var showsPortInUseWarning: Bool {
+        !isSelectedPortAvailable && settings.normalized().serverPort != activeServerPort
     }
 
     private var modelContextSection: some View {
@@ -509,6 +548,7 @@ private struct ConfigurationIntegerField: View {
     let title: String
     @Binding var value: Int
     let range: ClosedRange<Int>
+    var usesGroupingSeparator = true
 
     var body: some View {
         HStack(spacing: 8) {
@@ -516,7 +556,7 @@ private struct ConfigurationIntegerField: View {
                 .font(.body)
                 .foregroundStyle(.secondary)
             Spacer(minLength: 8)
-            TextField("", value: $value, format: .number)
+            TextField("", value: $value, format: .number.grouping(usesGroupingSeparator ? .automatic : .never))
                 .font(.body)
                 .multilineTextAlignment(.trailing)
                 .frame(width: 104)

--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -29,7 +29,6 @@ struct ModelConfigurationLayout<Content: View>: View {
                 ModelConfigurationView(
                     settings: $model.settings,
                     settingsRequireRestart: model.settingsRequireRestart,
-                    activeServerPort: model.activeServerPort,
                     onReset: model.resetSettings
                 )
                 .frame(width: 320)
@@ -63,12 +62,10 @@ struct ModelConfigurationLayout<Content: View>: View {
 struct ModelConfigurationView: View {
     @Binding var settings: NativSettings
     let settingsRequireRestart: Bool
-    let activeServerPort: Int?
     let onReset: () -> Void
     @State private var modelConfiguration: LocalModelConfigurationMetadata?
     @State private var isLoadingModelConfiguration = false
     @State private var modelConfigurationRevision = 0
-    @State private var isSelectedPortAvailable = true
 
     var body: some View {
         VStack(spacing: 0) {
@@ -85,7 +82,6 @@ struct ModelConfigurationView: View {
                     speculativeDecodingSection
                     structuredOutputSection
                     prefixCachingSection
-                    serverSection
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 18)
@@ -127,41 +123,6 @@ struct ModelConfigurationView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 16)
-    }
-
-    private var serverSection: some View {
-        ChatConfigurationSection(title: "Server") {
-            ConfigurationIntegerField(
-                title: "Port",
-                value: $settings.serverPort,
-                range: 1...65_535,
-                usesGroupingSeparator: false
-            )
-
-            if showsPortInUseWarning {
-                Label(
-                    "Port \(String(settings.normalized().serverPort)) is already in use — that port can’t be used.",
-                    systemImage: "exclamationmark.triangle.fill"
-                )
-                .font(.footnote)
-                .foregroundStyle(.orange)
-            } else {
-                Text("The local server listens at 127.0.0.1 on this port.")
-                    .configurationHintStyle()
-            }
-        }
-        .task(id: settings.normalized().serverPort) {
-            try? await Task.sleep(for: .milliseconds(250))
-            guard !Task.isCancelled else { return }
-            let port = settings.normalized().serverPort
-            let available = await Task.detached { ServerPortProbe.isAvailable(port) }.value
-            guard !Task.isCancelled else { return }
-            isSelectedPortAvailable = available
-        }
-    }
-
-    private var showsPortInUseWarning: Bool {
-        !isSelectedPortAvailable && settings.normalized().serverPort != activeServerPort
     }
 
     private var modelContextSection: some View {
@@ -548,7 +509,6 @@ private struct ConfigurationIntegerField: View {
     let title: String
     @Binding var value: Int
     let range: ClosedRange<Int>
-    var usesGroupingSeparator = true
 
     var body: some View {
         HStack(spacing: 8) {
@@ -556,7 +516,7 @@ private struct ConfigurationIntegerField: View {
                 .font(.body)
                 .foregroundStyle(.secondary)
             Spacer(minLength: 8)
-            TextField("", value: $value, format: .number.grouping(usesGroupingSeparator ? .automatic : .never))
+            TextField("", value: $value, format: .number)
                 .font(.body)
                 .multilineTextAlignment(.trailing)
                 .frame(width: 104)

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -152,7 +152,6 @@ final class ChatViewModel: ObservableObject {
     @Published private(set) var sendingStartedAt: Date?
     @Published private(set) var scrollToken = 0
 
-    private let client = NativChatClient()
     private let sessionStore = ChatSessionStore()
     private var activeTask: Task<Void, Never>?
     private var activeRequestID: UUID?
@@ -436,6 +435,8 @@ final class ChatViewModel: ObservableObject {
             if currentSessionID == queuedRequest.sessionID {
                 bumpScroll()
             }
+
+            let client = NativChatClient(baseURL: queuedRequest.settings.serverBaseURL)
 
             activeTask = Task { @MainActor [weak self] in
                 guard let self else {

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -171,7 +171,7 @@ struct DeveloperView: View {
                     spacing: 8
                 ) {
                     ForEach(ServerEndpoint.endpoints(in: selectedEndpointCategory)) { endpoint in
-                        ServerEndpointRow(endpoint: endpoint) {
+                        ServerEndpointRow(endpoint: endpoint, baseURL: model.settings.serverBaseURL) {
                             copyEndpoint(endpoint)
                         }
                     }
@@ -196,7 +196,7 @@ struct DeveloperView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text("Server endpoints")
                     .font(.callout.weight(.semibold))
-                Text(ServerEndpoint.baseURL.absoluteString)
+                Text(model.settings.serverBaseURL.absoluteString)
                     .font(.caption.monospaced())
                     .foregroundStyle(.secondary)
             }
@@ -339,19 +339,18 @@ struct DeveloperView: View {
     private func copyEndpoint(_ endpoint: ServerEndpoint) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(endpoint.absoluteURL, forType: .string)
+        pasteboard.setString(endpoint.absoluteURL(baseURL: model.settings.serverBaseURL), forType: .string)
     }
 }
 
 private struct ServerEndpoint: Identifiable {
-    static let baseURL = URL(string: "http://127.0.0.1:8080")!
-
     let method: ServerEndpointMethod
     let path: String
     let category: ServerEndpointCategory
 
     var id: String { "\(method.rawValue):\(path)" }
-    var absoluteURL: String { Self.baseURL.absoluteString + path }
+
+    func absoluteURL(baseURL: URL) -> String { baseURL.absoluteString + path }
 
     static func endpoints(in category: ServerEndpointCategory) -> [ServerEndpoint] {
         supported.filter { $0.category == category }
@@ -414,6 +413,7 @@ private enum ServerEndpointMethod: String {
 
 private struct ServerEndpointRow: View {
     let endpoint: ServerEndpoint
+    let baseURL: URL
     let copyAction: () -> Void
     @State private var isHovering = false
 
@@ -447,7 +447,7 @@ private struct ServerEndpointRow: View {
                 .fill(isHovering ? Color.secondary.opacity(0.08) : .clear)
         )
         .onHover { isHovering = $0 }
-        .help("Copy \(endpoint.absoluteURL)")
+        .help("Copy \(endpoint.absoluteURL(baseURL: baseURL))")
     }
 }
 

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -10,6 +10,7 @@ struct DeveloperView: View {
     @State private var logQuery = ""
     @State private var logLevelFilter: LogLevelFilter = .all
     @State private var selectedEndpointCategory: ServerEndpointCategory = .openAI
+    @State private var isSelectedPortAvailable = true
 
     var body: some View {
         ModelConfigurationLayout(
@@ -144,8 +145,10 @@ struct DeveloperView: View {
 
                     endpointCategoryPicker
                         .frame(width: 300, alignment: .leading)
+
+                    serverPortField
                 }
-                .frame(width: 560, alignment: .leading)
+                .frame(width: 660, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 9) {
                     endpointPanelTitle
@@ -154,6 +157,8 @@ struct DeveloperView: View {
                         endpointCategoryPicker
                             .frame(width: 320)
 
+                        serverPortField
+
                         Spacer()
                     }
                 }
@@ -161,6 +166,18 @@ struct DeveloperView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
+
+            if showsPortInUseWarning {
+                Label(
+                    "Port \(String(model.settings.normalized().serverPort)) is already in use — that port can’t be used.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.footnote)
+                .foregroundStyle(.orange)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 10)
+            }
 
             Divider()
 
@@ -201,6 +218,35 @@ struct DeveloperView: View {
                     .foregroundStyle(.secondary)
             }
         }
+    }
+
+    private var serverPortField: some View {
+        HStack(spacing: 6) {
+            Text("Port")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            TextField("", value: $model.settings.serverPort, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder)
+                .font(.callout.monospaced())
+                .multilineTextAlignment(.trailing)
+                .frame(width: 64)
+                .onChange(of: model.settings.serverPort) { _, newValue in
+                    model.settings.serverPort = min(max(newValue, 1), 65_535)
+                }
+        }
+        .help("The local server listens at 127.0.0.1 on this port. Changing it requires a server restart.")
+        .task(id: model.settings.normalized().serverPort) {
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled else { return }
+            let port = model.settings.normalized().serverPort
+            let available = await Task.detached { ServerPortProbe.isAvailable(port) }.value
+            guard !Task.isCancelled else { return }
+            isSelectedPortAvailable = available
+        }
+    }
+
+    private var showsPortInUseWarning: Bool {
+        !isSelectedPortAvailable && model.settings.normalized().serverPort != model.activeServerPort
     }
 
     private var endpointCategoryPicker: some View {

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -40,7 +40,6 @@ final class ImageGenerationViewModel: ObservableObject {
     @Published private(set) var statusText: String?
     @Published private(set) var errorText: String?
 
-    private let client = NativImageClient()
     private let sessionStore = ImageGenerationSessionStore()
     private var activeTask: Task<Void, Never>?
     private var storedSessions: [ImageGenerationSession] = []
@@ -206,6 +205,7 @@ final class ImageGenerationViewModel: ObservableObject {
         persistCurrentSession(updateTimestamp: true)
 
         activeTask?.cancel()
+        let client = NativImageClient(baseURL: appModel.settings.serverBaseURL)
         activeTask = Task { @MainActor [weak self, weak appModel] in
             guard let self else {
                 return

--- a/Sources/Nativ/Features/Integrations/IntegrationServices.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationServices.swift
@@ -113,8 +113,14 @@ enum IntegrationServiceError: LocalizedError {
 
 struct IntegrationProfileManager {
     static let providerID = "nativ"
-    static let openAIBaseURL = "http://127.0.0.1:8080/v1"
-    static let anthropicBaseURL = "http://127.0.0.1:8080"
+
+    static var openAIBaseURL: String {
+        NativSettings.load().serverBaseURL.absoluteString + "/v1"
+    }
+
+    static var anthropicBaseURL: String {
+        NativSettings.load().serverBaseURL.absoluteString
+    }
 
     private let fileManager = FileManager.default
 

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -249,7 +249,7 @@ final class IntegrationsViewModel: ObservableObject {
         // the management endpoint. The harness also sends this model on every
         // inference request, so subsequent responses stay on the selection.
         // Check the listener before starting a process because an earlier app
-        // session may still own the bundled server on port 8080.
+        // session may still own the bundled server on the configured port.
         if await inferenceEndpointIsReady() {
             try await loadModelThroughEndpoint(modelID)
             return
@@ -285,7 +285,7 @@ final class IntegrationsViewModel: ObservableObject {
             // /v1/models is part of the public inference API and does not
             // require a management API key. It also proves the listener that
             // the harness will use is ready.
-            var request = URLRequest(url: URL(string: "http://127.0.0.1:8080/v1/models")!)
+            var request = URLRequest(url: serverModel.settings.serverBaseURL.appendingPathComponent("v1/models"))
             request.timeoutInterval = 3
             request.cachePolicy = .reloadIgnoringLocalCacheData
             let (_, response) = try await URLSession.shared.data(for: request)
@@ -296,7 +296,7 @@ final class IntegrationsViewModel: ObservableObject {
     }
 
     private func loadModelThroughEndpoint(_ modelID: String) async throws {
-        var request = URLRequest(url: URL(string: "http://127.0.0.1:8080/v1/models/load")!)
+        var request = URLRequest(url: serverModel.settings.serverBaseURL.appendingPathComponent("v1/models/load"))
         request.httpMethod = "POST"
         request.timeoutInterval = 300
         request.cachePolicy = .reloadIgnoringLocalCacheData

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -33,7 +33,7 @@ final class NativModel: ObservableObject {
     var onMenuStateChanged: (() -> Void)?
 
     private let server = NativProcessController()
-    private let metricsClient = NativMetricsClient()
+    private var metricsClient = NativMetricsClient()
     private var metricsFetchTask: Task<Void, Never>?
     private var metricsTimer: Timer?
     private var metricsStartupGraceUntil: Date?
@@ -121,8 +121,16 @@ final class NativModel: ObservableObject {
         return !settings.hasSameLaunchConfiguration(as: settingsAppliedAtServerStart)
     }
 
+    var activeServerPort: Int? {
+        guard isRunning, let settingsAppliedAtServerStart else {
+            return nil
+        }
+        return settingsAppliedAtServerStart.normalized().serverPort
+    }
+
     func startServer() {
         var shouldStartMetrics = false
+        metricsClient = NativMetricsClient(baseURL: settings.serverBaseURL)
         do {
             var launchEnvironment = settings.launchEnvironment
             launchEnvironment["MLX_PLATFORM_ANALYTICS_DB_PATH"] = currentAnalyticsDatabaseURL().path

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -15,6 +15,7 @@ struct NativSettings: Codable, Equatable {
     var textToSpeechModelID: String?
     var speechToTextModelID: String?
     var serverAPIKey: String?
+    var serverPort: Int
     var maxTokens: Int
     var maxKVSize: Int
     var systemPrompt: String
@@ -53,6 +54,7 @@ struct NativSettings: Codable, Equatable {
         textToSpeechModelID: String? = nil,
         speechToTextModelID: String? = nil,
         serverAPIKey: String? = nil,
+        serverPort: Int = 8080,
         maxTokens: Int = 2048,
         maxKVSize: Int = 0,
         systemPrompt: String = "",
@@ -90,6 +92,7 @@ struct NativSettings: Codable, Equatable {
         self.textToSpeechModelID = textToSpeechModelID
         self.speechToTextModelID = speechToTextModelID
         self.serverAPIKey = serverAPIKey
+        self.serverPort = serverPort
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
         self.systemPrompt = systemPrompt
@@ -129,6 +132,7 @@ struct NativSettings: Codable, Equatable {
         case textToSpeechModelID
         case speechToTextModelID
         case serverAPIKey
+        case serverPort
         case selectedModelID
         case maxTokens
         case maxKVSize
@@ -173,6 +177,7 @@ struct NativSettings: Codable, Equatable {
         textToSpeechModelID = try container.decodeIfPresent(String.self, forKey: .textToSpeechModelID) ?? defaults.textToSpeechModelID
         speechToTextModelID = try container.decodeIfPresent(String.self, forKey: .speechToTextModelID) ?? defaults.speechToTextModelID
         serverAPIKey = try container.decodeIfPresent(String.self, forKey: .serverAPIKey) ?? defaults.serverAPIKey
+        serverPort = try container.decodeIfPresent(Int.self, forKey: .serverPort) ?? defaults.serverPort
         maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens) ?? defaults.maxTokens
         maxKVSize = try container.decodeIfPresent(Int.self, forKey: .maxKVSize) ?? defaults.maxKVSize
         systemPrompt = try container.decodeIfPresent(String.self, forKey: .systemPrompt) ?? defaults.systemPrompt
@@ -213,6 +218,7 @@ struct NativSettings: Codable, Equatable {
         try container.encodeIfPresent(textToSpeechModelID, forKey: .textToSpeechModelID)
         try container.encodeIfPresent(speechToTextModelID, forKey: .speechToTextModelID)
         try container.encodeIfPresent(serverAPIKey, forKey: .serverAPIKey)
+        try container.encode(serverPort, forKey: .serverPort)
         try container.encode(maxTokens, forKey: .maxTokens)
         try container.encode(maxKVSize, forKey: .maxKVSize)
         try container.encode(systemPrompt, forKey: .systemPrompt)
@@ -278,6 +284,7 @@ struct NativSettings: Codable, Equatable {
         settings.textToSpeechModelID = Self.normalizedModelID(settings.textToSpeechModelID)
         settings.speechToTextModelID = Self.normalizedModelID(settings.speechToTextModelID)
         settings.serverAPIKey = Self.normalizedModelID(settings.serverAPIKey)
+        settings.serverPort = min(max(settings.serverPort, 1), 65_535)
         settings.maxTokens = min(max(settings.maxTokens, 1), 262_144)
         settings.maxKVSize = min(max(settings.maxKVSize, 0), 1_048_576)
         settings.systemPrompt = settings.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -311,6 +318,7 @@ struct NativSettings: Codable, Equatable {
         return lhs.modelSearchPath == rhs.modelSearchPath
             && lhs.languageModelID == rhs.languageModelID
             && lhs.serverAPIKey == rhs.serverAPIKey
+            && lhs.serverPort == rhs.serverPort
             && lhs.maxTokens == rhs.maxTokens
             && lhs.maxKVSize == rhs.maxKVSize
             && lhs.kvQuantizationEnabled == rhs.kvQuantizationEnabled
@@ -333,6 +341,10 @@ struct NativSettings: Codable, Equatable {
             ))
     }
 
+    var serverBaseURL: URL {
+        URL(string: "http://127.0.0.1:\(min(max(serverPort, 1), 65_535))")!
+    }
+
     var launchEnvironment: [String: String] {
         let settings = normalized()
         var environment = [
@@ -353,6 +365,7 @@ struct NativSettings: Codable, Equatable {
     var launchArguments: [String] {
         let settings = normalized()
         var arguments = [
+            "--port", "\(settings.serverPort)",
             "--max-tokens", "\(settings.maxTokens)"
         ]
 

--- a/Sources/Nativ/Utilities/ServerPortProbe.swift
+++ b/Sources/Nativ/Utilities/ServerPortProbe.swift
@@ -1,0 +1,30 @@
+import Darwin
+import Foundation
+
+enum ServerPortProbe {
+    /// Whether a TCP listener can bind 127.0.0.1 on the given port right now.
+    static func isAvailable(_ port: Int) -> Bool {
+        guard (1...65_535).contains(port) else {
+            return false
+        }
+
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            return true
+        }
+        defer { close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(UInt16(port)).bigEndian
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let bindResult = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        return bindResult == 0
+    }
+}


### PR DESCRIPTION



This closes #9 to allow devs to add a server of their own for model endpoints, which before used to default to 8080, which is restrictive with multiple local servers.  