### PR TITLE
Fix app icon in updater UI

### DIFF
--- a/Sources/Nativ/SoftwareUpdater.swift
+++ b/Sources/Nativ/SoftwareUpdater.swift
@@ -1,6 +1,27 @@
+import AppKit
 import Combine
 import Sparkle
 import SwiftUI
+
+@MainActor
+enum NativApplicationIcon {
+    static let image: NSImage = {
+        guard let iconURL = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),
+              let icon = NSImage(contentsOf: iconURL) else {
+            return NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
+        }
+        icon.isTemplate = false
+        return icon
+    }()
+
+    static func registerForInAppUse() {
+        let applicationIconName = NSImage.applicationIconName
+        if let existingImage = NSImage(named: applicationIconName), existingImage !== image {
+            existingImage.setName(nil)
+        }
+        image.setName(applicationIconName)
+    }
+}
 
 @MainActor
 final class SoftwareUpdater {
@@ -11,6 +32,7 @@ final class SoftwareUpdater {
     }
 
     init() {
+        NativApplicationIcon.registerForInAppUse()
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -110,7 +110,7 @@ private struct WelcomeView: View {
 
     private var welcomeHeader: some View {
         VStack(spacing: 16) {
-            Image(nsImage: NSApplication.shared.applicationIconImage)
+            Image(nsImage: NativApplicationIcon.image)
                 .resizable()
                 .interpolation(.high)
                 .aspectRatio(contentMode: .fit)


### PR DESCRIPTION
## What changed

- Load the bundled `AppIcon.icns` as the canonical in-app application icon.
- Register that image under AppKit's application-icon name before Sparkle initializes.
- Use the same image explicitly in the welcome screen.

## Why

The corrected macOS app icon from #53 renders properly in Finder and the Dock, but Sparkle and other in-app surfaces can resolve a stale AppKit application-icon rendition. That stale image still includes the unwanted gray frame.

## Impact

Updater dialogs, including update errors, and the welcome screen now show the same corrected black rounded icon used by the application bundle.

## Validation

- `xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -derivedDataPath build/IconVerify CODE_SIGNING_ALLOWED=NO build`
- Reproduced Sparkle's update-error dialog and visually verified that the gray frame is gone.