### PR TITLE
Add capability manifest, generated docs, and CI (#31, #56)

### DIFF
--- a/.github/workflows/manifest-coalesce.yml
+++ b/.github/workflows/manifest-coalesce.yml
@@ -1,0 +1,40 @@
+name: Manifest dependency coalescing
+
+on:
+  issues:
+    types: [closed]
+  push:
+    branches: [main]
+    paths:
+      - "nativ.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: manifest-coalesce
+  cancel-in-progress: false
+
+jobs:
+  coalesce:
+    if: github.repository == 'Blaizzy/nativ'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install "pyyaml>=6"
+      - name: Coalesce (issue closed)
+        if: github.event_name == 'issues'
+        run: python3 scripts/coalesce_dependencies.py --closed-issue "${{ github.event.issue.number }}"
+      - name: Coalesce (manifest edit)
+        if: github.event_name == 'push'
+        run: |
+          git show "${{ github.event.before }}:nativ.yml" > /tmp/prev-nativ.yml 2>/dev/null || true
+          python3 scripts/coalesce_dependencies.py --previous /tmp/prev-nativ.yml --current nativ.yml

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,0 +1,40 @@
+name: Manifest
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "nativ.yml"
+      - "SUPPORT_MATRIX.md"
+      - "ROADMAP.md"
+      - "CHANGELOG.md"
+      - "scripts/render_manifest.py"
+      - ".github/workflows/manifest.yml"
+  pull_request:
+    paths:
+      - "nativ.yml"
+      - "SUPPORT_MATRIX.md"
+      - "ROADMAP.md"
+      - "CHANGELOG.md"
+      - "scripts/render_manifest.py"
+      - ".github/workflows/manifest.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manifest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install "pyyaml>=6"
+      - name: Validate nativ.yml and check generated docs are in sync
+        run: python3 scripts/render_manifest.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+<!-- Generated from nativ.yml by scripts/render_manifest.py. Do not edit by hand. -->
+
+## 0.0.1 — 2026-07
+
+- Initial public release.
+- Local chat and vision with streaming, image attachments, reasoning output, and persistent history.
+- Model library — discover, browse, download, inspect, switch, and remove MLX models.
+- Performance analytics dashboard.
+- OpenAI- and Anthropic-compatible local API server.
+- Coding-tool integrations (Codex, Claude Code, Pi, Hermes, OpenCode), developer workspace, and menu bar controls.
+- Advanced inference controls — sampling, thinking budgets, structured output, KV-cache quantization, prefix caching, and speculative decoding.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Inference runs on your Mac after a model has been downloaded. Model downloads an
 
 Support for dedicated audio-only and image-generation-only models is coming soon.
 
+## Roadmap and status
+
+- [Feature support matrix](SUPPORT_MATRIX.md) — what is shipped, experimental, or planned.
+- [Roadmap](ROADMAP.md) — committed and exploratory work, with the issue backlog.
+- [Changelog](CHANGELOG.md) — release history.
+
+All three are generated from [`nativ.yml`](nativ.yml), the single source of truth for capabilities and their status.
+
 ## How it works
 
 ```mermaid

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,12 +4,6 @@
 
 Committed and exploratory work, rendered from `nativ.yml`. Shipped capabilities are in [SUPPORT_MATRIX.md](SUPPORT_MATRIX.md).
 
-## Experimental
-
-### Custom local server port
-
-Choose the local server port from the Developer page (in progress on feature/custom-server-port; not yet on main).
-
 ## Planned
 
 ### Dedicated audio models (speech recognition & speech generation) (#15)
@@ -45,11 +39,7 @@ Coming soon. /v1/images/* routes and the ImageGeneration workspace are scaffolde
 - [ ] Wire the workspace: progress, cancellation, previews, and save/export.
 - [ ] Report load failures, generation failures, and unsupported parameters.
 - [ ] Track image-generation requests and timing in analytics.
-- [ ] Make the memory fit estimate activation-aware for diffusion (peak reserve, not weights-only). [#46]
-
-### Gated Hugging Face model downloads (#23)
-
-Authenticate with Hugging Face to download license-gated / access-requested models from within Nativ.
+- [x] Make the memory fit estimate activation-aware for diffusion (peak reserve, not weights-only). [#46, PR #47]
 
 ### Model metadata in /v1/models (context window, tools, vision) (#56)
 
@@ -79,6 +69,7 @@ Expose per-model max context window and tool/function-calling and vision support
 
 - [#24](https://github.com/Blaizzy/nativ/issues/24) Support macOS Sequoia by lowering the deployment target
 - [#30](https://github.com/Blaizzy/nativ/issues/30) Explore an iPad and iPhone version of Nativ
+- [#57](https://github.com/Blaizzy/nativ/issues/57) Allow installation as Homebrew Cask
 
 ### runtime
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,102 @@
+# Nativ — Roadmap
+
+<!-- Generated from nativ.yml by scripts/render_manifest.py. Do not edit by hand. -->
+
+Committed and exploratory work, rendered from `nativ.yml`. Shipped capabilities are in [SUPPORT_MATRIX.md](SUPPORT_MATRIX.md).
+
+## Experimental
+
+### Custom local server port
+
+Choose the local server port from the Developer page (in progress on feature/custom-server-port; not yet on main).
+
+## Planned
+
+### Dedicated audio models (speech recognition & speech generation) (#15)
+
+Coming soon. API surface (/v1/audio/*) is present; the dedicated audio-model runtime is not yet integrated.
+
+- [ ] Detect audio capabilities; distinguish transcription, translation, and text-to-speech.
+- [ ] Discover, download, display, select, load, and unload compatible audio models.
+- [ ] Route audio models through a dedicated runtime, not the language/vision path.
+- [ ] Serve /v1/audio/transcriptions, /v1/audio/translations, /v1/audio/speech by capability.
+- [ ] Handle audio file validation, formats, generated output, cancellation, and errors.
+- [ ] Add audio request and performance data to analytics.
+
+### Dedicated embedding models (#16)
+
+Not yet supported. Requires bundling mlx-embeddings and a dedicated embedding runtime.
+
+- [ ] Detect embedding capabilities from local and Hugging Face metadata.
+- [ ] Keep embedding models out of language-model selection; show them in the library with the correct type.
+- [ ] Add a dedicated load/unload runtime path for embedding models.
+- [ ] Implement OpenAI-compatible POST /v1/embeddings (string or array -> vectors, metadata, usage).
+- [ ] Surface model state, load failures, and unsupported architectures in app and logs.
+- [ ] Track embedding requests in analytics without assuming generated-token metrics.
+
+### Dedicated image-generation models (#14 #44 #46)
+
+Coming soon. /v1/images/* routes and the ImageGeneration workspace are scaffolded; the dedicated diffusion runtime and memory-aware fit estimate are not yet complete.
+
+- [ ] Detect image-generation models from local and Hugging Face metadata.
+- [ ] Discover, download, display, select, load, and unload compatible models.
+- [ ] Add a dedicated image-generation runtime, not the language/vision path.
+- [ ] Implement OpenAI-compatible POST /v1/images/generations (prompt, size, seed, step, output format).
+- [ ] Wire the workspace: progress, cancellation, previews, and save/export.
+- [ ] Report load failures, generation failures, and unsupported parameters.
+- [ ] Track image-generation requests and timing in analytics.
+- [ ] Make the memory fit estimate activation-aware for diffusion (peak reserve, not weights-only). [#46]
+
+### Gated Hugging Face model downloads (#23)
+
+Authenticate with Hugging Face to download license-gated / access-requested models from within Nativ.
+
+### Model metadata in /v1/models (context window, tools, vision) (#56)
+
+Expose per-model max context window and tool/function-calling and vision support in /v1/models so OpenAI-compatible clients (e.g. the community VSCode extension) need not hardcode them.
+
+- [ ] Add max context window / max output tokens to each /v1/models entry.
+- [ ] Advertise tool / function-calling support per model in /v1/models.
+- [ ] Advertise vision (image input) support per model in /v1/models.
+- [ ] Verify OpenAI-compatible tool calling end-to-end so the VSCode 'Agent' mode works.
+
+## Backlog by area
+
+### app
+
+- [#11](https://github.com/Blaizzy/nativ/issues/11) UI gets crunchy and stops updating unless fed input events
+- [#23](https://github.com/Blaizzy/nativ/issues/23) Support downloading gated Hugging Face models
+- [#26](https://github.com/Blaizzy/nativ/issues/26) Reduce and document the Nativ app bundle footprint
+- [#46](https://github.com/Blaizzy/nativ/issues/46) Image-gen fit estimate is weights-only and misleads for diffusion _( part of #44; depends on #14 )_
+
+### docs
+
+- [#27](https://github.com/Blaizzy/nativ/issues/27) Publish reproducible MLX performance benchmarks by Apple chip generation
+- [#29](https://github.com/Blaizzy/nativ/issues/29) Create a Mac hardware, model, and local-use-case guide
+- [#31](https://github.com/Blaizzy/nativ/issues/31) Add a public roadmap, changelog, and feature support matrix
+
+### platform
+
+- [#24](https://github.com/Blaizzy/nativ/issues/24) Support macOS Sequoia by lowering the deployment target
+- [#30](https://github.com/Blaizzy/nativ/issues/30) Explore an iPad and iPhone version of Nativ
+
+### runtime
+
+- [#4](https://github.com/Blaizzy/nativ/issues/4) Models fail to load with "Model type not supported"
+- [#14](https://github.com/Blaizzy/nativ/issues/14) Support image generation models
+- [#15](https://github.com/Blaizzy/nativ/issues/15) Support audio models
+- [#16](https://github.com/Blaizzy/nativ/issues/16) Support embedding models
+- [#22](https://github.com/Blaizzy/nativ/issues/22) Add support for Core AI and Apple Foundation Models
+- [#28](https://github.com/Blaizzy/nativ/issues/28) Evaluate DS4 as a backend for DeepSeek V4 Flash
+- [#44](https://github.com/Blaizzy/nativ/issues/44) Image-generation model support: memory-architecture suggestions & gotchas _( includes #46 )_
+
+### server
+
+- [#13](https://github.com/Blaizzy/nativ/issues/13) 405 when messaging in chat
+- [#56](https://github.com/Blaizzy/nativ/issues/56) /v1/models data - VSCode extension (Language Model Chat Provider)
+
+### website
+
+- [#32](https://github.com/Blaizzy/nativ/issues/32) Rewrite the landing page with concrete, unambiguous product messaging
+- [#34](https://github.com/Blaizzy/nativ/issues/34) Fix landing-page overflow and responsive mobile layout
+- [#35](https://github.com/Blaizzy/nativ/issues/35) Replace the contradictory "Universal · Apple Silicon" platform label

--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -11,17 +11,17 @@ Status: **Shipped** (in the current release) · **Experimental** (usable but uns
 | Advanced inference controls | Shipped | mlx-vlm | Sampling, thinking budgets, structured output, KV-cache quantization, prefix caching, and speculative decoding. |
 | Anthropic-compatible API | Shipped | mlx-vlm | /v1/messages and /v1/messages/count_tokens. |
 | Coding-tool integrations | Shipped | nativ | Configure and launch Codex, Claude Code, Pi, Hermes, and OpenCode against models served by Nativ. |
-| Developer workspace | Shipped | nativ | Runtime details, copyable endpoint URLs, live server-log search/filter, and server-health monitoring. |
-| Local chat & vision | Shipped | mlx-vlm | Streaming conversations, image attachments, reasoning output, response metrics, and persistent chat history. |
+| Custom local server port | Shipped | nativ | Choose the local server port from the Developer page (PRs |
+| Developer workspace | Shipped | nativ | Set the server port, add a Hugging Face token for gated models, inspect runtime details, copy endpoint URLs, search/filter live server logs, and monitor server health. |
+| Gated Hugging Face model downloads | Shipped | nativ | Add a Hugging Face token (in the Developer view or via HF_TOKEN) to download gated models (PR (#23) |
+| Local chat & vision | Shipped | mlx-vlm | Streaming conversations, image attachments (including clipboard paste and screenshot capture, PR |
 | Menu bar controls | Shipped | nativ | Start/stop the server, change the loaded model, check serving stats, and open the app without breaking focus. |
-| Model library | Shipped | mlx-vlm | Discover installed MLX models, browse compatible Hugging Face models, download, inspect capabilities, switch, or remove. |
+| Model library | Shipped | mlx-vlm | Discover installed MLX models (including those installed by LM Studio, PR |
 | OpenAI-compatible API | Shipped | mlx-vlm | /v1/chat/completions, /v1/responses (+ input_tokens, cancel, input_items), /v1/models. |
 | Performance analytics | Shipped | nativ | Request volume, token usage, time-to-first-token, decode speed, per-model performance, and recent activity. |
-| Custom local server port | Experimental | nativ | Choose the local server port from the Developer page (in progress on feature/custom-server-port; not yet on main). |
 | Dedicated audio models (speech recognition & speech generation) | Planned (0/6) | mlx-audio | Coming soon. API surface (/v1/audio/*) is present; the dedicated audio-model runtime is not yet integrated. (#15) |
 | Dedicated embedding models | Planned (0/6) | mlx-embeddings | Not yet supported. Requires bundling mlx-embeddings and a dedicated embedding runtime. (#16) |
-| Dedicated image-generation models | Planned (0/8) | mlx-vlm | Coming soon. /v1/images/* routes and the ImageGeneration workspace are scaffolded; the dedicated diffusion runtime and memory-aware fit estimate are not yet complete. (#14 #44 #46) |
-| Gated Hugging Face model downloads | Planned | nativ | Authenticate with Hugging Face to download license-gated / access-requested models from within Nativ. (#23) |
+| Dedicated image-generation models | Planned (1/8) | mlx-vlm | Coming soon. /v1/images/* routes and the ImageGeneration workspace are scaffolded; the dedicated diffusion runtime and memory-aware fit estimate are not yet complete. (#14 #44 #46) |
 | Model metadata in /v1/models (context window, tools, vision) | Planned (0/4) | mlx-vlm | Expose per-model max context window and tool/function-calling and vision support in /v1/models so OpenAI-compatible clients (e.g. the community VSCode extension) need not hardcode them. (#56) |
 
 ## Runtime providers

--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -1,0 +1,40 @@
+# Nativ — Feature Support Matrix
+
+<!-- Generated from nativ.yml by scripts/render_manifest.py. Do not edit by hand. -->
+
+Status: **Shipped** (in the current release) · **Experimental** (usable but unstable / in active development) · **Planned** (committed) · **Exploratory** (under investigation).
+
+## Capabilities
+
+| Capability | Status | Provider | Notes |
+| --- | --- | --- | --- |
+| Advanced inference controls | Shipped | mlx-vlm | Sampling, thinking budgets, structured output, KV-cache quantization, prefix caching, and speculative decoding. |
+| Anthropic-compatible API | Shipped | mlx-vlm | /v1/messages and /v1/messages/count_tokens. |
+| Coding-tool integrations | Shipped | nativ | Configure and launch Codex, Claude Code, Pi, Hermes, and OpenCode against models served by Nativ. |
+| Developer workspace | Shipped | nativ | Runtime details, copyable endpoint URLs, live server-log search/filter, and server-health monitoring. |
+| Local chat & vision | Shipped | mlx-vlm | Streaming conversations, image attachments, reasoning output, response metrics, and persistent chat history. |
+| Menu bar controls | Shipped | nativ | Start/stop the server, change the loaded model, check serving stats, and open the app without breaking focus. |
+| Model library | Shipped | mlx-vlm | Discover installed MLX models, browse compatible Hugging Face models, download, inspect capabilities, switch, or remove. |
+| OpenAI-compatible API | Shipped | mlx-vlm | /v1/chat/completions, /v1/responses (+ input_tokens, cancel, input_items), /v1/models. |
+| Performance analytics | Shipped | nativ | Request volume, token usage, time-to-first-token, decode speed, per-model performance, and recent activity. |
+| Custom local server port | Experimental | nativ | Choose the local server port from the Developer page (in progress on feature/custom-server-port; not yet on main). |
+| Dedicated audio models (speech recognition & speech generation) | Planned (0/6) | mlx-audio | Coming soon. API surface (/v1/audio/*) is present; the dedicated audio-model runtime is not yet integrated. (#15) |
+| Dedicated embedding models | Planned (0/6) | mlx-embeddings | Not yet supported. Requires bundling mlx-embeddings and a dedicated embedding runtime. (#16) |
+| Dedicated image-generation models | Planned (0/8) | mlx-vlm | Coming soon. /v1/images/* routes and the ImageGeneration workspace are scaffolded; the dedicated diffusion runtime and memory-aware fit estimate are not yet complete. (#14 #44 #46) |
+| Gated Hugging Face model downloads | Planned | nativ | Authenticate with Hugging Face to download license-gated / access-requested models from within Nativ. (#23) |
+| Model metadata in /v1/models (context window, tools, vision) | Planned (0/4) | mlx-vlm | Expose per-model max context window and tool/function-calling and vision support in /v1/models so OpenAI-compatible clients (e.g. the community VSCode extension) need not hardcode them. (#56) |
+
+## Runtime providers
+
+| Provider | Role | Version | Repo |
+| --- | --- | --- | --- |
+| mlx-vlm | bundled | `>=0.6.5` | Blaizzy/mlx-vlm |
+| mlx-audio | bundled | `==0.4.3` | Blaizzy/mlx-audio |
+| mlx-embeddings | planned | `—` | Blaizzy/mlx-embeddings |
+
+## Platform
+
+- Apple silicon: **required** (M1 or later)
+- Minimum macOS: **26.0**
+
+See [ROADMAP.md](ROADMAP.md) for planned work and [CHANGELOG.md](CHANGELOG.md) for release history. Tracked in [Blaizzy/nativ issues](https://github.com/Blaizzy/nativ/issues).

--- a/nativ.yml
+++ b/nativ.yml
@@ -1,0 +1,331 @@
+# nativ.yml — single source of truth for Nativ's capabilities, roadmap, and issue graph.
+#
+# The support matrix, roadmap, and changelog are rendered from this file — edit here, not
+# in the generated docs. Contributors completing a planned feature should flip the relevant
+# `status` and check off `tasks` in the same PR; CI validates the file and, when an item is
+# completed, flags any issue that `depends_on` it as ready to start.
+#
+# status vocabulary:
+#   shipped       — available in the current release
+#   experimental  — usable but unstable / behind a flag / in active development
+#   planned        — committed, not yet started or in progress
+#   exploratory   — under investigation, no commitment yet
+
+meta:
+  repo: Blaizzy/nativ
+  app_version: "0.0.1"
+  platform:
+    apple_silicon: required          # M1 or later
+    macos_min: "26.0"                # app deployment target; shared components build to 14.0
+  # Upstream MLX packages Nativ builds on. `role: bundled` ships inside the embedded server.
+  providers:
+    mlx-vlm:
+      role: bundled
+      version: ">=0.6.5"
+      repo: Blaizzy/mlx-vlm
+    mlx-audio:
+      role: bundled                  # pinned in the server bundle; feature integration still planned
+      version: "==0.4.3"
+      repo: Blaizzy/mlx-audio
+    mlx-embeddings:
+      role: planned                  # not yet integrated into Nativ
+      version: null
+      repo: Blaizzy/mlx-embeddings
+
+# ---------------------------------------------------------------------------------------
+# Capabilities — what a user can actually do. Each names the provider it rests on and the
+# issues that track it. `tasks` are the concrete, checkable steps for planned features.
+# ---------------------------------------------------------------------------------------
+capabilities:
+  - id: chat-vision
+    title: Local chat & vision
+    status: shipped
+    provider: mlx-vlm
+    note: Streaming conversations, image attachments, reasoning output, response metrics, and persistent chat history.
+
+  - id: model-library
+    title: Model library
+    status: shipped
+    provider: mlx-vlm
+    note: Discover installed MLX models, browse compatible Hugging Face models, download, inspect capabilities, switch, or remove.
+
+  - id: performance-analytics
+    title: Performance analytics
+    status: shipped
+    provider: nativ
+    note: Request volume, token usage, time-to-first-token, decode speed, per-model performance, and recent activity.
+
+  - id: openai-api
+    title: OpenAI-compatible API
+    status: shipped
+    provider: mlx-vlm
+    note: /v1/chat/completions, /v1/responses (+ input_tokens, cancel, input_items), /v1/models.
+
+  - id: anthropic-api
+    title: Anthropic-compatible API
+    status: shipped
+    provider: mlx-vlm
+    note: /v1/messages and /v1/messages/count_tokens.
+
+  - id: coding-integrations
+    title: Coding-tool integrations
+    status: shipped
+    provider: nativ
+    note: Configure and launch Codex, Claude Code, Pi, Hermes, and OpenCode against models served by Nativ.
+
+  - id: developer-workspace
+    title: Developer workspace
+    status: shipped
+    provider: nativ
+    note: Runtime details, copyable endpoint URLs, live server-log search/filter, and server-health monitoring.
+
+  - id: menu-bar
+    title: Menu bar controls
+    status: shipped
+    provider: nativ
+    note: Start/stop the server, change the loaded model, check serving stats, and open the app without breaking focus.
+
+  - id: advanced-inference
+    title: Advanced inference controls
+    status: shipped
+    provider: mlx-vlm
+    note: Sampling, thinking budgets, structured output, KV-cache quantization, prefix caching, and speculative decoding.
+
+  - id: custom-server-port
+    title: Custom local server port
+    status: experimental
+    provider: nativ
+    note: Choose the local server port from the Developer page (in progress on feature/custom-server-port; not yet on main).
+
+  - id: gated-hf-download
+    title: Gated Hugging Face model downloads
+    status: planned
+    provider: nativ
+    issues: [23]
+    note: Authenticate with Hugging Face to download license-gated / access-requested models from within Nativ.
+
+  - id: audio-models
+    title: Dedicated audio models (speech recognition & speech generation)
+    status: planned
+    provider: mlx-audio
+    issues: [15]
+    # Not yet wired into Nativ. The OpenAI audio routes are already exposed by the bundled
+    # server, but there is no dedicated audio-model runtime; blocker is Nativ-side integration,
+    # not an upstream mlx-audio issue.
+    note: Coming soon. API surface (/v1/audio/*) is present; the dedicated audio-model runtime is not yet integrated.
+    tasks:
+      - { done: false, text: "Detect audio capabilities; distinguish transcription, translation, and text-to-speech." }
+      - { done: false, text: "Discover, download, display, select, load, and unload compatible audio models." }
+      - { done: false, text: "Route audio models through a dedicated runtime, not the language/vision path." }
+      - { done: false, text: "Serve /v1/audio/transcriptions, /v1/audio/translations, /v1/audio/speech by capability." }
+      - { done: false, text: "Handle audio file validation, formats, generated output, cancellation, and errors." }
+      - { done: false, text: "Add audio request and performance data to analytics." }
+
+  - id: embeddings
+    title: Dedicated embedding models
+    status: planned
+    provider: mlx-embeddings
+    issues: [16]
+    # Not yet wired into Nativ, and mlx-embeddings is not yet bundled. Blocker is Nativ-side
+    # integration, not an upstream mlx-embeddings issue.
+    note: Not yet supported. Requires bundling mlx-embeddings and a dedicated embedding runtime.
+    tasks:
+      - { done: false, text: "Detect embedding capabilities from local and Hugging Face metadata." }
+      - { done: false, text: "Keep embedding models out of language-model selection; show them in the library with the correct type." }
+      - { done: false, text: "Add a dedicated load/unload runtime path for embedding models." }
+      - { done: false, text: "Implement OpenAI-compatible POST /v1/embeddings (string or array -> vectors, metadata, usage)." }
+      - { done: false, text: "Surface model state, load failures, and unsupported architectures in app and logs." }
+      - { done: false, text: "Track embedding requests in analytics without assuming generated-token metrics." }
+
+  - id: image-generation
+    title: Dedicated image-generation models
+    status: planned
+    provider: mlx-vlm
+    issues: [14, 44, 46]
+    note: Coming soon. /v1/images/* routes and the ImageGeneration workspace are scaffolded; the dedicated diffusion runtime and memory-aware fit estimate are not yet complete.
+    tasks:
+      - { done: false, text: "Detect image-generation models from local and Hugging Face metadata." }
+      - { done: false, text: "Discover, download, display, select, load, and unload compatible models." }
+      - { done: false, text: "Add a dedicated image-generation runtime, not the language/vision path." }
+      - { done: false, text: "Implement OpenAI-compatible POST /v1/images/generations (prompt, size, seed, step, output format)." }
+      - { done: false, text: "Wire the workspace: progress, cancellation, previews, and save/export." }
+      - { done: false, text: "Report load failures, generation failures, and unsupported parameters." }
+      - { done: false, text: "Track image-generation requests and timing in analytics." }
+      - { done: false, text: "Make the memory fit estimate activation-aware for diffusion (peak reserve, not weights-only). [#46]" }
+
+  - id: model-metadata-api
+    title: Model metadata in /v1/models (context window, tools, vision)
+    status: planned
+    provider: mlx-vlm
+    issues: [56]
+    note: Expose per-model max context window and tool/function-calling and vision support in /v1/models so OpenAI-compatible clients (e.g. the community VSCode extension) need not hardcode them.
+    tasks:
+      - { done: false, text: "Add max context window / max output tokens to each /v1/models entry." }
+      - { done: false, text: "Advertise tool / function-calling support per model in /v1/models." }
+      - { done: false, text: "Advertise vision (image input) support per model in /v1/models." }
+      - { done: false, text: "Verify OpenAI-compatible tool calling end-to-end so the VSCode 'Agent' mode works." }
+
+# ---------------------------------------------------------------------------------------
+# Issues — the full open backlog with notes and dependency edges.
+#   depends_on : cannot start until the listed items are completed/closed (drives coalescing)
+#   part_of    : a sub-issue of a larger tracking issue
+#   capability : the capability this issue advances
+#   area       : app | server | website | platform | docs | runtime
+# ---------------------------------------------------------------------------------------
+issues:
+  - number: 4
+    title: Models fail to load with "Model type not supported"
+    type: [enhancement]
+    area: runtime
+    capability: model-library
+    note: Server goes online then offline on load; BERT-style and other unsupported types are surfaced as hard failures rather than clear guidance.
+
+  - number: 11
+    title: UI gets crunchy and stops updating unless fed input events
+    type: [bug]
+    area: app
+    capability: chat-vision
+    note: SwiftUI stops redrawing at a smooth rate during inference and freezes without an input event; the "Working..." animation glitches.
+
+  - number: 13
+    title: 405 when messaging in chat
+    type: [bug]
+    area: server
+    capability: chat-vision
+    note: HTTP 405 (nginx) on chat with gemma-4-31b-it; points at a proxy/route-method mismatch in front of the chat endpoint.
+
+  - number: 14
+    title: Support image generation models
+    type: [enhancement]
+    area: runtime
+    capability: image-generation
+    note: Umbrella issue for first-class dedicated image-generation support, discovery through generation and export.
+
+  - number: 15
+    title: Support audio models
+    type: [enhancement]
+    area: runtime
+    capability: audio-models
+    note: Umbrella issue for first-class dedicated audio models (speech recognition and speech generation).
+
+  - number: 16
+    title: Support embedding models
+    type: [enhancement]
+    area: runtime
+    capability: embeddings
+    note: Umbrella issue for first-class dedicated embedding models and an OpenAI-compatible /v1/embeddings endpoint.
+
+  - number: 22
+    title: Add support for Core AI and Apple Foundation Models
+    type: [enhancement, feature-request]
+    area: runtime
+    status: exploratory
+    note: Requested integration of Apple's on-device Foundation Models / Core AI alongside the MLX runtime.
+
+  - number: 23
+    title: Support downloading gated Hugging Face models
+    type: [enhancement, feature-request]
+    area: app
+    capability: gated-hf-download
+    note: Add a secure HF token flow, detect gated repos before download, and distinguish auth vs license vs denied-access failures.
+
+  - number: 24
+    title: Support macOS Sequoia by lowering the deployment target
+    type: [enhancement]
+    area: platform
+    note: App targets macOS 26 while shared components build to 14; audit macOS 26-only APIs and add fallbacks so Sequoia (15) users can run Nativ.
+
+  - number: 26
+    title: Reduce and document the Nativ app bundle footprint
+    type: [enhancement]
+    area: app
+    note: ~1 GB bundle (largely the embedded Python runtime); produce a size breakdown, strip release artifacts, and document why Python is required.
+
+  - number: 27
+    title: Publish reproducible MLX performance benchmarks by Apple chip generation
+    type: [documentation, enhancement]
+    area: docs
+    note: Benchmark M1-M4+ across model sizes/quant/context with a llama.cpp baseline; record TTFT, prefill, decode, and memory.
+
+  - number: 28
+    title: Evaluate DS4 as a backend for DeepSeek V4 Flash
+    type: [enhancement]
+    area: runtime
+    status: exploratory
+    note: Investigate DS4 vs the MLX runtime for DeepSeek V4 Flash on Apple silicon; produce a go/no-go and integration design.
+
+  - number: 29
+    title: Create a Mac hardware, model, and local-use-case guide
+    type: [documentation, enhancement]
+    area: docs
+    note: Guide model/quant choices by memory tier (16/18, 24/32, 48/64+ GB), with heat, power, responsiveness, and workload expectations.
+
+  - number: 30
+    title: Explore an iPad and iPhone version of Nativ
+    type: [enhancement]
+    area: platform
+    status: exploratory
+    note: Feasibility of porting the Swift UI + MLX stack to iPadOS/iOS; identify macOS-only dependencies and realistic on-device model sizes.
+
+  - number: 31
+    title: Add a public roadmap, changelog, and feature support matrix
+    type: [documentation, enhancement]
+    area: docs
+    note: This manifest and its rendered docs. Users should assess maturity and support without reading commit history.
+
+  - number: 32
+    title: Rewrite the landing page with concrete, unambiguous product messaging
+    type: [documentation]
+    area: website
+    note: Replace "frontier intelligence" and generic slogans with concrete capabilities, limitations, and realistic model claims.
+
+  - number: 34
+    title: Fix landing-page overflow and responsive mobile layout
+    type: [bug]
+    area: website
+    note: Remove horizontal overflow and fix mobile rendering at 320/375/390/430 px; add viewport screenshot/browser tests.
+
+  - number: 35
+    title: Replace the contradictory "Universal · Apple Silicon" platform label
+    type: [bug]
+    area: website
+    note: '"Universal" implies Intel+Apple silicon; use "Apple silicon · M1 or later" and state macOS + memory requirements alongside it.'
+
+  - number: 44
+    title: "Image-generation model support: memory-architecture suggestions & gotchas"
+    type: [enhancement, feature-request]
+    area: runtime
+    capability: image-generation
+    children: [46]
+    note: External contributor guidance on diffusion serving/memory (staged component load/evict, tiled VAE decode, activation-peak sizing).
+
+  - number: 46
+    title: Image-gen fit estimate is weights-only and misleads for diffusion
+    type: [enhancement]
+    area: app
+    capability: image-generation
+    part_of: 44
+    depends_on: [14]
+    note: Weights-only fit estimate can pass "likely fits" then OOM at generation; needs an activation-peak reserve and multi-component aggregation.
+
+  - number: 56
+    title: /v1/models data - VSCode extension (Language Model Chat Provider)
+    type: [enhancement, feature-request]
+    area: server
+    capability: model-metadata-api
+    note: Community VSCode Language Model Chat Provider works for Ask/Plan; Agent mode is blocked and context/tools/vision are hardcoded because /v1/models lacks that metadata. The pin-icon refresh lag is a VSCode-side bug (also seen with Ollama), not actionable in Nativ.
+
+# ---------------------------------------------------------------------------------------
+# Changelog — one entry per release, newest first. Add an entry when you cut a release.
+# ---------------------------------------------------------------------------------------
+changelog:
+  - version: "0.0.1"
+    date: "2026-07"
+    notes:
+      - Initial public release.
+      - Local chat and vision with streaming, image attachments, reasoning output, and persistent history.
+      - Model library — discover, browse, download, inspect, switch, and remove MLX models.
+      - Performance analytics dashboard.
+      - OpenAI- and Anthropic-compatible local API server.
+      - Coding-tool integrations (Codex, Claude Code, Pi, Hermes, OpenCode), developer workspace, and menu bar controls.
+      - Advanced inference controls — sampling, thinking budgets, structured output, KV-cache quantization, prefix caching, and speculative decoding.

--- a/nativ.yml
+++ b/nativ.yml
@@ -41,13 +41,13 @@ capabilities:
     title: Local chat & vision
     status: shipped
     provider: mlx-vlm
-    note: Streaming conversations, image attachments, reasoning output, response metrics, and persistent chat history.
+    note: Streaming conversations, image attachments (including clipboard paste and screenshot capture, PR #39), reasoning output, response metrics, and persistent chat history.
 
   - id: model-library
     title: Model library
     status: shipped
     provider: mlx-vlm
-    note: Discover installed MLX models, browse compatible Hugging Face models, download, inspect capabilities, switch, or remove.
+    note: Discover installed MLX models (including those installed by LM Studio, PR #21), browse compatible Hugging Face models, download, inspect capabilities, switch, or remove.
 
   - id: performance-analytics
     title: Performance analytics
@@ -77,7 +77,7 @@ capabilities:
     title: Developer workspace
     status: shipped
     provider: nativ
-    note: Runtime details, copyable endpoint URLs, live server-log search/filter, and server-health monitoring.
+    note: Set the server port, add a Hugging Face token for gated models, inspect runtime details, copy endpoint URLs, search/filter live server logs, and monitor server health.
 
   - id: menu-bar
     title: Menu bar controls
@@ -93,16 +93,16 @@ capabilities:
 
   - id: custom-server-port
     title: Custom local server port
-    status: experimental
+    status: shipped
     provider: nativ
-    note: Choose the local server port from the Developer page (in progress on feature/custom-server-port; not yet on main).
+    note: Choose the local server port from the Developer page (PRs #19, #51).
 
   - id: gated-hf-download
     title: Gated Hugging Face model downloads
-    status: planned
+    status: shipped
     provider: nativ
     issues: [23]
-    note: Authenticate with Hugging Face to download license-gated / access-requested models from within Nativ.
+    note: Add a Hugging Face token (in the Developer view or via HF_TOKEN) to download gated models (PR #49). Issue #23 tracks remaining polish.
 
   - id: audio-models
     title: Dedicated audio models (speech recognition & speech generation)
@@ -151,7 +151,7 @@ capabilities:
       - { done: false, text: "Wire the workspace: progress, cancellation, previews, and save/export." }
       - { done: false, text: "Report load failures, generation failures, and unsupported parameters." }
       - { done: false, text: "Track image-generation requests and timing in analytics." }
-      - { done: false, text: "Make the memory fit estimate activation-aware for diffusion (peak reserve, not weights-only). [#46]" }
+      - { done: true, text: "Make the memory fit estimate activation-aware for diffusion (peak reserve, not weights-only). [#46, PR #47]" }
 
   - id: model-metadata-api
     title: Model metadata in /v1/models (context window, tools, vision)
@@ -306,7 +306,7 @@ issues:
     capability: image-generation
     part_of: 44
     depends_on: [14]
-    note: Weights-only fit estimate can pass "likely fits" then OOM at generation; needs an activation-peak reserve and multi-component aggregation.
+    note: Weights-only fit estimate can pass "likely fits" then OOM at generation. Activation-peak reserve landed in merged PR #47; issue remains open for multi-component (text encoder + transformer + VAE) aggregation.
 
   - number: 56
     title: /v1/models data - VSCode extension (Language Model Chat Provider)
@@ -314,6 +314,12 @@ issues:
     area: server
     capability: model-metadata-api
     note: Community VSCode Language Model Chat Provider works for Ask/Plan; Agent mode is blocked and context/tools/vision are hardcoded because /v1/models lacks that metadata. The pin-icon refresh lag is a VSCode-side bug (also seen with Ollama), not actionable in Nativ.
+
+  - number: 57
+    title: Allow installation as Homebrew Cask
+    type: [enhancement]
+    area: platform
+    note: Publish a Homebrew Cask so Nativ can be installed and auto-updated via `brew install --cask`, alongside the DMG download and build-from-source paths.
 
 # ---------------------------------------------------------------------------------------
 # Changelog — one entry per release, newest first. Add an entry when you cut a release.

--- a/scripts/coalesce_dependencies.py
+++ b/scripts/coalesce_dependencies.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Flag issues whose dependencies just completed (Phase 0 — same repo only).
+
+The dependency graph lives in nativ.yml as `depends_on: [<issue number>, ...]`.
+An issue's dependency is considered completed when either:
+
+  * that issue is closed on GitHub (`--closed-issue N`), or
+  * a manifest edit marks it done (`--previous`/`--current`): the issue was
+    removed, or its tracking capability flipped to `shipped`, or that
+    capability's task list became fully checked.
+
+For every dependent still open in the manifest, we post one comment saying it is
+ready to start. Comments carry a hidden marker so re-runs never duplicate them.
+
+Cross-repo coalescing (labelling issues in mlx-vlm / mlx-audio / mlx-embeddings)
+is intentionally out of scope here; it needs the GitHub App and lands in a later
+phase.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+MARKER = "<!-- nativ-coalesce:{dep} -->"
+
+
+def load(path):
+    if not path or not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _fully_done(cap):
+    tasks = cap.get("tasks", [])
+    return bool(tasks) and all(t.get("done") for t in tasks)
+
+
+def completed_from_diff(prev, cur):
+    """Issue numbers that a manifest edit marks as completed."""
+    if not prev:
+        return set()
+    done = set()
+    prev_nums = {i["number"] for i in prev.get("issues", [])}
+    cur_nums = {i["number"] for i in cur.get("issues", [])}
+    done |= prev_nums - cur_nums  # removed from the backlog
+
+    prev_caps = {c["id"]: c for c in prev.get("capabilities", [])}
+    for c in cur.get("capabilities", []):
+        was = prev_caps.get(c["id"])
+        if not was:
+            continue
+        shipped_now = c.get("status") == "shipped" and was.get("status") != "shipped"
+        tasks_now = _fully_done(c) and not _fully_done(was)
+        if shipped_now or tasks_now:
+            done |= set(c.get("issues", []))
+    return done
+
+
+def dependents(cur, completed):
+    """Open manifest issues that depend on any completed issue."""
+    out = []
+    for i in cur.get("issues", []):
+        blockers = set(i.get("depends_on", [])) & completed
+        if blockers:
+            out.append((i, sorted(blockers)))
+    return out
+
+
+def _run(args, **kw):
+    return subprocess.run(args, text=True, capture_output=True, **kw)
+
+
+def already_commented(number, dep, repo):
+    marker = MARKER.format(dep=dep)
+    r = _run(["gh", "issue", "view", str(number), "-R", repo, "--json", "comments"])
+    if r.returncode != 0:
+        return False
+    try:
+        comments = json.loads(r.stdout).get("comments", [])
+    except json.JSONDecodeError:
+        return False
+    return any(marker in (c.get("body") or "") for c in comments)
+
+
+def comment(number, deps, repo, dry_run):
+    for dep in deps:
+        if already_commented(number, dep, repo):
+            continue
+        body = (
+            f"{MARKER.format(dep=dep)}\n"
+            f"Dependency #{dep} is complete, so this issue is now **ready to start**.\n\n"
+            f"_Posted automatically from `nativ.yml`._"
+        )
+        if dry_run:
+            print(f"[dry-run] would comment on #{number} (dependency #{dep})")
+            continue
+        r = _run(["gh", "issue", "comment", str(number), "-R", repo, "--body", body])
+        if r.returncode != 0:
+            print(f"failed to comment on #{number}: {r.stderr}", file=sys.stderr)
+        else:
+            print(f"commented on #{number} (dependency #{dep})")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--current", default="nativ.yml")
+    ap.add_argument("--previous", help="prior nativ.yml (push diff)")
+    ap.add_argument("--closed-issue", type=int, help="issue number just closed")
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "Blaizzy/nativ"))
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    cur = load(args.current)
+    if cur is None:
+        sys.exit(f"missing manifest: {args.current}")
+
+    completed = completed_from_diff(load(args.previous), cur)
+    if args.closed_issue:
+        completed.add(args.closed_issue)
+
+    if not completed:
+        print("no completed dependencies; nothing to do.")
+        return
+
+    hits = dependents(cur, completed)
+    if not hits:
+        print(f"completed {sorted(completed)}; no open dependents.")
+        return
+
+    for issue, deps in hits:
+        comment(issue["number"], deps, args.repo, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_manifest.py
+++ b/scripts/render_manifest.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Render Nativ's capability manifest (nativ.yml) into human-readable docs.
+
+nativ.yml is the single source of truth. SUPPORT_MATRIX.md, ROADMAP.md, and
+CHANGELOG.md are generated from it and must never be edited by hand.
+
+Usage:
+  scripts/render_manifest.py           # write the three generated docs
+  scripts/render_manifest.py --check   # validate the manifest and fail on drift
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "nativ.yml"
+GENERATED = "<!-- Generated from nativ.yml by scripts/render_manifest.py. Do not edit by hand. -->"
+
+STATUS_ORDER = ["shipped", "experimental", "planned", "exploratory"]
+STATUS_LABEL = {
+    "shipped": "Shipped",
+    "experimental": "Experimental",
+    "planned": "Planned",
+    "exploratory": "Exploratory",
+}
+
+
+def load():
+    with open(MANIFEST) as f:
+        return yaml.safe_load(f)
+
+
+def validate(m):
+    errs = []
+    caps = m.get("capabilities", [])
+    issues = m.get("issues", [])
+
+    cap_ids = set()
+    for c in caps:
+        for k in ("id", "title", "status"):
+            if k not in c:
+                errs.append(f"capability missing '{k}': {c.get('id', c)}")
+        if c.get("status") not in STATUS_ORDER:
+            errs.append(f"capability '{c.get('id')}': invalid status '{c.get('status')}'")
+        if c.get("id") in cap_ids:
+            errs.append(f"duplicate capability id '{c.get('id')}'")
+        cap_ids.add(c.get("id"))
+        for t in c.get("tasks", []):
+            if "done" not in t or "text" not in t:
+                errs.append(f"capability '{c.get('id')}': malformed task {t}")
+
+    nums = set()
+    for i in issues:
+        if "number" not in i:
+            errs.append(f"issue missing 'number': {i}")
+        if i.get("number") in nums:
+            errs.append(f"duplicate issue #{i.get('number')}")
+        nums.add(i.get("number"))
+
+    for c in caps:
+        for n in c.get("issues", []):
+            if n not in nums:
+                errs.append(f"capability '{c['id']}' references missing issue #{n}")
+    for i in issues:
+        if i.get("capability") and i["capability"] not in cap_ids:
+            errs.append(f"issue #{i['number']} references missing capability '{i['capability']}'")
+        for edge in ("depends_on", "children"):
+            for n in i.get(edge, []):
+                if n not in nums:
+                    errs.append(f"issue #{i['number']} {edge} references missing #{n}")
+        if i.get("part_of") and i["part_of"] not in nums:
+            errs.append(f"issue #{i['number']} part_of references missing #{i['part_of']}")
+    return errs
+
+
+def _task_progress(cap):
+    tasks = cap.get("tasks", [])
+    if not tasks:
+        return None
+    done = sum(1 for t in tasks if t.get("done"))
+    return done, len(tasks)
+
+
+def render_support_matrix(m):
+    repo = m["meta"]["repo"]
+    lines = [
+        "# Nativ — Feature Support Matrix",
+        "",
+        GENERATED,
+        "",
+        "Status: **Shipped** (in the current release) · **Experimental** (usable but "
+        "unstable / in active development) · **Planned** (committed) · **Exploratory** "
+        "(under investigation).",
+        "",
+        "## Capabilities",
+        "",
+        "| Capability | Status | Provider | Notes |",
+        "| --- | --- | --- | --- |",
+    ]
+    caps = sorted(
+        m["capabilities"],
+        key=lambda c: (STATUS_ORDER.index(c["status"]), c["title"].lower()),
+    )
+    for c in caps:
+        status = STATUS_LABEL[c["status"]]
+        prog = _task_progress(c)
+        if prog:
+            status += f" ({prog[0]}/{prog[1]})"
+        issues = " ".join(f"#{n}" for n in c.get("issues", []))
+        note = c.get("note", "")
+        if issues:
+            note = f"{note} ({issues})" if note else issues
+        lines.append(f"| {c['title']} | {status} | {c.get('provider', '')} | {note} |")
+
+    lines += ["", "## Runtime providers", "", "| Provider | Role | Version | Repo |", "| --- | --- | --- | --- |"]
+    for name, p in m["meta"]["providers"].items():
+        version = p.get("version") or "—"
+        repo_ref = p.get("repo", "")
+        lines.append(f"| {name} | {p.get('role', '')} | `{version}` | {repo_ref} |")
+
+    plat = m["meta"]["platform"]
+    lines += [
+        "",
+        "## Platform",
+        "",
+        f"- Apple silicon: **{plat.get('apple_silicon', 'required')}** (M1 or later)",
+        f"- Minimum macOS: **{plat.get('macos_min')}**",
+        "",
+        f"See [ROADMAP.md](ROADMAP.md) for planned work and [CHANGELOG.md](CHANGELOG.md) "
+        f"for release history. Tracked in [{repo} issues](https://github.com/{repo}/issues).",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_roadmap(m):
+    repo = m["meta"]["repo"]
+    caps = m["capabilities"]
+    lines = [
+        "# Nativ — Roadmap",
+        "",
+        GENERATED,
+        "",
+        "Committed and exploratory work, rendered from `nativ.yml`. Shipped capabilities "
+        "are in [SUPPORT_MATRIX.md](SUPPORT_MATRIX.md).",
+        "",
+    ]
+
+    for status in ("experimental", "planned", "exploratory"):
+        group = [c for c in caps if c["status"] == status]
+        if not group:
+            continue
+        lines += [f"## {STATUS_LABEL[status]}", ""]
+        for c in sorted(group, key=lambda c: c["title"].lower()):
+            refs = " ".join(f"#{n}" for n in c.get("issues", []))
+            head = f"### {c['title']}"
+            if refs:
+                head += f" ({refs})"
+            lines.append(head)
+            if c.get("note"):
+                lines += ["", c["note"]]
+            tasks = c.get("tasks", [])
+            if tasks:
+                lines.append("")
+                for t in tasks:
+                    box = "x" if t.get("done") else " "
+                    lines.append(f"- [{box}] {t['text']}")
+            lines.append("")
+
+    lines += ["## Backlog by area", ""]
+    areas = sorted({i.get("area", "other") for i in m["issues"]})
+    for area in areas:
+        rows = [i for i in m["issues"] if i.get("area", "other") == area]
+        lines += [f"### {area}", ""]
+        for i in sorted(rows, key=lambda i: i["number"]):
+            edges = []
+            if i.get("part_of"):
+                edges.append(f"part of #{i['part_of']}")
+            if i.get("depends_on"):
+                edges.append("depends on " + ", ".join(f"#{n}" for n in i["depends_on"]))
+            if i.get("children"):
+                edges.append("includes " + ", ".join(f"#{n}" for n in i["children"]))
+            suffix = f" _( {'; '.join(edges)} )_" if edges else ""
+            lines.append(
+                f"- [#{i['number']}](https://github.com/{repo}/issues/{i['number']}) "
+                f"{i['title']}{suffix}"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def render_changelog(m):
+    lines = ["# Changelog", "", GENERATED, ""]
+    for rel in m.get("changelog", []):
+        header = f"## {rel['version']}"
+        if rel.get("date"):
+            header += f" — {rel['date']}"
+        lines += [header, ""]
+        for note in rel.get("notes", []):
+            lines.append(f"- {note}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+DOCS = {
+    "SUPPORT_MATRIX.md": render_support_matrix,
+    "ROADMAP.md": render_roadmap,
+    "CHANGELOG.md": render_changelog,
+}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true", help="validate + fail on drift instead of writing")
+    args = ap.parse_args()
+
+    m = load()
+    errs = validate(m)
+    if errs:
+        print("Manifest validation failed:", file=sys.stderr)
+        for e in errs:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.check:
+        stale = []
+        for name, fn in DOCS.items():
+            want = fn(m).rstrip("\n") + "\n"
+            path = ROOT / name
+            have = path.read_text() if path.exists() else None
+            if have != want:
+                stale.append(name)
+        if stale:
+            print("Generated docs are out of date with nativ.yml:", file=sys.stderr)
+            for s in stale:
+                print(f"  - {s}", file=sys.stderr)
+            print("\nRun: python3 scripts/render_manifest.py", file=sys.stderr)
+            sys.exit(1)
+        print("Manifest valid and docs in sync.")
+        return
+
+    for name, fn in DOCS.items():
+        (ROOT / name).write_text(fn(m).rstrip("\n") + "\n")
+        print(f"wrote {name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
nativ.yml is the single source of truth for capabilities, their status, the issue backlog, and an issue dependency graph. SUPPORT_MATRIX.md, ROADMAP.md, and CHANGELOG.md are generated from it by scripts/render_manifest.py; the README links all three.

CI:
- Manifest: validates nativ.yml and fails a PR when the generated docs drift.
- Manifest dependency coalescing: when an issue closes, or a manifest edit marks an issue done (removed, or its capability shipped / tasks all checked), comment on any open issue that depends_on it that it is ready to start. Same-repo only; cross-repo coalescing is deferred to a later phase.

next phase is like cross-repo automation, so manifest edit or closed issue in one repo can comment/label a dependent issue in another

this is draft atm