### PR TITLE
Remove the circular spinner from the Models download banner

### DIFF
--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -103,9 +103,6 @@ struct ModelsView: View {
     private var activeDownloadBanner: some View {
         if let modelID = downloadManager.downloadingModelID {
             HStack(spacing: 12) {
-                ProgressView(value: downloadManager.downloadProgress)
-                    .progressViewStyle(.circular)
-                    .controlSize(.small)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(NativFormatting.truncateModelName(
                         modelID.split(separator: "/").last.map(String.init) ?? modelID,


### PR DESCRIPTION
The active-download banner on the Models page shows a small circular progress spinner to the left of the model name and the "Downloading… N%" label. It's redundant with the percentage text (and with the per-row progress ring each model already shows), so this removes it for a cleaner banner. The name, progress label, and Pause/Cancel controls are unchanged.