### PR TITLE
Fix chat dropdown positioning

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -604,7 +604,9 @@ private struct ChatModelPickerMenuControl: NSViewRepresentable {
                 positioning: nil,
                 at: NSPoint(
                     x: -8,
-                    y: sender.bounds.maxY + menu.size.height + 4
+                    y: sender.isFlipped
+                        ? sender.bounds.minY - menu.size.height - 4
+                        : sender.bounds.maxY + menu.size.height + 4
                 ),
                 in: sender
             )


### PR DESCRIPTION
## Summary

- Position the chat model/reasoning dropdown above its trigger in flipped AppKit coordinates.
- Preserve the existing positioning behavior for non-flipped views.

## Root cause

The SwiftUI-hosted `NSButton` uses a flipped coordinate system, but the menu anchor always used the non-flipped Y calculation. In a normal window, that placed the menu below the composer and outside the app window.

## Impact

The dropdown now opens directly above the model picker and remains visible in normal-sized windows.

## Validation

- Regenerated the Xcode project and completed a successful Debug build.
- Ran the full unit test suite: 33 tests passed.
- Verified the dropdown visually in a 1240×720 runtime window.