### PR TITLE
Remove the Models sidebar download arrow

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -86,24 +86,6 @@ private enum ControlPanelLayout {
     static let coordinateSpaceName = "ControlPanelLayout"
 }
 
-/// A small pulsing download arrow shown next to the Models sidebar row while a model
-/// is downloading. When concurrent downloads are supported this can show the number of
-/// models still downloading beside the arrow.
-private struct ModelsDownloadArrow: View {
-    @State private var pulse = false
-
-    var body: some View {
-        Image(systemName: "arrow.down.circle.fill")
-            .font(.caption)
-            .foregroundStyle(.tint)
-            .opacity(pulse ? 0.4 : 1.0)
-            .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: pulse)
-            .onAppear { pulse = true }
-            .help("A model is downloading")
-            .accessibilityLabel("A model is downloading")
-    }
-}
-
 struct ControlPanelView: View {
     @ObservedObject var model: NativModel
     @ObservedObject var navigation: ControlPanelNavigation
@@ -114,7 +96,6 @@ struct ControlPanelView: View {
     @StateObject private var dashboard = DashboardViewModel()
     @StateObject private var systemMonitor = SystemMonitorStore()
     @StateObject private var launchAtLogin = LaunchAtLoginController()
-    @ObservedObject private var downloads = HuggingFaceDownloadManager.shared
     @State private var sidebarSelection: ControlPanelSidebarSelection = .tab(.chat)
     @State private var selectedTab: ControlPanelTab = .chat
     @State private var hoveredFooterControl: FooterControl?
@@ -197,9 +178,6 @@ struct ControlPanelView: View {
                     } label: {
                         HStack(spacing: 8) {
                             Label(tab.rawValue, systemImage: tab.systemImage)
-                            if tab == .models, downloads.downloadingModelID != nil {
-                                ModelsDownloadArrow()
-                            }
                             Spacer(minLength: 0)
                             if tab == .models,
                                model.isModelLoading,


### PR DESCRIPTION
Follow-up to #105. That PR both removed the floating download indicator and added a pulsing download arrow to the Models sidebar row. We'd like #105's contribution to stand as just the removal of the floating indicator, so this removes the sidebar arrow (the `ModelsDownloadArrow` view, its `HuggingFaceDownloadManager` observation, and the sidebar usage), restoring the Models row to its prior layout (label + model-loading percentage).

Net effect after #105 + this PR: the floating download indicator is gone, with no sidebar arrow added.