### PR TITLE
Add configurable server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use Nativ as a private chat app, a model manager, a performance dashboard, or an
 | **System monitor** | Inspect live per-core CPU load, GPU utilization, unified memory and swap pressure, disk throughput, capacity, and SMART health. |
 | **Local APIs** | OpenAI-compatible chat, Responses, image, audio, and model endpoints, plus Anthropic Messages endpoints. |
 | **Coding-tool integrations** | Configure and launch Codex, Claude Code, Pi, Hermes, and OpenCode against models served by Nativ. |
-| **Developer workspace** | Set the server port, add a Hugging Face token for gated models, inspect runtime details, copy endpoint URLs, search and filter live server logs, and monitor server health. |
+| **Developer workspace** | Set the server host and port, add a Hugging Face token for gated models, inspect runtime details, copy endpoint URLs, search and filter live server logs, and monitor server health. |
 | **Menu bar controls** | Start or stop the server, change the loaded model, check serving statistics, open the main app without breaking focus, or pin multiple live CPU, GPU, and RAM percentages and mini graphs. |
 | **Advanced inference controls** | Tune sampling, thinking budgets, structured output, KV-cache quantization, prefix caching, and speculative decoding. |
 
@@ -98,7 +98,7 @@ The first build can take a while because `NativServerKit` creates a relocatable 
 
 ## Use Nativ as a local API server
 
-By default, the app exposes its server at `http://127.0.0.1:8080`. You can change the port in the Developer page, which also lists every available endpoint and lets you copy URLs directly.
+By default, the app exposes its server at `http://127.0.0.1:8080`. You can change the host and port in the Developer page, which also lists every available endpoint and lets you copy URLs directly.
 
 For example, with a model selected:
 

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -123,6 +123,7 @@ private struct ChatImageToolExecutor {
         call: MLXChatToolCall,
         modelID: String,
         baseURL: URL,
+        apiKey: String?,
         references: [ChatImageAttachment]
     ) async throws -> ChatImageToolExecution {
         guard let name = call.function?.name else {
@@ -156,6 +157,7 @@ private struct ChatImageToolExecutor {
         )
         let outputs = try await ImageGenerationExecutor().run(
             baseURL: baseURL,
+            apiKey: apiKey,
             modelID: modelID,
             prompt: prompt,
             references: name == "edit_image" ? references : [],
@@ -801,7 +803,10 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func runChatLoop(_ queuedRequest: QueuedChatRequest) async throws {
-        let client = NativChatClient(baseURL: queuedRequest.settings.serverBaseURL)
+        let client = NativChatClient(
+            baseURL: queuedRequest.settings.serverBaseURL,
+            apiKey: queuedRequest.settings.serverAPIKey
+        )
         var assistantMessageID = queuedRequest.assistantMessageID
         var toolRounds = 0
         let maximumToolRounds = 4
@@ -867,6 +872,7 @@ final class ChatViewModel: ObservableObject {
                         call: toolCall,
                         modelID: imageModelID,
                         baseURL: queuedRequest.settings.serverBaseURL,
+                        apiKey: queuedRequest.settings.serverAPIKey,
                         references: references
                     )
                     updateToolMessage(

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -14,9 +14,7 @@ struct DeveloperView: View {
     @State private var logQuery = ""
     @State private var logLevelFilter: LogLevelFilter = .all
     @State private var selectedEndpointCategory: ServerEndpointCategory = .openAI
-    @State private var isSelectedEndpointAvailable = true
-    @State private var pendingServerRestartID: UUID?
-    @State private var serverRestartCountdown: Int?
+    @State private var selectedEndpointAvailability: ServerEndpointAvailability = .available
 
     var body: some View {
         ModelConfigurationLayout(
@@ -192,9 +190,9 @@ struct DeveloperView: View {
 
             serverRestartIndicator
 
-            if showsEndpointInUseWarning {
+            if let endpointAvailabilityWarning {
                 Label(
-                    "\(model.settings.serverBaseURL.absoluteString) is unavailable — the server can’t use that address.",
+                    endpointAvailabilityWarning,
                     systemImage: "exclamationmark.triangle.fill"
                 )
                 .font(.footnote)
@@ -225,21 +223,21 @@ struct DeveloperView: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
-        .task(id: serverEndpointProbeID) {
-            await restartServerAfterEndpointChange()
+        .onChange(of: serverEndpointProbeID) {
+            model.scheduleServerRestartForEndpointChange()
         }
     }
 
     @ViewBuilder
     private var serverRestartIndicator: some View {
-        if let serverRestartCountdown {
-            let timeUnit = serverRestartCountdown == 1 ? "second" : "seconds"
+        if let countdown = model.serverRestartCountdown {
+            let timeUnit = countdown == 1 ? "second" : "seconds"
 
             HStack(spacing: 8) {
                 ProgressView()
                     .controlSize(.small)
 
-                Text("Applying endpoint change — restarting server in \(serverRestartCountdown) \(timeUnit)…")
+                Text("Applying endpoint change — restarting server in \(countdown) \(timeUnit)…")
                     .font(.footnote.weight(.medium))
             }
             .foregroundStyle(.blue)
@@ -280,15 +278,15 @@ struct DeveloperView: View {
                 }
         }
         .help("The port the local server listens on. Changes restart a running server after 3 seconds.")
-        .task(id: serverEndpointProbeID) {
+        .task(id: serverEndpointAvailabilityProbeID) {
             try? await Task.sleep(for: .milliseconds(250))
             guard !Task.isCancelled else { return }
             let settings = model.settings.normalized()
-            let available = await Task.detached {
-                ServerPortProbe.isAvailable(host: settings.serverHost, port: settings.serverPort)
+            let availability = await Task.detached {
+                ServerPortProbe.availability(host: settings.serverHost, port: settings.serverPort)
             }.value
             guard !Task.isCancelled else { return }
-            isSelectedEndpointAvailable = available
+            selectedEndpointAvailability = availability
         }
     }
 
@@ -313,59 +311,27 @@ struct DeveloperView: View {
         return "\(settings.serverHost):\(settings.serverPort)"
     }
 
-    private var showsEndpointInUseWarning: Bool {
+    private var serverEndpointAvailabilityProbeID: String {
+        let activeEndpoint = model.activeServerBaseURL?.absoluteString ?? "offline"
+        return "\(serverEndpointProbeID):\(activeEndpoint)"
+    }
+
+    private var endpointAvailabilityWarning: String? {
         let settings = model.settings.normalized()
         let isActiveEndpoint = settings.serverHost == model.activeServerHost
             && settings.serverPort == model.activeServerPort
-        return !isSelectedEndpointAvailable && !isActiveEndpoint
-    }
-
-    private func restartServerAfterEndpointChange() async {
-        guard model.isRunning else {
-            return
+        guard !isActiveEndpoint, model.serverRestartCountdown == nil else {
+            return nil
         }
 
-        let scheduledSettings = model.settings.normalized()
-        let endpointHasChanged = scheduledSettings.serverHost != model.activeServerHost
-            || scheduledSettings.serverPort != model.activeServerPort
-        guard endpointHasChanged else {
-            return
+        switch selectedEndpointAvailability {
+        case .available:
+            return nil
+        case .addressInUse:
+            return "\(settings.serverBaseURL.absoluteString) is already in use — Nativ can’t bind to that address."
+        case .invalidAddress:
+            return "\(settings.serverBaseURL.absoluteString) can’t be used — check the host and port."
         }
-
-        let restartID = UUID()
-        pendingServerRestartID = restartID
-        defer {
-            if pendingServerRestartID == restartID {
-                pendingServerRestartID = nil
-                serverRestartCountdown = nil
-            }
-        }
-
-        for secondsRemaining in stride(from: 3, through: 1, by: -1) {
-            serverRestartCountdown = secondsRemaining
-            do {
-                try await Task.sleep(for: .seconds(1))
-            } catch {
-                return
-            }
-            guard !Task.isCancelled, model.isRunning else {
-                return
-            }
-        }
-
-        let currentSettings = model.settings.normalized()
-        guard currentSettings.serverHost == scheduledSettings.serverHost,
-              currentSettings.serverPort == scheduledSettings.serverPort
-        else {
-            return
-        }
-
-        let endpointStillNeedsRestart = currentSettings.serverHost != model.activeServerHost
-            || currentSettings.serverPort != model.activeServerPort
-        guard endpointStillNeedsRestart else {
-            return
-        }
-        model.restartServer()
     }
 
     private var endpointCategoryPicker: some View {

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -150,7 +150,7 @@ struct DeveloperView: View {
                 get: { model.settings.huggingFaceToken ?? "" },
                 set: { model.settings.huggingFaceToken = $0.isEmpty ? nil : $0 }
             ),
-            systemTokenSource: model.systemHuggingFaceCredential?.source
+            systemCredential: model.systemHuggingFaceCredential
         )
     }
 
@@ -511,18 +511,28 @@ private struct PanelHeaderAccent: View {
 
 private struct HuggingFaceAuthenticationPanel: View {
     @Binding var customToken: String
-    let systemTokenSource: HuggingFaceTokenSource?
+    let systemCredential: HuggingFaceCredential?
     @State private var isCustomTokenExpanded: Bool
     @State private var hasSelectedDisclosureState = false
 
-    init(customToken: Binding<String>, systemTokenSource: HuggingFaceTokenSource?) {
+    init(customToken: Binding<String>, systemCredential: HuggingFaceCredential?) {
         _customToken = customToken
-        self.systemTokenSource = systemTokenSource
-        _isCustomTokenExpanded = State(initialValue: systemTokenSource == nil)
+        self.systemCredential = systemCredential
+        _isCustomTokenExpanded = State(initialValue: systemCredential == nil)
     }
 
     private var hasCustomToken: Bool {
         HuggingFaceAuthentication.normalizedToken(customToken) != nil
+    }
+
+    private var systemTokenSource: HuggingFaceTokenSource? {
+        systemCredential?.source
+    }
+
+    private var activeTokenSummary: String? {
+        HuggingFaceAuthentication.tokenSummary(
+            hasCustomToken ? customToken : systemCredential?.token
+        )
     }
 
     var body: some View {
@@ -541,9 +551,19 @@ private struct HuggingFaceAuthenticationPanel: View {
 
                 Spacer()
 
-                Label(authenticationStatus, systemImage: authenticationStatusImage)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(authenticationStatusColor)
+                VStack(alignment: .trailing, spacing: 2) {
+                    Label(authenticationStatus, systemImage: authenticationStatusImage)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(authenticationStatusColor)
+
+                    if let activeTokenSummary {
+                        Text(activeTokenSummary)
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .privacySensitive()
+                    }
+                }
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -146,11 +146,10 @@ struct DeveloperView: View {
 
     private var huggingFaceAuthenticationPanel: some View {
         HuggingFaceAuthenticationPanel(
-            customToken: Binding(
-                get: { model.settings.huggingFaceToken ?? "" },
-                set: { model.settings.huggingFaceToken = $0.isEmpty ? nil : $0 }
-            ),
-            systemCredential: model.systemHuggingFaceCredential
+            customToken: model.settings.huggingFaceToken,
+            systemCredential: model.systemHuggingFaceCredential,
+            onSetCustomToken: model.setCustomHuggingFaceToken,
+            onLogOutSystemCredential: model.logOutSystemHuggingFaceCredential
         )
     }
 
@@ -510,16 +509,15 @@ private struct PanelHeaderAccent: View {
 }
 
 private struct HuggingFaceAuthenticationPanel: View {
-    @Binding var customToken: String
+    let customToken: String?
     let systemCredential: HuggingFaceCredential?
-    @State private var isCustomTokenExpanded: Bool
-    @State private var hasSelectedDisclosureState = false
-
-    init(customToken: Binding<String>, systemCredential: HuggingFaceCredential?) {
-        _customToken = customToken
-        self.systemCredential = systemCredential
-        _isCustomTokenExpanded = State(initialValue: systemCredential == nil)
-    }
+    let onSetCustomToken: (String?) -> Void
+    let onLogOutSystemCredential: () throws -> Void
+    @State private var replacementToken = ""
+    @State private var isReplacingToken = false
+    @State private var showsLogoutConfirmation = false
+    @State private var managementError: String?
+    @FocusState private var replacementFieldIsFocused: Bool
 
     private var hasCustomToken: Bool {
         HuggingFaceAuthentication.normalizedToken(customToken) != nil
@@ -529,10 +527,14 @@ private struct HuggingFaceAuthenticationPanel: View {
         systemCredential?.source
     }
 
-    private var activeTokenSummary: String? {
-        HuggingFaceAuthentication.tokenSummary(
+    private var activeTokenInfo: HuggingFaceTokenInfo? {
+        HuggingFaceAuthentication.tokenInfo(
             hasCustomToken ? customToken : systemCredential?.token
         )
+    }
+
+    private var hasActiveCredential: Bool {
+        hasCustomToken || systemCredential != nil
     }
 
     var body: some View {
@@ -551,19 +553,15 @@ private struct HuggingFaceAuthenticationPanel: View {
 
                 Spacer()
 
-                VStack(alignment: .trailing, spacing: 2) {
-                    Label(authenticationStatus, systemImage: authenticationStatusImage)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(authenticationStatusColor)
-
-                    if let activeTokenSummary {
-                        Text(activeTokenSummary)
-                            .font(.caption2.monospaced())
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .privacySensitive()
-                    }
-                }
+                Label(authenticationStatus, systemImage: authenticationStatusImage)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(authenticationStatusColor)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(
+                        authenticationStatusColor.opacity(0.12),
+                        in: Capsule()
+                    )
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
@@ -571,63 +569,78 @@ private struct HuggingFaceAuthenticationPanel: View {
 
             Divider()
 
-            VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        isCustomTokenExpanded.toggle()
-                        hasSelectedDisclosureState = true
-                    }
-                } label: {
-                    HStack(spacing: 10) {
-                        Image(systemName: "chevron.right")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.tertiary)
-                            .rotationEffect(.degrees(isCustomTokenExpanded ? 90 : 0))
-                            .frame(width: 10)
+            VStack(alignment: .leading, spacing: 12) {
+                credentialOverview
 
-                        Text("Use Custom Token")
+                Divider()
+
+                HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Custom Token Override")
                             .font(.callout.weight(.medium))
-
-                        Spacer()
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Use Custom Token")
-                .accessibilityValue(isCustomTokenExpanded ? "Expanded" : "Collapsed")
-
-                if isCustomTokenExpanded {
-                    VStack(alignment: .leading, spacing: 12) {
-                        HStack(spacing: 8) {
-                            SecureField("Enter token", text: $customToken)
-                                .textFieldStyle(.roundedBorder)
-                                .font(.callout.monospaced())
-                                .privacySensitive()
-                                .accessibilityLabel("Custom Hugging Face token")
-
-                            if hasCustomToken {
-                                Button {
-                                    customToken = ""
-                                } label: {
-                                    Image(systemName: "xmark.circle.fill")
-                                }
-                                .buttonStyle(.borderless)
-                                .foregroundStyle(.secondary)
-                                .help("Clear custom token")
-                            }
-
-                            Link(destination: URL(string: "https://huggingface.co/settings/tokens")!) {
-                                Label("Manage Tokens", systemImage: "arrow.up.right")
-                            }
-                            .buttonStyle(.bordered)
-                        }
-
-                        Text(authenticationDetail)
+                        Text(customTokenOverrideDescription)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    .padding(.top, 10)
-                    .transition(.opacity)
+
+                    Spacer(minLength: 12)
+
+                    Button {
+                        beginReplacingToken()
+                    } label: {
+                        Label(
+                            customTokenActionTitle,
+                            systemImage: "arrow.triangle.2.circlepath"
+                        )
+                    }
+                    .buttonStyle(.bordered)
+
+                    if hasCustomToken || systemCredential != nil {
+                        Button(role: .destructive) {
+                            requestLogout()
+                        } label: {
+                            Label(
+                                hasCustomToken ? "Remove Custom Token" : "Log Out",
+                                systemImage: "rectangle.portrait.and.arrow.right"
+                            )
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+
+                if isReplacingToken {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(hasCustomToken ? "Replace custom token" : "Use a custom token")
+                            .font(.caption.weight(.semibold))
+
+                        HStack(spacing: 8) {
+                            SecureField("Paste Hugging Face token", text: $replacementToken)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.callout.monospaced())
+                                .focused($replacementFieldIsFocused)
+                                .privacySensitive()
+                                .accessibilityLabel("Replacement Hugging Face token")
+                                .onSubmit(saveReplacementToken)
+
+                            Button("Cancel") {
+                                cancelReplacingToken()
+                            }
+                            .buttonStyle(.bordered)
+
+                            Button("Use Token") {
+                                saveReplacementToken()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(
+                                HuggingFaceAuthentication.normalizedToken(replacementToken) == nil
+                            )
+                        }
+
+                        Text("The running server restarts automatically after the credential changes.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
             .padding(.horizontal, 12)
@@ -639,47 +652,169 @@ private struct HuggingFaceAuthenticationPanel: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
-        .onChange(of: systemTokenSource) { previousSource, currentSource in
-            if previousSource == nil && currentSource != nil && !hasSelectedDisclosureState {
-                isCustomTokenExpanded = false
+        .confirmationDialog(
+            logoutConfirmationTitle,
+            isPresented: $showsLogoutConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(logoutConfirmationAction, role: .destructive) {
+                performLogout()
             }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(logoutConfirmationMessage)
         }
-        .onChange(of: customToken) { oldValue, newValue in
-            if oldValue != newValue {
-                hasSelectedDisclosureState = true
+        .alert(
+            "Unable to Log Out",
+            isPresented: Binding(
+                get: { managementError != nil },
+                set: { if !$0 { managementError = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                managementError = nil
             }
+        } message: {
+            Text(managementError ?? "An unknown error occurred.")
         }
     }
 
     private var authenticationStatus: String {
-        if hasCustomToken { return "Custom Token" }
-        if systemTokenSource == .environment { return "HF_TOKEN" }
-        if systemTokenSource == .credentialFile { return "HF Login" }
-        return "Not Configured"
+        hasActiveCredential ? "Configured" : "Not Configured"
     }
 
     private var authenticationStatusImage: String {
-        hasCustomToken || systemTokenSource != nil ? "checkmark.circle.fill" : "circle.dashed"
+        hasActiveCredential ? "checkmark.circle.fill" : "circle.dashed"
     }
 
     private var authenticationStatusColor: Color {
-        hasCustomToken || systemTokenSource != nil ? .green : .secondary
+        hasActiveCredential ? .green : .secondary
     }
 
-    private var authenticationDetail: String {
+    private var activeCredentialSource: String {
+        if hasCustomToken {
+            return "Custom Token"
+        }
+        switch systemTokenSource {
+        case .environment:
+            return "Environment · HF_TOKEN"
+        case .credentialFile:
+            return "Hugging Face Login"
+        case nil:
+            return "None"
+        }
+    }
+
+    private var customTokenActionTitle: String {
+        if hasCustomToken {
+            return "Replace Custom Token"
+        }
+        if systemCredential != nil {
+            return "Add Custom Override"
+        }
+        return "Add Token"
+    }
+
+    private var customTokenOverrideDescription: String {
         if hasCustomToken, let systemTokenDescription {
-            return "The custom token overrides \(systemTokenDescription). Access to a gated model must also be approved on Hugging Face."
+            return "Active. This token takes priority over \(systemTokenDescription)."
         }
         if hasCustomToken {
-            return "Using the custom token. Access to a gated model must also be approved on Hugging Face."
+            return "Active. Nativ uses this token for Hugging Face Hub requests."
         }
-        if systemTokenSource == .environment {
-            return "Using HF_TOKEN from your process or login-shell environment. Enter a custom token above to override it."
+        if let systemTokenDescription {
+            return "Optional. A custom token takes priority over \(systemTokenDescription)."
         }
-        if systemTokenSource == .credentialFile {
-            return "Using the token from your Hugging Face login. Enter a custom token above to override it."
+        return "Add a token for gated models without changing your shell environment."
+    }
+
+    private var credentialOverview: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Label(
+                    hasActiveCredential ? "Active Credential" : "No Active Credential",
+                    systemImage: hasActiveCredential ? "key.fill" : "key"
+                )
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(hasActiveCredential ? .primary : .secondary)
+
+                Spacer()
+
+                Link(destination: URL(string: "https://huggingface.co/settings/tokens")!) {
+                    Label("Manage on Hugging Face", systemImage: "arrow.up.right")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            HStack(spacing: 14) {
+                credentialAttribute(
+                    title: "Source",
+                    value: activeCredentialSource,
+                    systemImage: "tray.full"
+                )
+                .frame(minWidth: 160, alignment: .leading)
+
+                Divider()
+                    .frame(height: 36)
+
+                credentialAttribute(
+                    title: "Token",
+                    value: activeTokenInfo?.maskedValue ?? "Not available",
+                    systemImage: "ellipsis.rectangle",
+                    monospaced: true
+                )
+                .frame(minWidth: 190, maxWidth: .infinity, alignment: .leading)
+                .privacySensitive()
+
+                Divider()
+                    .frame(height: 36)
+
+                credentialAttribute(
+                    title: "Length",
+                    value: activeTokenLength,
+                    systemImage: "number"
+                )
+                .frame(minWidth: 110, alignment: .leading)
+            }
         }
-        return "Log in with the Hugging Face CLI, set HF_TOKEN, or enter a custom token. Access to a gated model must also be approved on Hugging Face."
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.secondary.opacity(0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+    }
+
+    private var activeTokenLength: String {
+        guard let characterCount = activeTokenInfo?.characterCount else {
+            return "—"
+        }
+        let unit = characterCount == 1 ? "character" : "characters"
+        return "\(characterCount) \(unit)"
+    }
+
+    private func credentialAttribute(
+        title: String,
+        value: String,
+        systemImage: String,
+        monospaced: Bool = false
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Label(title, systemImage: systemImage)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            Text(value)
+                .font(
+                    monospaced
+                        ? .caption.monospaced().weight(.medium)
+                        : .callout.weight(.medium)
+                )
+                .lineLimit(1)
+        }
     }
 
     private var systemTokenDescription: String? {
@@ -690,6 +825,71 @@ private struct HuggingFaceAuthenticationPanel: View {
             "your Hugging Face login"
         case nil:
             nil
+        }
+    }
+
+    private var logoutConfirmationTitle: String {
+        hasCustomToken ? "Remove custom token?" : "Log out of Hugging Face?"
+    }
+
+    private var logoutConfirmationAction: String {
+        hasCustomToken ? "Remove Token" : "Log Out"
+    }
+
+    private var logoutConfirmationMessage: String {
+        if hasCustomToken, let systemTokenDescription {
+            return "Nativ will remove its custom token, fall back to \(systemTokenDescription), and restart the running server."
+        }
+        if hasCustomToken {
+            return "Nativ will remove its custom token and restart the running server without Hugging Face authentication."
+        }
+        return "This removes the active Hugging Face CLI login file from this Mac and restarts the running server without it."
+    }
+
+    private func beginReplacingToken() {
+        replacementToken = ""
+        withAnimation(.easeInOut(duration: 0.15)) {
+            isReplacingToken = true
+        }
+        replacementFieldIsFocused = true
+    }
+
+    private func cancelReplacingToken() {
+        replacementFieldIsFocused = false
+        replacementToken = ""
+        withAnimation(.easeInOut(duration: 0.15)) {
+            isReplacingToken = false
+        }
+    }
+
+    private func saveReplacementToken() {
+        guard let token = HuggingFaceAuthentication.normalizedToken(replacementToken) else {
+            return
+        }
+        onSetCustomToken(token)
+        cancelReplacingToken()
+    }
+
+    private func requestLogout() {
+        if !hasCustomToken, systemTokenSource == .environment {
+            managementError =
+                HuggingFaceAuthenticationError.environmentTokenCannotBeRemoved
+                .localizedDescription
+            return
+        }
+        showsLogoutConfirmation = true
+    }
+
+    private func performLogout() {
+        cancelReplacingToken()
+        if hasCustomToken {
+            onSetCustomToken(nil)
+            return
+        }
+        do {
+            try onLogOutSystemCredential()
+        } catch {
+            managementError = error.localizedDescription
         }
     }
 }

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -4,6 +4,11 @@ import IOKit
 import NativServerKit
 import SwiftUI
 
+private enum EndpointEditorField: Hashable {
+    case host
+    case port
+}
+
 struct DeveloperView: View {
     private static let configurationToggleClearance: CGFloat = 36
 
@@ -15,6 +20,7 @@ struct DeveloperView: View {
     @State private var logLevelFilter: LogLevelFilter = .all
     @State private var selectedEndpointCategory: ServerEndpointCategory = .openAI
     @State private var selectedEndpointAvailability: ServerEndpointAvailability = .available
+    @FocusState private var focusedEndpointField: EndpointEditorField?
 
     var body: some View {
         ModelConfigurationLayout(
@@ -266,13 +272,18 @@ struct DeveloperView: View {
     private var serverPortField: some View {
         HStack(spacing: 6) {
             Text("Port")
-                .font(.callout)
-                .foregroundStyle(.secondary)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.primary)
             TextField("", value: $model.settings.serverPort, format: .number.grouping(.never))
-                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(.plain)
                 .font(.callout.monospaced())
                 .multilineTextAlignment(.trailing)
-                .frame(width: 64)
+                .focused($focusedEndpointField, equals: .port)
+                .editableFieldChrome(
+                    isFocused: focusedEndpointField == .port
+                )
+                .frame(width: 78)
+                .accessibilityLabel("Server port")
                 .onChange(of: model.settings.serverPort) { _, newValue in
                     model.settings.serverPort = min(max(newValue, 1), 65_535)
                 }
@@ -293,12 +304,17 @@ struct DeveloperView: View {
     private var serverHostField: some View {
         HStack(spacing: 6) {
             Text("Host")
-                .font(.callout)
-                .foregroundStyle(.secondary)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.primary)
             TextField("", text: $model.settings.serverHost)
-                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(.plain)
                 .font(.callout.monospaced())
-                .frame(width: 120)
+                .focused($focusedEndpointField, equals: .host)
+                .editableFieldChrome(
+                    isFocused: focusedEndpointField == .host
+                )
+                .frame(width: 144)
+                .accessibilityLabel("Server host")
                 .onSubmit {
                     model.settings.serverHost = model.settings.normalized().serverHost
                 }
@@ -376,13 +392,13 @@ struct DeveloperView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
-        .background(PanelHeaderAccent(tint: .teal))
+        .background(PanelHeaderAccent(tint: .blue))
     }
 
     private func logPanelTitle(_ output: LogOutput) -> some View {
         HStack(spacing: 10) {
             Image(systemName: "terminal")
-                .foregroundStyle(.teal)
+                .foregroundStyle(.blue)
 
             VStack(alignment: .leading, spacing: 1) {
                 Text("Server Output")
@@ -508,6 +524,42 @@ private struct PanelHeaderAccent: View {
     }
 }
 
+private struct EditableFieldChrome: ViewModifier {
+    let isFocused: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.horizontal, 9)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(
+                        isFocused
+                            ? Color.blue.opacity(0.08)
+                            : Color(nsColor: .textBackgroundColor)
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .stroke(
+                        isFocused ? Color.blue : Color.primary.opacity(0.22),
+                        lineWidth: isFocused ? 1.5 : 1
+                    )
+            )
+            .shadow(
+                color: isFocused ? Color.blue.opacity(0.16) : .clear,
+                radius: 3
+            )
+            .animation(.easeOut(duration: 0.12), value: isFocused)
+    }
+}
+
+private extension View {
+    func editableFieldChrome(isFocused: Bool) -> some View {
+        modifier(EditableFieldChrome(isFocused: isFocused))
+    }
+}
+
 private enum HuggingFaceTokenMetadataState {
     case idle
     case loading
@@ -554,7 +606,7 @@ private struct HuggingFaceAuthenticationPanel: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 10) {
                 Image(systemName: "key.horizontal")
-                    .foregroundStyle(.purple)
+                    .foregroundStyle(.blue)
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Hugging Face Authentication")
@@ -578,7 +630,7 @@ private struct HuggingFaceAuthenticationPanel: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
-            .background(PanelHeaderAccent(tint: .purple))
+            .background(PanelHeaderAccent(tint: .blue))
 
             Divider()
 
@@ -1109,6 +1161,7 @@ private struct LogOutput {
 
 private struct LogSearchField: View {
     @Binding var text: String
+    @FocusState private var isFocused: Bool
 
     var body: some View {
         HStack(spacing: 7) {
@@ -1117,6 +1170,8 @@ private struct LogSearchField: View {
 
             TextField("Search logs", text: $text)
                 .textFieldStyle(.plain)
+                .focused($isFocused)
+                .accessibilityLabel("Search server logs")
 
             if !text.isEmpty {
                 Button {
@@ -1129,16 +1184,7 @@ private struct LogSearchField: View {
                 .help("Clear search")
             }
         }
-        .padding(.horizontal, 9)
-        .frame(height: 28)
-        .background(
-            RoundedRectangle(cornerRadius: 7)
-                .fill(Color(nsColor: .textBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 7)
-                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        )
+        .editableFieldChrome(isFocused: isFocused)
     }
 }
 

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -221,6 +221,9 @@ struct DeveloperView: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
+        .task(id: serverEndpointProbeID) {
+            await restartServerAfterEndpointChange()
+        }
     }
 
     private var endpointPanelTitle: some View {
@@ -252,7 +255,7 @@ struct DeveloperView: View {
                     model.settings.serverPort = min(max(newValue, 1), 65_535)
                 }
         }
-        .help("The port the local server listens on. Changing it requires a server restart.")
+        .help("The port the local server listens on. Changes restart a running server after 3 seconds.")
         .task(id: serverEndpointProbeID) {
             try? await Task.sleep(for: .milliseconds(250))
             guard !Task.isCancelled else { return }
@@ -278,7 +281,7 @@ struct DeveloperView: View {
                     model.settings.serverHost = model.settings.normalized().serverHost
                 }
         }
-        .help("The host or IP address the local server binds to. Changing it requires a server restart.")
+        .help("The host or IP address the local server binds to. Changes restart a running server after 3 seconds.")
     }
 
     private var serverEndpointProbeID: String {
@@ -291,6 +294,42 @@ struct DeveloperView: View {
         let isActiveEndpoint = settings.serverHost == model.activeServerHost
             && settings.serverPort == model.activeServerPort
         return !isSelectedEndpointAvailable && !isActiveEndpoint
+    }
+
+    private func restartServerAfterEndpointChange() async {
+        guard model.isRunning else {
+            return
+        }
+
+        let scheduledSettings = model.settings.normalized()
+        let endpointHasChanged = scheduledSettings.serverHost != model.activeServerHost
+            || scheduledSettings.serverPort != model.activeServerPort
+        guard endpointHasChanged else {
+            return
+        }
+
+        do {
+            try await Task.sleep(for: .seconds(3))
+        } catch {
+            return
+        }
+        guard !Task.isCancelled, model.isRunning else {
+            return
+        }
+
+        let currentSettings = model.settings.normalized()
+        guard currentSettings.serverHost == scheduledSettings.serverHost,
+              currentSettings.serverPort == scheduledSettings.serverPort
+        else {
+            return
+        }
+
+        let endpointStillNeedsRestart = currentSettings.serverHost != model.activeServerHost
+            || currentSettings.serverPort != model.activeServerPort
+        guard endpointStillNeedsRestart else {
+            return
+        }
+        model.restartServer()
     }
 
     private var endpointCategoryPicker: some View {

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -508,6 +508,13 @@ private struct PanelHeaderAccent: View {
     }
 }
 
+private enum HuggingFaceTokenMetadataState {
+    case idle
+    case loading
+    case loaded(HuggingFaceTokenMetadata)
+    case unavailable
+}
+
 private struct HuggingFaceAuthenticationPanel: View {
     let customToken: String?
     let systemCredential: HuggingFaceCredential?
@@ -517,6 +524,7 @@ private struct HuggingFaceAuthenticationPanel: View {
     @State private var isAddingToken = false
     @State private var showsLogoutConfirmation = false
     @State private var managementError: String?
+    @State private var tokenMetadataState = HuggingFaceTokenMetadataState.idle
     @FocusState private var tokenFieldIsFocused: Bool
 
     private var hasCustomToken: Bool {
@@ -527,14 +535,19 @@ private struct HuggingFaceAuthenticationPanel: View {
         systemCredential?.source
     }
 
-    private var activeTokenInfo: HuggingFaceTokenInfo? {
-        HuggingFaceAuthentication.tokenInfo(
-            hasCustomToken ? customToken : systemCredential?.token
+    private var activeToken: String? {
+        HuggingFaceAuthentication.effectiveToken(
+            customToken: customToken,
+            environmentToken: systemCredential?.token
         )
     }
 
+    private var activeTokenInfo: HuggingFaceTokenInfo? {
+        HuggingFaceAuthentication.tokenInfo(activeToken)
+    }
+
     private var hasActiveCredential: Bool {
-        hasCustomToken || systemCredential != nil
+        activeToken != nil
     }
 
     var body: some View {
@@ -641,6 +654,9 @@ private struct HuggingFaceAuthenticationPanel: View {
         } message: {
             Text(managementError ?? "An unknown error occurred.")
         }
+        .task(id: activeToken) {
+            await loadTokenMetadata(for: activeToken)
+        }
     }
 
     private var authenticationStatus: String {
@@ -706,6 +722,26 @@ private struct HuggingFaceAuthenticationPanel: View {
                     .frame(height: 36)
 
                 credentialAttribute(
+                    title: "Token Name",
+                    value: activeTokenName,
+                    systemImage: "tag"
+                )
+                .frame(minWidth: 100, alignment: .leading)
+
+                Divider()
+                    .frame(height: 36)
+
+                credentialAttribute(
+                    title: "Permission",
+                    value: activeTokenPermission,
+                    systemImage: "lock.shield"
+                )
+                .frame(minWidth: 90, alignment: .leading)
+
+                Divider()
+                    .frame(height: 36)
+
+                credentialAttribute(
                     title: "Length",
                     value: activeTokenLength,
                     systemImage: "number"
@@ -730,6 +766,32 @@ private struct HuggingFaceAuthenticationPanel: View {
         }
         let unit = characterCount == 1 ? "character" : "characters"
         return "\(characterCount) \(unit)"
+    }
+
+    private var activeTokenName: String {
+        switch tokenMetadataState {
+        case .idle:
+            "—"
+        case .loading:
+            "Checking…"
+        case .loaded(let metadata):
+            metadata.name ?? "Not reported"
+        case .unavailable:
+            "Unavailable"
+        }
+    }
+
+    private var activeTokenPermission: String {
+        switch tokenMetadataState {
+        case .idle:
+            "—"
+        case .loading:
+            "Checking…"
+        case .loaded(let metadata):
+            metadata.permission ?? "Not reported"
+        case .unavailable:
+            "Unavailable"
+        }
     }
 
     private func credentialAttribute(
@@ -804,6 +866,33 @@ private struct HuggingFaceAuthenticationPanel: View {
         }
         onSetCustomToken(token)
         cancelAddingToken()
+    }
+
+    @MainActor
+    private func loadTokenMetadata(for token: String?) async {
+        tokenMetadataState = .idle
+        guard let token else {
+            return
+        }
+        if let cachedMetadata = HuggingFaceTokenMetadataCache.load(for: token) {
+            tokenMetadataState = .loaded(cachedMetadata)
+            return
+        }
+
+        tokenMetadataState = .loading
+        do {
+            let metadata = try await HuggingFaceAuthentication.tokenMetadata(for: token)
+            guard !Task.isCancelled else {
+                return
+            }
+            try? HuggingFaceTokenMetadataCache.save(metadata, for: token)
+            tokenMetadataState = .loaded(metadata)
+        } catch {
+            guard !Task.isCancelled else {
+                return
+            }
+            tokenMetadataState = .unavailable
+        }
     }
 
     private func requestLogout() {

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -150,7 +150,7 @@ struct DeveloperView: View {
                 get: { model.settings.huggingFaceToken ?? "" },
                 set: { model.settings.huggingFaceToken = $0.isEmpty ? nil : $0 }
             ),
-            hasEnvironmentToken: model.environmentHuggingFaceToken != nil
+            systemTokenSource: model.systemHuggingFaceCredential?.source
         )
     }
 
@@ -511,14 +511,14 @@ private struct PanelHeaderAccent: View {
 
 private struct HuggingFaceAuthenticationPanel: View {
     @Binding var customToken: String
-    let hasEnvironmentToken: Bool
+    let systemTokenSource: HuggingFaceTokenSource?
     @State private var isCustomTokenExpanded: Bool
     @State private var hasSelectedDisclosureState = false
 
-    init(customToken: Binding<String>, hasEnvironmentToken: Bool) {
+    init(customToken: Binding<String>, systemTokenSource: HuggingFaceTokenSource?) {
         _customToken = customToken
-        self.hasEnvironmentToken = hasEnvironmentToken
-        _isCustomTokenExpanded = State(initialValue: !hasEnvironmentToken)
+        self.systemTokenSource = systemTokenSource
+        _isCustomTokenExpanded = State(initialValue: systemTokenSource == nil)
     }
 
     private var hasCustomToken: Bool {
@@ -619,8 +619,8 @@ private struct HuggingFaceAuthenticationPanel: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
-        .onChange(of: hasEnvironmentToken) { wasAvailable, isAvailable in
-            if !wasAvailable && isAvailable && !hasSelectedDisclosureState {
+        .onChange(of: systemTokenSource) { previousSource, currentSource in
+            if previousSource == nil && currentSource != nil && !hasSelectedDisclosureState {
                 isCustomTokenExpanded = false
             }
         }
@@ -633,29 +633,44 @@ private struct HuggingFaceAuthenticationPanel: View {
 
     private var authenticationStatus: String {
         if hasCustomToken { return "Custom Token" }
-        if hasEnvironmentToken { return "HF_TOKEN" }
+        if systemTokenSource == .environment { return "HF_TOKEN" }
+        if systemTokenSource == .credentialFile { return "HF Login" }
         return "Not Configured"
     }
 
     private var authenticationStatusImage: String {
-        hasCustomToken || hasEnvironmentToken ? "checkmark.circle.fill" : "circle.dashed"
+        hasCustomToken || systemTokenSource != nil ? "checkmark.circle.fill" : "circle.dashed"
     }
 
     private var authenticationStatusColor: Color {
-        hasCustomToken || hasEnvironmentToken ? .green : .secondary
+        hasCustomToken || systemTokenSource != nil ? .green : .secondary
     }
 
     private var authenticationDetail: String {
-        if hasCustomToken && hasEnvironmentToken {
-            return "The custom token overrides HF_TOKEN from your environment. Access to a gated model must also be approved on Hugging Face."
+        if hasCustomToken, let systemTokenDescription {
+            return "The custom token overrides \(systemTokenDescription). Access to a gated model must also be approved on Hugging Face."
         }
         if hasCustomToken {
             return "Using the custom token. Access to a gated model must also be approved on Hugging Face."
         }
-        if hasEnvironmentToken {
+        if systemTokenSource == .environment {
             return "Using HF_TOKEN from your process or login-shell environment. Enter a custom token above to override it."
         }
-        return "Set HF_TOKEN in your environment or enter a custom token. Access to a gated model must also be approved on Hugging Face."
+        if systemTokenSource == .credentialFile {
+            return "Using the token from your Hugging Face login. Enter a custom token above to override it."
+        }
+        return "Log in with the Hugging Face CLI, set HF_TOKEN, or enter a custom token. Access to a gated model must also be approved on Hugging Face."
+    }
+
+    private var systemTokenDescription: String? {
+        switch systemTokenSource {
+        case .environment:
+            "HF_TOKEN from your environment"
+        case .credentialFile:
+            "your Hugging Face login"
+        case nil:
+            nil
+        }
     }
 }
 

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -33,7 +33,7 @@ struct DeveloperView: View {
                         pageHeader
                         runtimeGrid
                         serverEndpointsPanel
-                        huggingFaceAuthenticationPanel
+                        authenticationPanels
                         logPanel
                             .frame(height: max(320, geometry.size.height - 550))
                     }
@@ -52,7 +52,7 @@ struct DeveloperView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Developer")
                     .font(.title2.weight(.semibold))
-                Text("Runtime diagnostics, Hub authentication, API endpoints, and live server output.")
+                Text("Runtime diagnostics, server authentication, API endpoints, and live server output.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
@@ -157,6 +157,30 @@ struct DeveloperView: View {
             onSetCustomToken: model.setCustomHuggingFaceToken,
             onLogOutSystemCredential: model.logOutSystemHuggingFaceCredential
         )
+    }
+
+    private var serverAPIAuthenticationPanel: some View {
+        ServerAPIAuthenticationPanel(
+            token: model.settings.serverAPIKey,
+            onSetToken: model.setServerAPIKey
+        )
+    }
+
+    private var authenticationPanels: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(
+                    .adaptive(minimum: 500),
+                    spacing: 12,
+                    alignment: .top
+                )
+            ],
+            alignment: .leading,
+            spacing: 12
+        ) {
+            huggingFaceAuthenticationPanel
+            serverAPIAuthenticationPanel
+        }
     }
 
     private var serverEndpointsPanel: some View {
@@ -560,6 +584,295 @@ private extension View {
     }
 }
 
+private struct ServerAPIAuthenticationPanel: View {
+    let token: String?
+    let onSetToken: (String?) -> Void
+    @State private var tokenEntry = ""
+    @State private var isEditingToken = false
+    @State private var showsRemovalConfirmation = false
+    @FocusState private var tokenFieldIsFocused: Bool
+
+    private var activeToken: String? {
+        ServerAPIAuthentication.normalizedToken(token)
+    }
+
+    private var tokenInfo: ServerAPITokenInfo? {
+        ServerAPIAuthentication.tokenInfo(activeToken)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "lock.shield")
+                    .foregroundStyle(.blue)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Server API Authentication")
+                        .font(.callout.weight(.semibold))
+                    Text("Protect API requests with a custom Bearer token.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Label(authenticationStatus, systemImage: authenticationStatusImage)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(authenticationStatusColor)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(
+                        authenticationStatusColor.opacity(0.12),
+                        in: Capsule()
+                    )
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(PanelHeaderAccent(tint: .blue))
+
+            Divider()
+
+            Group {
+                if isEditingToken {
+                    tokenEditor
+                } else {
+                    credentialOverview
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+        .confirmationDialog(
+            "Remove the server API token?",
+            isPresented: $showsRemovalConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Remove Token", role: .destructive) {
+                onSetToken(nil)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "API requests will no longer require this token. "
+                    + "The running server restarts automatically."
+            )
+        }
+    }
+
+    private var authenticationStatus: String {
+        activeToken == nil ? "Not Configured" : "Configured"
+    }
+
+    private var authenticationStatusImage: String {
+        activeToken == nil ? "circle.dashed" : "checkmark.circle.fill"
+    }
+
+    private var authenticationStatusColor: Color {
+        activeToken == nil ? .secondary : .green
+    }
+
+    private var credentialOverview: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Label(
+                    activeToken == nil ? "No Active Credential" : "Active Credential",
+                    systemImage: activeToken == nil ? "key" : "key.fill"
+                )
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(activeToken == nil ? .secondary : .primary)
+
+                Spacer()
+
+                if activeToken != nil {
+                    Button {
+                        copyToken()
+                    } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
+                    .buttonStyle(.bordered)
+                    .help("Copy the active server API token")
+
+                    Button {
+                        beginEditingToken()
+                    } label: {
+                        Label("Change", systemImage: "pencil")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button(role: .destructive) {
+                        showsRemovalConfirmation = true
+                    } label: {
+                        Label("Remove", systemImage: "trash")
+                    }
+                    .buttonStyle(.bordered)
+                } else {
+                    Button {
+                        beginEditingToken()
+                    } label: {
+                        Label("Add Token", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+
+            HStack(spacing: 14) {
+                credentialAttribute(
+                    title: "Token",
+                    value: tokenInfo?.maskedValue ?? "Not available",
+                    systemImage: "ellipsis.rectangle",
+                    monospaced: true
+                )
+                .frame(minWidth: 190, maxWidth: .infinity, alignment: .leading)
+                .privacySensitive()
+
+                Divider()
+                    .frame(height: 36)
+
+                credentialAttribute(
+                    title: "Length",
+                    value: activeTokenLength,
+                    systemImage: "number"
+                )
+                .frame(minWidth: 110, alignment: .leading)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.secondary.opacity(0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+    }
+
+    private var tokenEditor: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label(
+                    activeToken == nil ? "Add Server API Token" : "Replace Server API Token",
+                    systemImage: "key.fill"
+                )
+                .font(.caption.weight(.semibold))
+
+                Spacer()
+
+                Button {
+                    tokenEntry = ServerAPIAuthentication.generateToken()
+                    tokenFieldIsFocused = true
+                } label: {
+                    Label("Generate Secure Token", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+            }
+
+            HStack(spacing: 8) {
+                SecureField("Paste or generate a server API token", text: $tokenEntry)
+                    .textFieldStyle(.plain)
+                    .font(.callout.monospaced())
+                    .focused($tokenFieldIsFocused)
+                    .editableFieldChrome(isFocused: tokenFieldIsFocused)
+                    .privacySensitive()
+                    .accessibilityLabel("Server API token")
+                    .onSubmit(saveToken)
+
+                Button("Cancel") {
+                    cancelEditingToken()
+                }
+                .buttonStyle(.bordered)
+
+                Button("Save Token") {
+                    saveToken()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(ServerAPIAuthentication.normalizedToken(tokenEntry) == nil)
+            }
+
+            Text("Clients send this value as an Authorization Bearer token.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.secondary.opacity(0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
+        .task {
+            tokenFieldIsFocused = true
+        }
+    }
+
+    private var activeTokenLength: String {
+        guard let characterCount = tokenInfo?.characterCount else {
+            return "—"
+        }
+        let unit = characterCount == 1 ? "character" : "characters"
+        return "\(characterCount) \(unit)"
+    }
+
+    private func credentialAttribute(
+        title: String,
+        value: String,
+        systemImage: String,
+        monospaced: Bool = false
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Label(title, systemImage: systemImage)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            Text(value)
+                .font(
+                    monospaced
+                        ? .caption.monospaced().weight(.medium)
+                        : .callout.weight(.medium)
+                )
+                .lineLimit(1)
+        }
+    }
+
+    private func beginEditingToken() {
+        tokenEntry = ""
+        isEditingToken = true
+    }
+
+    private func cancelEditingToken() {
+        isEditingToken = false
+        tokenFieldIsFocused = false
+        tokenEntry = ""
+    }
+
+    private func saveToken() {
+        guard let token = ServerAPIAuthentication.normalizedToken(tokenEntry) else {
+            return
+        }
+        onSetToken(token)
+        isEditingToken = false
+        tokenFieldIsFocused = false
+        tokenEntry = ""
+    }
+
+    private func copyToken() {
+        guard let activeToken else {
+            return
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(activeToken, forType: .string)
+    }
+}
+
 private enum HuggingFaceTokenMetadataState {
     case idle
     case loading
@@ -767,7 +1080,7 @@ private struct HuggingFaceAuthenticationPanel: View {
                     systemImage: "ellipsis.rectangle",
                     monospaced: true
                 )
-                .frame(minWidth: 190, maxWidth: .infinity, alignment: .leading)
+                .frame(minWidth: 130, maxWidth: .infinity, alignment: .leading)
                 .privacySensitive()
 
                 Divider()
@@ -778,7 +1091,7 @@ private struct HuggingFaceAuthenticationPanel: View {
                     value: activeTokenName,
                     systemImage: "tag"
                 )
-                .frame(minWidth: 100, alignment: .leading)
+                .frame(minWidth: 72, alignment: .leading)
 
                 Divider()
                     .frame(height: 36)
@@ -788,7 +1101,7 @@ private struct HuggingFaceAuthenticationPanel: View {
                     value: activeTokenPermission,
                     systemImage: "lock.shield"
                 )
-                .frame(minWidth: 90, alignment: .leading)
+                .frame(minWidth: 72, alignment: .leading)
 
                 Divider()
                     .frame(height: 36)
@@ -798,7 +1111,7 @@ private struct HuggingFaceAuthenticationPanel: View {
                     value: activeTokenLength,
                     systemImage: "number"
                 )
-                .frame(minWidth: 110, alignment: .leading)
+                .frame(minWidth: 88, alignment: .leading)
             }
         }
         .padding(12)

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -737,12 +737,12 @@ private struct ServerEndpointRow: View {
         Button(action: copyAction) {
             HStack(spacing: 8) {
                 Text(endpoint.method.rawValue)
-                    .font(.caption2.monospaced().weight(.bold))
+                    .font(.caption.monospaced().weight(.bold))
                     .foregroundStyle(endpoint.method.tint)
                     .frame(width: 42, alignment: .leading)
 
                 Text(endpoint.path)
-                    .font(.caption.monospaced())
+                    .font(.callout.monospaced())
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -718,6 +718,10 @@ private enum ServerEndpointMethod: String {
     case post = "POST"
     case delete = "DELETE"
 
+    var displayTitle: String {
+        self == .delete ? "DEL" : rawValue
+    }
+
     var tint: Color {
         switch self {
         case .get: .blue
@@ -736,7 +740,7 @@ private struct ServerEndpointRow: View {
     var body: some View {
         Button(action: copyAction) {
             HStack(spacing: 8) {
-                Text(endpoint.method.rawValue)
+                Text(endpoint.method.displayTitle)
                     .font(.system(size: 12, weight: .bold, design: .monospaced))
                     .foregroundStyle(endpoint.method.tint)
                     .frame(width: 42, alignment: .leading)

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -737,12 +737,12 @@ private struct ServerEndpointRow: View {
         Button(action: copyAction) {
             HStack(spacing: 8) {
                 Text(endpoint.method.rawValue)
-                    .font(.caption.monospaced().weight(.bold))
+                    .font(.system(size: 12, weight: .bold, design: .monospaced))
                     .foregroundStyle(endpoint.method.tint)
                     .frame(width: 42, alignment: .leading)
 
                 Text(endpoint.path)
-                    .font(.footnote.monospaced())
+                    .font(.system(size: 12, design: .monospaced))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -742,7 +742,7 @@ private struct ServerEndpointRow: View {
                     .frame(width: 42, alignment: .leading)
 
                 Text(endpoint.path)
-                    .font(.callout.monospaced())
+                    .font(.footnote.monospaced())
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -513,11 +513,11 @@ private struct HuggingFaceAuthenticationPanel: View {
     let systemCredential: HuggingFaceCredential?
     let onSetCustomToken: (String?) -> Void
     let onLogOutSystemCredential: () throws -> Void
-    @State private var replacementToken = ""
-    @State private var isReplacingToken = false
+    @State private var tokenEntry = ""
+    @State private var isAddingToken = false
     @State private var showsLogoutConfirmation = false
     @State private var managementError: String?
-    @FocusState private var replacementFieldIsFocused: Bool
+    @FocusState private var tokenFieldIsFocused: Bool
 
     private var hasCustomToken: Bool {
         HuggingFaceAuthentication.normalizedToken(customToken) != nil
@@ -572,67 +572,31 @@ private struct HuggingFaceAuthenticationPanel: View {
             VStack(alignment: .leading, spacing: 12) {
                 credentialOverview
 
-                Divider()
-
-                HStack(alignment: .center, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Custom Token Override")
-                            .font(.callout.weight(.medium))
-                        Text(customTokenOverrideDescription)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Spacer(minLength: 12)
-
-                    Button {
-                        beginReplacingToken()
-                    } label: {
-                        Label(
-                            customTokenActionTitle,
-                            systemImage: "arrow.triangle.2.circlepath"
-                        )
-                    }
-                    .buttonStyle(.bordered)
-
-                    if hasCustomToken || systemCredential != nil {
-                        Button(role: .destructive) {
-                            requestLogout()
-                        } label: {
-                            Label(
-                                hasCustomToken ? "Remove Custom Token" : "Log Out",
-                                systemImage: "rectangle.portrait.and.arrow.right"
-                            )
-                        }
-                        .buttonStyle(.bordered)
-                    }
-                }
-
-                if isReplacingToken {
+                if isAddingToken {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text(hasCustomToken ? "Replace custom token" : "Use a custom token")
+                        Text("Add Hugging Face token")
                             .font(.caption.weight(.semibold))
 
                         HStack(spacing: 8) {
-                            SecureField("Paste Hugging Face token", text: $replacementToken)
+                            SecureField("Paste Hugging Face token", text: $tokenEntry)
                                 .textFieldStyle(.roundedBorder)
                                 .font(.callout.monospaced())
-                                .focused($replacementFieldIsFocused)
+                                .focused($tokenFieldIsFocused)
                                 .privacySensitive()
-                                .accessibilityLabel("Replacement Hugging Face token")
-                                .onSubmit(saveReplacementToken)
+                                .accessibilityLabel("Hugging Face token")
+                                .onSubmit(saveToken)
 
                             Button("Cancel") {
-                                cancelReplacingToken()
+                                cancelAddingToken()
                             }
                             .buttonStyle(.bordered)
 
                             Button("Use Token") {
-                                saveReplacementToken()
+                                saveToken()
                             }
                             .buttonStyle(.borderedProminent)
                             .disabled(
-                                HuggingFaceAuthentication.normalizedToken(replacementToken) == nil
+                                HuggingFaceAuthentication.normalizedToken(tokenEntry) == nil
                             )
                         }
 
@@ -691,43 +655,6 @@ private struct HuggingFaceAuthenticationPanel: View {
         hasActiveCredential ? .green : .secondary
     }
 
-    private var activeCredentialSource: String {
-        if hasCustomToken {
-            return "Custom Token"
-        }
-        switch systemTokenSource {
-        case .environment:
-            return "Environment · HF_TOKEN"
-        case .credentialFile:
-            return "Hugging Face Login"
-        case nil:
-            return "None"
-        }
-    }
-
-    private var customTokenActionTitle: String {
-        if hasCustomToken {
-            return "Replace Custom Token"
-        }
-        if systemCredential != nil {
-            return "Add Custom Override"
-        }
-        return "Add Token"
-    }
-
-    private var customTokenOverrideDescription: String {
-        if hasCustomToken, let systemTokenDescription {
-            return "Active. This token takes priority over \(systemTokenDescription)."
-        }
-        if hasCustomToken {
-            return "Active. Nativ uses this token for Hugging Face Hub requests."
-        }
-        if let systemTokenDescription {
-            return "Optional. A custom token takes priority over \(systemTokenDescription)."
-        }
-        return "Add a token for gated models without changing your shell environment."
-    }
-
     private var credentialOverview: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 8) {
@@ -740,6 +667,25 @@ private struct HuggingFaceAuthenticationPanel: View {
 
                 Spacer()
 
+                if hasCustomToken || systemCredential != nil {
+                    Button(role: .destructive) {
+                        requestLogout()
+                    } label: {
+                        Label(
+                            "Log Out",
+                            systemImage: "rectangle.portrait.and.arrow.right"
+                        )
+                    }
+                    .buttonStyle(.bordered)
+                } else {
+                    Button {
+                        beginAddingToken()
+                    } label: {
+                        Label("Add Token", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+
                 Link(destination: URL(string: "https://huggingface.co/settings/tokens")!) {
                     Label("Manage on Hugging Face", systemImage: "arrow.up.right")
                 }
@@ -747,16 +693,6 @@ private struct HuggingFaceAuthenticationPanel: View {
             }
 
             HStack(spacing: 14) {
-                credentialAttribute(
-                    title: "Source",
-                    value: activeCredentialSource,
-                    systemImage: "tray.full"
-                )
-                .frame(minWidth: 160, alignment: .leading)
-
-                Divider()
-                    .frame(height: 36)
-
                 credentialAttribute(
                     title: "Token",
                     value: activeTokenInfo?.maskedValue ?? "Not available",
@@ -829,11 +765,11 @@ private struct HuggingFaceAuthenticationPanel: View {
     }
 
     private var logoutConfirmationTitle: String {
-        hasCustomToken ? "Remove custom token?" : "Log out of Hugging Face?"
+        "Log out of Hugging Face?"
     }
 
     private var logoutConfirmationAction: String {
-        hasCustomToken ? "Remove Token" : "Log Out"
+        "Log Out"
     }
 
     private var logoutConfirmationMessage: String {
@@ -846,28 +782,28 @@ private struct HuggingFaceAuthenticationPanel: View {
         return "This removes the active Hugging Face CLI login file from this Mac and restarts the running server without it."
     }
 
-    private func beginReplacingToken() {
-        replacementToken = ""
+    private func beginAddingToken() {
+        tokenEntry = ""
         withAnimation(.easeInOut(duration: 0.15)) {
-            isReplacingToken = true
+            isAddingToken = true
         }
-        replacementFieldIsFocused = true
+        tokenFieldIsFocused = true
     }
 
-    private func cancelReplacingToken() {
-        replacementFieldIsFocused = false
-        replacementToken = ""
+    private func cancelAddingToken() {
+        tokenFieldIsFocused = false
+        tokenEntry = ""
         withAnimation(.easeInOut(duration: 0.15)) {
-            isReplacingToken = false
+            isAddingToken = false
         }
     }
 
-    private func saveReplacementToken() {
-        guard let token = HuggingFaceAuthentication.normalizedToken(replacementToken) else {
+    private func saveToken() {
+        guard let token = HuggingFaceAuthentication.normalizedToken(tokenEntry) else {
             return
         }
         onSetCustomToken(token)
-        cancelReplacingToken()
+        cancelAddingToken()
     }
 
     private func requestLogout() {
@@ -881,7 +817,6 @@ private struct HuggingFaceAuthenticationPanel: View {
     }
 
     private func performLogout() {
-        cancelReplacingToken()
         if hasCustomToken {
             onSetCustomToken(nil)
             return

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -187,6 +187,7 @@ struct DeveloperView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
+            .background(PanelHeaderAccent(tint: .blue))
 
             serverRestartIndicator
 
@@ -376,12 +377,13 @@ struct DeveloperView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
+        .background(PanelHeaderAccent(tint: .teal))
     }
 
     private func logPanelTitle(_ output: LogOutput) -> some View {
         HStack(spacing: 10) {
             Image(systemName: "terminal")
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.teal)
 
             VStack(alignment: .leading, spacing: 1) {
                 Text("Server Output")
@@ -474,6 +476,39 @@ struct DeveloperView: View {
     }
 }
 
+private struct PanelHeaderAccent: View {
+    let tint: Color
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+
+                LinearGradient(
+                    colors: [.clear, tint.opacity(0.12)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(maxWidth: 420)
+            }
+
+            Capsule()
+                .fill(
+                    LinearGradient(
+                        colors: [tint.opacity(0.25), tint.opacity(0.85)],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .frame(width: 120, height: 3)
+                .padding(.top, 2)
+                .padding(.trailing, 16)
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}
+
 private struct HuggingFaceAuthenticationPanel: View {
     @Binding var customToken: String
     let hasEnvironmentToken: Bool
@@ -512,6 +547,7 @@ private struct HuggingFaceAuthenticationPanel: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
+            .background(PanelHeaderAccent(tint: .purple))
 
             Divider()
 

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -14,7 +14,7 @@ struct DeveloperView: View {
     @State private var logQuery = ""
     @State private var logLevelFilter: LogLevelFilter = .all
     @State private var selectedEndpointCategory: ServerEndpointCategory = .openAI
-    @State private var isSelectedPortAvailable = true
+    @State private var isSelectedEndpointAvailable = true
 
     var body: some View {
         ModelConfigurationLayout(
@@ -163,9 +163,11 @@ struct DeveloperView: View {
                     endpointCategoryPicker
                         .frame(width: 300, alignment: .leading)
 
+                    serverHostField
+
                     serverPortField
                 }
-                .frame(width: 660, alignment: .leading)
+                .frame(width: 850, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 9) {
                     endpointPanelTitle
@@ -173,6 +175,8 @@ struct DeveloperView: View {
                     HStack(spacing: 10) {
                         endpointCategoryPicker
                             .frame(width: 320)
+
+                        serverHostField
 
                         serverPortField
 
@@ -184,9 +188,9 @@ struct DeveloperView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
 
-            if showsPortInUseWarning {
+            if showsEndpointInUseWarning {
                 Label(
-                    "Port \(String(model.settings.normalized().serverPort)) is already in use — that port can’t be used.",
+                    "\(model.settings.serverBaseURL.absoluteString) is unavailable — the server can’t use that address.",
                     systemImage: "exclamationmark.triangle.fill"
                 )
                 .font(.footnote)
@@ -248,19 +252,45 @@ struct DeveloperView: View {
                     model.settings.serverPort = min(max(newValue, 1), 65_535)
                 }
         }
-        .help("The local server listens at 127.0.0.1 on this port. Changing it requires a server restart.")
-        .task(id: model.settings.normalized().serverPort) {
+        .help("The port the local server listens on. Changing it requires a server restart.")
+        .task(id: serverEndpointProbeID) {
             try? await Task.sleep(for: .milliseconds(250))
             guard !Task.isCancelled else { return }
-            let port = model.settings.normalized().serverPort
-            let available = await Task.detached { ServerPortProbe.isAvailable(port) }.value
+            let settings = model.settings.normalized()
+            let available = await Task.detached {
+                ServerPortProbe.isAvailable(host: settings.serverHost, port: settings.serverPort)
+            }.value
             guard !Task.isCancelled else { return }
-            isSelectedPortAvailable = available
+            isSelectedEndpointAvailable = available
         }
     }
 
-    private var showsPortInUseWarning: Bool {
-        !isSelectedPortAvailable && model.settings.normalized().serverPort != model.activeServerPort
+    private var serverHostField: some View {
+        HStack(spacing: 6) {
+            Text("Host")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            TextField("", text: $model.settings.serverHost)
+                .textFieldStyle(.roundedBorder)
+                .font(.callout.monospaced())
+                .frame(width: 120)
+                .onSubmit {
+                    model.settings.serverHost = model.settings.normalized().serverHost
+                }
+        }
+        .help("The host or IP address the local server binds to. Changing it requires a server restart.")
+    }
+
+    private var serverEndpointProbeID: String {
+        let settings = model.settings.normalized()
+        return "\(settings.serverHost):\(settings.serverPort)"
+    }
+
+    private var showsEndpointInUseWarning: Bool {
+        let settings = model.settings.normalized()
+        let isActiveEndpoint = settings.serverHost == model.activeServerHost
+            && settings.serverPort == model.activeServerPort
+        return !isSelectedEndpointAvailable && !isActiveEndpoint
     }
 
     private var endpointCategoryPicker: some View {

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -480,29 +480,29 @@ private struct PanelHeaderAccent: View {
     let tint: Color
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        ZStack(alignment: .topLeading) {
             HStack(spacing: 0) {
-                Spacer(minLength: 0)
-
                 LinearGradient(
-                    colors: [.clear, tint.opacity(0.12)],
+                    colors: [tint.opacity(0.12), .clear],
                     startPoint: .leading,
                     endPoint: .trailing
                 )
                 .frame(maxWidth: 420)
+
+                Spacer(minLength: 0)
             }
 
             Capsule()
                 .fill(
                     LinearGradient(
-                        colors: [tint.opacity(0.25), tint.opacity(0.85)],
+                        colors: [tint.opacity(0.85), tint.opacity(0.25)],
                         startPoint: .leading,
                         endPoint: .trailing
                     )
                 )
                 .frame(width: 120, height: 3)
                 .padding(.top, 2)
-                .padding(.trailing, 16)
+                .padding(.leading, 16)
         }
         .allowsHitTesting(false)
         .accessibilityHidden(true)

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -15,6 +15,8 @@ struct DeveloperView: View {
     @State private var logLevelFilter: LogLevelFilter = .all
     @State private var selectedEndpointCategory: ServerEndpointCategory = .openAI
     @State private var isSelectedEndpointAvailable = true
+    @State private var pendingServerRestartID: UUID?
+    @State private var serverRestartCountdown: Int?
 
     var body: some View {
         ModelConfigurationLayout(
@@ -188,6 +190,8 @@ struct DeveloperView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
 
+            serverRestartIndicator
+
             if showsEndpointInUseWarning {
                 Label(
                     "\(model.settings.serverBaseURL.absoluteString) is unavailable — the server can’t use that address.",
@@ -223,6 +227,26 @@ struct DeveloperView: View {
         )
         .task(id: serverEndpointProbeID) {
             await restartServerAfterEndpointChange()
+        }
+    }
+
+    @ViewBuilder
+    private var serverRestartIndicator: some View {
+        if let serverRestartCountdown {
+            let timeUnit = serverRestartCountdown == 1 ? "second" : "seconds"
+
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+
+                Text("Applying endpoint change — restarting server in \(serverRestartCountdown) \(timeUnit)…")
+                    .font(.footnote.weight(.medium))
+            }
+            .foregroundStyle(.blue)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 10)
+            .accessibilityElement(children: .combine)
         }
     }
 
@@ -308,13 +332,25 @@ struct DeveloperView: View {
             return
         }
 
-        do {
-            try await Task.sleep(for: .seconds(3))
-        } catch {
-            return
+        let restartID = UUID()
+        pendingServerRestartID = restartID
+        defer {
+            if pendingServerRestartID == restartID {
+                pendingServerRestartID = nil
+                serverRestartCountdown = nil
+            }
         }
-        guard !Task.isCancelled, model.isRunning else {
-            return
+
+        for secondsRemaining in stride(from: 3, through: 1, by: -1) {
+            serverRestartCountdown = secondsRemaining
+            do {
+                try await Task.sleep(for: .seconds(1))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, model.isRunning else {
+                return
+            }
         }
 
         let currentSettings = model.settings.normalized()

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -34,13 +34,14 @@ struct ImageRequestSettings: Equatable, Codable, Sendable {
 struct ImageGenerationExecutor {
     func run(
         baseURL: URL,
+        apiKey: String?,
         modelID: String,
         prompt: String,
         references: [ChatImageAttachment],
         settings: ImageRequestSettings,
         seed: Int?
     ) async throws -> [GeneratedImage] {
-        let client = NativImageClient(baseURL: baseURL)
+        let client = NativImageClient(baseURL: baseURL, apiKey: apiKey)
         let response: MLXImageResponse
         if references.isEmpty {
             response = try await client.generate(MLXImageGenerationRequest(
@@ -398,7 +399,9 @@ final class ImageGenerationViewModel: ObservableObject {
         bumpScroll()
 
         activeTask?.cancel()
-        let serverBaseURL = appModel.settings.serverBaseURL
+        let serverSettings = appModel.settings.normalized()
+        let serverBaseURL = serverSettings.serverBaseURL
+        let serverAPIKey = serverSettings.serverAPIKey
         activeTask = Task { @MainActor [weak self, weak appModel] in
             guard let self else {
                 return
@@ -407,6 +410,7 @@ final class ImageGenerationViewModel: ObservableObject {
             do {
                 let outputs = try await ImageGenerationExecutor().run(
                     baseURL: serverBaseURL,
+                    apiKey: serverAPIKey,
                     modelID: requestModelID,
                     prompt: requestPrompt,
                     references: references,

--- a/Sources/Nativ/Features/Integrations/CodexCLIProfile.swift
+++ b/Sources/Nativ/Features/Integrations/CodexCLIProfile.swift
@@ -3,6 +3,7 @@ import Foundation
 enum CodexCLIProfile {
     static let name = "nativ"
     static let providerID = "nativ"
+    static let apiKeyEnvironmentVariable = "NATIV_API_KEY"
 
     static func configurationURL(in homeDirectory: URL) -> URL {
         homeDirectory.appendingPathComponent(".codex/\(name).config.toml")
@@ -28,6 +29,7 @@ enum CodexCLIProfile {
         [model_providers.\(tomlString(providerID))]
         name = "Nativ"
         base_url = \(tomlString(baseURL))
+        env_key = \(tomlString(apiKeyEnvironmentVariable))
         wire_api = "responses"
 
         """

--- a/Sources/Nativ/Features/Integrations/IntegrationServices.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationServices.swift
@@ -614,7 +614,10 @@ struct IntegrationProfileManager {
         case .pi:
             return (["--provider", Self.providerID, "--model", selectedModelID], [:])
         case .codex:
-            return (["--profile", Self.providerID, "--model", selectedModelID], [:])
+            return (
+                ["--profile", Self.providerID, "--model", selectedModelID],
+                [CodexCLIProfile.apiKeyEnvironmentVariable: apiKey]
+            )
         case .claudeCode:
             return (
                 ["--settings", configurationURL(for: tool).path, "--model", selectedModelID],

--- a/Sources/Nativ/Features/Integrations/IntegrationServices.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationServices.swift
@@ -8,6 +8,7 @@ struct IntegrationProfileManager {
     private let homeDirectory: URL
     private let applicationSupportDirectory: URL
     let serverBaseURL: URL
+    let apiKey: String
 
     var openAIBaseURL: String {
         serverBaseURL.appendingPathComponent("v1").absoluteString
@@ -19,6 +20,7 @@ struct IntegrationProfileManager {
 
     init(
         serverBaseURL: URL,
+        serverAPIKey: String? = nil,
         fileManager: FileManager = .default,
         homeDirectory: URL? = nil,
         applicationSupportDirectory: URL? = nil
@@ -27,6 +29,12 @@ struct IntegrationProfileManager {
         self.fileManager = fileManager
         self.homeDirectory = resolvedHomeDirectory
         self.serverBaseURL = serverBaseURL
+        let normalizedAPIKey = serverAPIKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let normalizedAPIKey, !normalizedAPIKey.isEmpty {
+            self.apiKey = normalizedAPIKey
+        } else {
+            self.apiKey = "nativ"
+        }
         self.applicationSupportDirectory = applicationSupportDirectory
             ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? resolvedHomeDirectory
@@ -337,7 +345,7 @@ struct IntegrationProfileManager {
         providers[Self.providerID] = [
             "baseUrl": openAIBaseURL,
             "api": "openai-completions",
-            "apiKey": "nativ",
+            "apiKey": apiKey,
             "compat": [
                 "supportsDeveloperRole": false,
                 "supportsReasoningEffort": false,
@@ -366,7 +374,7 @@ struct IntegrationProfileManager {
     private func claudeSettings(selectedModelID: String) -> [String: Any] {
         [
             "env": [
-                "ANTHROPIC_AUTH_TOKEN": "nativ",
+                "ANTHROPIC_AUTH_TOKEN": apiKey,
                 "ANTHROPIC_API_KEY": "",
                 "ANTHROPIC_BASE_URL": anthropicBaseURL,
                 "ANTHROPIC_MODEL": selectedModelID,
@@ -396,13 +404,13 @@ struct IntegrationProfileManager {
           default: \(yamlString(selectedModelID))
           provider: custom
           base_url: \(yamlString(openAIBaseURL))
-          api_key: nativ
+          api_key: \(yamlString(apiKey))
         display:
           streaming: true
         custom_providers:
           - name: nativ
             base_url: \(yamlString(openAIBaseURL))
-            api_key: nativ
+            api_key: \(yamlString(apiKey))
             api_mode: chat_completions
             models:
         \(modelLines)
@@ -452,7 +460,7 @@ struct IntegrationProfileManager {
                     "name": "Nativ",
                     "options": [
                         "baseURL": openAIBaseURL,
-                        "apiKey": "nativ"
+                        "apiKey": apiKey
                     ],
                     "models": modelCatalog
                 ]
@@ -461,7 +469,7 @@ struct IntegrationProfileManager {
     }
 
     private func configureAider() throws {
-        let contents = "OPENAI_API_BASE=\(openAIBaseURL)\nOPENAI_API_KEY=nativ\n"
+        let contents = "OPENAI_API_BASE=\(openAIBaseURL)\nOPENAI_API_KEY=\(apiKey)\n"
         try writeText(contents, to: configurationURL(for: .aider))
     }
 
@@ -508,7 +516,7 @@ struct IntegrationProfileManager {
                 Self.providerID: [
                     "type": "openai-compat",
                     "base_url": openAIBaseURL,
-                    "api_key": "nativ",
+                    "api_key": apiKey,
                     "models": providerModels
                 ]
             ]
@@ -517,7 +525,7 @@ struct IntegrationProfileManager {
     }
 
     private func configureQwenCode(selectedModelID: String) throws {
-        let contents = "OPENAI_API_KEY=nativ\nOPENAI_BASE_URL=\(openAIBaseURL)\nOPENAI_MODEL=\(selectedModelID)\n"
+        let contents = "OPENAI_API_KEY=\(apiKey)\nOPENAI_BASE_URL=\(openAIBaseURL)\nOPENAI_MODEL=\(selectedModelID)\n"
         try writeText(contents, to: configurationURL(for: .qwenCode))
     }
 
@@ -535,7 +543,7 @@ struct IntegrationProfileManager {
         var providers = modelsRoot["providers"] as? [String: Any] ?? [:]
         providers[Self.providerID] = [
             "baseUrl": openAIBaseURL,
-            "apiKey": "nativ",
+            "apiKey": apiKey,
             "api": "openai-completions",
             "models": models.map(openClawModel)
         ]
@@ -589,7 +597,7 @@ struct IntegrationProfileManager {
             lines.append("    provider: openai")
             lines.append("    apiBase: \(yamlString(openAIBaseURL))")
             lines.append("    model: \(yamlString(model.id))")
-            lines.append("    apiKey: nativ")
+            lines.append("    apiKey: \(yamlString(apiKey))")
             lines.append("    roles:")
             lines.append("      - chat")
             lines.append("      - edit")
@@ -611,7 +619,7 @@ struct IntegrationProfileManager {
             return (
                 ["--settings", configurationURL(for: tool).path, "--model", selectedModelID],
                 [
-                    "ANTHROPIC_AUTH_TOKEN": "nativ",
+                    "ANTHROPIC_AUTH_TOKEN": apiKey,
                     "ANTHROPIC_API_KEY": "",
                     "ANTHROPIC_BASE_URL": anthropicBaseURL
                 ]
@@ -631,7 +639,7 @@ struct IntegrationProfileManager {
         case .goose:
             return (
                 ["session", "start", "--provider", Self.providerID],
-                ["NATIV_API_KEY": "nativ", "GOOSE_MODEL": selectedModelID]
+                ["NATIV_API_KEY": apiKey, "GOOSE_MODEL": selectedModelID]
             )
         case .crush:
             return ([], ["CRUSH_GLOBAL_CONFIG": configurationURL(for: tool).path])
@@ -639,7 +647,7 @@ struct IntegrationProfileManager {
             return (
                 [],
                 [
-                    "OPENAI_API_KEY": "nativ",
+                    "OPENAI_API_KEY": apiKey,
                     "OPENAI_BASE_URL": openAIBaseURL,
                     "OPENAI_MODEL": selectedModelID
                 ]
@@ -647,7 +655,7 @@ struct IntegrationProfileManager {
         case .openClaw:
             return (["agent", "--model", "\(Self.providerID)/\(selectedModelID)"], [:])
         case .zed:
-            return (["."], ["NATIV_API_KEY": "nativ"])
+            return (["."], ["NATIV_API_KEY": apiKey])
         case .continueDev:
             return (["--config", configurationURL(for: tool).path], [:])
         case .vscode, .cursor, .jetbrains:

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import NativServerKit
 import SwiftUI
 
 extension IntegrationModelDescriptor {
@@ -67,8 +68,15 @@ final class IntegrationsViewModel: ObservableObject {
         serverModel.activeServerBaseURL ?? serverModel.settings.serverBaseURL
     }
 
+    private var serverAPIKey: String? {
+        serverModel.settings.normalized().serverAPIKey
+    }
+
     private var profiles: IntegrationProfileManager {
-        IntegrationProfileManager(serverBaseURL: integrationServerBaseURL)
+        IntegrationProfileManager(
+            serverBaseURL: integrationServerBaseURL,
+            serverAPIKey: serverAPIKey
+        )
     }
 
     func appear() {
@@ -257,6 +265,7 @@ final class IntegrationsViewModel: ObservableObject {
             var request = URLRequest(url: integrationServerBaseURL.appendingPathComponent("v1/models"))
             request.timeoutInterval = 3
             request.cachePolicy = .reloadIgnoringLocalCacheData
+            NativServerAuthorization.authorize(&request, apiKey: serverAPIKey)
             let (_, response) = try await URLSession.shared.data(for: request)
             return (response as? HTTPURLResponse).map { (200..<300).contains($0.statusCode) } ?? false
         } catch {
@@ -270,6 +279,7 @@ final class IntegrationsViewModel: ObservableObject {
         request.timeoutInterval = 300
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        NativServerAuthorization.authorize(&request, apiKey: serverAPIKey)
         request.httpBody = try JSONSerialization.data(withJSONObject: ["model": modelID])
 
         do {

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -64,10 +64,7 @@ final class IntegrationsViewModel: ObservableObject {
     }
 
     private var integrationServerBaseURL: URL {
-        guard let activeServerPort = serverModel.activeServerPort else {
-            return serverModel.settings.serverBaseURL
-        }
-        return URL(string: "http://127.0.0.1:\(activeServerPort)")!
+        serverModel.activeServerBaseURL ?? serverModel.settings.serverBaseURL
     }
 
     private var profiles: IntegrationProfileManager {

--- a/Sources/Nativ/Features/Models/HuggingFaceCache.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceCache.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Locates the Hugging Face hub cache using the same environment variables
@@ -86,9 +87,77 @@ struct HuggingFaceTokenInfo: Equatable, Sendable {
     let characterCount: Int
 }
 
+struct HuggingFaceTokenMetadata: Codable, Equatable, Sendable {
+    let name: String?
+    let permission: String?
+}
+
+enum HuggingFaceTokenMetadataCache {
+    static func load(
+        for token: String,
+        from url: URL = storageURL
+    ) -> HuggingFaceTokenMetadata? {
+        guard let token = HuggingFaceAuthentication.normalizedToken(token),
+              let data = try? Data(contentsOf: url),
+              let record = try? PropertyListDecoder().decode(CacheRecord.self, from: data),
+              record.tokenFingerprint == fingerprint(for: token) else {
+            return nil
+        }
+        return record.metadata
+    }
+
+    static func save(
+        _ metadata: HuggingFaceTokenMetadata,
+        for token: String,
+        to url: URL = storageURL
+    ) throws {
+        guard let token = HuggingFaceAuthentication.normalizedToken(token) else {
+            return
+        }
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let record = CacheRecord(
+            tokenFingerprint: fingerprint(for: token),
+            metadata: metadata
+        )
+        let data = try PropertyListEncoder().encode(record)
+        try data.write(to: url, options: .atomic)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private struct CacheRecord: Codable {
+        let tokenFingerprint: String
+        let metadata: HuggingFaceTokenMetadata
+    }
+
+    private static func fingerprint(for token: String) -> String {
+        SHA256.hash(data: Data(token.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private static var storageURL: URL {
+        let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+        let baseURL = applicationSupport ?? FileManager.default.homeDirectoryForCurrentUser
+        return baseURL
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("HuggingFaceTokenMetadata.plist")
+    }
+}
+
 enum HuggingFaceAuthenticationError: LocalizedError, Equatable {
     case environmentTokenCannotBeRemoved
     case missingCredentialFile
+    case invalidResponse
+    case requestFailed(Int)
 
     var errorDescription: String? {
         switch self {
@@ -96,6 +165,10 @@ enum HuggingFaceAuthenticationError: LocalizedError, Equatable {
             "HF_TOKEN is managed by your environment. Remove it from your shell configuration, then restart Nativ."
         case .missingCredentialFile:
             "Nativ could not locate the Hugging Face login file."
+        case .invalidResponse:
+            "Hugging Face returned an invalid authentication response."
+        case .requestFailed(let statusCode):
+            "Hugging Face rejected the authentication request (HTTP \(statusCode))."
         }
     }
 }
@@ -108,6 +181,15 @@ enum HuggingFaceAuthentication {
         "HF_HOME",
         "XDG_CACHE_HOME"
     ]
+    private static let whoAmIURL = URL(string: "https://huggingface.co/api/whoami-v2")!
+    private static let metadataSession: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieStorage = nil
+        configuration.httpShouldSetCookies = false
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        return URLSession(configuration: configuration)
+    }()
 
     static func token(
         in environment: [String: String] = ProcessInfo.processInfo.environment
@@ -188,6 +270,38 @@ enum HuggingFaceAuthentication {
         )
     }
 
+    static func tokenMetadata(for token: String) async throws -> HuggingFaceTokenMetadata {
+        guard let token = normalizedToken(token) else {
+            throw HuggingFaceAuthenticationError.invalidResponse
+        }
+
+        var request = URLRequest(
+            url: whoAmIURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 10
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Nativ/1.0", forHTTPHeaderField: "User-Agent")
+        authorize(&request, token: token)
+
+        let (data, response) = try await metadataSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HuggingFaceAuthenticationError.invalidResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw HuggingFaceAuthenticationError.requestFailed(httpResponse.statusCode)
+        }
+        return try decodeTokenMetadata(from: data)
+    }
+
+    static func decodeTokenMetadata(from data: Data) throws -> HuggingFaceTokenMetadata {
+        let response = try JSONDecoder().decode(HuggingFaceWhoAmIResponse.self, from: data)
+        return HuggingFaceTokenMetadata(
+            name: normalizedToken(response.auth?.accessToken?.displayName),
+            permission: normalizedToken(response.auth?.accessToken?.role)
+        )
+    }
+
     static func logOut(
         credential: HuggingFaceCredential,
         removeCredentialFile: (String) throws -> Void = {
@@ -211,5 +325,18 @@ enum HuggingFaceAuthentication {
             return path
         }
         return (homeDirectory as NSString).appendingPathComponent(String(path.dropFirst(2)))
+    }
+}
+
+private struct HuggingFaceWhoAmIResponse: Decodable {
+    let auth: Authentication?
+
+    struct Authentication: Decodable {
+        let accessToken: AccessToken?
+    }
+
+    struct AccessToken: Decodable {
+        let displayName: String?
+        let role: String?
     }
 }

--- a/Sources/Nativ/Features/Models/HuggingFaceCache.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceCache.swift
@@ -72,6 +72,32 @@ enum HuggingFaceTokenSource: Equatable, Sendable {
 struct HuggingFaceCredential: Equatable, Sendable {
     let token: String
     let source: HuggingFaceTokenSource
+    let filePath: String?
+
+    init(token: String, source: HuggingFaceTokenSource, filePath: String? = nil) {
+        self.token = token
+        self.source = source
+        self.filePath = filePath
+    }
+}
+
+struct HuggingFaceTokenInfo: Equatable, Sendable {
+    let maskedValue: String
+    let characterCount: Int
+}
+
+enum HuggingFaceAuthenticationError: LocalizedError, Equatable {
+    case environmentTokenCannotBeRemoved
+    case missingCredentialFile
+
+    var errorDescription: String? {
+        switch self {
+        case .environmentTokenCannotBeRemoved:
+            "HF_TOKEN is managed by your environment. Remove it from your shell configuration, then restart Nativ."
+        case .missingCredentialFile:
+            "Nativ could not locate the Hugging Face login file."
+        }
+    }
 }
 
 enum HuggingFaceAuthentication {
@@ -107,7 +133,11 @@ enum HuggingFaceAuthentication {
         guard let token = normalizedToken(readTokenFile(path)) else {
             return nil
         }
-        return HuggingFaceCredential(token: token, source: .credentialFile)
+        return HuggingFaceCredential(
+            token: token,
+            source: .credentialFile,
+            filePath: path
+        )
     }
 
     static func credentialFilePath(
@@ -145,15 +175,32 @@ enum HuggingFaceAuthentication {
         return trimmed
     }
 
-    static func tokenSummary(_ token: String?) -> String? {
+    static func tokenInfo(_ token: String?) -> HuggingFaceTokenInfo? {
         guard let token = normalizedToken(token) else {
             return nil
         }
 
         let prefix = token.hasPrefix("hf_") ? "hf_" : ""
         let suffix = token.count > 8 ? String(token.suffix(4)) : ""
-        let characterLabel = token.count == 1 ? "character" : "characters"
-        return "\(prefix)••••••••\(suffix) · \(token.count) \(characterLabel)"
+        return HuggingFaceTokenInfo(
+            maskedValue: "\(prefix)••••••••\(suffix)",
+            characterCount: token.count
+        )
+    }
+
+    static func logOut(
+        credential: HuggingFaceCredential,
+        removeCredentialFile: (String) throws -> Void = {
+            try FileManager.default.removeItem(atPath: $0)
+        }
+    ) throws {
+        guard credential.source == .credentialFile else {
+            throw HuggingFaceAuthenticationError.environmentTokenCannotBeRemoved
+        }
+        guard let filePath = credential.filePath else {
+            throw HuggingFaceAuthenticationError.missingCredentialFile
+        }
+        try removeCredentialFile(filePath)
     }
 
     private static func expandHome(in path: String, homeDirectory: String) -> String {

--- a/Sources/Nativ/Features/Models/HuggingFaceCache.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceCache.swift
@@ -145,6 +145,17 @@ enum HuggingFaceAuthentication {
         return trimmed
     }
 
+    static func tokenSummary(_ token: String?) -> String? {
+        guard let token = normalizedToken(token) else {
+            return nil
+        }
+
+        let prefix = token.hasPrefix("hf_") ? "hf_" : ""
+        let suffix = token.count > 8 ? String(token.suffix(4)) : ""
+        let characterLabel = token.count == 1 ? "character" : "characters"
+        return "\(prefix)••••••••\(suffix) · \(token.count) \(characterLabel)"
+    }
+
     private static func expandHome(in path: String, homeDirectory: String) -> String {
         if path == "~" {
             return homeDirectory

--- a/Sources/Nativ/Features/Models/HuggingFaceCache.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceCache.swift
@@ -63,14 +63,69 @@ enum HuggingFaceCache {
 }
 
 /// Resolves and applies Hugging Face authentication without persisting tokens
-/// discovered in the process or login-shell environment.
+/// discovered in the process, login-shell environment, or local Hub login.
+enum HuggingFaceTokenSource: Equatable, Sendable {
+    case environment
+    case credentialFile
+}
+
+struct HuggingFaceCredential: Equatable, Sendable {
+    let token: String
+    let source: HuggingFaceTokenSource
+}
+
 enum HuggingFaceAuthentication {
     static let environmentVariableName = "HF_TOKEN"
+    static let discoveryEnvironmentVariableNames = [
+        environmentVariableName,
+        "HF_TOKEN_PATH",
+        "HF_HOME",
+        "XDG_CACHE_HOME"
+    ]
 
     static func token(
         in environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> String? {
         normalizedToken(environment[environmentVariableName])
+    }
+
+    static func systemCredential(
+        in environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
+        readTokenFile: (String) -> String? = {
+            try? String(contentsOfFile: $0, encoding: .utf8)
+        }
+    ) -> HuggingFaceCredential? {
+        if let token = token(in: environment) {
+            return HuggingFaceCredential(token: token, source: .environment)
+        }
+
+        let path = credentialFilePath(
+            environment: environment,
+            homeDirectory: homeDirectory
+        )
+        guard let token = normalizedToken(readTokenFile(path)) else {
+            return nil
+        }
+        return HuggingFaceCredential(token: token, source: .credentialFile)
+    }
+
+    static func credentialFilePath(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path
+    ) -> String {
+        if let tokenPath = normalizedToken(environment["HF_TOKEN_PATH"]) {
+            return expandHome(in: tokenPath, homeDirectory: homeDirectory)
+        }
+        if let huggingFaceHome = normalizedToken(environment["HF_HOME"]) {
+            return (expandHome(in: huggingFaceHome, homeDirectory: homeDirectory) as NSString)
+                .appendingPathComponent("token")
+        }
+        if let cacheHome = normalizedToken(environment["XDG_CACHE_HOME"]) {
+            return (expandHome(in: cacheHome, homeDirectory: homeDirectory) as NSString)
+                .appendingPathComponent("huggingface/token")
+        }
+        return (homeDirectory as NSString).appendingPathComponent(".cache/huggingface/token")
     }
 
     static func effectiveToken(customToken: String?, environmentToken: String?) -> String? {
@@ -88,5 +143,15 @@ enum HuggingFaceAuthentication {
             return nil
         }
         return trimmed
+    }
+
+    private static func expandHome(in path: String, homeDirectory: String) -> String {
+        if path == "~" {
+            return homeDirectory
+        }
+        guard path.hasPrefix("~/") else {
+            return path
+        }
+        return (homeDirectory as NSString).appendingPathComponent(String(path.dropFirst(2)))
     }
 }

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -26,14 +26,15 @@ enum Main {
             }
 
             do {
+                let smokeHost = ProcessInfo.processInfo.environment["NATIV_SMOKE_HOST"] ?? "127.0.0.1"
                 let smokePort = ProcessInfo.processInfo.environment["NATIV_SMOKE_PORT"] ?? "18080"
-                try server.start(arguments: ["--host", "127.0.0.1", "--port", smokePort])
+                try server.start(arguments: ["--host", smokeHost, "--port", smokePort])
                 guard server.isRunning else {
                     fputs("mlx-vlm-server exited before stop was requested\n", stderr)
                     exit(EXIT_FAILURE)
                 }
-                guard waitForMetricsEndpoint(port: smokePort) else {
-                    fputs("mlx-vlm-server did not expose /metrics on port \(smokePort)\n", stderr)
+                guard waitForMetricsEndpoint(host: smokeHost, port: smokePort) else {
+                    fputs("mlx-vlm-server did not expose /metrics at \(smokeHost):\(smokePort)\n", stderr)
                     try? server.stop()
                     exit(EXIT_FAILURE)
                 }
@@ -53,10 +54,14 @@ enum Main {
         NativApplication.main()
     }
 
-    private static func waitForMetricsEndpoint(port: String, timeout: TimeInterval = 5) -> Bool {
+    private static func waitForMetricsEndpoint(
+        host: String,
+        port: String,
+        timeout: TimeInterval = 5
+    ) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if checkMetricsEndpoint(port: port) {
+            if checkMetricsEndpoint(host: host, port: port) {
                 return true
             }
             Thread.sleep(forTimeInterval: 0.2)
@@ -64,8 +69,9 @@ enum Main {
         return false
     }
 
-    private static func checkMetricsEndpoint(port: String) -> Bool {
-        guard let url = URL(string: "http://127.0.0.1:\(port)/metrics") else {
+    private static func checkMetricsEndpoint(host: String, port: String) -> Bool {
+        let urlHost = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+        guard let url = URL(string: "http://\(urlHost):\(port)/metrics") else {
             return false
         }
 

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -131,6 +131,20 @@ final class NativModel: ObservableObject {
         restartServerForHuggingFaceCredentialChangeIfNeeded()
     }
 
+    func setServerAPIKey(_ token: String?) {
+        let normalizedToken = ServerAPIAuthentication.normalizedToken(token)
+        guard normalizedToken != settings.normalized().serverAPIKey else {
+            return
+        }
+
+        settings.serverAPIKey = normalizedToken
+        guard isRunning,
+              normalizedToken != settingsAppliedAtServerStart?.serverAPIKey else {
+            return
+        }
+        restartServer()
+    }
+
     func logOutSystemHuggingFaceCredential() throws {
         guard let credential = systemHuggingFaceCredential else {
             return
@@ -326,7 +340,7 @@ final class NativModel: ObservableObject {
 
         stopServer()
         guard !server.isRunning else {
-            appendLog("\nCould not stop the current server to apply the endpoint change.\n")
+            appendLog("\nCould not stop the current server to apply the configuration change.\n")
             return
         }
         startServer()

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -33,6 +33,7 @@ final class NativModel: ObservableObject {
     @Published private(set) var modelPreloadMemoryWarning: ModelPreloadMemoryWarning?
     @Published private(set) var metricsLoading = false
     @Published private(set) var environmentHuggingFaceToken = HuggingFaceAuthentication.token()
+    @Published private(set) var serverRestartCountdown: Int?
     @Published var settings = NativSettings.load() {
         didSet {
             settings.save()
@@ -55,6 +56,8 @@ final class NativModel: ObservableObject {
     private var preservedSessionTokenActivity: [SessionTokenActivitySample] = []
     private var isStoppingForModelSwitch = false
     private var pendingModelPreloadSwitch: PendingModelPreloadSwitch?
+    private var pendingServerRestartID: UUID?
+    private var serverRestartTask: Task<Void, Never>?
 
     private let maxLogCharacters = 250_000
     private let maxSessionActivitySamples = 120
@@ -251,6 +254,7 @@ final class NativModel: ObservableObject {
     }
 
     func stopServer(preserveSessionStats: Bool = false) {
+        cancelPendingServerRestart()
         modelLoadingProgress = nil
         if preserveSessionStats {
             preserveCurrentSessionStats()
@@ -297,6 +301,76 @@ final class NativModel: ObservableObject {
             return
         }
         startServer()
+    }
+
+    func scheduleServerRestartForEndpointChange() {
+        cancelPendingServerRestart()
+        guard isRunning else {
+            return
+        }
+
+        let scheduledSettings = settings.normalized()
+        let endpointHasChanged = scheduledSettings.serverHost != activeServerHost
+            || scheduledSettings.serverPort != activeServerPort
+        guard endpointHasChanged else {
+            return
+        }
+
+        let restartID = UUID()
+        pendingServerRestartID = restartID
+        serverRestartCountdown = 3
+        serverRestartTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+            defer {
+                self.clearPendingServerRestart(id: restartID)
+            }
+
+            for secondsRemaining in stride(from: 3, through: 1, by: -1) {
+                guard !Task.isCancelled, self.isRunning else {
+                    return
+                }
+                self.serverRestartCountdown = secondsRemaining
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+            }
+
+            let currentSettings = self.settings.normalized()
+            guard currentSettings.serverHost == scheduledSettings.serverHost,
+                  currentSettings.serverPort == scheduledSettings.serverPort
+            else {
+                return
+            }
+
+            let endpointStillNeedsRestart = currentSettings.serverHost != self.activeServerHost
+                || currentSettings.serverPort != self.activeServerPort
+            guard endpointStillNeedsRestart else {
+                return
+            }
+
+            self.clearPendingServerRestart(id: restartID)
+            self.restartServer()
+        }
+    }
+
+    private func cancelPendingServerRestart() {
+        serverRestartTask?.cancel()
+        serverRestartTask = nil
+        pendingServerRestartID = nil
+        serverRestartCountdown = nil
+    }
+
+    private func clearPendingServerRestart(id: UUID) {
+        guard pendingServerRestartID == id else {
+            return
+        }
+        serverRestartTask = nil
+        pendingServerRestartID = nil
+        serverRestartCountdown = nil
     }
 
     func switchLanguageModel(to modelID: String?) {

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -126,6 +126,28 @@ final class NativModel: ObservableObject {
         )
     }
 
+    func setCustomHuggingFaceToken(_ token: String?) {
+        settings.huggingFaceToken = HuggingFaceAuthentication.normalizedToken(token)
+        restartServerForHuggingFaceCredentialChangeIfNeeded()
+    }
+
+    func logOutSystemHuggingFaceCredential() throws {
+        guard let credential = systemHuggingFaceCredential else {
+            return
+        }
+        try HuggingFaceAuthentication.logOut(credential: credential)
+        systemHuggingFaceCredential = nil
+        restartServerForHuggingFaceCredentialChangeIfNeeded()
+    }
+
+    private func restartServerForHuggingFaceCredentialChangeIfNeeded() {
+        guard isRunning,
+              effectiveHuggingFaceToken != huggingFaceTokenAppliedAtServerStart else {
+            return
+        }
+        restartServer()
+    }
+
     var metricsAreStale: Bool {
         guard let lastMetricsFetchAt else {
             return true

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -286,6 +286,19 @@ final class NativModel: ObservableObject {
         }
     }
 
+    func restartServer() {
+        guard server.isRunning else {
+            return
+        }
+
+        stopServer()
+        guard !server.isRunning else {
+            appendLog("\nCould not stop the current server to apply the endpoint change.\n")
+            return
+        }
+        startServer()
+    }
+
     func switchLanguageModel(to modelID: String?) {
         switchPreloadedModel(to: modelID, for: .language)
     }

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -200,6 +200,20 @@ final class NativModel: ObservableObject {
         return settingsAppliedAtServerStart.normalized().serverPort
     }
 
+    var activeServerHost: String? {
+        guard isRunning, let settingsAppliedAtServerStart else {
+            return nil
+        }
+        return settingsAppliedAtServerStart.normalized().serverHost
+    }
+
+    var activeServerBaseURL: URL? {
+        guard isRunning, let settingsAppliedAtServerStart else {
+            return nil
+        }
+        return settingsAppliedAtServerStart.serverBaseURL
+    }
+
     func startServer() {
         var shouldStartMetrics = false
         metricsClient = NativMetricsClient(baseURL: settings.serverBaseURL)

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -32,7 +32,8 @@ final class NativModel: ObservableObject {
     @Published private(set) var modelLoadingProgress: Double?
     @Published private(set) var modelPreloadMemoryWarning: ModelPreloadMemoryWarning?
     @Published private(set) var metricsLoading = false
-    @Published private(set) var environmentHuggingFaceToken = HuggingFaceAuthentication.token()
+    @Published private(set) var systemHuggingFaceCredential =
+        HuggingFaceAuthentication.systemCredential()
     @Published private(set) var serverRestartCountdown: Int?
     @Published var settings = NativSettings.load() {
         didSet {
@@ -85,7 +86,10 @@ final class NativModel: ObservableObject {
             names.append(contentsOf: HuggingFaceCache.environmentVariableNames)
         }
         if needsTokenEnvironment {
-            names.append(HuggingFaceAuthentication.environmentVariableName)
+            for name in HuggingFaceAuthentication.discoveryEnvironmentVariableNames
+            where !names.contains(name) {
+                names.append(name)
+            }
         }
 
         let environmentVariableNames = names
@@ -105,8 +109,11 @@ final class NativModel: ObservableObject {
                 }
             }
             if needsTokenEnvironment {
-                self.environmentHuggingFaceToken = HuggingFaceAuthentication.token(
-                    in: shellEnvironment
+                let effectiveEnvironment = processEnvironment.merging(shellEnvironment) {
+                    _, shellValue in shellValue
+                }
+                self.systemHuggingFaceCredential = HuggingFaceAuthentication.systemCredential(
+                    in: effectiveEnvironment
                 )
             }
         }
@@ -115,7 +122,7 @@ final class NativModel: ObservableObject {
     var effectiveHuggingFaceToken: String? {
         HuggingFaceAuthentication.effectiveToken(
             customToken: settings.huggingFaceToken,
-            environmentToken: environmentHuggingFaceToken
+            environmentToken: systemHuggingFaceCredential?.token
         )
     }
 

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -583,19 +583,22 @@ final class NativModel: ObservableObject {
         }
         server.onTermination = { [weak self] status in
             Task { @MainActor [weak self] in
-                self?.appendLog("\nmlx-vlm-server stopped with status \(status)\n")
-                self?.isRunning = false
-                self?.settingsAppliedAtServerStart = nil
-                self?.huggingFaceTokenAppliedAtServerStart = nil
-                self?.stopMetricsPolling(clearSession: true)
-                self?.metricsLoading = false
-                self?.modelLoadingProgress = nil
-                if self?.isStoppingForModelSwitch != true {
-                    self?.modelSwitchInProgress = false
-                    self?.modelSwitchTargetID = nil
-                    self?.clearPreservedSessionStats()
+                guard let self, !self.server.isRunning else {
+                    return
                 }
-                self?.notifyMenuStateChanged()
+                self.appendLog("\nmlx-vlm-server stopped with status \(status)\n")
+                self.isRunning = false
+                self.settingsAppliedAtServerStart = nil
+                self.huggingFaceTokenAppliedAtServerStart = nil
+                self.stopMetricsPolling(clearSession: true)
+                self.metricsLoading = false
+                self.modelLoadingProgress = nil
+                if !self.isStoppingForModelSwitch {
+                    self.modelSwitchInProgress = false
+                    self.modelSwitchTargetID = nil
+                    self.clearPreservedSessionStats()
+                }
+                self.notifyMenuStateChanged()
             }
         }
     }

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -145,6 +145,8 @@ struct NativSettings: Codable, Equatable {
         HuggingFaceCache.defaultHubPath()
     }
 
+    static let defaultServerHost = "127.0.0.1"
+
     var modelSearchPath: String
     var additionalModelSearchPaths: [String]
     var languageModelID: String?
@@ -153,6 +155,7 @@ struct NativSettings: Codable, Equatable {
     var speechToTextModelID: String?
     var serverAPIKey: String?
     var huggingFaceToken: String?
+    var serverHost: String
     var serverPort: Int
     var maxTokens: Int
     var maxKVSize: Int
@@ -193,6 +196,7 @@ struct NativSettings: Codable, Equatable {
         speechToTextModelID: String? = nil,
         serverAPIKey: String? = nil,
         huggingFaceToken: String? = nil,
+        serverHost: String = Self.defaultServerHost,
         serverPort: Int = 8080,
         maxTokens: Int = 2048,
         maxKVSize: Int = 0,
@@ -232,6 +236,7 @@ struct NativSettings: Codable, Equatable {
         self.speechToTextModelID = speechToTextModelID
         self.serverAPIKey = serverAPIKey
         self.huggingFaceToken = huggingFaceToken
+        self.serverHost = serverHost
         self.serverPort = serverPort
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -273,6 +278,7 @@ struct NativSettings: Codable, Equatable {
         case speechToTextModelID
         case serverAPIKey
         case huggingFaceToken
+        case serverHost
         case serverPort
         case selectedModelID
         case maxTokens
@@ -319,6 +325,7 @@ struct NativSettings: Codable, Equatable {
         speechToTextModelID = try container.decodeIfPresent(String.self, forKey: .speechToTextModelID) ?? defaults.speechToTextModelID
         serverAPIKey = try container.decodeIfPresent(String.self, forKey: .serverAPIKey) ?? defaults.serverAPIKey
         huggingFaceToken = try container.decodeIfPresent(String.self, forKey: .huggingFaceToken) ?? defaults.huggingFaceToken
+        serverHost = try container.decodeIfPresent(String.self, forKey: .serverHost) ?? defaults.serverHost
         serverPort = try container.decodeIfPresent(Int.self, forKey: .serverPort) ?? defaults.serverPort
         maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens) ?? defaults.maxTokens
         maxKVSize = try container.decodeIfPresent(Int.self, forKey: .maxKVSize) ?? defaults.maxKVSize
@@ -361,6 +368,7 @@ struct NativSettings: Codable, Equatable {
         try container.encodeIfPresent(speechToTextModelID, forKey: .speechToTextModelID)
         try container.encodeIfPresent(serverAPIKey, forKey: .serverAPIKey)
         try container.encodeIfPresent(huggingFaceToken, forKey: .huggingFaceToken)
+        try container.encode(serverHost, forKey: .serverHost)
         try container.encode(serverPort, forKey: .serverPort)
         try container.encode(maxTokens, forKey: .maxTokens)
         try container.encode(maxKVSize, forKey: .maxKVSize)
@@ -428,6 +436,7 @@ struct NativSettings: Codable, Equatable {
         settings.speechToTextModelID = Self.normalizedModelID(settings.speechToTextModelID)
         settings.serverAPIKey = Self.normalizedModelID(settings.serverAPIKey)
         settings.huggingFaceToken = HuggingFaceAuthentication.normalizedToken(settings.huggingFaceToken)
+        settings.serverHost = Self.normalizedServerHost(settings.serverHost)
         settings.serverPort = min(max(settings.serverPort, 1), 65_535)
         settings.maxTokens = min(max(settings.maxTokens, 1), 262_144)
         settings.maxKVSize = min(max(settings.maxKVSize, 0), 1_048_576)
@@ -466,6 +475,7 @@ struct NativSettings: Codable, Equatable {
             && lhs.speechToTextModelID == rhs.speechToTextModelID
             && lhs.serverAPIKey == rhs.serverAPIKey
             && lhs.huggingFaceToken == rhs.huggingFaceToken
+            && lhs.serverHost == rhs.serverHost
             && lhs.serverPort == rhs.serverPort
             && lhs.maxTokens == rhs.maxTokens
             && lhs.maxKVSize == rhs.maxKVSize
@@ -490,7 +500,9 @@ struct NativSettings: Codable, Equatable {
     }
 
     var serverBaseURL: URL {
-        URL(string: "http://127.0.0.1:\(min(max(serverPort, 1), 65_535))")!
+        let settings = normalized()
+        let host = Self.urlHost(settings.serverHost)
+        return URL(string: "http://\(host):\(settings.serverPort)")!
     }
 
     var launchEnvironment: [String: String] {
@@ -516,6 +528,7 @@ struct NativSettings: Codable, Equatable {
     var launchArguments: [String] {
         let settings = normalized()
         var arguments = [
+            "--host", settings.serverHost,
             "--port", "\(settings.serverPort)",
             "--max-tokens", "\(settings.maxTokens)"
         ]
@@ -626,6 +639,38 @@ struct NativSettings: Codable, Equatable {
     private static func normalizedModelID(_ value: String?) -> String? {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private static func normalizedServerHost(_ value: String) -> String {
+        var host = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if host.hasPrefix("["), host.hasSuffix("]") {
+            host.removeFirst()
+            host.removeLast()
+        }
+        guard !host.isEmpty else {
+            return defaultServerHost
+        }
+
+        let candidate = "http://\(urlHost(host)):8080"
+        guard let components = URLComponents(string: candidate),
+              components.host != nil,
+              components.port == 8080,
+              components.path.isEmpty,
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil
+        else {
+            return defaultServerHost
+        }
+        return host
+    }
+
+    private static func urlHost(_ host: String) -> String {
+        guard host.contains(":") else {
+            return host
+        }
+        return "[\(host.replacingOccurrences(of: "%", with: "%25"))]"
     }
 
     private static func nonEmpty(_ value: String, fallback: String) -> String {

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -1,5 +1,48 @@
 import Foundation
 import NativServerKit
+import Security
+
+struct ServerAPITokenInfo: Equatable, Sendable {
+    let maskedValue: String
+    let characterCount: Int
+}
+
+enum ServerAPIAuthentication {
+    static func normalizedToken(_ token: String?) -> String? {
+        guard let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    static func tokenInfo(_ token: String?) -> ServerAPITokenInfo? {
+        guard let token = normalizedToken(token) else {
+            return nil
+        }
+
+        let prefix = token.hasPrefix("nativ_") ? "nativ_" : ""
+        let suffix = token.count > 8 ? String(token.suffix(4)) : ""
+        return ServerAPITokenInfo(
+            maskedValue: "\(prefix)••••••••\(suffix)",
+            characterCount: token.count
+        )
+    }
+
+    static func generateToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            return "nativ_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
+        }
+
+        let token = Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "nativ_\(token)"
+    }
+}
 
 enum ModelPreloadSlot: String, CaseIterable, Identifiable, Sendable {
     case language
@@ -434,7 +477,7 @@ struct NativSettings: Codable, Equatable {
         settings.imageGenerationModelID = Self.normalizedModelID(settings.imageGenerationModelID)
         settings.textToSpeechModelID = Self.normalizedModelID(settings.textToSpeechModelID)
         settings.speechToTextModelID = Self.normalizedModelID(settings.speechToTextModelID)
-        settings.serverAPIKey = Self.normalizedModelID(settings.serverAPIKey)
+        settings.serverAPIKey = ServerAPIAuthentication.normalizedToken(settings.serverAPIKey)
         settings.huggingFaceToken = HuggingFaceAuthentication.normalizedToken(settings.huggingFaceToken)
         settings.serverHost = Self.normalizedServerHost(settings.serverHost)
         settings.serverPort = min(max(settings.serverPort, 1), 65_535)

--- a/Sources/Nativ/Utilities/ServerPortProbe.swift
+++ b/Sources/Nativ/Utilities/ServerPortProbe.swift
@@ -1,11 +1,17 @@
 import Darwin
 import Foundation
 
+enum ServerEndpointAvailability: Equatable {
+    case available
+    case addressInUse
+    case invalidAddress
+}
+
 enum ServerPortProbe {
-    /// Whether a TCP listener can bind the given host and port right now.
-    static func isAvailable(host: String, port: Int) -> Bool {
+    /// Classifies whether a TCP listener can bind the given host and port right now.
+    static func availability(host: String, port: Int) -> ServerEndpointAvailability {
         guard (1...65_535).contains(port) else {
-            return false
+            return .invalidAddress
         }
 
         var hints = addrinfo()
@@ -18,23 +24,28 @@ enum ServerPortProbe {
         guard getaddrinfo(host, String(port), &hints, &addresses) == 0,
               let firstAddress = addresses
         else {
-            return false
+            return .invalidAddress
         }
         defer { freeaddrinfo(firstAddress) }
 
+        var foundAddressInUse = false
         var address: UnsafeMutablePointer<addrinfo>? = firstAddress
         while let candidate = address {
             let info = candidate.pointee
             let descriptor = socket(info.ai_family, info.ai_socktype, info.ai_protocol)
             if descriptor >= 0 {
                 let bindResult = Darwin.bind(descriptor, info.ai_addr, info.ai_addrlen)
+                let bindError = errno
                 close(descriptor)
                 if bindResult == 0 {
-                    return true
+                    return .available
+                }
+                if bindError == EADDRINUSE {
+                    foundAddressInUse = true
                 }
             }
             address = info.ai_next
         }
-        return false
+        return foundAddressInUse ? .addressInUse : .invalidAddress
     }
 }

--- a/Sources/Nativ/Utilities/ServerPortProbe.swift
+++ b/Sources/Nativ/Utilities/ServerPortProbe.swift
@@ -2,29 +2,39 @@ import Darwin
 import Foundation
 
 enum ServerPortProbe {
-    /// Whether a TCP listener can bind 127.0.0.1 on the given port right now.
-    static func isAvailable(_ port: Int) -> Bool {
+    /// Whether a TCP listener can bind the given host and port right now.
+    static func isAvailable(host: String, port: Int) -> Bool {
         guard (1...65_535).contains(port) else {
             return false
         }
 
-        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
-        guard descriptor >= 0 else {
-            return true
+        var hints = addrinfo()
+        hints.ai_flags = AI_NUMERICSERV
+        hints.ai_family = host.contains(":") ? AF_INET6 : AF_INET
+        hints.ai_socktype = SOCK_STREAM
+        hints.ai_protocol = IPPROTO_TCP
+
+        var addresses: UnsafeMutablePointer<addrinfo>?
+        guard getaddrinfo(host, String(port), &hints, &addresses) == 0,
+              let firstAddress = addresses
+        else {
+            return false
         }
-        defer { close(descriptor) }
+        defer { freeaddrinfo(firstAddress) }
 
-        var address = sockaddr_in()
-        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-        address.sin_family = sa_family_t(AF_INET)
-        address.sin_port = in_port_t(UInt16(port)).bigEndian
-        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
-
-        let bindResult = withUnsafePointer(to: &address) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+        var address: UnsafeMutablePointer<addrinfo>? = firstAddress
+        while let candidate = address {
+            let info = candidate.pointee
+            let descriptor = socket(info.ai_family, info.ai_socktype, info.ai_protocol)
+            if descriptor >= 0 {
+                let bindResult = Darwin.bind(descriptor, info.ai_addr, info.ai_addrlen)
+                close(descriptor)
+                if bindResult == 0 {
+                    return true
+                }
             }
+            address = info.ai_next
         }
-        return bindResult == 0
+        return false
     }
 }

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Security
 import SwiftUI
 
 enum WelcomePreferences {
@@ -73,7 +72,9 @@ private struct WelcomeView: View {
         self.onComplete = onComplete
         let settings = model.settings.normalized()
         _selectedModelID = State(initialValue: settings.languageModelID)
-        _serverAPIKey = State(initialValue: settings.serverAPIKey ?? WelcomeAPIKeyGenerator.makeKey())
+        _serverAPIKey = State(
+            initialValue: settings.serverAPIKey ?? ServerAPIAuthentication.generateToken()
+        )
     }
 
     var body: some View {
@@ -383,7 +384,7 @@ private struct WelcomeView: View {
                     .font(.subheadline.weight(.medium))
                 Spacer()
                 Button("Generate New") {
-                    serverAPIKey = WelcomeAPIKeyGenerator.makeKey()
+                    serverAPIKey = ServerAPIAuthentication.generateToken()
                     isAPIKeyFieldFocused = true
                 }
                 .buttonStyle(.borderless)
@@ -876,22 +877,6 @@ private struct WelcomeBackground: View {
                 .offset(x: -360, y: -250)
         }
         .ignoresSafeArea()
-    }
-}
-
-private enum WelcomeAPIKeyGenerator {
-    static func makeKey() -> String {
-        var bytes = [UInt8](repeating: 0, count: 32)
-        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
-            return "nativ_\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
-        }
-
-        let token = Data(bytes)
-            .base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-        return "nativ_\(token)"
     }
 }
 

--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -522,6 +522,7 @@ public struct MLXChatCompletionRequest: Encodable, Equatable, Sendable {
 
 public final class NativChatClient {
     private let baseURL: URL
+    private let apiKey: String?
     private let session: URLSession
     private let timeout: TimeInterval
     private let decoder = JSONDecoder()
@@ -529,9 +530,11 @@ public final class NativChatClient {
 
     public init(
         baseURL: URL = URL(string: "http://127.0.0.1:8080")!,
+        apiKey: String? = nil,
         timeout: TimeInterval = 600
     ) {
         self.baseURL = baseURL
+        self.apiKey = apiKey
         self.timeout = timeout
 
         let configuration = URLSessionConfiguration.ephemeral
@@ -719,13 +722,14 @@ public final class NativChatClient {
         throw NativChatError.missingAssistantContent
     }
 
-    private func makeURLRequest(payload: MLXChatCompletionRequest, accepts: String) throws -> URLRequest {
+    func makeURLRequest(payload: MLXChatCompletionRequest, accepts: String) throws -> URLRequest {
         var request = URLRequest(url: baseURL.appendingPathComponent("v1/chat/completions"))
         request.httpMethod = "POST"
         request.timeoutInterval = timeout
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(accepts, forHTTPHeaderField: "Accept")
+        NativServerAuthorization.authorize(&request, apiKey: apiKey)
         request.httpBody = try encoder.encode(payload)
         return request
     }

--- a/Sources/NativServerKit/NativImageClient.swift
+++ b/Sources/NativServerKit/NativImageClient.swift
@@ -172,6 +172,7 @@ public struct MLXImageResponseData: Decodable, Equatable, Sendable {
 
 public final class NativImageClient {
     private let baseURL: URL
+    private let apiKey: String?
     private let session: URLSession
     private let timeout: TimeInterval
     private let decoder = JSONDecoder()
@@ -179,9 +180,11 @@ public final class NativImageClient {
 
     public init(
         baseURL: URL = URL(string: "http://127.0.0.1:8080")!,
+        apiKey: String? = nil,
         timeout: TimeInterval = 1_800
     ) {
         self.baseURL = baseURL
+        self.apiKey = apiKey
         self.timeout = timeout
 
         let configuration = URLSessionConfiguration.ephemeral
@@ -231,13 +234,7 @@ public final class NativImageClient {
         _ payload: Payload,
         path: String
     ) async throws -> MLXImageResponse {
-        var request = URLRequest(url: baseURL.appendingPathComponent(path))
-        request.httpMethod = "POST"
-        request.timeoutInterval = timeout
-        request.cachePolicy = .reloadIgnoringLocalCacheData
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.httpBody = try encoder.encode(payload)
+        let request = try makeURLRequest(payload, path: path)
 
         let (data, response) = try await session.data(for: request)
 
@@ -249,5 +246,20 @@ public final class NativImageClient {
         }
 
         return try decoder.decode(MLXImageResponse.self, from: data)
+    }
+
+    func makeURLRequest<Payload: Encodable>(
+        _ payload: Payload,
+        path: String
+    ) throws -> URLRequest {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.httpMethod = "POST"
+        request.timeoutInterval = timeout
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        NativServerAuthorization.authorize(&request, apiKey: apiKey)
+        request.httpBody = try encoder.encode(payload)
+        return request
     }
 }

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -591,8 +591,12 @@ public final class NativProcessController {
             observe(pipe: outputPipe)
             observe(pipe: errorPipe)
 
-            process.terminationHandler = { [weak self] process in
-                self?.handleTermination(status: process.terminationStatus)
+            process.terminationHandler = { [weak self, outputPipe, errorPipe] process in
+                self?.handleTermination(
+                    process: process,
+                    outputPipe: outputPipe,
+                    errorPipe: errorPipe
+                )
             }
 
             do {
@@ -638,18 +642,23 @@ public final class NativProcessController {
         }
     }
 
-    private func handleTermination(status: Int32) {
-        let pipes = lock.withLock {
-            let pipes = (self.outputPipe, self.errorPipe)
+    private func handleTermination(
+        process: Process,
+        outputPipe: Pipe,
+        errorPipe: Pipe
+    ) {
+        lock.withLock {
+            guard self.process === process else {
+                return
+            }
             self.process = nil
             self.outputPipe = nil
             self.errorPipe = nil
-            return pipes
         }
 
-        pipes.0?.fileHandleForReading.readabilityHandler = nil
-        pipes.1?.fileHandleForReading.readabilityHandler = nil
-        onTermination?(status)
+        outputPipe.fileHandleForReading.readabilityHandler = nil
+        errorPipe.fileHandleForReading.readabilityHandler = nil
+        onTermination?(process.terminationStatus)
     }
 }
 

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+public enum NativServerAuthorization {
+    public static func authorize(_ request: inout URLRequest, apiKey: String?) {
+        guard let apiKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !apiKey.isEmpty else {
+            return
+        }
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    }
+}
+
 public enum NativError: Error, CustomStringConvertible {
     case missingDistribution(Bundle)
     case missingExecutable(URL)
@@ -532,9 +542,7 @@ public final class NativMetricsClient {
         var request = URLRequest(url: baseURL.appendingPathComponent(path))
         request.timeoutInterval = timeout
         request.cachePolicy = .reloadIgnoringLocalCacheData
-        if let apiKey, !apiKey.isEmpty {
-            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
+        NativServerAuthorization.authorize(&request, apiKey: apiKey)
 
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {

--- a/Tests/NativTests/HuggingFaceCacheTests.swift
+++ b/Tests/NativTests/HuggingFaceCacheTests.swift
@@ -133,6 +133,92 @@ final class HuggingFaceAuthenticationTests: XCTestCase {
         XCTAssertNil(HuggingFaceAuthentication.token(in: ["HF_TOKEN": " \n "]))
     }
 
+    func testSystemCredentialPrefersEnvironmentToken() {
+        var readCredentialFile = false
+
+        let credential = HuggingFaceAuthentication.systemCredential(
+            in: ["HF_TOKEN": " hf_environment "],
+            homeDirectory: "/Users/example"
+        ) { _ in
+            readCredentialFile = true
+            return "hf_file"
+        }
+
+        XCTAssertEqual(
+            credential,
+            HuggingFaceCredential(token: "hf_environment", source: .environment)
+        )
+        XCTAssertFalse(readCredentialFile)
+    }
+
+    func testSystemCredentialReadsLocalLoginToken() {
+        var requestedPath: String?
+
+        let credential = HuggingFaceAuthentication.systemCredential(
+            in: [:],
+            homeDirectory: "/Users/example"
+        ) { path in
+            requestedPath = path
+            return "  hf_login\n"
+        }
+
+        XCTAssertEqual(requestedPath, "/Users/example/.cache/huggingface/token")
+        XCTAssertEqual(
+            credential,
+            HuggingFaceCredential(token: "hf_login", source: .credentialFile)
+        )
+    }
+
+    func testSystemCredentialIgnoresMissingAndBlankLoginToken() {
+        XCTAssertNil(
+            HuggingFaceAuthentication.systemCredential(
+                in: [:],
+                homeDirectory: "/Users/example",
+                readTokenFile: { _ in nil }
+            )
+        )
+        XCTAssertNil(
+            HuggingFaceAuthentication.systemCredential(
+                in: [:],
+                homeDirectory: "/Users/example",
+                readTokenFile: { _ in " \n " }
+            )
+        )
+    }
+
+    func testCredentialFilePathUsesHuggingFacePrecedence() {
+        let homeDirectory = "/Users/example"
+
+        XCTAssertEqual(
+            HuggingFaceAuthentication.credentialFilePath(
+                environment: [
+                    "HF_TOKEN_PATH": "~/credentials/hf-token",
+                    "HF_HOME": "/Volumes/hugging-face",
+                    "XDG_CACHE_HOME": "/Volumes/cache"
+                ],
+                homeDirectory: homeDirectory
+            ),
+            "/Users/example/credentials/hf-token"
+        )
+        XCTAssertEqual(
+            HuggingFaceAuthentication.credentialFilePath(
+                environment: [
+                    "HF_HOME": "/Volumes/hugging-face",
+                    "XDG_CACHE_HOME": "/Volumes/cache"
+                ],
+                homeDirectory: homeDirectory
+            ),
+            "/Volumes/hugging-face/token"
+        )
+        XCTAssertEqual(
+            HuggingFaceAuthentication.credentialFilePath(
+                environment: ["XDG_CACHE_HOME": "/Volumes/cache"],
+                homeDirectory: homeDirectory
+            ),
+            "/Volumes/cache/huggingface/token"
+        )
+    }
+
     func testCustomTokenOverridesEnvironmentToken() {
         XCTAssertEqual(
             HuggingFaceAuthentication.effectiveToken(

--- a/Tests/NativTests/HuggingFaceCacheTests.swift
+++ b/Tests/NativTests/HuggingFaceCacheTests.swift
@@ -133,16 +133,16 @@ final class HuggingFaceAuthenticationTests: XCTestCase {
         XCTAssertNil(HuggingFaceAuthentication.token(in: ["HF_TOKEN": " \n "]))
     }
 
-    func testTokenSummaryMasksCredentialAndShowsLength() {
+    func testTokenInfoMasksCredentialAndShowsLength() {
         XCTAssertEqual(
-            HuggingFaceAuthentication.tokenSummary(" hf_1234567890abcdef\n"),
-            "hf_••••••••cdef · 19 characters"
+            HuggingFaceAuthentication.tokenInfo(" hf_1234567890abcdef\n"),
+            HuggingFaceTokenInfo(maskedValue: "hf_••••••••cdef", characterCount: 19)
         )
         XCTAssertEqual(
-            HuggingFaceAuthentication.tokenSummary("short"),
-            "•••••••• · 5 characters"
+            HuggingFaceAuthentication.tokenInfo("short"),
+            HuggingFaceTokenInfo(maskedValue: "••••••••", characterCount: 5)
         )
-        XCTAssertNil(HuggingFaceAuthentication.tokenSummary(" \n "))
+        XCTAssertNil(HuggingFaceAuthentication.tokenInfo(" \n "))
     }
 
     func testSystemCredentialPrefersEnvironmentToken() {
@@ -177,7 +177,11 @@ final class HuggingFaceAuthenticationTests: XCTestCase {
         XCTAssertEqual(requestedPath, "/Users/example/.cache/huggingface/token")
         XCTAssertEqual(
             credential,
-            HuggingFaceCredential(token: "hf_login", source: .credentialFile)
+            HuggingFaceCredential(
+                token: "hf_login",
+                source: .credentialFile,
+                filePath: "/Users/example/.cache/huggingface/token"
+            )
         )
     }
 
@@ -229,6 +233,53 @@ final class HuggingFaceAuthenticationTests: XCTestCase {
             ),
             "/Volumes/cache/huggingface/token"
         )
+    }
+
+    func testLogoutRemovesCredentialFile() throws {
+        var removedPath: String?
+        let credential = HuggingFaceCredential(
+            token: "hf_login",
+            source: .credentialFile,
+            filePath: "/Users/example/.cache/huggingface/token"
+        )
+
+        try HuggingFaceAuthentication.logOut(credential: credential) { path in
+            removedPath = path
+        }
+
+        XCTAssertEqual(removedPath, "/Users/example/.cache/huggingface/token")
+    }
+
+    func testLogoutRejectsEnvironmentToken() {
+        let credential = HuggingFaceCredential(
+            token: "hf_environment",
+            source: .environment
+        )
+
+        XCTAssertThrowsError(
+            try HuggingFaceAuthentication.logOut(credential: credential)
+        ) { error in
+            XCTAssertEqual(
+                error as? HuggingFaceAuthenticationError,
+                .environmentTokenCannotBeRemoved
+            )
+        }
+    }
+
+    func testLogoutRejectsCredentialWithoutFilePath() {
+        let credential = HuggingFaceCredential(
+            token: "hf_login",
+            source: .credentialFile
+        )
+
+        XCTAssertThrowsError(
+            try HuggingFaceAuthentication.logOut(credential: credential)
+        ) { error in
+            XCTAssertEqual(
+                error as? HuggingFaceAuthenticationError,
+                .missingCredentialFile
+            )
+        }
     }
 
     func testCustomTokenOverridesEnvironmentToken() {

--- a/Tests/NativTests/HuggingFaceCacheTests.swift
+++ b/Tests/NativTests/HuggingFaceCacheTests.swift
@@ -133,6 +133,18 @@ final class HuggingFaceAuthenticationTests: XCTestCase {
         XCTAssertNil(HuggingFaceAuthentication.token(in: ["HF_TOKEN": " \n "]))
     }
 
+    func testTokenSummaryMasksCredentialAndShowsLength() {
+        XCTAssertEqual(
+            HuggingFaceAuthentication.tokenSummary(" hf_1234567890abcdef\n"),
+            "hf_••••••••cdef · 19 characters"
+        )
+        XCTAssertEqual(
+            HuggingFaceAuthentication.tokenSummary("short"),
+            "•••••••• · 5 characters"
+        )
+        XCTAssertNil(HuggingFaceAuthentication.tokenSummary(" \n "))
+    }
+
     func testSystemCredentialPrefersEnvironmentToken() {
         var readCredentialFile = false
 

--- a/Tests/NativTests/HuggingFaceCacheTests.swift
+++ b/Tests/NativTests/HuggingFaceCacheTests.swift
@@ -145,6 +145,77 @@ final class HuggingFaceAuthenticationTests: XCTestCase {
         XCTAssertNil(HuggingFaceAuthentication.tokenInfo(" \n "))
     }
 
+    func testTokenMetadataDecodesNameAndPermission() throws {
+        let data = Data(
+            """
+            {
+              "auth": {
+                "accessToken": {
+                  "displayName": "localai",
+                  "role": "write"
+                }
+              }
+            }
+            """.utf8
+        )
+
+        XCTAssertEqual(
+            try HuggingFaceAuthentication.decodeTokenMetadata(from: data),
+            HuggingFaceTokenMetadata(name: "localai", permission: "write")
+        )
+    }
+
+    func testTokenMetadataToleratesMissingDetails() throws {
+        XCTAssertEqual(
+            try HuggingFaceAuthentication.decodeTokenMetadata(
+                from: Data(#"{"auth":{"accessToken":{}}}"#.utf8)
+            ),
+            HuggingFaceTokenMetadata(name: nil, permission: nil)
+        )
+    }
+
+    func testTokenMetadataCachePersistsForMatchingToken() throws {
+        let cacheURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("HuggingFaceTokenMetadata.plist")
+        defer {
+            try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent())
+        }
+        let metadata = HuggingFaceTokenMetadata(name: "localai", permission: "write")
+
+        try HuggingFaceTokenMetadataCache.save(
+            metadata,
+            for: "hf_example",
+            to: cacheURL
+        )
+
+        XCTAssertEqual(
+            HuggingFaceTokenMetadataCache.load(for: "hf_example", from: cacheURL),
+            metadata
+        )
+        XCTAssertNil(
+            HuggingFaceTokenMetadataCache.load(for: "hf_different", from: cacheURL)
+        )
+    }
+
+    func testTokenMetadataCacheDoesNotPersistRawToken() throws {
+        let cacheURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("HuggingFaceTokenMetadata.plist")
+        defer {
+            try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent())
+        }
+
+        try HuggingFaceTokenMetadataCache.save(
+            HuggingFaceTokenMetadata(name: "token-name", permission: "read"),
+            for: "hf_private_value",
+            to: cacheURL
+        )
+
+        let storedData = try Data(contentsOf: cacheURL)
+        XCTAssertFalse(String(decoding: storedData, as: UTF8.self).contains("hf_private_value"))
+    }
+
     func testSystemCredentialPrefersEnvironmentToken() {
         var readCredentialFile = false
 

--- a/Tests/NativTests/IntegrationServicesTests.swift
+++ b/Tests/NativTests/IntegrationServicesTests.swift
@@ -70,6 +70,26 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertEqual(Set(IntegrationTool.allCases), Self.coveredTools)
     }
 
+    func testConfiguredServerAPIKeyIsUsedByProfilesAndLaunchEnvironment() throws {
+        manager = IntegrationProfileManager(
+            serverBaseURL: serverBaseURL,
+            serverAPIKey: "  nativ_configured_token\n",
+            homeDirectory: homeDirectory,
+            applicationSupportDirectory: applicationSupportDirectory
+        )
+
+        try configure(.pi)
+
+        let root = try json(at: manager.configurationURL(for: .pi))
+        let providers = try XCTUnwrap(root["providers"] as? [String: Any])
+        let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
+        XCTAssertEqual(provider["apiKey"] as? String, "nativ_configured_token")
+        XCTAssertTrue(
+            launchCommand(for: .goose)
+                .contains("export NATIV_API_KEY='nativ_configured_token'")
+        )
+    }
+
     func testPiConfigurationAndLaunchCommand() throws {
         let configurationURL = manager.configurationURL(for: .pi)
         try FileManager.default.createDirectory(
@@ -350,7 +370,7 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertTrue(contents.contains("provider: openai"))
         XCTAssertTrue(contents.contains("apiBase: \"http://nativ.test:49152/v1\""))
         XCTAssertTrue(contents.contains("model: \"org/local-model\""))
-        XCTAssertTrue(contents.contains("apiKey: nativ"))
+        XCTAssertTrue(contents.contains("apiKey: \"nativ\""))
         XCTAssertEqual(
             launchCommand(for: .continueDev),
             "cd '/tmp/Nativ Project'\n'/tools/cn' '--config' '\(configurationURL.path)'"

--- a/Tests/NativTests/IntegrationServicesTests.swift
+++ b/Tests/NativTests/IntegrationServicesTests.swift
@@ -24,7 +24,7 @@ final class IntegrationServicesTests: XCTestCase {
     private var homeDirectory: URL!
     private var applicationSupportDirectory: URL!
     private var manager: IntegrationProfileManager!
-    private let serverBaseURL = URL(string: "http://127.0.0.1:49152")!
+    private let serverBaseURL = URL(string: "http://nativ.test:49152")!
 
     private let selectedModel = IntegrationModelDescriptor(
         id: "org/local-model",
@@ -85,7 +85,7 @@ final class IntegrationServicesTests: XCTestCase {
         let providers = try XCTUnwrap(root["providers"] as? [String: Any])
         XCTAssertNotNil(providers["existing"])
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
-        XCTAssertEqual(provider["baseUrl"] as? String, "http://127.0.0.1:49152/v1")
+        XCTAssertEqual(provider["baseUrl"] as? String, "http://nativ.test:49152/v1")
         XCTAssertEqual(provider["api"] as? String, "openai-completions")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
@@ -121,7 +121,7 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: baseConfigurationURL, encoding: .utf8), baseConfiguration)
         XCTAssertEqual(
             profile,
-            CodexCLIProfile.contents(selectedModelID: basicModel.id, baseURL: "http://127.0.0.1:49152/v1")
+            CodexCLIProfile.contents(selectedModelID: basicModel.id, baseURL: "http://nativ.test:49152/v1")
         )
         XCTAssertFalse(profile.contains(selectedModel.id))
         XCTAssertEqual(profile.components(separatedBy: "# Managed by Nativ.").count - 1, 1)
@@ -139,7 +139,7 @@ final class IntegrationServicesTests: XCTestCase {
         let environment = try XCTUnwrap(root["env"] as? [String: Any])
         XCTAssertEqual(environment["ANTHROPIC_AUTH_TOKEN"] as? String, "nativ")
         XCTAssertEqual(environment["ANTHROPIC_API_KEY"] as? String, "")
-        XCTAssertEqual(environment["ANTHROPIC_BASE_URL"] as? String, "http://127.0.0.1:49152")
+        XCTAssertEqual(environment["ANTHROPIC_BASE_URL"] as? String, "http://nativ.test:49152")
         XCTAssertEqual(environment["ANTHROPIC_MODEL"] as? String, selectedModel.id)
         XCTAssertEqual(environment["ANTHROPIC_SMALL_FAST_MODEL"] as? String, selectedModel.id)
         XCTAssertEqual(
@@ -148,7 +148,7 @@ final class IntegrationServicesTests: XCTestCase {
             cd '/tmp/Nativ Project'
             export ANTHROPIC_API_KEY=''
             export ANTHROPIC_AUTH_TOKEN='nativ'
-            export ANTHROPIC_BASE_URL='http://127.0.0.1:49152'
+            export ANTHROPIC_BASE_URL='http://nativ.test:49152'
             '/tools/claude' '--settings' '\(configurationURL.path)' '--model' 'org/local-model'
             """
         )
@@ -160,7 +160,7 @@ final class IntegrationServicesTests: XCTestCase {
         let configurationURL = manager.configurationURL(for: .hermes)
         let configuration = try String(contentsOf: configurationURL, encoding: .utf8)
         XCTAssertTrue(configuration.contains("default: \"org/local-model\""))
-        XCTAssertTrue(configuration.contains("base_url: \"http://127.0.0.1:49152/v1\""))
+        XCTAssertTrue(configuration.contains("base_url: \"http://nativ.test:49152/v1\""))
         XCTAssertTrue(configuration.contains("\"org/local-model\":\n        context_length: 32768\n        supports_vision: true"))
         XCTAssertTrue(configuration.contains("\"org/basic-model\":\n        context_length: 131072"))
         XCTAssertEqual(
@@ -186,7 +186,7 @@ final class IntegrationServicesTests: XCTestCase {
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["npm"] as? String, "@ai-sdk/openai-compatible")
         let options = try XCTUnwrap(provider["options"] as? [String: Any])
-        XCTAssertEqual(options["baseURL"] as? String, "http://127.0.0.1:49152/v1")
+        XCTAssertEqual(options["baseURL"] as? String, "http://nativ.test:49152/v1")
         let models = try XCTUnwrap(provider["models"] as? [String: Any])
         let selected = try XCTUnwrap(models[selectedModel.id] as? [String: Any])
         XCTAssertEqual(selected["attachment"] as? Bool, true)
@@ -212,7 +212,7 @@ final class IntegrationServicesTests: XCTestCase {
 
         let configurationURL = manager.configurationURL(for: .aider)
         let contents = try String(contentsOf: configurationURL, encoding: .utf8)
-        XCTAssertTrue(contents.contains("OPENAI_API_BASE=http://127.0.0.1:49152/v1"))
+        XCTAssertTrue(contents.contains("OPENAI_API_BASE=http://nativ.test:49152/v1"))
         XCTAssertTrue(contents.contains("OPENAI_API_KEY=nativ"))
         XCTAssertEqual(
             launchCommand(for: .aider),
@@ -228,7 +228,7 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertEqual(root["name"] as? String, "nativ")
         XCTAssertEqual(root["engine"] as? String, "openai")
         XCTAssertEqual(root["api_key_env"] as? String, "NATIV_API_KEY")
-        XCTAssertEqual(root["base_url"] as? String, "http://127.0.0.1:49152/v1/chat/completions")
+        XCTAssertEqual(root["base_url"] as? String, "http://nativ.test:49152/v1/chat/completions")
         let models = try XCTUnwrap(root["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
         XCTAssertEqual(models[0]["name"] as? String, selectedModel.id)
@@ -253,7 +253,7 @@ final class IntegrationServicesTests: XCTestCase {
         let providers = try XCTUnwrap(root["providers"] as? [String: Any])
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["type"] as? String, "openai-compat")
-        XCTAssertEqual(provider["base_url"] as? String, "http://127.0.0.1:49152/v1")
+        XCTAssertEqual(provider["base_url"] as? String, "http://nativ.test:49152/v1")
         XCTAssertEqual(provider["api_key"] as? String, "nativ")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
@@ -281,14 +281,14 @@ final class IntegrationServicesTests: XCTestCase {
         let configurationURL = manager.configurationURL(for: .qwenCode)
         let contents = try String(contentsOf: configurationURL, encoding: .utf8)
         XCTAssertTrue(contents.contains("OPENAI_API_KEY=nativ"))
-        XCTAssertTrue(contents.contains("OPENAI_BASE_URL=http://127.0.0.1:49152/v1"))
+        XCTAssertTrue(contents.contains("OPENAI_BASE_URL=http://nativ.test:49152/v1"))
         XCTAssertTrue(contents.contains("OPENAI_MODEL=org/local-model"))
         XCTAssertEqual(
             launchCommand(for: .qwenCode),
             """
             cd '/tmp/Nativ Project'
             export OPENAI_API_KEY='nativ'
-            export OPENAI_BASE_URL='http://127.0.0.1:49152/v1'
+            export OPENAI_BASE_URL='http://nativ.test:49152/v1'
             export OPENAI_MODEL='org/local-model'
             '/tools/qwen'
             """
@@ -303,7 +303,7 @@ final class IntegrationServicesTests: XCTestCase {
         let modelsRoot = try XCTUnwrap(root["models"] as? [String: Any])
         let providers = try XCTUnwrap(modelsRoot["providers"] as? [String: Any])
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
-        XCTAssertEqual(provider["baseUrl"] as? String, "http://127.0.0.1:49152/v1")
+        XCTAssertEqual(provider["baseUrl"] as? String, "http://nativ.test:49152/v1")
         XCTAssertEqual(provider["api"] as? String, "openai-completions")
         XCTAssertEqual(provider["apiKey"] as? String, "nativ")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
@@ -325,7 +325,7 @@ final class IntegrationServicesTests: XCTestCase {
         let languageModels = try XCTUnwrap(root["language_models"] as? [String: Any])
         let openAICompatible = try XCTUnwrap(languageModels["openai_compatible"] as? [String: Any])
         let provider = try XCTUnwrap(openAICompatible["nativ"] as? [String: Any])
-        XCTAssertEqual(provider["api_url"] as? String, "http://127.0.0.1:49152/v1")
+        XCTAssertEqual(provider["api_url"] as? String, "http://nativ.test:49152/v1")
         let models = try XCTUnwrap(provider["available_models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
         XCTAssertEqual(models[0]["name"] as? String, selectedModel.id)
@@ -348,7 +348,7 @@ final class IntegrationServicesTests: XCTestCase {
         let configurationURL = manager.configurationURL(for: .continueDev)
         let contents = try String(contentsOf: configurationURL, encoding: .utf8)
         XCTAssertTrue(contents.contains("provider: openai"))
-        XCTAssertTrue(contents.contains("apiBase: \"http://127.0.0.1:49152/v1\""))
+        XCTAssertTrue(contents.contains("apiBase: \"http://nativ.test:49152/v1\""))
         XCTAssertTrue(contents.contains("model: \"org/local-model\""))
         XCTAssertTrue(contents.contains("apiKey: nativ"))
         XCTAssertEqual(

--- a/Tests/NativTests/IntegrationServicesTests.swift
+++ b/Tests/NativTests/IntegrationServicesTests.swift
@@ -85,6 +85,10 @@ final class IntegrationServicesTests: XCTestCase {
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["apiKey"] as? String, "nativ_configured_token")
         XCTAssertTrue(
+            launchCommand(for: .codex)
+                .contains("export NATIV_API_KEY='nativ_configured_token'")
+        )
+        XCTAssertTrue(
             launchCommand(for: .goose)
                 .contains("export NATIV_API_KEY='nativ_configured_token'")
         )
@@ -147,7 +151,11 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertEqual(profile.components(separatedBy: "# Managed by Nativ.").count - 1, 1)
         XCTAssertEqual(
             launchCommand(for: .codex),
-            "cd '/tmp/Nativ Project'\n'/tools/codex' '--profile' 'nativ' '--model' 'org/local-model'"
+            """
+            cd '/tmp/Nativ Project'
+            export NATIV_API_KEY='nativ'
+            '/tools/codex' '--profile' 'nativ' '--model' 'org/local-model'
+            """
         )
     }
 

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -73,6 +73,38 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertFalse(original.hasSameLaunchConfiguration(as: changed))
     }
 
+    func testServerAPITokenIsNormalizedMaskedAndPassedToServer() {
+        let settings = NativSettings(serverAPIKey: "  nativ_1234567890abcdef\n")
+        let normalized = settings.normalized()
+
+        XCTAssertEqual(normalized.serverAPIKey, "nativ_1234567890abcdef")
+        XCTAssertEqual(
+            ServerAPIAuthentication.tokenInfo(normalized.serverAPIKey),
+            ServerAPITokenInfo(
+                maskedValue: "nativ_••••••••cdef",
+                characterCount: 22
+            )
+        )
+        XCTAssertEqual(
+            normalized.launchEnvironment["MLX_VLM_SERVER_API_KEY"],
+            "nativ_1234567890abcdef"
+        )
+    }
+
+    func testBlankServerAPITokenIsOmitted() {
+        let settings = NativSettings(serverAPIKey: " \n ").normalized()
+
+        XCTAssertNil(settings.serverAPIKey)
+        XCTAssertNil(settings.launchEnvironment["MLX_VLM_SERVER_API_KEY"])
+    }
+
+    func testGeneratedServerAPITokenHasNativPrefix() {
+        let token = ServerAPIAuthentication.generateToken()
+
+        XCTAssertTrue(token.hasPrefix("nativ_"))
+        XCTAssertEqual(token, ServerAPIAuthentication.normalizedToken(token))
+    }
+
     func testEveryPreloadSelectionRequiresServerRestart() {
         let original = NativSettings()
 

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -105,6 +105,63 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertEqual(token, ServerAPIAuthentication.normalizedToken(token))
     }
 
+    func testServerAuthorizationAddsBearerHeader() {
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:8080/health")!)
+
+        NativServerAuthorization.authorize(&request, apiKey: "  nativ_test_token\n")
+
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Authorization"),
+            "Bearer nativ_test_token"
+        )
+    }
+
+    func testServerAuthorizationOmitsBlankToken() {
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:8080/health")!)
+
+        NativServerAuthorization.authorize(&request, apiKey: " \n ")
+
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    func testChatClientAddsServerAuthorization() throws {
+        let client = NativChatClient(
+            baseURL: URL(string: "http://127.0.0.1:8080")!,
+            apiKey: "nativ_chat_token"
+        )
+        let payload = MLXChatCompletionRequest(
+            model: "org/model",
+            messages: [MLXChatMessage(role: "user", content: "Hello")],
+            maxTokens: 1,
+            temperature: 0,
+            topK: 0,
+            topP: 1,
+            minP: 0
+        )
+
+        let request = try client.makeURLRequest(payload: payload, accepts: "application/json")
+
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Authorization"),
+            "Bearer nativ_chat_token"
+        )
+    }
+
+    func testImageClientAddsServerAuthorization() throws {
+        let client = NativImageClient(
+            baseURL: URL(string: "http://127.0.0.1:8080")!,
+            apiKey: "nativ_image_token"
+        )
+        let payload = MLXImageGenerationRequest(model: "org/model", prompt: "A lighthouse")
+
+        let request = try client.makeURLRequest(payload, path: "v1/images/generations")
+
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Authorization"),
+            "Bearer nativ_image_token"
+        )
+    }
+
     func testEveryPreloadSelectionRequiresServerRestart() {
         let original = NativSettings()
 

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -11,8 +11,9 @@ final class NativSettingsTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            Array(settings.launchArguments.prefix(10)),
+            Array(settings.launchArguments.prefix(12)),
             [
+                "--host", "127.0.0.1",
                 "--port", "8080",
                 "--max-tokens", "2048",
                 "--model", "org/language",
@@ -40,6 +41,36 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertFalse(settings.launchArguments.contains("--image-model"))
         XCTAssertFalse(settings.launchArguments.contains("--tts-model"))
         XCTAssertFalse(settings.launchArguments.contains("--stt-model"))
+    }
+
+    func testServerHostIsNormalizedAndPassedToServer() {
+        let settings = NativSettings(serverHost: "  0.0.0.0  ", serverPort: 9_001)
+
+        XCTAssertEqual(settings.normalized().serverHost, "0.0.0.0")
+        XCTAssertEqual(settings.serverBaseURL.absoluteString, "http://0.0.0.0:9001")
+        XCTAssertTrue(settings.launchArguments.containsAdjacent("--host", "0.0.0.0"))
+    }
+
+    func testIPv6ServerHostProducesValidBaseURL() {
+        let settings = NativSettings(serverHost: "[::1]", serverPort: 9_002)
+
+        XCTAssertEqual(settings.normalized().serverHost, "::1")
+        XCTAssertEqual(settings.serverBaseURL.absoluteString, "http://[::1]:9002")
+        XCTAssertTrue(settings.launchArguments.containsAdjacent("--host", "::1"))
+    }
+
+    func testMissingServerHostUsesLoopbackDefault() throws {
+        let settings = try JSONDecoder().decode(NativSettings.self, from: Data("{}".utf8))
+
+        XCTAssertEqual(settings.serverHost, "127.0.0.1")
+    }
+
+    func testServerHostRequiresServerRestart() {
+        let original = NativSettings()
+        var changed = original
+        changed.serverHost = "0.0.0.0"
+
+        XCTAssertFalse(original.hasSameLaunchConfiguration(as: changed))
     }
 
     func testEveryPreloadSelectionRequiresServerRestart() {


### PR DESCRIPTION
## Summary

- add a persisted server host setting beside the existing configurable port
- pass the selected host to the server and use it for clients, copied endpoints, active integration profiles, availability checks, and lifecycle smoke tests
- support hostname, IPv4, and IPv6 URL generation while retaining `127.0.0.1` as the backward-compatible default
- show a live countdown and restart a running server three seconds after the latest host or port edit without retriggering on page navigation
- distinguish an address already in use from an invalid host or port in endpoint warnings
- preserve the replacement process and active endpoint when the previous server’s termination callback arrives late
- add color accents to the Developer panel headers for clearer visual separation
- detect existing Hugging Face CLI login credentials without exposing the token, including custom `HF_TOKEN_PATH`, `HF_HOME`, and XDG locations
- show the active Hugging Face credential source with a masked suffix and token length
- organize Hugging Face authentication into status, active credential, and custom override sections with replace and logout controls
- update integration coverage and documentation for dynamic hosts

## Why

The server port was configurable, but the bind host and several derived URLs were still hard-coded to `127.0.0.1`. This prevented users from binding Nativ to another local interface or wildcard address and caused generated integration endpoints to ignore the intended host.

## Impact

Users can configure both host and port from the Developer page. Changing either automatically restarts a running server after a three-second debounce, while an offline server remains offline. Existing settings continue to use the loopback default.

## Validation

- `xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -derivedDataPath build/XcodeDerivedData CODE_SIGNING_ALLOWED=NO -skipPackageUpdates test`
- 73 tests passed
- `git diff --check`
