### PR TITLE
Add Copy Conversation and Export as Text to chat context menu

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 enum ControlPanelTab: String, CaseIterable, Identifiable {
     case chat = "Chat"
@@ -129,11 +130,18 @@ struct ControlPanelView: View {
                         isCurrent: isCurrentRecent(recent),
                         isSelectionDisabled: isRecentSelectionDisabled(recent),
                         isDeleteDisabled: isRecentDeleteDisabled(recent),
+                        canExport: canExportRecent(recent),
                         onSelect: {
                             applySidebarSelection(recent.selection)
                         },
                         onDelete: {
                             deleteRecentSession(recent)
+                        },
+                        onCopyConversation: {
+                            copyRecentConversation(recent)
+                        },
+                        onExportFile: {
+                            exportRecentConversation(recent)
                         }
                     )
                     .listRowInsets(sidebarItemInsets)
@@ -249,6 +257,38 @@ struct ControlPanelView: View {
             return
         }
         createRecentSession()
+    }
+
+    private func canExportRecent(_ recent: ControlPanelRecentSession) -> Bool {
+        if case .chat = recent.selection {
+            return true
+        }
+        return false
+    }
+
+    private func copyRecentConversation(_ recent: ControlPanelRecentSession) {
+        guard case .chat(let sessionID) = recent.selection,
+              let text = chat.conversationText(for: sessionID)
+        else {
+            return
+        }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    private func exportRecentConversation(_ recent: ControlPanelRecentSession) {
+        guard case .chat(let sessionID) = recent.selection,
+              let text = chat.conversationText(for: sessionID)
+        else {
+            return
+        }
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "\(recent.title).txt"
+        panel.allowedContentTypes = [.plainText]
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+        try? text.write(to: url, atomically: true, encoding: .utf8)
     }
 
     private func deleteRecentSession(_ recent: ControlPanelRecentSession) {
@@ -481,8 +521,11 @@ private struct ControlPanelRecentSessionRow: View {
     let isCurrent: Bool
     let isSelectionDisabled: Bool
     let isDeleteDisabled: Bool
+    let canExport: Bool
     let onSelect: () -> Void
     let onDelete: () -> Void
+    let onCopyConversation: () -> Void
+    let onExportFile: () -> Void
     @State private var isHovering = false
     @State private var isDeleteHovering = false
 
@@ -538,6 +581,19 @@ private struct ControlPanelRecentSessionRow: View {
                 Label("Open", systemImage: "arrow.up.right.square")
             }
             .disabled(isSelectionDisabled)
+
+            if canExport {
+                Button {
+                    onCopyConversation()
+                } label: {
+                    Label("Copy Conversation", systemImage: "doc.on.doc")
+                }
+                Button {
+                    onExportFile()
+                } label: {
+                    Label("Export as Text\u{2026}", systemImage: "square.and.arrow.up")
+                }
+            }
 
             Button(role: .destructive) {
                 onDelete()

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -312,6 +312,38 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
+    func conversationText(for sessionID: UUID) -> String? {
+        guard let session = storedSessions.first(where: { $0.id == sessionID }) else {
+            return nil
+        }
+        var lines = [session.displayTitle, ""]
+        for message in session.messages {
+            let speaker: String
+            switch message.role {
+            case .user:
+                speaker = "You"
+            case .assistant:
+                speaker = message.modelID.map { NativFormatting.truncateModelName($0, maxLength: 60) } ?? "Assistant"
+            case .error:
+                speaker = "Error"
+            }
+            let content = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            if content.isEmpty && message.imageAttachments.isEmpty {
+                continue
+            }
+            lines.append("\(speaker):")
+            if !message.imageAttachments.isEmpty {
+                let count = message.imageAttachments.count
+                lines.append("[\(count) attachment\(count == 1 ? "" : "s")]")
+            }
+            if !content.isEmpty {
+                lines.append(content)
+            }
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
     func send(using appModel: NativModel) {
         let settings = appModel.settings.normalized()
         guard canSend(isRunning: appModel.isRunning, selectedModelID: settings.languageModelID),


### PR DESCRIPTION
Right-clicking a chat in the sidebar now offers copying the whole conversation to the clipboard or exporting it as a plain-text file, alongside Open and Delete. Text is rendered speaker-by-speaker from the stored session.