### PR TITLE
Improve text readability and selection

### DIFF
--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -1117,12 +1117,12 @@ private struct SystemOverviewMetric: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(SystemMonitorPalette.metricLabel)
                 Text(value)
                     .font(.title3.weight(.semibold).monospacedDigit())
                 Text(detail)
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(SystemMonitorPalette.metricDetail)
                     .lineLimit(1)
             }
         }
@@ -1970,6 +1970,8 @@ private enum SystemMonitorPalette {
     static let orange = Color(red: 1.00, green: 0.55, blue: 0.17)
     static let red = Color(red: 1.00, green: 0.23, blue: 0.28)
     static let positive = Color(red: 0.18, green: 0.72, blue: 0.38)
+    static let metricLabel = Color.primary.opacity(0.72)
+    static let metricDetail = Color.primary.opacity(0.58)
 }
 
 private struct SystemMonitorPanelModifier: ViewModifier {

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -40,6 +40,7 @@ struct WelcomeGateView: View {
                 .transition(.opacity)
             }
         }
+        .textSelection(.enabled)
         .animation(.easeInOut(duration: 0.25), value: hasCompletedWelcome)
     }
 }


### PR DESCRIPTION
## Summary

- Increase the contrast of small labels in the System Monitor overview metric cards.
- Replace the faint secondary/tertiary metric text styles with adaptive primary text opacity values.
- Enable app-wide SwiftUI text selection from the welcome/control-panel root so static text can be selected across the app.

## Why

Some small card text was too light on the light card background, making details like core counts and memory/disk status hard to read. Text outside the chat transcript also lacked a general selection affordance, so users could not easily drag-select labels, settings text, and other static content.

## Validation

- Built the app with Xcode using an unsigned Debug build: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/nativ-derived-data CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' DEVELOPMENT_TEAM='' build`
- Previously opened `/tmp/nativ-derived-data/Build/Products/Debug/Nativ.app` successfully after the first commit.

Note: a normal signed build is blocked locally because the configured Mac Development certificate for team `V8MWN7GKJ5` is not installed.