### PR TITLE
Simplify Developer runtime cards to icon + value

### DIFF
--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -63,34 +63,27 @@ struct DeveloperView: View {
             spacing: 10
         ) {
             RuntimeInfoCard(
-                title: "Apple chip",
                 value: runtime.chipName,
-                detail: "Apple silicon",
                 systemImage: "cpu",
                 tint: .blue
             )
 
             RuntimeInfoCard(
-                title: "Memory",
                 value: "\(byteCount(runtime.usedMemoryBytes)) of \(byteCount(runtime.totalMemoryBytes))",
-                detail: "\(memoryUsagePercent)%",
                 systemImage: "memorychip",
                 tint: memoryUsageTint,
-                progress: runtime.memoryUsageFraction
+                progress: runtime.memoryUsageFraction,
+                progressLabel: "\(memoryUsagePercent)%"
             )
 
             RuntimeInfoCard(
-                title: "macOS",
-                value: runtime.macOSVersion,
-                detail: runtime.macOSBuild,
+                value: "macOS \(runtime.macOSVersion)",
                 systemImage: "macbook",
                 tint: .teal
             )
 
             RuntimeInfoCard(
-                title: "mlx-vlm",
-                value: runtime.mlxVLMVersion,
-                detail: "Bundled runtime",
+                value: "mlx-vlm \(runtime.mlxVLMVersion)",
                 systemImage: "shippingbox",
                 tint: .orange
             )
@@ -612,26 +605,21 @@ private struct LogToolbarActionButton: View {
 }
 
 private struct RuntimeInfoCard: View {
-    let title: String
     let value: String
-    let detail: String
     let systemImage: String
     let tint: Color
     var progress: Double?
+    var progressLabel: String?
 
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
+        HStack(alignment: progress == nil ? .center : .top, spacing: 10) {
             Image(systemName: systemImage)
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(tint)
                 .frame(width: 28, height: 28)
                 .background(RoundedRectangle(cornerRadius: 8).fill(tint.opacity(0.12)))
 
-            VStack(alignment: .leading, spacing: 3) {
-                Text(title)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-
+            VStack(alignment: .leading, spacing: 4) {
                 Text(value)
                     .font(.callout.weight(.semibold))
                     .lineLimit(1)
@@ -643,25 +631,21 @@ private struct RuntimeInfoCard: View {
                             .progressViewStyle(.linear)
                             .tint(tint)
 
-                        Text(detail)
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .lineLimit(1)
-                            .fixedSize()
+                        if let progressLabel {
+                            Text(progressLabel)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                                .fixedSize()
+                        }
                     }
-                        .padding(.top, 2)
-                } else {
-                    Text(detail)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(11)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .frame(height: 82, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 64, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 11)
                 .fill(Color(nsColor: .controlBackgroundColor))


### PR DESCRIPTION
Simplified the runtime cards, removing redundant stuff (e.g. "Apple chip" / "Apple M2" / "Apple silicon")

