### PR TITLE
Coalesce streamed chat updates to keep the UI responsive

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -134,6 +134,7 @@ struct ChatView: View {
 @MainActor
 final class ChatViewModel: ObservableObject {
     private static let liveDecodeRateRefreshInterval: TimeInterval = 0.25
+    private static let streamFlushInterval: TimeInterval = 1.0 / 30.0
 
     private struct QueuedChatRequest {
         let id: UUID
@@ -160,6 +161,11 @@ final class ChatViewModel: ObservableObject {
     private var storedSessions: [ChatSession] = []
     private var currentSession: ChatSession?
     private var liveDecodeRateRefreshDates: [UUID: Date] = [:]
+    private var pendingStreamContent: [UUID: String] = [:]
+    private var pendingStreamReasoning: [UUID: String] = [:]
+    private var pendingStreamMetrics: [UUID: MLXChatStreamDelta] = [:]
+    private var streamFlushDates: [UUID: Date] = [:]
+    private var streamFlushTasks: [UUID: Task<Void, Never>] = [:]
     private weak var appModel: NativModel?
 
     init() {
@@ -584,42 +590,98 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func append(event: MLXChatStreamDelta, to id: UUID, in sessionID: UUID) {
-        let hasTextDelta = event.content?.isEmpty == false
-            || event.reasoningContent?.isEmpty == false
-        let shouldRefreshMetrics = shouldRefreshLiveMetrics(
-            event,
-            for: id
-        )
-        guard hasTextDelta || shouldRefreshMetrics else {
+        // Accumulate deltas into buffers and flush to the published message at a
+        // capped cadence. Applying every token synchronously starves the main
+        // run loop, which freezes the transcript, thinking bubble, and "Working"
+        // animation until an input event (issue #11).
+        if let reasoningContent = event.reasoningContent, !reasoningContent.isEmpty {
+            pendingStreamReasoning[id, default: ""] += reasoningContent
+        }
+        if let content = event.content, !content.isEmpty {
+            pendingStreamContent[id, default: ""] += content
+        }
+        if shouldRefreshLiveMetrics(event, for: id) {
+            pendingStreamMetrics[id] = event
+        }
+
+        guard hasPendingStreamUpdate(id) else {
+            return
+        }
+
+        let now = Date()
+        if let lastFlush = streamFlushDates[id],
+           now.timeIntervalSince(lastFlush) < Self.streamFlushInterval {
+            scheduleStreamFlush(id, in: sessionID)
+            return
+        }
+        flushStream(id, in: sessionID)
+    }
+
+    private func hasPendingStreamUpdate(_ id: UUID) -> Bool {
+        pendingStreamContent[id]?.isEmpty == false
+            || pendingStreamReasoning[id]?.isEmpty == false
+            || pendingStreamMetrics[id] != nil
+    }
+
+    private func scheduleStreamFlush(_ id: UUID, in sessionID: UUID) {
+        guard streamFlushTasks[id] == nil else {
+            return
+        }
+        streamFlushTasks[id] = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.streamFlushInterval * 1_000_000_000))
+            guard let self, !Task.isCancelled else {
+                return
+            }
+            self.streamFlushTasks[id] = nil
+            self.flushStream(id, in: sessionID)
+        }
+    }
+
+    private func flushStream(_ id: UUID, in sessionID: UUID) {
+        streamFlushTasks[id]?.cancel()
+        streamFlushTasks[id] = nil
+
+        let content = pendingStreamContent.removeValue(forKey: id) ?? ""
+        let reasoning = pendingStreamReasoning.removeValue(forKey: id) ?? ""
+        let metrics = pendingStreamMetrics.removeValue(forKey: id)
+        guard !content.isEmpty || !reasoning.isEmpty || metrics != nil else {
             return
         }
 
         updateMessage(id, in: sessionID) { message in
-            if let reasoningContent = event.reasoningContent {
-                message.reasoningContent.append(reasoningContent)
+            if !reasoning.isEmpty {
+                message.reasoningContent.append(reasoning)
             }
-            if let content = event.content {
-                if !content.isEmpty,
-                   !message.reasoningContent.isEmpty,
-                   message.thinkingDuration == nil {
+            if !content.isEmpty {
+                if !message.reasoningContent.isEmpty, message.thinkingDuration == nil {
                     message.thinkingDuration = Date().timeIntervalSince(message.createdAt)
                 }
                 message.content.append(content)
             }
-            if shouldRefreshMetrics {
+            if let metrics {
                 message.responseMetrics = ChatResponseMetrics(
                     totalTokens: message.responseMetrics?.totalTokens,
-                    generatedTokens: event.generatedTokens
+                    generatedTokens: metrics.generatedTokens
                         ?? message.responseMetrics?.generatedTokens,
-                    decodeTokensPerSecond: event.decodeTokensPerSecond
+                    decodeTokensPerSecond: metrics.decodeTokensPerSecond
                         ?? message.responseMetrics?.decodeTokensPerSecond,
                     peakMemoryGB: message.responseMetrics?.peakMemoryGB
                 )
             }
         }
-        if hasTextDelta, currentSessionID == sessionID {
+        streamFlushDates[id] = Date()
+        if (!content.isEmpty || !reasoning.isEmpty), currentSessionID == sessionID {
             bumpScroll()
         }
+    }
+
+    private func clearStreamBuffers(_ id: UUID) {
+        streamFlushTasks[id]?.cancel()
+        streamFlushTasks.removeValue(forKey: id)
+        pendingStreamContent.removeValue(forKey: id)
+        pendingStreamReasoning.removeValue(forKey: id)
+        pendingStreamMetrics.removeValue(forKey: id)
+        streamFlushDates.removeValue(forKey: id)
     }
 
     private func shouldRefreshLiveMetrics(
@@ -652,6 +714,8 @@ final class ChatViewModel: ObservableObject {
         responseMetrics: ChatResponseMetrics?,
         isCancelled: Bool
     ) {
+        flushStream(id, in: sessionID)
+        clearStreamBuffers(id)
         liveDecodeRateRefreshDates.removeValue(forKey: id)
         updateMessage(id, in: sessionID) { message in
             message.isStreaming = false
@@ -679,6 +743,7 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func failAssistantMessage(_ id: UUID, in sessionID: UUID, error: Error) {
+        clearStreamBuffers(id)
         liveDecodeRateRefreshDates.removeValue(forKey: id)
         guard updateMessage(id, in: sessionID, mutate: { message in
             message.role = .error


### PR DESCRIPTION
When each streamed token is applied to the messages component on the main actor, the constant updates saturate the run loop, so live UI like the transcript, the thinking bubble, and the "Working" animation stops repainting until some input event nudges it (issue #11). Buffering the content, reasoning, and metric deltas and flushing them to the view at ~30 Hz moves those writes off the per-token path, so the main thread is no longer starved during generation. A trailing flush guarantees the last partial chunk still lands, and a final flush on completion or cancellation applies whatever remains in the buffer. The result is a transcript and thinking bubble that update smoothly the whole way through a response instead of freezing mid generation.

