### PR TITLE
Add settings page and sidebar server controls

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		4882FE7E8C689152D428AB2E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 0D3574097911A448F62ED273 /* Sparkle */; };
 		4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
 		506A12DCE5B56E53208A8BA2 /* NativServerKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1651E057CC5D05857CF1595 /* NativServerKit.swift */; };
+		5620EDCF472DEF4388E8E526 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDD9C3FE179B2E8D76FC769 /* SettingsView.swift */; };
 		575DCB7EC96DAB35B415434C /* ImageGenerationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4B44C59153CB242FE92D3A /* ImageGenerationView.swift */; };
 		58AEDA213E27344F01AE5A6B /* NativServerKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61598EC22589683F1A54B047 /* ChatConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF9F903E2609C4A522C19CF /* ChatConfigurationView.swift */; };
@@ -40,6 +41,7 @@
 		B47F34B1273BEEAA4D5DD314 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553434CA19B929108FF740F /* ChatView.swift */; };
 		B55A6BE5C7B03181E2CD03D6 /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
 		BC0753B567DC8935199FCDFB /* ImageGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239C5B241E83468B75C43E5A /* ImageGenerationViewModel.swift */; };
+		BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */; };
 		BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5919AB4E9488642C73886266 /* ShellEnvironment.swift */; };
 		C84FA1A269F12B130EAEB57B /* ModelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EB7572F271F7D68DC3F97D /* ModelsView.swift */; };
 		C8B10834D4DF407907FCCF6C /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5919AB4E9488642C73886266 /* ShellEnvironment.swift */; };
@@ -95,8 +97,10 @@
 		594711E024396C78703CE05A /* NativSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSettings.swift; sourceTree = "<group>"; };
 		5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NativServerKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		64BBF79010B8120057237B52 /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
+		676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginController.swift; sourceTree = "<group>"; };
 		677360D86DDAFAB194A995E7 /* Main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Main.swift; sourceTree = "<group>"; };
 		6BB0CD839020E3F5FF4F8DED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6CDD9C3FE179B2E8D76FC769 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatting.swift; sourceTree = "<group>"; };
 		7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceHub.swift; sourceTree = "<group>"; };
 		822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareUpdater.swift; sourceTree = "<group>"; };
@@ -142,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */,
+				676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */,
 				BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */,
 				330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */,
 				5919AB4E9488642C73886266 /* ShellEnvironment.swift */,
@@ -221,6 +226,14 @@
 			path = IssueReport;
 			sourceTree = "<group>";
 		};
+		4D59C5326FE266C76E71C52A /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				6CDD9C3FE179B2E8D76FC769 /* SettingsView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		6FC4F77BDC88A365FD01B7C9 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -249,6 +262,7 @@
 				28D631CB7BF8B65D28E11E43 /* Integrations */,
 				40D3B01A6A8BFAE6E98FDD3C /* IssueReport */,
 				BAC9F35045D83344BC059CB2 /* Models */,
+				4D59C5326FE266C76E71C52A /* Settings */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -391,7 +405,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 2660;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					1622B274F4DF5A85C2FDB081 = {
 						DevelopmentTeam = V8MWN7GKJ5;
@@ -421,8 +435,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				1622B274F4DF5A85C2FDB081 /* NativServerKit */,
+				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				51AD42FA29E71F2450386688 /* NativTests */,
 			);
 		};
@@ -496,6 +510,7 @@
 				2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */,
 				E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */,
 				71659335E55225ABCBB4E993 /* IssueReport.swift in Sources */,
+				BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */,
 				1423FD497A75A14770FCA9E1 /* LocalModelDiscovery.swift in Sources */,
 				482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */,
 				DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */,
@@ -505,6 +520,7 @@
 				4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */,
 				ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */,
 				F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */,
+				5620EDCF472DEF4388E8E526 /* SettingsView.swift in Sources */,
 				C8B10834D4DF407907FCCF6C /* ShellEnvironment.swift in Sources */,
 				E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */,
 				8B4DF732A8A6AA5FFBE11982 /* StatsView.swift in Sources */,
@@ -554,15 +570,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = arm64;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -570,7 +584,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(NATIV_SERVER_KIT_BUNDLE_IDENTIFIER)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -582,6 +595,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = arm64;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -612,7 +626,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -630,7 +643,6 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -645,8 +657,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Configuration/Nativ-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Nativ;
@@ -670,8 +680,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Configuration/Nativ-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Nativ;
@@ -691,15 +699,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = arm64;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -707,7 +713,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(NATIV_SERVER_KIT_BUNDLE_IDENTIFIER)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -735,6 +740,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = arm64;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -765,7 +771,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -790,7 +795,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;

--- a/Nativ.xcodeproj/xcshareddata/xcschemes/Nativ.xcscheme
+++ b/Nativ.xcodeproj/xcshareddata/xcschemes/Nativ.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2660"
-   version = "1.3">
+   LastUpgradeVersion = "1430"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,7 +27,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -49,6 +51,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,6 +74,8 @@
             ReferencedContainer = "container:Nativ.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -87,6 +93,8 @@
             ReferencedContainer = "container:Nativ.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -335,6 +335,7 @@ private final class ModelMenuSectionHeaderView: NSView {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private let model = NativModel()
+    let softwareUpdater = SoftwareUpdater()
     private let controlPanelNavigation = ControlPanelNavigation()
     private let runtime = SystemRuntimeMonitor()
     private var mainWindowOpener: (() -> Void)?
@@ -436,7 +437,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     @objc private func openModelsFromMenu(_ sender: Any?) {
-        openSettings()
+        controlPanelNavigation.open(.models)
+        showMainWindow()
     }
 
     @objc private func openWelcomeFromMenu(_ sender: Any?) {
@@ -456,6 +458,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             model: model,
             navigation: controlPanelNavigation,
             runtime: runtime,
+            softwareUpdater: softwareUpdater,
             onComplete: { [weak self] modelID, serverAPIKey in
                 self?.completeWelcome(modelID: modelID, serverAPIKey: serverAPIKey)
             }
@@ -467,7 +470,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     func openSettings() {
-        controlPanelNavigation.open(.models)
+        controlPanelNavigation.open(.settings)
         showMainWindow()
     }
 

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -9,6 +9,7 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
     case models = "Models"
     case integrations = "Integrations"
     case developer = "Developer"
+    case settings = "Settings"
 
     static var allCases: [ControlPanelTab] {
         [.chat, .dashboard, .models, .integrations, .developer]
@@ -30,6 +31,8 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
             "puzzlepiece.extension"
         case .developer:
             "hammer"
+        case .settings:
+            "gearshape"
         }
     }
 }
@@ -57,15 +60,24 @@ final class ControlPanelNavigation: ObservableObject {
     }
 }
 
+private enum FooterControl {
+    case settings
+    case server
+    case reportIssue
+}
+
 struct ControlPanelView: View {
     let model: NativModel
     @ObservedObject var navigation: ControlPanelNavigation
     @ObservedObject var runtime: SystemRuntimeMonitor
+    let softwareUpdater: SoftwareUpdater
     @StateObject private var chat = ChatViewModel()
     @StateObject private var imageGeneration = ImageGenerationViewModel()
     @StateObject private var dashboard = DashboardViewModel()
+    @StateObject private var launchAtLogin = LaunchAtLoginController()
     @State private var sidebarSelection: ControlPanelSidebarSelection = .tab(.chat)
     @State private var selectedTab: ControlPanelTab = .chat
+    @State private var hoveredFooterControl: FooterControl?
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .all
     @State private var isModelConfigurationVisible = false
     @State private var isFullScreen = false
@@ -101,6 +113,26 @@ struct ControlPanelView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification)) { _ in
             isFullScreen = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            launchAtLogin.refresh()
+        }
+        .alert(
+            "Unable to Update Start at Login",
+            isPresented: Binding(
+                get: { launchAtLogin.errorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        launchAtLogin.errorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                launchAtLogin.errorMessage = nil
+            }
+        } message: {
+            Text(launchAtLogin.errorMessage ?? "An unknown error occurred.")
         }
     }
 
@@ -181,31 +213,115 @@ struct ControlPanelView: View {
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
-                Divider()
-                Menu {
-                    ForEach(IssueReportCategory.allCases) { category in
-                        Button {
-                            reportIssue(category: category)
-                        } label: {
-                            Label(category.displayName, systemImage: category.systemImage)
-                        }
-                    }
-                } label: {
-                    Label("Report an Issue", systemImage: "ladybug")
-                        .font(.callout)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
+                HStack(spacing: 4) {
+                    settingsButton
+                    serverToggleButton
+                    issueReportMenu
+                    Spacer(minLength: 0)
                 }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-                .help("Report a problem with prefilled app diagnostics")
+                .padding(.horizontal, 12)
+                .padding(.vertical, 5)
             }
         }
         .navigationTitle("Nativ")
         .background(ControlPanelSidebarSurfaceReader())
+    }
+
+    private var issueReportMenu: some View {
+        Menu {
+            ForEach(IssueReportCategory.allCases) { category in
+                Button {
+                    reportIssue(category: category)
+                } label: {
+                    Label(category.displayName, systemImage: category.systemImage)
+                }
+            }
+        } label: {
+            Color.clear
+                .frame(width: 40, height: 40)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 40, height: 40)
+        .overlay {
+            footerIcon(
+                systemName: "ladybug",
+                size: 17,
+                isHovered: hoveredFooterControl == .reportIssue
+            )
+                .allowsHitTesting(false)
+        }
+        .onHover { isHovering in
+            updateFooterHover(.reportIssue, isHovering: isHovering)
+        }
+        .help("Report an Issue")
+        .accessibilityLabel("Report an Issue")
+    }
+
+    private var settingsButton: some View {
+        Button {
+            applySidebarSelection(.tab(.settings))
+        } label: {
+            footerIcon(
+                systemName: "gearshape",
+                size: 18,
+                color: selectedTab == .settings ? .accentColor : .secondary,
+                isHovered: hoveredFooterControl == .settings
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering in
+            updateFooterHover(.settings, isHovering: isHovering)
+        }
+        .help("Settings")
+        .accessibilityLabel("Settings")
+    }
+
+    private var serverToggleButton: some View {
+        Button {
+            model.toggleServer()
+        } label: {
+            footerIcon(
+                systemName: model.isRunning ? "stop.circle" : "play.circle",
+                size: 17,
+                color: model.isRunning ? .red : .green,
+                isHovered: hoveredFooterControl == .server
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(model.modelSwitchInProgress)
+        .onHover { isHovering in
+            updateFooterHover(.server, isHovering: isHovering)
+        }
+        .help(model.isRunning ? "Stop Server" : "Start Server")
+        .accessibilityLabel(model.isRunning ? "Stop Server" : "Start Server")
+    }
+
+    private func footerIcon(
+        systemName: String,
+        size: CGFloat,
+        color: Color = .secondary,
+        isHovered: Bool
+    ) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: size, weight: .medium))
+            .foregroundStyle(color)
+            .frame(width: 40, height: 40)
+            .background {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.primary.opacity(isHovered ? 0.08 : 0))
+            }
+            .contentShape(Rectangle())
+            .animation(.easeOut(duration: 0.12), value: isHovered)
+    }
+
+    private func updateFooterHover(_ control: FooterControl, isHovering: Bool) {
+        if isHovering {
+            hoveredFooterControl = control
+        } else if hoveredFooterControl == control {
+            hoveredFooterControl = nil
+        }
     }
 
     private func reportIssue(category: IssueReportCategory) {
@@ -261,6 +377,11 @@ struct ControlPanelView: View {
                         model: model,
                         runtime: runtime,
                         showsConfiguration: $isModelConfigurationVisible
+                    )
+                case .settings:
+                    SettingsView(
+                        softwareUpdater: softwareUpdater,
+                        launchAtLogin: launchAtLogin
                     )
                 }
             }
@@ -695,5 +816,10 @@ private extension View {
 }
 
 #Preview {
-    ControlPanelView(model: .init(), navigation: .init(), runtime: .init())
+    ControlPanelView(
+        model: .init(),
+        navigation: .init(),
+        runtime: .init(),
+        softwareUpdater: .init()
+    )
 }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -233,105 +233,99 @@ struct ControlPanelView: View {
     }
 
     private var issueReportMenu: some View {
-        Menu {
-            ForEach(IssueReportCategory.allCases) { category in
-                Button {
-                    reportIssue(category: category)
-                } label: {
-                    Label(category.displayName, systemImage: category.systemImage)
+        footerControl(.reportIssue, tooltip: "Report an Issue") {
+            Menu {
+                ForEach(IssueReportCategory.allCases) { category in
+                    Button {
+                        reportIssue(category: category)
+                    } label: {
+                        Label(category.displayName, systemImage: category.systemImage)
+                    }
                 }
+            } label: {
+                footerIcon(systemName: "ladybug")
             }
-        } label: {
-            footerIcon(
-                systemName: "ladybug",
-                isHovered: hoveredFooterControl == .reportIssue
-            )
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .tint(.secondary)
+            .foregroundStyle(.secondary)
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .tint(.secondary)
-        .foregroundStyle(.secondary)
-        .frame(width: 40, height: 40)
-        .onHover { isHovering in
-            updateFooterHover(.reportIssue, isHovering: isHovering)
-        }
-        .help("Report an Issue")
-        .accessibilityLabel("Report an Issue")
     }
 
     private var settingsButton: some View {
-        Button {
-            applySidebarSelection(.tab(.settings))
-        } label: {
-            footerIcon(
-                systemName: "gearshape",
-                color: .secondary,
-                isHovered: hoveredFooterControl == .settings
-            )
+        footerControl(.settings, tooltip: "Settings") {
+            Button {
+                applySidebarSelection(.tab(.settings))
+            } label: {
+                footerIcon(systemName: "gearshape")
+            }
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
-        .onHover { isHovering in
-            updateFooterHover(.settings, isHovering: isHovering)
-        }
-        .help("Settings")
-        .accessibilityLabel("Settings")
     }
 
     private var serverToggleButton: some View {
-        Button {
-            model.toggleServer()
-        } label: {
-            footerIcon(
-                systemName: model.isRunning ? "stop.circle" : "play.circle",
-                color: .secondary,
-                isHovered: hoveredFooterControl == .server
-            )
+        footerControl(
+            .server,
+            tooltip: model.isRunning ? "Stop Server" : "Start Server"
+        ) {
+            Button {
+                model.toggleServer()
+            } label: {
+                footerIcon(systemName: model.isRunning ? "stop.circle" : "play.circle")
+            }
+            .buttonStyle(.plain)
+            .disabled(model.modelSwitchInProgress)
         }
-        .buttonStyle(.plain)
-        .disabled(model.modelSwitchInProgress)
-        .onHover { isHovering in
-            updateFooterHover(.server, isHovering: isHovering)
-        }
-        .help(model.isRunning ? "Stop Server" : "Start Server")
-        .accessibilityLabel(model.isRunning ? "Stop Server" : "Start Server")
     }
 
     private var supportButton: some View {
-        Button {
-            guard let url = URL(string: "https://github.com/Blaizzy/nativ") else {
-                return
+        footerControl(.support, tooltip: "Star Nativ on GitHub") {
+            Button {
+                guard let url = URL(string: "https://github.com/Blaizzy/nativ") else {
+                    return
+                }
+                NSWorkspace.shared.open(url)
+            } label: {
+                footerIcon(
+                    systemName: hoveredFooterControl == .support ? "heart.fill" : "heart"
+                )
             }
-            NSWorkspace.shared.open(url)
-        } label: {
-            footerIcon(
-                systemName: hoveredFooterControl == .support ? "heart.fill" : "heart",
-                color: .secondary,
-                isHovered: hoveredFooterControl == .support
-            )
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
-        .onHover { isHovering in
-            updateFooterHover(.support, isHovering: isHovering)
-        }
-        .help("Star Nativ on GitHub")
-        .accessibilityLabel("Star Nativ on GitHub")
     }
 
     private func footerIcon(
-        systemName: String,
-        color: Color = .secondary,
-        isHovered: Bool
+        systemName: String
     ) -> some View {
         Image(systemName: systemName)
             .font(.system(size: 15, weight: .medium))
-            .foregroundStyle(color)
+            .foregroundStyle(.secondary)
+            .frame(width: 40, height: 40)
+            .contentShape(Rectangle())
+    }
+
+    private func footerControl<Content: View>(
+        _ control: FooterControl,
+        tooltip: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        content()
             .frame(width: 40, height: 40)
             .background {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.primary.opacity(isHovered ? 0.08 : 0))
+                    .fill(Color.primary.opacity(hoveredFooterControl == control ? 0.08 : 0))
+            }
+            .overlay {
+                FooterControlTrackingView(
+                    tooltip: tooltip,
+                    onHover: { isHovering in
+                        updateFooterHover(control, isHovering: isHovering)
+                    }
+                )
             }
             .contentShape(Rectangle())
-            .animation(.easeOut(duration: 0.12), value: isHovered)
+            .accessibilityLabel(tooltip)
+            .animation(.easeOut(duration: 0.12), value: hoveredFooterControl == control)
     }
 
     private func updateFooterHover(_ control: FooterControl, isHovering: Bool) {
@@ -535,6 +529,64 @@ struct ControlPanelView: View {
         "Create a new chat"
     }
 
+}
+
+private struct FooterControlTrackingView: NSViewRepresentable {
+    let tooltip: String
+    let onHover: (Bool) -> Void
+
+    func makeNSView(context: Context) -> FooterControlTrackingNSView {
+        FooterControlTrackingNSView(tooltip: tooltip, onHover: onHover)
+    }
+
+    func updateNSView(_ view: FooterControlTrackingNSView, context: Context) {
+        view.toolTip = tooltip
+        view.onHover = onHover
+    }
+}
+
+@MainActor
+private final class FooterControlTrackingNSView: NSView {
+    var onHover: (Bool) -> Void
+    private var hoverTrackingArea: NSTrackingArea?
+
+    init(tooltip: String, onHover: @escaping (Bool) -> Void) {
+        self.onHover = onHover
+        super.init(frame: .zero)
+        toolTip = tooltip
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea {
+            removeTrackingArea(hoverTrackingArea)
+        }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.activeInActiveApp, .inVisibleRect, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        hoverTrackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onHover(true)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onHover(false)
+    }
 }
 
 private struct ControlPanelSidebarSurfaceReader: NSViewRepresentable {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -62,6 +62,7 @@ final class ControlPanelNavigation: ObservableObject {
 
 private enum FooterControl {
     case settings
+    case support
     case server
     case reportIssue
 }
@@ -218,6 +219,7 @@ struct ControlPanelView: View {
 
                 HStack(spacing: 4) {
                     settingsButton
+                    supportButton
                     serverToggleButton
                     issueReportMenu
                 }
@@ -292,6 +294,27 @@ struct ControlPanelView: View {
         }
         .help(model.isRunning ? "Stop Server" : "Start Server")
         .accessibilityLabel(model.isRunning ? "Stop Server" : "Start Server")
+    }
+
+    private var supportButton: some View {
+        Button {
+            guard let url = URL(string: "https://github.com/Blaizzy/nativ") else {
+                return
+            }
+            NSWorkspace.shared.open(url)
+        } label: {
+            footerIcon(
+                systemName: hoveredFooterControl == .support ? "heart.fill" : "heart",
+                color: .secondary,
+                isHovered: hoveredFooterControl == .support
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering in
+            updateFooterHover(.support, isHovering: isHovering)
+        }
+        .help("Star Nativ on GitHub")
+        .accessibilityLabel("Star Nativ on GitHub")
     }
 
     private func footerIcon(

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -213,12 +213,15 @@ struct ControlPanelView: View {
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
+                Divider()
+                    .overlay(Color.secondary.opacity(0.25))
+
                 HStack(spacing: 4) {
                     settingsButton
                     serverToggleButton
                     issueReportMenu
-                    Spacer(minLength: 0)
                 }
+                .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 5)
             }
@@ -237,21 +240,16 @@ struct ControlPanelView: View {
                 }
             }
         } label: {
-            Color.clear
-                .frame(width: 40, height: 40)
-                .contentShape(Rectangle())
+            footerIcon(
+                systemName: "ladybug",
+                isHovered: hoveredFooterControl == .reportIssue
+            )
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
+        .tint(.secondary)
+        .foregroundStyle(.secondary)
         .frame(width: 40, height: 40)
-        .overlay {
-            footerIcon(
-                systemName: "ladybug",
-                size: 17,
-                isHovered: hoveredFooterControl == .reportIssue
-            )
-                .allowsHitTesting(false)
-        }
         .onHover { isHovering in
             updateFooterHover(.reportIssue, isHovering: isHovering)
         }
@@ -265,8 +263,7 @@ struct ControlPanelView: View {
         } label: {
             footerIcon(
                 systemName: "gearshape",
-                size: 18,
-                color: selectedTab == .settings ? .accentColor : .secondary,
+                color: .secondary,
                 isHovered: hoveredFooterControl == .settings
             )
         }
@@ -284,8 +281,7 @@ struct ControlPanelView: View {
         } label: {
             footerIcon(
                 systemName: model.isRunning ? "stop.circle" : "play.circle",
-                size: 17,
-                color: model.isRunning ? .red : .green,
+                color: .secondary,
                 isHovered: hoveredFooterControl == .server
             )
         }
@@ -300,12 +296,11 @@ struct ControlPanelView: View {
 
     private func footerIcon(
         systemName: String,
-        size: CGFloat,
         color: Color = .secondary,
         isHovered: Bool
     ) -> some View {
         Image(systemName: systemName)
-            .font(.system(size: size, weight: .medium))
+            .font(.system(size: 15, weight: .medium))
             .foregroundStyle(color)
             .frame(width: 40, height: 40)
             .background {

--- a/Sources/Nativ/Features/Settings/SettingsView.swift
+++ b/Sources/Nativ/Features/Settings/SettingsView.swift
@@ -1,0 +1,137 @@
+import AppKit
+import SwiftUI
+
+struct SettingsView: View {
+    let softwareUpdater: SoftwareUpdater
+    @ObservedObject var launchAtLogin: LaunchAtLoginController
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                pageHeader
+                generalSettings
+            }
+            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, 28)
+            .padding(.vertical, 26)
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private var pageHeader: some View {
+        HStack(spacing: 18) {
+            Image(nsImage: NSApplication.shared.applicationIconImage)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 80, height: 80)
+                .shadow(color: .black.opacity(0.2), radius: 12, y: 6)
+                .accessibilityLabel("Nativ app icon")
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Nativ")
+                    .font(.largeTitle.weight(.semibold))
+                Text(appVersionLabel)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Text("Local AI, native to your Mac.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var generalSettings: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("General")
+                .font(.headline)
+
+            VStack(spacing: 0) {
+                settingsRow(
+                    title: "Software Updates",
+                    description: "Check for a newer version of Nativ.",
+                    systemImage: "arrow.triangle.2.circlepath"
+                ) {
+                    CheckForUpdatesCommand(updater: softwareUpdater.updater)
+                        .buttonStyle(.bordered)
+                }
+
+                Divider()
+                    .padding(.leading, 52)
+
+                settingsRow(
+                    title: "Start at Login",
+                    description: launchAtLogin.requiresApproval
+                        ? "Approval is required in System Settings."
+                        : "Open Nativ automatically when you log in.",
+                    systemImage: "person.crop.circle.badge.checkmark"
+                ) {
+                    Toggle("", isOn: Binding(
+                        get: { launchAtLogin.isEnabled },
+                        set: { launchAtLogin.setEnabled($0) }
+                    ))
+                    .labelsHidden()
+                }
+
+                if launchAtLogin.requiresApproval {
+                    Divider()
+                        .padding(.leading, 52)
+
+                    HStack {
+                        Spacer()
+                        Button("Open Login Items Settings…") {
+                            launchAtLogin.openSystemSettings()
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 12)
+                }
+            }
+            .background(Color(nsColor: .controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+            )
+        }
+    }
+
+    private func settingsRow<Accessory: View>(
+        title: String,
+        description: String,
+        systemImage: String,
+        @ViewBuilder accessory: () -> Accessory
+    ) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: systemImage)
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.body.weight(.medium))
+                Text(description)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 20)
+            accessory()
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 15)
+    }
+
+    private var appVersionLabel: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let build = info?["CFBundleVersion"] as? String
+        if let build, !build.isEmpty {
+            return "Version \(version) (\(build))"
+        }
+        return "Version \(version)"
+    }
+}

--- a/Sources/Nativ/Features/Settings/SettingsView.swift
+++ b/Sources/Nativ/Features/Settings/SettingsView.swift
@@ -20,7 +20,7 @@ struct SettingsView: View {
     }
 
     private var pageHeader: some View {
-        HStack(spacing: 18) {
+        VStack(spacing: 14) {
             Image(nsImage: NSApplication.shared.applicationIconImage)
                 .resizable()
                 .interpolation(.high)
@@ -29,7 +29,7 @@ struct SettingsView: View {
                 .shadow(color: .black.opacity(0.2), radius: 12, y: 6)
                 .accessibilityLabel("Nativ app icon")
 
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(spacing: 5) {
                 Text("Nativ")
                     .font(.largeTitle.weight(.semibold))
                 Text(appVersionLabel)
@@ -39,7 +39,9 @@ struct SettingsView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
+            .multilineTextAlignment(.center)
         }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     private var generalSettings: some View {

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -88,7 +88,6 @@ enum Main {
 
 private struct NativApplication: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    private let softwareUpdater = SoftwareUpdater()
 
     var body: some Scene {
         Window("Nativ", id: "main") {
@@ -100,7 +99,7 @@ private struct NativApplication: App {
         .windowBackgroundDragBehavior(.enabled)
         .commands {
             CommandGroup(after: .appInfo) {
-                CheckForUpdatesCommand(updater: softwareUpdater.updater)
+                CheckForUpdatesCommand(updater: appDelegate.softwareUpdater.updater)
             }
 
             CommandGroup(replacing: .newItem) {

--- a/Sources/Nativ/Utilities/LaunchAtLoginController.swift
+++ b/Sources/Nativ/Utilities/LaunchAtLoginController.swift
@@ -1,0 +1,44 @@
+import Combine
+import Foundation
+import ServiceManagement
+
+@MainActor
+final class LaunchAtLoginController: ObservableObject {
+    @Published private(set) var isEnabled = false
+    @Published private(set) var requiresApproval = false
+    @Published var errorMessage: String?
+
+    private let service = SMAppService.mainApp
+
+    init() {
+        refresh()
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        do {
+            if enabled {
+                if service.status == .requiresApproval {
+                    SMAppService.openSystemSettingsLoginItems()
+                } else if service.status != .enabled {
+                    try service.register()
+                }
+            } else if service.status != .notRegistered {
+                try service.unregister()
+            }
+            refresh()
+        } catch {
+            refresh()
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func openSystemSettings() {
+        SMAppService.openSystemSettingsLoginItems()
+    }
+
+    func refresh() {
+        let status = service.status
+        isEnabled = status == .enabled || status == .requiresApproval
+        requiresApproval = status == .requiresApproval
+    }
+}

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -20,6 +20,7 @@ struct WelcomeGateView: View {
     @ObservedObject var model: NativModel
     @ObservedObject var navigation: ControlPanelNavigation
     @ObservedObject var runtime: SystemRuntimeMonitor
+    let softwareUpdater: SoftwareUpdater
     let onComplete: (_ modelID: String?, _ serverAPIKey: String?) -> Void
 
     var body: some View {
@@ -28,7 +29,8 @@ struct WelcomeGateView: View {
                 ControlPanelView(
                     model: model,
                     navigation: navigation,
-                    runtime: runtime
+                    runtime: runtime,
+                    softwareUpdater: softwareUpdater
                 )
             } else {
                 WelcomeView(model: model) { modelID, serverAPIKey in


### PR DESCRIPTION
## Summary

- add a full Settings page with the Nativ logo, version, update checker, and Start at Login control
- add centered sidebar footer controls for Settings, GitHub support, Start/Stop Server, and Report an Issue
- add a heart shortcut that opens `Blaizzy/nativ` for the signed-in user to star
- keep footer icons consistently gray and sized with the sidebar navigation
- add hover states, contextual tooltips, a subtle divider, and a working report-category menu
- reuse the shared software updater and implement macOS login-item registration through `SMAppService`

## Why

Core app controls were scattered or unavailable from the main window. This gives users direct access to settings and server lifecycle actions without turning Settings into a dropdown.

The report menu also needed a native clickable label: the earlier invisible overlay normalized its appearance but prevented reliable menu activation. The visible native menu label now receives clicks while retaining the gray footer styling.

GitHub requires an authenticated account write to star a repository. Because Nativ has no GitHub OAuth integration, the heart opens the repository for the signed-in user to confirm the star instead of silently modifying their account.

## User impact

Users can open a dedicated Settings page, check for updates, manage launch at login, toggle the local server, support the project on GitHub, and report categorized issues directly from the sidebar footer.

## Validation

- rebased on current `origin/main`
- `xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -derivedDataPath build/XcodeDerivedData CODE_SIGNING_ALLOWED=NO clean build`
- incremental Debug build after adding the heart shortcut
- launched the rebuilt app and visually verified footer alignment, sizing, gray tint, divider, hover states, and tooltips
- click-tested the report issue menu and server toggle behavior