### PR TITLE
Allow attaching the signed appcast to an existing release via workfllow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Publish macOS Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)build and attach the signed appcast to"
+        required: true
 
 permissions:
   contents: write
@@ -13,13 +18,13 @@ concurrency:
 
 jobs:
   build-notarize-publish:
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: macos-26
     env:
       APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
       APP_BUNDLE_ID: ${{ vars.NATIV_BUNDLE_IDENTIFIER }}
       FRAMEWORK_BUNDLE_ID: ${{ vars.NATIV_SERVER_KIT_BUNDLE_IDENTIFIER }}
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
       GH_TOKEN: ${{ github.token }}
       SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
       NOTARY_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -29,7 +34,7 @@ jobs:
       - name: Check out release tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Validate release configuration
         env:
@@ -107,8 +112,8 @@ jobs:
           version="${RELEASE_TAG#v}"
           echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
           echo "RELEASE_BUILD_NUMBER=$(date -u +%Y%m%d%H%M)" >> "$GITHUB_ENV"
-          jq -r '.release.body // ""' "$GITHUB_EVENT_PATH" \
-            > "$RUNNER_TEMP/release-notes.md"
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json body --jq '.body // ""' > "$RUNNER_TEMP/release-notes.md"
 
       - name: Build, sign, notarize, and create appcast
         run: |
@@ -120,10 +125,11 @@ jobs:
       - name: Upload notarized app and appcast to GitHub Release
         run: |
           set -euo pipefail
-          upload_url="$(jq -r '.release.upload_url // empty' "$GITHUB_EVENT_PATH")"
+          release_id="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.id')"
+          upload_url="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq '.upload_url')"
           upload_url="${upload_url%%\{*}"
           if [[ "$upload_url" != https://uploads.github.com/* ]]; then
-            echo "::error::Release event does not contain a valid GitHub upload URL"
+            echo "::error::Could not resolve a GitHub upload URL for $RELEASE_TAG"
             exit 1
           fi
 
@@ -134,6 +140,11 @@ jobs:
           for asset in "${assets[@]}"; do
             IFS='|' read -r asset_path content_type <<< "$asset"
             asset_name="$(basename "$asset_path")"
+            existing_asset_id="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id/assets" \
+              --jq ".[] | select(.name == \"$asset_name\") | .id")"
+            if [[ -n "$existing_asset_id" ]]; then
+              gh api -X DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id/assets/$existing_asset_id"
+            fi
             response_path="$RUNNER_TEMP/release-upload-${asset_name}.json"
             curl \
               --silent \


### PR DESCRIPTION


The release workflow only ran on release publish, so a release created outside it (e.g. the first release) has no appcast.xml, and the Sparkle feed at releases/latest/download/appcast.xml returns 404.

Add a workflow_dispatch trigger that takes a tag input and reuses the same build/notarize/appcast/upload path against that existing tag, resolving the tag, upload URL, and release notes from the GitHub API instead of the release event payload, and replacing any same-named asset so re-runs are idempotent.

for issue #85 