### PR TITLE
Show model loading failures to users

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -1010,6 +1010,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return submenu
         }
 
+        if let failure = model.modelLoadFailure {
+            let titleItem = disabledMenuItem(failure.title)
+            titleItem.image = menuIcon(
+                "exclamationmark.triangle.fill",
+                description: "Model loading failed"
+            )
+            titleItem.toolTip = failure.message
+            submenu.addItem(titleItem)
+
+            let messageItem = disabledMenuItem(
+                NativFormatting.truncateModelName(failure.message, maxLength: 64)
+            )
+            messageItem.toolTip = failure.message
+            submenu.addItem(messageItem)
+            submenu.addItem(.separator())
+        }
+
         submenu.addItem(modelOptionMenuItem(title: "Load on demand", modelID: nil))
 
         let selectedModelID = model.settings.normalized().languageModelID
@@ -1120,6 +1137,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 return "Model: Loading \(percentage)"
             }
             return "Model: Loading…"
+        }
+        if model.modelLoadFailure != nil {
+            return "Model: Load failed"
         }
         return "Model: \(selectedModelMenuTitle)"
     }
@@ -1485,9 +1505,12 @@ private struct SessionStatsContainerView: View {
                     modelName: model.selectedModelDisplay,
                     isHighlighted: highlightState.isHighlighted,
                     section: section,
-                    statusText: model.settings.normalized().languageModelID == nil
+                    statusText: model.modelLoadFailure != nil
+                        ? "Load failed"
+                        : model.settings.normalized().languageModelID == nil
                         ? "Starting server…"
-                        : model.modelLoadingStatusText ?? "Loading model…"
+                        : model.modelLoadingStatusText ?? "Loading model…",
+                    failure: model.modelLoadFailure
                 )
             }
         }
@@ -1746,6 +1769,7 @@ private struct SessionStatsLoadingMenuView: View {
     let isHighlighted: Bool
     let section: SessionStatsSection
     let statusText: String
+    let failure: ModelLoadFailure?
 
     private var primaryTextColor: Color {
         SessionStatsMenuPalette.primary(isHighlighted)
@@ -1764,13 +1788,16 @@ private struct SessionStatsLoadingMenuView: View {
     }
 
     private var modelIndicatorColor: Color {
+        if failure != nil {
+            return .red
+        }
         switch modelName {
         case "On demand":
-            .orange
+            return .orange
         case "None":
-            .red
+            return .red
         default:
-            .green
+            return .green
         }
     }
 
@@ -1789,13 +1816,24 @@ private struct SessionStatsLoadingMenuView: View {
             case .body:
                 ZStack(alignment: .topTrailing) {
                     VStack(spacing: 10) {
-                        ProgressView()
-                            .controlSize(.regular)
-                            .tint(primaryTextColor)
-                        Text("Session stats will appear when the server is ready.")
-                            .font(.caption)
-                            .foregroundStyle(secondaryTextColor)
-                            .multilineTextAlignment(.center)
+                        if let failure {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.title2)
+                                .foregroundStyle(.orange)
+                            Text(failure.message)
+                                .font(.caption)
+                                .foregroundStyle(secondaryTextColor)
+                                .multilineTextAlignment(.center)
+                                .textSelection(.enabled)
+                        } else {
+                            ProgressView()
+                                .controlSize(.regular)
+                                .tint(primaryTextColor)
+                            Text("Session stats will appear when the server is ready.")
+                                .font(.caption)
+                                .foregroundStyle(secondaryTextColor)
+                                .multilineTextAlignment(.center)
+                        }
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -1811,8 +1849,12 @@ private struct SessionStatsLoadingMenuView: View {
         .foregroundStyle(primaryTextColor)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(section == .header
-            ? "Nativ Server is loading \(modelName)"
-            : "Waiting for session statistics")
+            ? failure == nil
+                ? "Nativ Server is loading \(modelName)"
+                : "Nativ Server could not load \(modelName)"
+            : failure == nil
+                ? "Waiting for session statistics"
+                : failure?.message ?? "Model loading failed")
     }
 
     private var header: some View {
@@ -1836,9 +1878,14 @@ private struct SessionStatsLoadingMenuView: View {
             Spacer(minLength: 16)
 
             HStack(spacing: 5) {
-                ProgressView()
-                    .controlSize(.small)
-                    .tint(primaryTextColor)
+                if failure == nil {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(primaryTextColor)
+                } else {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
                 Text(statusText)
                     .font(.headline)
             }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -86,6 +86,50 @@ private enum ControlPanelLayout {
     static let coordinateSpaceName = "ControlPanelLayout"
 }
 
+private struct GlobalModelLoadFailureBanner: View {
+    let failure: ModelLoadFailure
+    let onOpenModels: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(failure.title)
+                    .font(.callout.weight(.semibold))
+                Text(failure.message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 12)
+
+            Button("Open Models", action: onOpenModels)
+                .buttonStyle(.bordered)
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .help("Dismiss model loading error")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: 680)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.orange.opacity(0.3), lineWidth: 0.75)
+        }
+        .shadow(color: .black.opacity(0.14), radius: 10, y: 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
 struct ControlPanelView: View {
     @ObservedObject var model: NativModel
     @ObservedObject var navigation: ControlPanelNavigation
@@ -122,6 +166,18 @@ struct ControlPanelView: View {
         .navigationSplitViewStyle(.balanced)
         .coordinateSpace(name: ControlPanelLayout.coordinateSpaceName)
         .frame(minWidth: 1040, minHeight: 600)
+        .overlay(alignment: .top) {
+            if selectedTab != .models, let failure = model.modelLoadFailure {
+                GlobalModelLoadFailureBanner(
+                    failure: failure,
+                    onOpenModels: { navigation.open(.models) },
+                    onDismiss: { model.clearModelLoadFailure() }
+                )
+                .padding(.top, 10)
+                .padding(.horizontal, 16)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: selectedTab)
         .background {
             ControlPanelWindowStateReader(isFullScreen: $isFullScreen)
                 .frame(width: 0, height: 0)

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -612,6 +612,7 @@ final class ChatViewModel: ObservableObject {
         else {
             return
         }
+        appModel.clearModelLoadFailure(for: modelID)
 
         let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let imageAttachments = pendingImageAttachments
@@ -775,6 +776,10 @@ final class ChatViewModel: ObservableObject {
                 } catch let error as URLError where error.code == .cancelled {
                     finishActiveAssistantAsCancelled(in: queuedRequest.sessionID)
                 } catch {
+                    appModel?.reportModelLoadFailure(
+                        modelID: queuedRequest.settings.languageModelID,
+                        error: error
+                    )
                     if let activeAssistantMessageID {
                         failAssistantMessage(
                             activeAssistantMessageID,

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -361,6 +361,7 @@ final class ImageGenerationViewModel: ObservableObject {
         else {
             return
         }
+        appModel.clearModelLoadFailure(for: requestModelID)
 
         var settings = requestSettings
         settings.count = min(max(settings.count, 1), 10)
@@ -437,6 +438,10 @@ final class ImageGenerationViewModel: ObservableObject {
             } catch let error as URLError where error.code == .cancelled {
                 finishCancelledTurn(turn.id)
             } catch {
+                appModel?.reportModelLoadFailure(
+                    modelID: requestModelID,
+                    error: error
+                )
                 updateTurn(turn.id) { current in
                     current.status = .failed
                     current.errorMessage = error.localizedDescription

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -149,6 +149,7 @@ final class IntegrationsViewModel: ObservableObject {
         }
 
         rememberWorkingDirectory(workingDirectory, for: tool)
+        serverModel.clearModelLoadFailure(for: selectedModelID)
         activeOperation = tool
         Task {
             do {
@@ -165,6 +166,10 @@ final class IntegrationsViewModel: ObservableObject {
                     workingDirectory: workingDirectory
                 )
             } catch {
+                serverModel.reportModelLoadFailure(
+                    modelID: selectedModelID,
+                    error: error
+                )
                 errorMessage = error.localizedDescription
             }
             activeOperation = nil
@@ -312,18 +317,16 @@ final class IntegrationsViewModel: ObservableObject {
     }
 
     private func serverErrorMessage(from data: Data) -> String? {
-        if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let detail = object["detail"] as? String,
-           !detail.isEmpty {
+        let text = String(decoding: data, as: UTF8.self)
+        if let detail = NativServerErrorMessage.detail(from: text) {
             return detail
         }
-        guard let text = String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-              !text.isEmpty
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty
         else {
             return nil
         }
-        return text
+        return trimmedText
     }
 
     private func workingDirectoryKey(for tool: IntegrationTool) -> String {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -70,6 +70,7 @@ struct ModelsView: View {
                 pageHeader
                 Divider()
                 activeDownloadBanner
+                modelLoadFailureBanner
 
                 switch section {
                 case .installed:
@@ -96,6 +97,22 @@ struct ModelsView: View {
         .onDisappear {
             localLibrary.cancel()
             hubLibrary.cancel()
+        }
+    }
+
+    @ViewBuilder
+    private var modelLoadFailureBanner: some View {
+        if let failure = model.modelLoadFailure {
+            ModelsNotice(
+                title: failure.title,
+                message: failure.message,
+                systemImage: "exclamationmark.triangle.fill",
+                color: .orange,
+                onDismiss: { model.clearModelLoadFailure() }
+            )
+            .padding(.horizontal, 22)
+            .padding(.vertical, 10)
+            Divider()
         }
     }
 
@@ -880,6 +897,7 @@ private struct InstalledModelRow: View {
 
     @State private var isHovered = false
     @State private var showsDeleteConfirmation = false
+    @State private var showsUnsupportedModelInformation = false
 
     private var isSelected: Bool {
         !selectedPreloadSlots.isEmpty
@@ -892,11 +910,11 @@ private struct InstalledModelRow: View {
     var body: some View {
         HStack(spacing: 10) {
             Button {
-                guard let preferredPreloadSlot,
-                    !isSelectionDisabled
-                else {
+                guard let preferredPreloadSlot else {
+                    showsUnsupportedModelInformation = true
                     return
                 }
+                guard !isSelectionDisabled else { return }
                 onSetPreload(
                     preferredPreloadSlot,
                     !selectedPreloadSlots.contains(preferredPreloadSlot)
@@ -922,6 +940,13 @@ private struct InstalledModelRow: View {
                                     title: modelLoadingPercentage.map { "Loading model · \($0)%" }
                                         ?? "Loading model",
                                     systemImage: "arrow.triangle.2.circlepath",
+                                    color: .orange
+                                )
+                            }
+                            if preloadSlots.isEmpty {
+                                ModelPill(
+                                    title: "Not supported",
+                                    systemImage: "exclamationmark.triangle",
                                     color: .orange
                                 )
                             }
@@ -1011,6 +1036,13 @@ private struct InstalledModelRow: View {
         .onHover { isHovered = $0 }
         .animation(.easeOut(duration: 0.14), value: isHovered)
         .modelRowBackground(isHighlighted: isSelected, isHovered: isHovered)
+        .alert("Model isn’t supported", isPresented: $showsUnsupportedModelInformation) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(
+                "\(localModel.repoID) is installed in your Hugging Face cache, but Nativ can’t use it for chat, image generation, text-to-speech, or speech-to-text."
+            )
+        }
         .alert("Delete \(modelName(localModel.repoID))?", isPresented: $showsDeleteConfirmation) {
             Button("Delete Model", role: .destructive, action: onDelete)
             Button("Cancel", role: .cancel) {}
@@ -1323,6 +1355,7 @@ private struct ModelsNotice: View {
     let message: String
     let systemImage: String
     let color: Color
+    var onDismiss: (() -> Void)? = nil
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -1335,6 +1368,14 @@ private struct ModelsNotice: View {
                     .textSelection(.enabled)
             }
             Spacer()
+            if let onDismiss {
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .help("Dismiss")
+            }
         }
         .padding(12)
         .background(RoundedRectangle(cornerRadius: 10).fill(color.opacity(0.08)))

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -18,6 +18,20 @@ private struct PendingModelPreloadSwitch {
     let onSelectionAccepted: () -> Void
 }
 
+struct ModelLoadFailure: Equatable, Identifiable, Sendable {
+    let id = UUID()
+    let modelID: String?
+    let message: String
+
+    var title: String {
+        guard let modelID else {
+            return "Couldn’t load model"
+        }
+        let name = modelID.split(separator: "/").last.map(String.init) ?? modelID
+        return "Couldn’t load \(name)"
+    }
+}
+
 @MainActor
 final class NativModel: ObservableObject {
     @Published private(set) var isRunning = false
@@ -30,6 +44,7 @@ final class NativModel: ObservableObject {
     @Published private(set) var modelSwitchInProgress = false
     @Published private(set) var modelSwitchTargetID: String?
     @Published private(set) var modelLoadingProgress: Double?
+    @Published private(set) var modelLoadFailure: ModelLoadFailure?
     @Published private(set) var modelPreloadMemoryWarning: ModelPreloadMemoryWarning?
     @Published private(set) var metricsLoading = false
     @Published private(set) var systemHuggingFaceCredential =
@@ -59,8 +74,10 @@ final class NativModel: ObservableObject {
     private var pendingModelPreloadSwitch: PendingModelPreloadSwitch?
     private var pendingServerRestartID: UUID?
     private var serverRestartTask: Task<Void, Never>?
+    private var currentServerOutput = ""
 
     private let maxLogCharacters = 250_000
+    private let maxCurrentServerOutputCharacters = 50_000
     private let maxSessionActivitySamples = 120
 
     init() {
@@ -262,6 +279,8 @@ final class NativModel: ObservableObject {
 
     func startServer() {
         var shouldStartMetrics = false
+        clearModelLoadFailure()
+        currentServerOutput = ""
         metricsClient = NativMetricsClient(baseURL: settings.serverBaseURL)
         modelLoadingProgress = settings.normalized().languageModelID == nil ? nil : 0
         do {
@@ -477,6 +496,7 @@ final class NativModel: ObservableObject {
         guard !modelSwitchInProgress else {
             return
         }
+        clearModelLoadFailure()
 
         var nextSettings = settings
         nextSettings.setModelID(modelID, for: slot)
@@ -584,6 +604,30 @@ final class NativModel: ObservableObject {
         logText = ""
     }
 
+    func reportModelLoadFailure(modelID: String?, error: Error) {
+        reportModelLoadFailure(modelID: modelID, message: error.localizedDescription)
+    }
+
+    func reportModelLoadFailure(modelID: String?, message: String) {
+        guard let message = NativServerErrorMessage.modelLoadFailure(in: message) else {
+            return
+        }
+        setModelLoadFailure(modelID: modelID, message: message)
+    }
+
+    func clearModelLoadFailure(for modelID: String? = nil) {
+        guard let currentFailure = modelLoadFailure else {
+            return
+        }
+        if let modelID,
+           let failedModelID = currentFailure.modelID,
+           failedModelID != modelID {
+            return
+        }
+        self.modelLoadFailure = nil
+        notifyMenuStateChanged()
+    }
+
     func refreshMetricsIfRunning(force: Bool = false) {
         isRunning = server.isRunning
         guard isRunning else {
@@ -628,6 +672,20 @@ final class NativModel: ObservableObject {
             Task { @MainActor [weak self] in
                 guard let self, !self.server.isRunning else {
                     return
+                }
+                let wasLoadingModel = self.modelSwitchInProgress
+                    || self.metricsLoading
+                    || self.modelLoadingProgress != nil
+                if wasLoadingModel,
+                   status != 0,
+                   !self.isStoppingForModelSwitch,
+                   let message = NativServerErrorMessage.modelLoadFailure(
+                       in: self.currentServerOutput
+                    ) {
+                    self.setModelLoadFailure(
+                        modelID: self.modelSwitchTargetID,
+                        message: message
+                    )
                 }
                 self.appendLog("\nmlx-vlm-server stopped with status \(status)\n")
                 self.isRunning = false
@@ -783,7 +841,19 @@ final class NativModel: ObservableObject {
         let visibleText = visibleLines.joined(separator: "\n")
         if !visibleText.isEmpty {
             appendLog(visibleText)
+            currentServerOutput.append(visibleText)
+            if currentServerOutput.count > maxCurrentServerOutputCharacters {
+                currentServerOutput.removeFirst(
+                    currentServerOutput.count - maxCurrentServerOutputCharacters
+                )
+            }
         }
+    }
+
+    private func setModelLoadFailure(modelID: String?, message: String) {
+        modelLoadFailure = ModelLoadFailure(modelID: modelID, message: message)
+        appendLog("\n\(message)\n")
+        notifyMenuStateChanged()
     }
 
     private func recordSessionActivity(promptTokenCount: Int, generatedTokenCount: Int) {

--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -11,11 +11,11 @@ public enum NativChatError: Error, LocalizedError, CustomStringConvertible {
         case .invalidResponse:
             return "Invalid chat response"
         case .httpStatus(let statusCode, let body):
-            let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedBody.isEmpty {
-                return "Chat endpoint returned HTTP \(statusCode)"
-            }
-            return "Chat endpoint returned HTTP \(statusCode): \(trimmedBody)"
+            return NativServerErrorMessage.endpointFailure(
+                endpoint: "Chat endpoint",
+                statusCode: statusCode,
+                responseBody: body
+            )
         case .missingAssistantContent:
             return "Chat response did not include assistant content"
         case .malformedStreamEvent(let event):

--- a/Sources/NativServerKit/NativImageClient.swift
+++ b/Sources/NativServerKit/NativImageClient.swift
@@ -10,11 +10,11 @@ public enum NativImageError: Error, LocalizedError, CustomStringConvertible {
         case .invalidResponse:
             return "Invalid image response"
         case .httpStatus(let statusCode, let body):
-            let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedBody.isEmpty {
-                return "Image endpoint returned HTTP \(statusCode)"
-            }
-            return "Image endpoint returned HTTP \(statusCode): \(trimmedBody)"
+            return NativServerErrorMessage.endpointFailure(
+                endpoint: "Image endpoint",
+                statusCode: statusCode,
+                responseBody: body
+            )
         case .missingImageData:
             return "Image response did not include image data"
         }

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -10,6 +10,97 @@ public enum NativServerAuthorization {
     }
 }
 
+public enum NativServerErrorMessage {
+    public static func detail(from responseBody: String) -> String? {
+        let trimmedBody = responseBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBody.isEmpty,
+              let data = trimmedBody.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        if let detail = normalized(object["detail"] as? String) {
+            return detail
+        }
+        if let error = object["error"] as? [String: Any],
+           let message = normalized(error["message"] as? String) {
+            return message
+        }
+        return normalized(object["error"] as? String)
+    }
+
+    public static func endpointFailure(
+        endpoint: String,
+        statusCode: Int,
+        responseBody: String
+    ) -> String {
+        if let detail = detail(from: responseBody) {
+            return detail
+        }
+
+        let trimmedBody = responseBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedBody.isEmpty else {
+            return "\(endpoint) returned HTTP \(statusCode)"
+        }
+        return "\(endpoint) returned HTTP \(statusCode): \(trimmedBody)"
+    }
+
+    public static func modelLoadFailure(in text: String) -> String? {
+        let structuredMessage = detail(from: text)
+        let candidates = [structuredMessage, text].compactMap { $0 }
+        let markers = [
+            "Failed to load image generation model:",
+            "Unsupported image generation model:",
+            "Failed to load image edit model:",
+            "Unsupported image edit model:",
+            "Failed to load audio model:",
+            "Unsupported audio model:",
+            "Failed to load model:",
+            "Model not found:",
+        ]
+
+        for candidate in candidates {
+            for line in candidate.split(whereSeparator: \.isNewline).reversed() {
+                let value = String(line)
+                for marker in markers {
+                    guard let range = value.range(
+                        of: marker,
+                        options: [.caseInsensitive]
+                    ) else {
+                        continue
+                    }
+                    return normalized(String(value[range.lowerBound...]))
+                }
+
+                guard let errorRange = value.range(
+                    of: "Error loading model ",
+                    options: [.caseInsensitive]
+                ) else {
+                    continue
+                }
+                let suffix = value[errorRange.upperBound...]
+                guard let separator = suffix.range(of: ":"),
+                      let reason = normalized(String(suffix[separator.upperBound...]))
+                else {
+                    continue
+                }
+                return "Failed to load model: \(reason)"
+            }
+        }
+        return nil
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        return value
+    }
+}
+
 public enum NativError: Error, CustomStringConvertible {
     case missingDistribution(Bundle)
     case missingExecutable(URL)

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -355,6 +355,61 @@ final class NativChatToolProtocolTests: XCTestCase {
             #"{"prompt":"A lighthouse"}"#
         )
     }
+
+    func testServerErrorMessageExtractsFastAPIDetail() {
+        let body =
+            #"{"detail":"Failed to load model: Model type bert not supported."}"#
+
+        XCTAssertEqual(
+            NativServerErrorMessage.detail(from: body),
+            "Failed to load model: Model type bert not supported."
+        )
+        XCTAssertEqual(
+            NativChatError.httpStatus(400, body).localizedDescription,
+            "Failed to load model: Model type bert not supported."
+        )
+        XCTAssertEqual(
+            NativImageError.httpStatus(400, body).localizedDescription,
+            "Failed to load model: Model type bert not supported."
+        )
+    }
+
+    func testServerErrorMessagePreservesHTTPFallback() {
+        XCTAssertEqual(
+            NativServerErrorMessage.endpointFailure(
+                endpoint: "Chat endpoint",
+                statusCode: 503,
+                responseBody: ""
+            ),
+            "Chat endpoint returned HTTP 503"
+        )
+        XCTAssertEqual(
+            NativServerErrorMessage.endpointFailure(
+                endpoint: "Image endpoint",
+                statusCode: 500,
+                responseBody: "backend unavailable"
+            ),
+            "Image endpoint returned HTTP 500: backend unavailable"
+        )
+    }
+
+    func testModelLoadFailureIsExtractedFromServerLogs() {
+        let output = """
+            INFO: Waiting for application startup.
+            ERROR loading model mlx-community/BERT: Model type bert not supported.
+            ERROR: Application startup failed.
+            """
+
+        XCTAssertEqual(
+            NativServerErrorMessage.modelLoadFailure(in: output),
+            "Failed to load model: Model type bert not supported."
+        )
+        XCTAssertNil(
+            NativServerErrorMessage.modelLoadFailure(
+                in: "Chat endpoint returned HTTP 400: Prompt is too long."
+            )
+        )
+    }
 }
 
 extension Array where Element == String {


### PR DESCRIPTION
## Summary

- parse structured server error details for chat, image generation, and integrations
- track model startup failures and show dismissible feedback in the Models page, control panel, menu, and session stats
- label unsupported cached models and explain why they cannot be selected when clicked
- add coverage for FastAPI error details, fallback HTTP messages, and startup-log extraction

## Why

mlx-vlm now returns actionable HTTP 400 details when a model cannot be loaded ([Blaizzy/mlx-vlm#1717](https://github.com/Blaizzy/mlx-vlm/pull/1717)), but Nativ did not consistently surface those details. Startup failures could leave the UI looking like it was still loading, and clicking a cached model with no supported preload role was a silent no-op.

## User impact

Users now get the server's useful failure reason in the workflow where loading failed and in app-wide status surfaces. Unsupported models are visibly marked and explain that Nativ cannot use them for its supported serving roles.

## Validation

- `xcodebuild -project Nativ.xcodeproj -scheme Nativ -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test` — 92 tests passed
- `python3 -m py_compile PythonDistribution/Overlay/nativ_server.py PythonDistribution/Scripts/build_mlx_vlm_server.py`
- `git diff --check`