### PR TITLE
Only allow generative (text/vision) models in the chat model picker

### DIFF
--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -82,8 +82,8 @@ struct LocalModel: Identifiable, Equatable, Sendable {
     }
 
     var isEligibleForLanguageModelPicker: Bool {
-        !capabilities.contains(.speechToText)
-            && !capabilities.contains(.textToSpeech)
+        (capabilities.contains(.text) || capabilities.contains(.vision))
+            && !capabilities.contains(.imageGeneration)
     }
 
     var parameterSizeLabel: String? {
@@ -934,8 +934,10 @@ enum LocalModelDiscovery {
             "causallm", "conditionalgeneration", "language", "llm", "gpt",
             "gemma", "qwen", "mistral", "llama", "deepseek", "cohere"
         ]
+        let generativeArchitectures = ["forcausallm", "forconditionalgeneration", "lmheadmodel"]
         if primaryTask.includesLanguageCapability(
             fallbackMatch: textDescriptors.contains(where: descriptors.contains)
+                || generativeArchitectures.contains(where: descriptors.contains)
         ) {
             capabilities.insert(.text)
         }

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -82,8 +82,10 @@ struct LocalModel: Identifiable, Equatable, Sendable {
     }
 
     var isEligibleForLanguageModelPicker: Bool {
-        (capabilities.contains(.text) || capabilities.contains(.vision))
-            && !capabilities.contains(.imageGeneration)
+        // Any text-generative model qualifies (chat + omni), even if it also carries an
+        // image-generation tag. A vision model qualifies only when it isn't image-gen/editing.
+        capabilities.contains(.text)
+            || (capabilities.contains(.vision) && !capabilities.contains(.imageGeneration))
     }
 
     var parameterSizeLabel: String? {

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -204,6 +204,18 @@ final class NativModel: ObservableObject {
         var shouldStartMetrics = false
         metricsClient = NativMetricsClient(baseURL: settings.serverBaseURL)
         modelLoadingProgress = settings.normalized().languageModelID == nil ? nil : 0
+        var launchArguments = settings.launchArguments
+        if let languageModelID = settings.normalized().languageModelID,
+           isKnownNonGenerativeModel(languageModelID),
+           let modelFlagIndex = launchArguments.firstIndex(of: "--model"),
+           modelFlagIndex + 1 < launchArguments.count {
+            // A stale, non-chat selection (e.g. a BERT encoder) would make the
+            // server abort while pre-loading it. Start on-demand instead so it
+            // still comes up.
+            launchArguments.removeSubrange(modelFlagIndex...(modelFlagIndex + 1))
+            modelLoadingProgress = nil
+            appendLog("\n\(languageModelID) is not a text-generation model — starting the server without pre-loading it. Pick a chat model to load one.\n")
+        }
         do {
             var launchEnvironment = settings.launchEnvironment
             launchEnvironment["MLX_PLATFORM_ANALYTICS_DB_PATH"] = currentAnalyticsDatabaseURL().path
@@ -211,7 +223,7 @@ final class NativModel: ObservableObject {
                 launchEnvironment[HuggingFaceAuthentication.environmentVariableName] = effectiveHuggingFaceToken
             }
             try server.start(
-                arguments: settings.launchArguments,
+                arguments: launchArguments,
                 environment: launchEnvironment
             )
             isRunning = true
@@ -234,6 +246,53 @@ final class NativModel: ObservableObject {
             startMetricsPolling()
         }
         notifyMenuStateChanged()
+    }
+
+    /// Returns true only when the model is present locally and its config's
+    /// architectures are all non-generative (e.g. a BERT/RoBERTa encoder), which
+    /// mlx-vlm cannot load as a chat model. Any uncertainty returns false, so a
+    /// genuine chat model is never skipped.
+    private func isKnownNonGenerativeModel(_ repoID: String) -> Bool {
+        let cacheName = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+        let fileManager = FileManager.default
+
+        var roots: [String] = []
+        let configured = settings.normalized().modelSearchPath.trimmingCharacters(in: .whitespaces)
+        if !configured.isEmpty {
+            roots.append((configured as NSString).expandingTildeInPath)
+        }
+        if let hubCache = ProcessInfo.processInfo.environment["HF_HUB_CACHE"] {
+            roots.append(hubCache)
+        }
+        roots.append(("~/.cache/huggingface/hub" as NSString).expandingTildeInPath)
+
+        let generativeMarkers = ["forcausallm", "forconditionalgeneration", "lmheadmodel"]
+        for root in roots {
+            let snapshots = URL(fileURLWithPath: root)
+                .appendingPathComponent(cacheName)
+                .appendingPathComponent("snapshots")
+            guard let revisions = try? fileManager.contentsOfDirectory(
+                at: snapshots,
+                includingPropertiesForKeys: nil
+            ) else {
+                continue
+            }
+            for revision in revisions {
+                let configURL = revision.appendingPathComponent("config.json")
+                guard let data = try? Data(contentsOf: configURL),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let architectures = json["architectures"] as? [String],
+                      !architectures.isEmpty
+                else {
+                    continue
+                }
+                let isGenerative = architectures
+                    .map { $0.lowercased() }
+                    .contains { arch in generativeMarkers.contains { arch.contains($0) } }
+                return !isGenerative
+            }
+        }
+        return false
     }
 
     func stopServer(preserveSessionStats: Bool = false) {

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -256,15 +256,9 @@ final class NativModel: ObservableObject {
         let cacheName = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
         let fileManager = FileManager.default
 
-        var roots: [String] = []
-        let configured = settings.normalized().modelSearchPath.trimmingCharacters(in: .whitespaces)
-        if !configured.isEmpty {
-            roots.append((configured as NSString).expandingTildeInPath)
-        }
-        if let hubCache = ProcessInfo.processInfo.environment["HF_HUB_CACHE"] {
-            roots.append(hubCache)
-        }
-        roots.append(("~/.cache/huggingface/hub" as NSString).expandingTildeInPath)
+        // Consolidated roots (primary folder + user-added folders + HF hub cache) so
+        // this check also covers models the user keeps in custom folders.
+        let roots = settings.normalized().modelSearchRoots
 
         let generativeMarkers = ["forcausallm", "forconditionalgeneration", "lmheadmodel"]
         for root in roots {

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -623,6 +623,30 @@ struct NativSettings: Codable, Equatable {
         NSString(string: modelSearchPath).expandingTildeInPath
     }
 
+    /// All directories to search for a locally-available model: the primary model
+    /// folder, any user-added folders, and the Hugging Face hub cache. Consolidated
+    /// here so callers don't each re-derive the roots (and each miss custom folders).
+    var modelSearchRoots: [String] {
+        var roots: [String] = []
+        let primary = expandedModelSearchPath.trimmingCharacters(in: .whitespaces)
+        if !primary.isEmpty {
+            roots.append(primary)
+        }
+        for path in additionalModelSearchPaths {
+            let expanded = NSString(string: path).expandingTildeInPath
+                .trimmingCharacters(in: .whitespaces)
+            if !expanded.isEmpty {
+                roots.append(expanded)
+            }
+        }
+        if let hubCache = ProcessInfo.processInfo.environment["HF_HUB_CACHE"], !hubCache.isEmpty {
+            roots.append(hubCache)
+        }
+        roots.append(NSString(string: "~/.cache/huggingface/hub").expandingTildeInPath)
+        var seen = Set<String>()
+        return roots.filter { seen.insert($0).inserted }
+    }
+
     private static func normalizedModelID(_ value: String?) -> String? {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil


### PR DESCRIPTION
## Problem
The chat model picker is a denylist (`LocalModel.isEligibleForLanguageModelPicker` = `!speechToText && !textToSpeech`), so non-generative models a user downloads — encoders like `google-bert/bert-base-uncased` / `FacebookAI/xlm-roberta-base`, embeddings, ASR, time-series — still appear and can be selected as the chat model. Selecting one and starting the server pre-loads it as `text_generation`; mlx-vlm/mlx-lm has no matching architecture, so startup aborts:

```
ERROR - Error loading model google-bert/bert-base-uncased: Model type bert not supported
ModuleNotFoundError: No module named 'mlx_lm.models.bert'
Application startup failed. Exiting.  (exit status 3)
```

The app is then effectively bricked — the server won't come up and the menu bar is unresponsive, with no in-UI way to recover.

## Fix
- **Picker becomes an allowlist of *generative* models:** text **and multimodal vision-language** models both qualify (`.text` *or* `.vision`); only models with no generative capability — encoders, embeddings, ASR, forecasting, pure image-gen — drop out. Multimodal/VLM models are **not** excluded.
- **More robust generative detection:** infer `.text` from causal/generation architectures (`*ForCausalLM` / `*ForConditionalGeneration` / `*LMHeadModel`) in addition to the existing name heuristics, so legitimate chat models (Phi, SmolLM, …) aren't accidentally filtered out.
- **A stale non-generative selection no longer bricks startup:** when the configured chat model's local `config.json` shows only non-generative architectures, its `--model` pre-load flag is dropped (load-on-demand) so the server still starts, with a log note. The check is conservative — any uncertainty leaves the model untouched.

_Screenshots to follow._

