### PR TITLE
Show recommended models during onboarding

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -413,12 +413,13 @@ final class HuggingFaceModelLibrary: ObservableObject {
         pageNumber = 1
 
         searchTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 let page = try await client.search(query: query, sort: sort, token: token)
                 try Task.checkCancellation()
                 self.buffer = page.models
                 self.nextPageURL = page.nextPageURL
-                try await self.fillBuffer(upTo: self.pageSize)
+                try await self.fillBuffer(upTo: self.pageSize, token: token)
                 try Task.checkCancellation()
                 self.models = self.slice(forPage: 1)
                 self.error = nil
@@ -426,12 +427,12 @@ final class HuggingFaceModelLibrary: ObservableObject {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
-                self?.buffer = []
-                self?.models = []
-                self?.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                self.buffer = []
+                self.models = []
+                self.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
             guard !Task.isCancelled else { return }
-            self?.isSearching = false
+            self.isSearching = false
         }
     }
 
@@ -467,8 +468,9 @@ final class HuggingFaceModelLibrary: ObservableObject {
         error = nil
 
         searchTask = Task { [weak self] in
+            guard let self else { return }
             do {
-                let page = try await client.page(at: nextPageURL, token: token)
+                try await self.fillBuffer(upTo: target * self.pageSize, token: token)
                 try Task.checkCancellation()
                 let nextModels = self.slice(forPage: target)
                 if !nextModels.isEmpty {
@@ -480,17 +482,17 @@ final class HuggingFaceModelLibrary: ObservableObject {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
-                self?.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                self.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
             guard !Task.isCancelled else { return }
-            self?.isSearching = false
+            self.isSearching = false
         }
     }
 
-    private func fillBuffer(upTo count: Int) async throws {
+    private func fillBuffer(upTo count: Int, token: String?) async throws {
         var fetches = 0
         while buffer.count < count, let url = nextPageURL, fetches < 8 {
-            let nextPage = try await client.page(at: url)
+            let nextPage = try await client.page(at: url, token: token)
             try Task.checkCancellation()
             buffer.append(contentsOf: nextPage.models)
             nextPageURL = nextPage.nextPageURL

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -413,13 +413,12 @@ final class HuggingFaceModelLibrary: ObservableObject {
         pageNumber = 1
 
         searchTask = Task { [weak self] in
-            guard let self else { return }
             do {
                 let page = try await client.search(query: query, sort: sort, token: token)
                 try Task.checkCancellation()
                 self.buffer = page.models
                 self.nextPageURL = page.nextPageURL
-                try await self.fillBuffer(upTo: self.pageSize, token: token)
+                try await self.fillBuffer(upTo: self.pageSize)
                 try Task.checkCancellation()
                 self.models = self.slice(forPage: 1)
                 self.error = nil
@@ -427,12 +426,12 @@ final class HuggingFaceModelLibrary: ObservableObject {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
-                self.buffer = []
-                self.models = []
-                self.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                self?.buffer = []
+                self?.models = []
+                self?.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
             guard !Task.isCancelled else { return }
-            self.isSearching = false
+            self?.isSearching = false
         }
     }
 
@@ -468,9 +467,8 @@ final class HuggingFaceModelLibrary: ObservableObject {
         error = nil
 
         searchTask = Task { [weak self] in
-            guard let self else { return }
             do {
-                try await self.fillBuffer(upTo: target * self.pageSize, token: token)
+                let page = try await client.page(at: nextPageURL, token: token)
                 try Task.checkCancellation()
                 let nextModels = self.slice(forPage: target)
                 if !nextModels.isEmpty {
@@ -482,17 +480,17 @@ final class HuggingFaceModelLibrary: ObservableObject {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
-                self.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                self?.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
             guard !Task.isCancelled else { return }
-            self.isSearching = false
+            self?.isSearching = false
         }
     }
 
-    private func fillBuffer(upTo count: Int, token: String?) async throws {
+    private func fillBuffer(upTo count: Int) async throws {
         var fetches = 0
         while buffer.count < count, let url = nextPageURL, fetches < 8 {
-            let nextPage = try await client.page(at: url, token: token)
+            let nextPage = try await client.page(at: url)
             try Task.checkCancellation()
             buffer.append(contentsOf: nextPage.models)
             nextPageURL = nextPage.nextPageURL

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -413,6 +413,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
         pageNumber = 1
 
         searchTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 let page = try await client.search(query: query, sort: sort, token: token)
                 try Task.checkCancellation()
@@ -426,12 +427,12 @@ final class HuggingFaceModelLibrary: ObservableObject {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
-                self?.buffer = []
-                self?.models = []
-                self?.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                self.buffer = []
+                self.models = []
+                self.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
             guard !Task.isCancelled else { return }
-            self?.isSearching = false
+            self.isSearching = false
         }
     }
 
@@ -461,15 +462,19 @@ final class HuggingFaceModelLibrary: ObservableObject {
             error = nil
             return
         }
+        guard let nextPageURL else { return }
 
         searchTask?.cancel()
         isSearching = true
         error = nil
 
         searchTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 let page = try await client.page(at: nextPageURL, token: token)
                 try Task.checkCancellation()
+                self.buffer.append(contentsOf: page.models)
+                self.nextPageURL = page.nextPageURL
                 let nextModels = self.slice(forPage: target)
                 if !nextModels.isEmpty {
                     self.pageNumber = target
@@ -480,17 +485,17 @@ final class HuggingFaceModelLibrary: ObservableObject {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
-                self?.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                self.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
             guard !Task.isCancelled else { return }
-            self?.isSearching = false
+            self.isSearching = false
         }
     }
 
     private func fillBuffer(upTo count: Int) async throws {
         var fetches = 0
         while buffer.count < count, let url = nextPageURL, fetches < 8 {
-            let nextPage = try await client.page(at: url)
+            let nextPage = try await client.page(at: url, token: nil)
             try Task.checkCancellation()
             buffer.append(contentsOf: nextPage.models)
             nextPageURL = nextPage.nextPageURL

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -50,8 +50,12 @@ private struct WelcomeView: View {
 
     @ObservedObject var model: NativModel
     @StateObject private var modelLibrary = LocalModelLibrary()
+    @StateObject private var hubLibrary = HuggingFaceModelLibrary()
+    @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
     @State private var step = Step.model
     @State private var selectedModelID: String?
+    @State private var downloadedRecommendedModelID: String?
+    @State private var didRequestRecommendedModels = false
     @State private var showsAPIKeyEditor = false
     @State private var serverAPIKey: String
     @FocusState private var isAPIKeyFieldFocused: Bool
@@ -94,8 +98,13 @@ private struct WelcomeView: View {
         .task(id: modelSearchPath) {
             modelLibrary.scan(path: model.settings.modelSearchPath)
         }
+        .onChange(of: modelLibrary.isScanning) { _, isScanning in
+            guard !isScanning else { return }
+            loadRecommendedModelsIfNeeded()
+        }
         .onDisappear {
             modelLibrary.cancel()
+            hubLibrary.cancel()
         }
     }
 
@@ -146,16 +155,17 @@ private struct WelcomeView: View {
 
                         Spacer()
 
-                        if modelLibrary.isScanning {
+                        if modelLibrary.isScanning || hubLibrary.isSearching {
                             ProgressView()
                                 .controlSize(.small)
                         } else {
                             Button {
-                                modelLibrary.scan(path: model.settings.modelSearchPath)
+                                refreshModelChoices()
                             } label: {
                                 Image(systemName: "arrow.clockwise")
                             }
                             .buttonStyle(.borderless)
+                            .disabled(downloadManager.downloadingModelID != nil)
                             .help("Refresh installed models")
                         }
                     }
@@ -181,6 +191,10 @@ private struct WelcomeView: View {
                                 ) {
                                     selectedModelID = localModel.repoID
                                 }
+                            }
+
+                            if shouldShowRecommendedModels {
+                                recommendedModelsSection
                             }
                         }
                         .padding(12)
@@ -208,6 +222,70 @@ private struct WelcomeView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
+                .disabled(downloadManager.downloadingModelID != nil)
+                .help(downloadManager.downloadingModelID == nil
+                    ? "Continue setup"
+                    : "Finish or cancel the model download before continuing")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var recommendedModelsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Recommended downloads")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("Hugging Face")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 4)
+            .padding(.top, 4)
+
+            if hubLibrary.isSearching && recommendedModels.isEmpty {
+                HStack(spacing: 10) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Finding models for this Mac…")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .frame(minHeight: 54)
+            } else if recommendedModels.isEmpty {
+                Label(
+                    hubLibrary.error == nil
+                        ? "No recommended models are available right now."
+                        : "Couldn’t load recommended models.",
+                    systemImage: hubLibrary.error == nil
+                        ? "shippingbox"
+                        : "wifi.exclamationmark"
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .frame(minHeight: 54)
+            } else {
+                ForEach(recommendedModels) { hubModel in
+                    WelcomeDownloadModelRow(
+                        model: hubModel,
+                        isDownloaded: downloadedRecommendedModelID == hubModel.id,
+                        isSelected: selectedModelID == hubModel.id,
+                        isDownloading: downloadManager.downloadingModelID == hubModel.id,
+                        downloadProgress: downloadManager.downloadingModelID == hubModel.id
+                            ? downloadManager.downloadProgress
+                            : 0,
+                        anotherDownloadIsActive: downloadManager.downloadingModelID != nil,
+                        downloadError: downloadManager.errorByModelID[hubModel.id],
+                        onSelect: { selectedModelID = hubModel.id },
+                        onDownload: { downloadRecommendedModel(hubModel) },
+                        onCancel: { downloadManager.removeDownload() }
+                    )
+                }
             }
         }
     }
@@ -352,8 +430,36 @@ private struct WelcomeView: View {
         }
     }
 
+    private var shouldShowRecommendedModels: Bool {
+        !modelLibrary.isScanning && pickerModels.isEmpty
+    }
+
+    private var recommendedModels: [HuggingFaceModel] {
+        let candidates = hubLibrary.models.filter { hubModel in
+            !hubModel.isPrivate
+                && !hubModel.isGated
+                && hubModel.capabilities.contains(.text)
+                && (hubModel.libraryName?.localizedCaseInsensitiveContains("mlx") == true
+                    || hubModel.tags.contains(where: { $0.localizedCaseInsensitiveContains("mlx") })
+                    || hubModel.id.lowercased().hasPrefix("mlx-community/"))
+        }
+        return Array(candidates.sorted { lhs, rhs in
+            let lhsFits = lhs.memoryEstimate?.isUsable != false
+            let rhsFits = rhs.memoryEstimate?.isUsable != false
+            if lhsFits != rhsFits {
+                return lhsFits
+            }
+            return lhs.downloads > rhs.downloads
+        }.prefix(6))
+    }
+
     private var modelSearchPath: String {
         model.settings.normalized().expandedModelSearchPath
+    }
+
+    private var missingDefaultModelCache: Bool {
+        modelLibrary.error == LocalModelDiscoveryError.pathNotFound("").errorDescription
+            && modelSearchPath == LocalModelDiscovery.expandedPath(NativSettings.defaultModelSearchPath)
     }
 
     private var normalizedAPIKey: String? {
@@ -362,12 +468,12 @@ private struct WelcomeView: View {
     }
 
     private var modelScanMessage: (text: String, systemImage: String, isError: Bool)? {
-        if let error = modelLibrary.error {
+        if let error = modelLibrary.error, !missingDefaultModelCache {
             return (error, "exclamationmark.triangle.fill", true)
         }
         if !modelLibrary.isScanning, pickerModels.isEmpty {
             return (
-                "No compatible language models are installed. You can continue with load on demand.",
+                "No compatible language models are installed. Download one above or continue with load on demand.",
                 "info.circle",
                 false
             )
@@ -377,6 +483,41 @@ private struct WelcomeView: View {
 
     private func finish(serverAPIKey: String?) {
         onComplete(selectedModelID, serverAPIKey)
+    }
+
+    private func refreshModelChoices() {
+        modelLibrary.scan(path: model.settings.modelSearchPath)
+        if pickerModels.isEmpty {
+            requestRecommendedModels()
+        }
+    }
+
+    private func loadRecommendedModelsIfNeeded() {
+        guard pickerModels.isEmpty, !didRequestRecommendedModels else { return }
+        requestRecommendedModels()
+    }
+
+    private func requestRecommendedModels() {
+        didRequestRecommendedModels = true
+        hubLibrary.search(
+            query: "mlx-community",
+            sort: .downloads,
+            token: model.effectiveHuggingFaceToken
+        )
+    }
+
+    private func downloadRecommendedModel(_ hubModel: HuggingFaceModel) {
+        selectedModelID = nil
+        downloadManager.download(
+            repoID: hubModel.id,
+            cachePath: model.settings.modelSearchPath,
+            token: model.effectiveHuggingFaceToken
+        ) {
+            downloadedRecommendedModelID = hubModel.id
+            selectedModelID = hubModel.id
+            modelLibrary.scan(path: model.settings.modelSearchPath)
+            NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
+        }
     }
 }
 
@@ -554,6 +695,144 @@ private struct WelcomeModelPickerRow: View {
             return "\(title), \(selection)"
         }
         return "\(title), \(memoryEstimate.compatibilityLabel), \(selection)"
+    }
+}
+
+private struct WelcomeDownloadModelRow: View {
+    let model: HuggingFaceModel
+    let isDownloaded: Bool
+    let isSelected: Bool
+    let isDownloading: Bool
+    let downloadProgress: Double
+    let anotherDownloadIsActive: Bool
+    let downloadError: String?
+    let onSelect: () -> Void
+    let onDownload: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 12) {
+                modelIcon
+
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 7) {
+                        Text(modelName)
+                            .font(.body.weight(.medium))
+                            .lineLimit(1)
+                            .layoutPriority(1)
+
+                        if let memoryEstimate = model.memoryEstimate,
+                           !memoryEstimate.isUsable {
+                            WelcomeMemoryFitBadge(estimate: memoryEstimate)
+                        }
+                    }
+
+                    Text(modelDetail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 10)
+
+                if isDownloaded && isSelected {
+                    Label("Selected", systemImage: "checkmark.circle.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.green)
+                        .fixedSize()
+                } else if isDownloaded {
+                    Button("Use", action: onSelect)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                } else if isDownloading {
+                    HStack(spacing: 8) {
+                        VStack(alignment: .trailing, spacing: 3) {
+                            ProgressView(value: downloadProgress)
+                                .frame(width: 74)
+                            Text(downloadProgress > 0
+                                ? "\(Int((downloadProgress * 100).rounded()))%"
+                                : "Starting…")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Button(action: onCancel) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Cancel and remove download")
+                    }
+                    .fixedSize()
+                } else {
+                    Button("Download", action: onDownload)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(anotherDownloadIsActive)
+                        .help("Download \(model.id) to the configured cache")
+                }
+            }
+
+            if let downloadError {
+                Label(downloadError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .textSelection(.enabled)
+                    .padding(.leading, 48)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(minHeight: 54)
+        .background(Color.secondary.opacity(0.045), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    @ViewBuilder
+    private var modelIcon: some View {
+        if let provider = model.provider,
+           let image = LocalModelProviderIcon.image(for: provider) {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 22, height: 22)
+                .frame(width: 36, height: 36)
+                .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 9))
+        } else {
+            Image(systemName: "arrow.down.app.fill")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: 36, height: 36)
+                .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 9))
+        }
+    }
+
+    private var modelName: String {
+        model.id.split(separator: "/").last.map(String.init) ?? model.id
+    }
+
+    private var modelDetail: String {
+        var details: [String] = []
+        if let provider = model.provider {
+            details.append(provider.displayName)
+        }
+        if let sizeBytes = model.sizeBytes {
+            details.append(ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file))
+        }
+        details.append("\(compactCount(model.downloads)) downloads")
+        return details.joined(separator: " · ")
+    }
+
+    private func compactCount(_ value: Int) -> String {
+        switch value {
+        case 1_000_000...:
+            return String(format: "%.1fM", Double(value) / 1_000_000)
+        case 1_000...:
+            return String(format: "%.1fK", Double(value) / 1_000)
+        default:
+            return NumberFormatter.localizedString(from: NSNumber(value: value), number: .decimal)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show compatible Hugging Face MLX recommendations when onboarding finds no installed language models
- let users download, cancel, monitor, and select a first model without leaving onboarding
- prioritize models likely to fit the Mac while retaining load-on-demand
- fix the model-library task ownership and pagination compile errors exposed by the CI build

## Root cause
The onboarding picker only scanned the local cache. On a fresh installation, that left users with no model choices and no path to acquire one.

The CI failure came from `HuggingFaceHub.swift`: weak `self` was used as non-optional, the next-page URL was not unwrapped, and a newly required token argument was omitted.

## Validation
- `make xcode-build` passed
- test suite passed: 27 tests, 0 failures
