### PR TITLE
docs: list all coding-agent and editor integrations in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use Nativ as a private chat app, a model manager, a performance dashboard, or an
 | **Model library** | Discover installed MLX models , browse and download compatible models from Hugging Face with fit warnings for your memory, inspect capabilities, switch models, or remove old ones. |
 | **Performance analytics** | Track request volume, token usage, time to first token, decode speed, model performance, and recent activity. |
 | **Local APIs** | OpenAI-compatible chat, Responses, image, audio, and model endpoints, plus Anthropic Messages endpoints. |
-| **Coding-tool integrations** | Configure and launch Codex, Claude Code, Pi, Hermes, and OpenCode against models served by Nativ. |
+| **Coding-tool integrations** | Launch terminal coding agents — Codex, Claude Code, Pi, Hermes, OpenCode, Aider, Goose, Crush, Qwen Code, OpenClaw — and set up editors — VS Code, Cursor, Zed, JetBrains, Cline, Continue — against models served by Nativ. |
 | **Developer workspace** | Set the server port, add a Hugging Face token for gated models, inspect runtime details, copy endpoint URLs, search and filter live server logs, and monitor server health. |
 | **Menu bar controls** | Start or stop the server, change the loaded model, check serving statistics, and open the main app without breaking focus. |
 | **Advanced inference controls** | Tune sampling, thinking budgets, structured output, KV-cache quantization, prefix caching, and speculative decoding. |
@@ -82,7 +82,7 @@ On first launch:
 1. Choose an installed language model, download a recommended one, or continue with load-on-demand.
 2. Optionally generate an API key to protect the server's management endpoints.
 3. Open **Models** to download or select a compatible model.
-4. Start chatting, inspect analytics, or connect one of the supported coding tools.
+4. Start chatting, inspect analytics, or connect one of the supported coding agents and editors.
 
 ### Build from source
 


### PR DESCRIPTION
The **Coding-tool integrations** feature row still listed only the original five tools. This updates it to the full set now on `main`, and adjusts the quick-start step to match.

## Changes
- **Feature table** — now lists terminal coding agents (Codex, Claude Code, Pi, Hermes, OpenCode, Aider, Goose, Crush, Qwen Code, OpenClaw) and editors (VS Code, Cursor, Zed, JetBrains, Cline, Continue).
- **Quick start** — "supported coding tools" → "supported coding agents and editors".

Docs-only; no build/test impact.