### PR TITLE
Invalidate client URLSessions on deinit to fix file-descriptor leak

### DIFF
--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -432,6 +432,10 @@ public final class NativChatClient {
         self.session = URLSession(configuration: configuration)
     }
 
+    deinit {
+        session.finishTasksAndInvalidate()
+    }
+
     public func completeChat(_ request: MLXChatCompletionRequest) async throws -> MLXChatCompletion {
         var payload = request
         payload.stream = false

--- a/Sources/NativServerKit/NativImageClient.swift
+++ b/Sources/NativServerKit/NativImageClient.swift
@@ -191,6 +191,10 @@ public final class NativImageClient {
         self.session = URLSession(configuration: configuration)
     }
 
+    deinit {
+        session.finishTasksAndInvalidate()
+    }
+
     public func generate(_ request: MLXImageGenerationRequest) async throws -> MLXImageResponse {
         try await post(
             request,

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -506,6 +506,10 @@ public final class NativMetricsClient {
         self.session = URLSession(configuration: configuration)
     }
 
+    deinit {
+        session.finishTasksAndInvalidate()
+    }
+
     public func fetchMetrics(apiKey: String? = nil) async throws -> NativMetrics {
         let paths = ["metrics", "v1/metrics"]
         var lastError: Error?


### PR DESCRIPTION
The chat, image, and metrics clients each create an ephemeral URLSession but never invalidate it, so its underlying sockets/file descriptors are retained until process exit. The metrics client is recreated on server start and polled while the app idles, so descriptors accumulate over a long-running session until the process hits its open-file limit, causing  a CoreAnimation "Too many open files" crash seen in #84.

This includes deinit so descriptors are released when the client is deallocated.