### PR TITLE
Fix chat scrolling during streaming

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -24,6 +24,7 @@ struct ChatView: View {
     @State private var transcriptScrollPosition = ScrollPosition(edge: .bottom)
     @State private var composerHeight: CGFloat = 0
     @State private var followsLatestMessage = true
+    @State private var isUserScrollingTranscript = false
 
     var body: some View {
         ModelConfigurationLayout(
@@ -114,10 +115,24 @@ struct ChatView: View {
             .padding(.bottom, max(18, composerHeight))
         }
         .scrollPosition($transcriptScrollPosition)
-        .onScrollGeometryChange(for: Bool.self) { geometry in
-            geometry.visibleRect.maxY >= geometry.contentSize.height - 160
-        } action: { _, isNearBottom in
-            followsLatestMessage = isNearBottom
+        .onScrollPhaseChange { _, newPhase, context in
+            switch newPhase {
+            case .tracking, .interacting:
+                isUserScrollingTranscript = true
+                followsLatestMessage = false
+            case .decelerating:
+                if isUserScrollingTranscript {
+                    followsLatestMessage = false
+                }
+            case .idle:
+                guard isUserScrollingTranscript else {
+                    return
+                }
+                isUserScrollingTranscript = false
+                followsLatestMessage = isAtTranscriptBottom(context.geometry)
+            case .animating:
+                break
+            }
         }
         .onChange(of: chat.scrollToken) { _, _ in
             if followsLatestMessage {
@@ -132,6 +147,10 @@ struct ChatView: View {
             followsLatestMessage = true
             transcriptScrollPosition.scrollTo(edge: .bottom)
         }
+    }
+
+    private func isAtTranscriptBottom(_ geometry: ScrollGeometry) -> Bool {
+        geometry.visibleRect.maxY >= geometry.contentSize.height - 8
     }
 }
 


### PR DESCRIPTION
## Summary

- Stop automatic transcript following as soon as the user begins scrolling.
- Preserve the user's position through tracking and deceleration.
- Resume following only when the scroll gesture ends at the transcript bottom.

## Root cause

Auto-follow was controlled by a 160-point near-bottom geometry threshold. During streaming, frequent content updates could issue another scroll-to-bottom before an upward gesture moved beyond that threshold, pulling the transcript back down.

## Impact

Users can now scroll up and review earlier messages while a response continues streaming. The transcript still follows new text when the user remains at the bottom.

## Validation

- `make xcode-build`
- Full Xcode unit-test scheme: 33 tests passed, 0 failures