### PR TITLE
Replace the floating download indicator with a Models sidebar download arrow

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -86,115 +86,21 @@ private enum ControlPanelLayout {
     static let coordinateSpaceName = "ControlPanelLayout"
 }
 
-private struct GlobalDownloadChip: View {
-    @ObservedObject private var downloads = HuggingFaceDownloadManager.shared
-    var onOpen: () -> Void
-    @State private var offset: CGSize = .zero
-    @State private var dragOrigin: CGSize = .zero
-    @State private var isHovering = false
-    @State private var hiddenModelID: String?
+/// A small pulsing download arrow shown next to the Models sidebar row while a model
+/// is downloading. When concurrent downloads are supported this can show the number of
+/// models still downloading beside the arrow.
+private struct ModelsDownloadArrow: View {
+    @State private var pulse = false
 
     var body: some View {
-        if let modelID = downloads.downloadingModelID, hiddenModelID != modelID {
-            let percent = Int((downloads.downloadProgress * 100).rounded())
-            ZStack(alignment: .topTrailing) {
-                // The draggable chip: a progress ring with the percentage inside, then the
-                // model name. Drag it out of the way; a click opens the Models page.
-                HStack(spacing: 10) {
-                    progressCircle(percent: percent)
-                        .frame(width: 38, height: 38)
-                    Text(shortName(modelID))
-                        .font(.caption.weight(.semibold))
-                        .lineLimit(1)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 7)
-                .background(.regularMaterial, in: Capsule())
-                .overlay(Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 0.5))
-                .shadow(color: .black.opacity(0.16), radius: 10, y: 4)
-                .contentShape(Capsule())
-                .gesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { value in
-                            offset = CGSize(
-                                width: dragOrigin.width + value.translation.width,
-                                height: dragOrigin.height + value.translation.height
-                            )
-                        }
-                        .onEnded { value in
-                            // Near-zero move = a click → open Models; a real drag keeps the spot.
-                            if abs(value.translation.width) < 4, abs(value.translation.height) < 4 {
-                                offset = dragOrigin
-                                onOpen()
-                            } else {
-                                dragOrigin = offset
-                            }
-                        }
-                )
-
-                // Hovering the chip floats a small ✕ at the corner that hides the indicator
-                // for this download (it keeps downloading; the Models page still shows it).
-                dismissBadge(modelID: modelID)
-                    .offset(x: 2, y: -2)
-            }
-            // A generous hover region so gliding onto the floating ✕ doesn't drop the hover.
-            .padding(10)
-            .contentShape(Rectangle())
-            .offset(offset)
-            .onHover { isHovering = $0 }
-            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isHovering)
-            .help("Drag to move \u{00b7} click to open \u{00b7} hover for \u{00d7} to hide")
-            .accessibilityLabel("Downloading \(shortName(modelID)), \(percent) percent. Open the Models page.")
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    private func dismissBadge(modelID: String) -> some View {
-        Button {
-            hiddenModelID = modelID
-        } label: {
-            Image(systemName: "xmark")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(.secondary)
-                .frame(width: 18, height: 18)
-                .background(.regularMaterial, in: Circle())
-                .overlay(Circle().stroke(Color.primary.opacity(0.10), lineWidth: 0.5))
-                .shadow(color: .black.opacity(0.18), radius: 3, y: 1)
-        }
-        .buttonStyle(.plain)
-        .help("Hide this download indicator")
-        .accessibilityLabel("Hide download indicator")
-        .opacity(isHovering ? 1 : 0)
-        .allowsHitTesting(isHovering)
-    }
-
-    @ViewBuilder
-    private func progressCircle(percent: Int) -> some View {
-        ZStack {
-            Circle().stroke(Color.secondary.opacity(0.22), lineWidth: 3)
-            if downloads.isDownloadPaused {
-                Image(systemName: "pause.fill")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(.secondary)
-            } else if downloads.downloadProgress <= 0.0001 {
-                // Bytes haven't started (Hugging Face is still resolving file metadata) —
-                // show a preparing spinner rather than a stuck "0".
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Circle()
-                    .trim(from: 0, to: downloads.downloadProgress)
-                    .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 3, lineCap: .round))
-                    .rotationEffect(.degrees(-90))
-                Text("\(percent)")
-                    .font(.system(size: 11, weight: .semibold).monospacedDigit())
-            }
-        }
-    }
-
-    private func shortName(_ modelID: String) -> String {
-        let last = modelID.split(separator: "/").last.map(String.init) ?? modelID
-        return NativFormatting.truncateModelName(last, maxLength: 22)
+        Image(systemName: "arrow.down.circle.fill")
+            .font(.caption)
+            .foregroundStyle(.tint)
+            .opacity(pulse ? 0.4 : 1.0)
+            .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: pulse)
+            .onAppear { pulse = true }
+            .help("A model is downloading")
+            .accessibilityLabel("A model is downloading")
     }
 }
 
@@ -208,6 +114,7 @@ struct ControlPanelView: View {
     @StateObject private var dashboard = DashboardViewModel()
     @StateObject private var systemMonitor = SystemMonitorStore()
     @StateObject private var launchAtLogin = LaunchAtLoginController()
+    @ObservedObject private var downloads = HuggingFaceDownloadManager.shared
     @State private var sidebarSelection: ControlPanelSidebarSelection = .tab(.chat)
     @State private var selectedTab: ControlPanelTab = .chat
     @State private var hoveredFooterControl: FooterControl?
@@ -234,13 +141,6 @@ struct ControlPanelView: View {
         .navigationSplitViewStyle(.balanced)
         .coordinateSpace(name: ControlPanelLayout.coordinateSpaceName)
         .frame(minWidth: 1040, minHeight: 600)
-        .overlay(alignment: .top) {
-            if selectedTab != .models {
-                GlobalDownloadChip(onOpen: { navigation.open(.models) })
-                    .padding(.top, 10)
-            }
-        }
-        .animation(.easeInOut(duration: 0.2), value: selectedTab)
         .background {
             ControlPanelWindowStateReader(isFullScreen: $isFullScreen)
                 .frame(width: 0, height: 0)
@@ -297,6 +197,9 @@ struct ControlPanelView: View {
                     } label: {
                         HStack(spacing: 8) {
                             Label(tab.rawValue, systemImage: tab.systemImage)
+                            if tab == .models, downloads.downloadingModelID != nil {
+                                ModelsDownloadArrow()
+                            }
                             Spacer(minLength: 0)
                             if tab == .models,
                                model.isModelLoading,


### PR DESCRIPTION
PR #99 added a floating download chip that appears over the app whenever a model is downloading and you're not on the Models page. This replaces that floating indicator with a small download arrow next to the "Models" item in the sidebar, shown while a model is downloading.

Why: the floating chip overlapped content, could be dragged around, and lingered on top of every page. A sidebar arrow keeps the "a download is running" signal always visible in a predictable place, without covering the UI or needing to be dismissed.

Details: removes the GlobalDownloadChip overlay/struct; adds a pulsing arrow.down.circle.fill next to the Models sidebar row driven by HuggingFaceDownloadManager.downloadingModelID; the Models-page download banner (progress + pause/cancel) is unchanged.

Follow-up: once multiple concurrent model downloads are supported, this arrow will show the number of models still downloading next to it.