### PR TITLE
Secure server API key storage

### DIFF
--- a/PythonDistribution/Overlay/nativ_server.py
+++ b/PythonDistribution/Overlay/nativ_server.py
@@ -41,6 +41,7 @@ PUBLIC_API_PATHS = {
     "/openapi.json",
     "/redoc",
 }
+SERVER_API_KEY_SHA256_ENV = "MLX_PLATFORM_SERVER_API_KEY_SHA256"
 MODEL_LOAD_PROGRESS_PREFIX = "__NATIV_MODEL_LOAD_PROGRESS__:"
 MODEL_LOAD_EVAL_BATCH_BYTES = 64 * 1024 * 1024
 
@@ -574,17 +575,30 @@ def request_has_valid_api_key(request: Request, expected_sha256: str) -> bool:
     return secrets.compare_digest(supplied_sha256, expected_sha256)
 
 
-def install_database_api_key_authentication() -> None:
-    if getattr(base.app.state, "nativ_database_api_key_authentication_installed", False):
+def expected_server_api_key_sha256() -> str | None:
+    if SERVER_API_KEY_SHA256_ENV in os.environ:
+        verifier = os.environ[SERVER_API_KEY_SHA256_ENV].strip().lower()
+        if not verifier:
+            return None
+        if len(verifier) == 64 and all(character in "0123456789abcdef" for character in verifier):
+            return verifier
+        logging.error("Rejecting API requests because %s is malformed", SERVER_API_KEY_SHA256_ENV)
+        return "invalid"
+
+    return ANALYTICS_STORE.server_api_key_sha256()
+
+
+def install_server_api_key_authentication() -> None:
+    if getattr(base.app.state, "nativ_server_api_key_authentication_installed", False):
         return
-    base.app.state.nativ_database_api_key_authentication_installed = True
+    base.app.state.nativ_server_api_key_authentication_installed = True
 
     @base.app.middleware("http")
     async def database_api_key_middleware(request: Request, call_next):
         if request.method == "OPTIONS" or request.url.path in PUBLIC_API_PATHS:
             return await call_next(request)
 
-        expected_sha256 = ANALYTICS_STORE.server_api_key_sha256()
+        expected_sha256 = expected_server_api_key_sha256()
         if expected_sha256 is None:
             return await call_next(request)
         if request_has_valid_api_key(request, expected_sha256):
@@ -1340,7 +1354,7 @@ def install_metrics_overlay() -> None:
 
 
 def main() -> None:
-    install_database_api_key_authentication()
+    install_server_api_key_authentication()
     install_metrics_overlay()
     install_metrics_access_log_filter()
     original_argparse = base_cli.argparse
@@ -1357,7 +1371,7 @@ def main() -> None:
 
 
 install_model_load_progress()
-install_database_api_key_authentication()
+install_server_api_key_authentication()
 install_metrics_overlay()
 
 

--- a/PythonDistribution/Overlay/nativ_server.py
+++ b/PythonDistribution/Overlay/nativ_server.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import atexit
-import hashlib
 import importlib
 import json
 import logging
 import os
-import secrets
 import sqlite3
+import sys
 import time
 import uuid
 from contextvars import ContextVar
@@ -37,7 +36,7 @@ TRACKED_PATHS = {
     "/v1/responses",
 }
 METRICS_PATHS = {"/metrics", "/v1/metrics"}
-SERVER_API_KEY_SHA256_ENV = "MLX_PLATFORM_SERVER_API_KEY_SHA256"
+SERVER_API_KEY_STDIN_ENV = "MLX_PLATFORM_SERVER_API_KEY_STDIN"
 MODEL_LOAD_PROGRESS_PREFIX = "__NATIV_MODEL_LOAD_PROGRESS__:"
 MODEL_LOAD_EVAL_BATCH_BYTES = 64 * 1024 * 1024
 
@@ -348,20 +347,6 @@ class AnalyticsStore:
             """
         )
 
-    def server_api_key_sha256(self) -> str | None:
-        with self._lock:
-            row = self._connection.execute(
-                """
-                SELECT api_key_sha256
-                FROM server_credentials
-                WHERE id = 1
-                """
-            ).fetchone()
-        if row is None:
-            return None
-        verifier = str(row[0]).strip().lower()
-        return verifier if verifier else None
-
     def _start_session(self) -> None:
         started_at = time.time()
         with self._lock:
@@ -561,47 +546,25 @@ class AnalyticsStore:
 ANALYTICS_STORE = AnalyticsStore(analytics_db_path())
 
 
-def request_has_valid_api_key(request: Request, expected_sha256: str) -> bool:
-    authorization = request.headers.get("Authorization", "")
-    scheme, separator, token = authorization.partition(" ")
-    if not separator or scheme.lower() != "bearer" or not token:
-        return False
-
-    supplied_sha256 = hashlib.sha256(token.encode("utf-8")).hexdigest()
-    return secrets.compare_digest(supplied_sha256, expected_sha256)
+def read_server_api_key_from_stdin() -> str | None:
+    if os.environ.get(SERVER_API_KEY_STDIN_ENV) != "1":
+        return None
+    token = sys.stdin.buffer.read().decode("utf-8").strip()
+    return token if token else None
 
 
-def expected_server_api_key_sha256() -> str | None:
-    if SERVER_API_KEY_SHA256_ENV in os.environ:
-        verifier = os.environ[SERVER_API_KEY_SHA256_ENV].strip().lower()
-        if not verifier:
-            return None
-        if len(verifier) == 64 and all(character in "0123456789abcdef" for character in verifier):
-            return verifier
-        logging.error("Rejecting API requests because %s is malformed", SERVER_API_KEY_SHA256_ENV)
-        return "invalid"
-
-    return ANALYTICS_STORE.server_api_key_sha256()
-
-
-def require_server_api_key(request: Request) -> None:
-    expected_sha256 = expected_server_api_key_sha256()
-    if expected_sha256 is None or request_has_valid_api_key(request, expected_sha256):
+def install_server_api_key_source() -> None:
+    if getattr(base.app.state, "nativ_server_api_key_source_installed", False):
         return
-    raise HTTPException(
-        status_code=401,
-        detail="Invalid API key",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
-
-
-def install_server_api_key_verifier() -> None:
-    if getattr(base.app.state, "nativ_server_api_key_verifier_installed", False):
+    base.app.state.nativ_server_api_key_source_installed = True
+    if SERVER_API_KEY_STDIN_ENV not in os.environ:
         return
-    base.app.state.nativ_server_api_key_verifier_installed = True
-    # Preserve mlx-vlm's endpoint-level authentication boundary while replacing
-    # its plaintext environment lookup with Nativ's hash-backed verifier.
-    base_app._require_management_api_key = require_server_api_key
+
+    server_api_key = read_server_api_key_from_stdin()
+    # Keep mlx-vlm's authentication guard as the only enforcement path. Its
+    # current management routes and upcoming inference-router dependency both
+    # resolve this key source when handling a request.
+    base_app._server_api_key = lambda: server_api_key
 
 
 class MetricsTracker:
@@ -1347,7 +1310,7 @@ def install_metrics_overlay() -> None:
 
 
 def main() -> None:
-    install_server_api_key_verifier()
+    install_server_api_key_source()
     install_metrics_overlay()
     install_metrics_access_log_filter()
     original_argparse = base_cli.argparse
@@ -1364,7 +1327,7 @@ def main() -> None:
 
 
 install_model_load_progress()
-install_server_api_key_verifier()
+install_server_api_key_source()
 install_metrics_overlay()
 
 

--- a/PythonDistribution/Overlay/nativ_server.py
+++ b/PythonDistribution/Overlay/nativ_server.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import atexit
+import hashlib
 import json
 import logging
 import os
+import secrets
 import sqlite3
 import time
 import uuid
@@ -16,7 +18,7 @@ from typing import Any
 
 import mlx.core as mx
 from fastapi import HTTPException, Request
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 from mlx.utils import tree_flatten
 
 import mlx_vlm.server as base
@@ -33,6 +35,12 @@ TRACKED_PATHS = {
     "/v1/responses",
 }
 METRICS_PATHS = {"/metrics", "/v1/metrics"}
+PUBLIC_API_PATHS = {
+    "/docs",
+    "/docs/oauth2-redirect",
+    "/openapi.json",
+    "/redoc",
+}
 MODEL_LOAD_PROGRESS_PREFIX = "__NATIV_MODEL_LOAD_PROGRESS__:"
 MODEL_LOAD_EVAL_BATCH_BYTES = 64 * 1024 * 1024
 
@@ -324,6 +332,12 @@ class AnalyticsStore:
                 loaded_adapter TEXT
             );
 
+            CREATE TABLE IF NOT EXISTS server_credentials (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                api_key_sha256 TEXT NOT NULL,
+                updated_at REAL NOT NULL
+            );
+
             CREATE INDEX IF NOT EXISTS idx_request_events_completed_at
                 ON request_events (completed_at);
             CREATE INDEX IF NOT EXISTS idx_request_events_model_completed_at
@@ -336,6 +350,20 @@ class AnalyticsStore:
                 ON analytics_buckets (granularity, model_id, bucket_start);
             """
         )
+
+    def server_api_key_sha256(self) -> str | None:
+        with self._lock:
+            row = self._connection.execute(
+                """
+                SELECT api_key_sha256
+                FROM server_credentials
+                WHERE id = 1
+                """
+            ).fetchone()
+        if row is None:
+            return None
+        verifier = str(row[0]).strip().lower()
+        return verifier if verifier else None
 
     def _start_session(self) -> None:
         started_at = time.time()
@@ -534,6 +562,39 @@ class AnalyticsStore:
 
 
 ANALYTICS_STORE = AnalyticsStore(analytics_db_path())
+
+
+def request_has_valid_api_key(request: Request, expected_sha256: str) -> bool:
+    authorization = request.headers.get("Authorization", "")
+    scheme, separator, token = authorization.partition(" ")
+    if not separator or scheme.lower() != "bearer" or not token:
+        return False
+
+    supplied_sha256 = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    return secrets.compare_digest(supplied_sha256, expected_sha256)
+
+
+def install_database_api_key_authentication() -> None:
+    if getattr(base.app.state, "nativ_database_api_key_authentication_installed", False):
+        return
+    base.app.state.nativ_database_api_key_authentication_installed = True
+
+    @base.app.middleware("http")
+    async def database_api_key_middleware(request: Request, call_next):
+        if request.method == "OPTIONS" or request.url.path in PUBLIC_API_PATHS:
+            return await call_next(request)
+
+        expected_sha256 = ANALYTICS_STORE.server_api_key_sha256()
+        if expected_sha256 is None:
+            return await call_next(request)
+        if request_has_valid_api_key(request, expected_sha256):
+            return await call_next(request)
+
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Invalid API key"},
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 class MetricsTracker:
@@ -1279,6 +1340,7 @@ def install_metrics_overlay() -> None:
 
 
 def main() -> None:
+    install_database_api_key_authentication()
     install_metrics_overlay()
     install_metrics_access_log_filter()
     original_argparse = base_cli.argparse
@@ -1295,6 +1357,7 @@ def main() -> None:
 
 
 install_model_load_progress()
+install_database_api_key_authentication()
 install_metrics_overlay()
 
 

--- a/PythonDistribution/Overlay/nativ_server.py
+++ b/PythonDistribution/Overlay/nativ_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import atexit
 import hashlib
+import importlib
 import json
 import logging
 import os
@@ -18,7 +19,7 @@ from typing import Any
 
 import mlx.core as mx
 from fastapi import HTTPException, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 from mlx.utils import tree_flatten
 
 import mlx_vlm.server as base
@@ -27,6 +28,7 @@ import mlx_vlm.server.generation as base_generation
 import mlx_vlm.server.openai as base_openai
 
 
+base_app = importlib.import_module("mlx_vlm.server.app")
 BACKEND_NAME = f"mlx_vlm/{base.__version__}"
 TRACKED_PATHS = {
     "/chat/completions",
@@ -35,12 +37,6 @@ TRACKED_PATHS = {
     "/v1/responses",
 }
 METRICS_PATHS = {"/metrics", "/v1/metrics"}
-PUBLIC_API_PATHS = {
-    "/docs",
-    "/docs/oauth2-redirect",
-    "/openapi.json",
-    "/redoc",
-}
 SERVER_API_KEY_SHA256_ENV = "MLX_PLATFORM_SERVER_API_KEY_SHA256"
 MODEL_LOAD_PROGRESS_PREFIX = "__NATIV_MODEL_LOAD_PROGRESS__:"
 MODEL_LOAD_EVAL_BATCH_BYTES = 64 * 1024 * 1024
@@ -588,27 +584,24 @@ def expected_server_api_key_sha256() -> str | None:
     return ANALYTICS_STORE.server_api_key_sha256()
 
 
-def install_server_api_key_authentication() -> None:
-    if getattr(base.app.state, "nativ_server_api_key_authentication_installed", False):
+def require_server_api_key(request: Request) -> None:
+    expected_sha256 = expected_server_api_key_sha256()
+    if expected_sha256 is None or request_has_valid_api_key(request, expected_sha256):
         return
-    base.app.state.nativ_server_api_key_authentication_installed = True
+    raise HTTPException(
+        status_code=401,
+        detail="Invalid API key",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
-    @base.app.middleware("http")
-    async def database_api_key_middleware(request: Request, call_next):
-        if request.method == "OPTIONS" or request.url.path in PUBLIC_API_PATHS:
-            return await call_next(request)
 
-        expected_sha256 = expected_server_api_key_sha256()
-        if expected_sha256 is None:
-            return await call_next(request)
-        if request_has_valid_api_key(request, expected_sha256):
-            return await call_next(request)
-
-        return JSONResponse(
-            status_code=401,
-            content={"detail": "Invalid API key"},
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+def install_server_api_key_verifier() -> None:
+    if getattr(base.app.state, "nativ_server_api_key_verifier_installed", False):
+        return
+    base.app.state.nativ_server_api_key_verifier_installed = True
+    # Preserve mlx-vlm's endpoint-level authentication boundary while replacing
+    # its plaintext environment lookup with Nativ's hash-backed verifier.
+    base_app._require_management_api_key = require_server_api_key
 
 
 class MetricsTracker:
@@ -1354,7 +1347,7 @@ def install_metrics_overlay() -> None:
 
 
 def main() -> None:
-    install_server_api_key_authentication()
+    install_server_api_key_verifier()
     install_metrics_overlay()
     install_metrics_access_log_filter()
     original_argparse = base_cli.argparse
@@ -1371,7 +1364,7 @@ def main() -> None:
 
 
 install_model_load_progress()
-install_server_api_key_authentication()
+install_server_api_key_verifier()
 install_metrics_overlay()
 
 

--- a/Sources/Nativ/Features/Dashboard/NativAnalyticsStore.swift
+++ b/Sources/Nativ/Features/Dashboard/NativAnalyticsStore.swift
@@ -928,6 +928,12 @@ private let schemaSQL = """
         loaded_adapter TEXT
     );
 
+    CREATE TABLE IF NOT EXISTS server_credentials (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        api_key_sha256 TEXT NOT NULL,
+        updated_at REAL NOT NULL
+    );
+
     CREATE INDEX IF NOT EXISTS idx_request_events_completed_at
         ON request_events (completed_at);
     CREATE INDEX IF NOT EXISTS idx_request_events_model_completed_at

--- a/Sources/Nativ/Features/Integrations/CodexCLIProfile.swift
+++ b/Sources/Nativ/Features/Integrations/CodexCLIProfile.swift
@@ -18,6 +18,7 @@ enum CodexCLIProfile {
         let url = configurationURL(in: homeDirectory)
         try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data(contents(selectedModelID: selectedModelID, baseURL: baseURL).utf8).write(to: url, options: .atomic)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
     static func contents(selectedModelID: String, baseURL: String) -> String {

--- a/Sources/Nativ/Features/Integrations/IntegrationServices.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationServices.swift
@@ -3,6 +3,7 @@ import Foundation
 
 struct IntegrationProfileManager {
     static let providerID = CodexCLIProfile.providerID
+    static let apiKeyEnvironmentVariable = "NATIV_API_KEY"
 
     private let fileManager: FileManager
     private let homeDirectory: URL
@@ -106,7 +107,8 @@ struct IntegrationProfileManager {
             return openAICompatible[Self.providerID] != nil
         case .codex, .hermes, .aider, .qwenCode, .continueDev:
             guard let text = String(data: data, encoding: .utf8) else { return false }
-            return text.contains(Self.providerID) && text.contains(openAIBaseURL)
+            return text.range(of: Self.providerID, options: .caseInsensitive) != nil
+                && text.contains(openAIBaseURL)
         case .vscode, .cursor, .jetbrains:
             return false
         case .cline:
@@ -170,16 +172,12 @@ struct IntegrationProfileManager {
         selectedModelID: String,
         workingDirectory: URL
     ) throws {
-        let scriptURL = try terminalScriptURL(for: tool)
-        let script = "#!/bin/zsh\n" + launchCommand(
+        let scriptURL = try prepareTerminalLaunchScript(
             tool: tool,
             executableURL: executableURL,
             selectedModelID: selectedModelID,
-            workingDirectory: workingDirectory,
-            usesExec: true
+            workingDirectory: workingDirectory
         )
-        try writeText(script, to: scriptURL)
-        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
@@ -193,6 +191,42 @@ struct IntegrationProfileManager {
         guard process.terminationStatus == 0 else {
             throw IntegrationServiceError.terminalLaunchFailed("open exited with status \(process.terminationStatus)")
         }
+    }
+
+    func prepareTerminalLaunchScript(
+        tool: IntegrationTool,
+        executableURL: URL,
+        selectedModelID: String,
+        workingDirectory: URL
+    ) throws -> URL {
+        let scriptURL = try terminalScriptURL(for: tool)
+        let script = terminalLaunchScript(
+            tool: tool,
+            executableURL: executableURL,
+            selectedModelID: selectedModelID,
+            workingDirectory: workingDirectory
+        )
+        try writeLaunchScript(script, to: scriptURL)
+        return scriptURL
+    }
+
+    func terminalLaunchScript(
+        tool: IntegrationTool,
+        executableURL: URL,
+        selectedModelID: String,
+        workingDirectory: URL
+    ) -> String {
+        """
+        #!/bin/zsh
+        rm -f -- "$0"
+        \(launchCommand(
+            tool: tool,
+            executableURL: executableURL,
+            selectedModelID: selectedModelID,
+            workingDirectory: workingDirectory,
+            usesExec: true
+        ))
+        """
     }
 
     func launchCommand(
@@ -345,7 +379,7 @@ struct IntegrationProfileManager {
         providers[Self.providerID] = [
             "baseUrl": openAIBaseURL,
             "api": "openai-completions",
-            "apiKey": apiKey,
+            "apiKey": Self.apiKeyEnvironmentVariable,
             "compat": [
                 "supportsDeveloperRole": false,
                 "supportsReasoningEffort": false,
@@ -374,7 +408,6 @@ struct IntegrationProfileManager {
     private func claudeSettings(selectedModelID: String) -> [String: Any] {
         [
             "env": [
-                "ANTHROPIC_AUTH_TOKEN": apiKey,
                 "ANTHROPIC_API_KEY": "",
                 "ANTHROPIC_BASE_URL": anthropicBaseURL,
                 "ANTHROPIC_MODEL": selectedModelID,
@@ -404,13 +437,11 @@ struct IntegrationProfileManager {
           default: \(yamlString(selectedModelID))
           provider: custom
           base_url: \(yamlString(openAIBaseURL))
-          api_key: \(yamlString(apiKey))
         display:
           streaming: true
         custom_providers:
           - name: nativ
             base_url: \(yamlString(openAIBaseURL))
-            api_key: \(yamlString(apiKey))
             api_mode: chat_completions
             models:
         \(modelLines)
@@ -460,7 +491,7 @@ struct IntegrationProfileManager {
                     "name": "Nativ",
                     "options": [
                         "baseURL": openAIBaseURL,
-                        "apiKey": apiKey
+                        "apiKey": "{env:\(Self.apiKeyEnvironmentVariable)}"
                     ],
                     "models": modelCatalog
                 ]
@@ -469,7 +500,7 @@ struct IntegrationProfileManager {
     }
 
     private func configureAider() throws {
-        let contents = "OPENAI_API_BASE=\(openAIBaseURL)\nOPENAI_API_KEY=\(apiKey)\n"
+        let contents = "# Managed by Nativ.\nOPENAI_API_BASE=\(openAIBaseURL)\n"
         try writeText(contents, to: configurationURL(for: .aider))
     }
 
@@ -516,7 +547,7 @@ struct IntegrationProfileManager {
                 Self.providerID: [
                     "type": "openai-compat",
                     "base_url": openAIBaseURL,
-                    "api_key": apiKey,
+                    "api_key": "$\(Self.apiKeyEnvironmentVariable)",
                     "models": providerModels
                 ]
             ]
@@ -525,7 +556,12 @@ struct IntegrationProfileManager {
     }
 
     private func configureQwenCode(selectedModelID: String) throws {
-        let contents = "OPENAI_API_KEY=\(apiKey)\nOPENAI_BASE_URL=\(openAIBaseURL)\nOPENAI_MODEL=\(selectedModelID)\n"
+        let contents = """
+        # Managed by Nativ. Credentials are injected only for the launched process.
+        OPENAI_BASE_URL=\(openAIBaseURL)
+        OPENAI_MODEL=\(selectedModelID)
+
+        """
         try writeText(contents, to: configurationURL(for: .qwenCode))
     }
 
@@ -543,7 +579,7 @@ struct IntegrationProfileManager {
         var providers = modelsRoot["providers"] as? [String: Any] ?? [:]
         providers[Self.providerID] = [
             "baseUrl": openAIBaseURL,
-            "apiKey": apiKey,
+            "apiKey": "${\(Self.apiKeyEnvironmentVariable)}",
             "api": "openai-completions",
             "models": models.map(openClawModel)
         ]
@@ -597,7 +633,7 @@ struct IntegrationProfileManager {
             lines.append("    provider: openai")
             lines.append("    apiBase: \(yamlString(openAIBaseURL))")
             lines.append("    model: \(yamlString(model.id))")
-            lines.append("    apiKey: \(yamlString(apiKey))")
+            lines.append("    apiKey: ${{ secrets.\(Self.apiKeyEnvironmentVariable) }}")
             lines.append("    roles:")
             lines.append("      - chat")
             lines.append("      - edit")
@@ -612,7 +648,10 @@ struct IntegrationProfileManager {
     ) -> (arguments: [String], environment: [String: String]) {
         switch tool {
         case .pi:
-            return (["--provider", Self.providerID, "--model", selectedModelID], [:])
+            return (
+                ["--provider", Self.providerID, "--model", selectedModelID],
+                [Self.apiKeyEnvironmentVariable: apiKey]
+            )
         case .codex:
             return (
                 ["--profile", Self.providerID, "--model", selectedModelID],
@@ -628,16 +667,22 @@ struct IntegrationProfileManager {
                 ]
             )
         case .hermes:
-            return (["-p", Self.providerID, "chat", "--provider", "custom", "--model", selectedModelID], [:])
+            return (
+                ["-p", Self.providerID, "chat", "--provider", "custom", "--model", selectedModelID],
+                ["OPENAI_API_KEY": apiKey, "OPENAI_BASE_URL": openAIBaseURL]
+            )
         case .openCode:
             return (
                 ["--model", "\(Self.providerID)/\(selectedModelID)"],
-                ["OPENCODE_CONFIG": configurationURL(for: tool).path]
+                [
+                    Self.apiKeyEnvironmentVariable: apiKey,
+                    "OPENCODE_CONFIG": configurationURL(for: tool).path
+                ]
             )
         case .aider:
             return (
                 ["--env-file", configurationURL(for: tool).path, "--model", "openai/\(selectedModelID)"],
-                [:]
+                ["OPENAI_API_BASE": openAIBaseURL, "OPENAI_API_KEY": apiKey]
             )
         case .goose:
             return (
@@ -645,7 +690,13 @@ struct IntegrationProfileManager {
                 ["NATIV_API_KEY": apiKey, "GOOSE_MODEL": selectedModelID]
             )
         case .crush:
-            return ([], ["CRUSH_GLOBAL_CONFIG": configurationURL(for: tool).path])
+            return (
+                [],
+                [
+                    "CRUSH_GLOBAL_CONFIG": configurationURL(for: tool).path,
+                    Self.apiKeyEnvironmentVariable: apiKey
+                ]
+            )
         case .qwenCode:
             return (
                 [],
@@ -656,11 +707,17 @@ struct IntegrationProfileManager {
                 ]
             )
         case .openClaw:
-            return (["agent", "--model", "\(Self.providerID)/\(selectedModelID)"], [:])
+            return (
+                ["agent", "--model", "\(Self.providerID)/\(selectedModelID)"],
+                [Self.apiKeyEnvironmentVariable: apiKey]
+            )
         case .zed:
             return (["."], ["NATIV_API_KEY": apiKey])
         case .continueDev:
-            return (["--config", configurationURL(for: tool).path], [:])
+            return (
+                ["--config", configurationURL(for: tool).path],
+                [Self.apiKeyEnvironmentVariable: apiKey]
+            )
         case .vscode, .cursor, .jetbrains:
             return ([], [:])
         case .cline:
@@ -686,6 +743,23 @@ struct IntegrationProfileManager {
     private func writeData(_ data: Data, to url: URL) throws {
         try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try data.write(to: url, options: .atomic)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    private func writeLaunchScript(_ script: String, to url: URL) throws {
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+        guard fileManager.createFile(
+            atPath: url.path,
+            contents: Data(script.utf8),
+            attributes: [.posixPermissions: 0o700]
+        ) else {
+            throw IntegrationServiceError.terminalLaunchFailed(
+                "Unable to write the temporary launch script."
+            )
+        }
     }
 
     private func shellQuote(_ value: String) -> String {

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -64,6 +64,10 @@ final class IntegrationsViewModel: ObservableObject {
         profiles.openAIBaseURL
     }
 
+    var integrationAPIKey: String {
+        profiles.apiKey
+    }
+
     private var integrationServerBaseURL: URL {
         serverModel.activeServerBaseURL ?? serverModel.settings.serverBaseURL
     }
@@ -564,7 +568,7 @@ private struct IntegrationDetailView: View {
         IntegrationPanel(title: "Guided setup", systemImage: "sparkles") {
             Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 8) {
                 IntegrationConfigurationRow(label: "Endpoint", value: viewModel.integrationEndpoint)
-                IntegrationConfigurationRow(label: "API key", value: "nativ")
+                IntegrationConfigurationRow(label: "API key", value: viewModel.integrationAPIKey)
             }
 
             VStack(alignment: .leading, spacing: 8) {

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -326,7 +326,7 @@ final class NativModel: ObservableObject {
         } catch {
             appendLog(
                 "\nCouldn’t synchronize the server credential database; "
-                    + "starting with the process verifier instead: \(error)\n"
+                    + "starting with the Keychain credential instead: \(error)\n"
             )
         }
         do {
@@ -337,7 +337,8 @@ final class NativModel: ObservableObject {
             }
             try server.start(
                 arguments: settings.launchArguments,
-                environment: launchEnvironment
+                environment: launchEnvironment,
+                standardInput: settings.serverAPIKeyStandardInput
             )
             isRunning = true
             settingsAppliedAtServerStart = settings.normalized()

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -318,11 +318,18 @@ final class NativModel: ObservableObject {
         currentServerOutput = ""
         metricsClient = NativMetricsClient(baseURL: settings.serverBaseURL)
         modelLoadingProgress = settings.normalized().languageModelID == nil ? nil : 0
+        let analyticsDatabaseURL = currentAnalyticsDatabaseURL()
         do {
-            let analyticsDatabaseURL = currentAnalyticsDatabaseURL()
             try settings.synchronizeServerAPICredential(
                 databaseURL: analyticsDatabaseURL
             )
+        } catch {
+            appendLog(
+                "\nCouldn’t synchronize the server credential database; "
+                    + "starting with the process verifier instead: \(error)\n"
+            )
+        }
+        do {
             var launchEnvironment = settings.launchEnvironment
             launchEnvironment["MLX_PLATFORM_ANALYTICS_DB_PATH"] = analyticsDatabaseURL.path
             if let effectiveHuggingFaceToken {

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -319,8 +319,12 @@ final class NativModel: ObservableObject {
         metricsClient = NativMetricsClient(baseURL: settings.serverBaseURL)
         modelLoadingProgress = settings.normalized().languageModelID == nil ? nil : 0
         do {
+            let analyticsDatabaseURL = currentAnalyticsDatabaseURL()
+            try settings.synchronizeServerAPICredential(
+                databaseURL: analyticsDatabaseURL
+            )
             var launchEnvironment = settings.launchEnvironment
-            launchEnvironment["MLX_PLATFORM_ANALYTICS_DB_PATH"] = currentAnalyticsDatabaseURL().path
+            launchEnvironment["MLX_PLATFORM_ANALYTICS_DB_PATH"] = analyticsDatabaseURL.path
             if let effectiveHuggingFaceToken {
                 launchEnvironment[HuggingFaceAuthentication.environmentVariableName] = effectiveHuggingFaceToken
             }

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -279,7 +279,7 @@ struct ServerAPITokenInfo: Equatable, Sendable {
 }
 
 enum ServerAPIAuthentication {
-    static let verifierEnvironmentVariableName = "MLX_PLATFORM_SERVER_API_KEY_SHA256"
+    static let standardInputEnvironmentVariableName = "MLX_PLATFORM_SERVER_API_KEY_STDIN"
 
     static func normalizedToken(_ token: String?) -> String? {
         guard let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -880,12 +880,11 @@ struct NativSettings: Codable, Equatable {
     var launchEnvironment: [String: String] {
         let settings = normalized()
         var environment = [
-            "HF_HUB_CACHE": settings.expandedModelSearchPath
+            "HF_HUB_CACHE": settings.expandedModelSearchPath,
+            ServerAPIAuthentication.standardInputEnvironmentVariableName: "1"
         ]
 
         environment["APC_ENABLED"] = settings.prefixCachingEnabled ? "1" : "0"
-        environment[ServerAPIAuthentication.verifierEnvironmentVariableName] = settings.serverAPIKey
-            .map(ServerAPICredentialDatabase.verifier(for:)) ?? ""
         if let huggingFaceToken = settings.huggingFaceToken {
             environment[HuggingFaceAuthentication.environmentVariableName] = huggingFaceToken
         }
@@ -894,6 +893,10 @@ struct NativSettings: Codable, Equatable {
             environment["APC_BLOCK_SIZE"] = "\(settings.prefixCacheBlockSize)"
         }
         return environment
+    }
+
+    var serverAPIKeyStandardInput: Data {
+        Data((normalized().serverAPIKey ?? "").utf8)
     }
 
     var launchArguments: [String] {

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -279,6 +279,8 @@ struct ServerAPITokenInfo: Equatable, Sendable {
 }
 
 enum ServerAPIAuthentication {
+    static let verifierEnvironmentVariableName = "MLX_PLATFORM_SERVER_API_KEY_SHA256"
+
     static func normalizedToken(_ token: String?) -> String? {
         guard let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else {
@@ -882,6 +884,8 @@ struct NativSettings: Codable, Equatable {
         ]
 
         environment["APC_ENABLED"] = settings.prefixCachingEnabled ? "1" : "0"
+        environment[ServerAPIAuthentication.verifierEnvironmentVariableName] = settings.serverAPIKey
+            .map(ServerAPICredentialDatabase.verifier(for:)) ?? ""
         if let huggingFaceToken = settings.huggingFaceToken {
             environment[HuggingFaceAuthentication.environmentVariableName] = huggingFaceToken
         }

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -1,6 +1,277 @@
+import CryptoKit
 import Foundation
 import NativServerKit
 import Security
+import SQLite3
+
+enum ServerAPICredentialPersistenceError: Error {
+    case keychain(OSStatus)
+    case invalidKeychainData
+    case sqlite(String)
+}
+
+struct ServerAPICredentialDatabase {
+    let databaseURL: URL
+
+    static func defaultDatabaseURL() -> URL {
+        let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.homeDirectoryForCurrentUser
+
+        return applicationSupport
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("Analytics.sqlite3")
+    }
+
+    static func verifier(for token: String) -> String {
+        SHA256.hash(data: Data(token.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    func synchronize(token: String?) throws {
+        let connection = try openConnection()
+        defer {
+            sqlite3_close(connection)
+        }
+
+        if let token = ServerAPIAuthentication.normalizedToken(token) {
+            let statement = try prepare(
+                """
+                INSERT INTO server_credentials (id, api_key_sha256, updated_at)
+                VALUES (1, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    api_key_sha256 = excluded.api_key_sha256,
+                    updated_at = excluded.updated_at
+                """,
+                connection: connection
+            )
+            defer {
+                sqlite3_finalize(statement)
+            }
+
+            let verifier = Self.verifier(for: token)
+            sqlite3_bind_text(
+                statement,
+                1,
+                verifier,
+                -1,
+                serverCredentialSQLiteTransientDestructor
+            )
+            sqlite3_bind_double(statement, 2, Date().timeIntervalSince1970)
+            try stepToCompletion(statement, connection: connection)
+        } else {
+            try execute(
+                "DELETE FROM server_credentials WHERE id = 1;",
+                connection: connection
+            )
+        }
+    }
+
+    func storedVerifier() throws -> String? {
+        let connection = try openConnection()
+        defer {
+            sqlite3_close(connection)
+        }
+
+        let statement = try prepare(
+            "SELECT api_key_sha256 FROM server_credentials WHERE id = 1;",
+            connection: connection
+        )
+        defer {
+            sqlite3_finalize(statement)
+        }
+
+        switch sqlite3_step(statement) {
+        case SQLITE_ROW:
+            guard let value = sqlite3_column_text(statement, 0) else {
+                return nil
+            }
+            return String(cString: value)
+        case SQLITE_DONE:
+            return nil
+        default:
+            throw sqliteError(connection)
+        }
+    }
+
+    private func openConnection() throws -> OpaquePointer {
+        try FileManager.default.createDirectory(
+            at: databaseURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        var connection: OpaquePointer?
+        let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        guard sqlite3_open_v2(databaseURL.path, &connection, flags, nil) == SQLITE_OK,
+              let connection else {
+            let message = connection
+                .flatMap(sqlite3_errmsg)
+                .map(String.init(cString:)) ?? "Unable to open credential database"
+            sqlite3_close(connection)
+            throw ServerAPICredentialPersistenceError.sqlite(message)
+        }
+
+        do {
+            try execute("PRAGMA journal_mode = WAL;", connection: connection)
+            try execute("PRAGMA synchronous = NORMAL;", connection: connection)
+            try execute("PRAGMA busy_timeout = 3000;", connection: connection)
+            try execute(Self.schemaSQL, connection: connection)
+            return connection
+        } catch {
+            sqlite3_close(connection)
+            throw error
+        }
+    }
+
+    private func prepare(
+        _ sql: String,
+        connection: OpaquePointer
+    ) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(connection, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw sqliteError(connection)
+        }
+        return statement
+    }
+
+    private func execute(
+        _ sql: String,
+        connection: OpaquePointer
+    ) throws {
+        guard sqlite3_exec(connection, sql, nil, nil, nil) == SQLITE_OK else {
+            throw sqliteError(connection)
+        }
+    }
+
+    private func stepToCompletion(
+        _ statement: OpaquePointer,
+        connection: OpaquePointer
+    ) throws {
+        guard sqlite3_step(statement) == SQLITE_DONE else {
+            throw sqliteError(connection)
+        }
+    }
+
+    private func sqliteError(
+        _ connection: OpaquePointer
+    ) -> ServerAPICredentialPersistenceError {
+        let message = sqlite3_errmsg(connection)
+            .map(String.init(cString:)) ?? "Unknown SQLite error"
+        return .sqlite(message)
+    }
+
+    private static let schemaSQL = """
+        CREATE TABLE IF NOT EXISTS server_credentials (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            api_key_sha256 TEXT NOT NULL,
+            updated_at REAL NOT NULL
+        );
+        """
+}
+
+struct ServerAPIKeychain {
+    let service: String
+    let account: String
+
+    init(
+        service: String = "dev.local.Nativ.server-api-key",
+        account: String = "nativ-server"
+    ) {
+        self.service = service
+        self.account = account
+    }
+
+    func load() throws -> String? {
+        var query = baseQuery
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess else {
+            throw ServerAPICredentialPersistenceError.keychain(status)
+        }
+        guard let data = item as? Data,
+              let token = String(data: data, encoding: .utf8) else {
+            throw ServerAPICredentialPersistenceError.invalidKeychainData
+        }
+        return ServerAPIAuthentication.normalizedToken(token)
+    }
+
+    func save(_ token: String?) throws {
+        guard let token = ServerAPIAuthentication.normalizedToken(token) else {
+            let status = SecItemDelete(baseQuery as CFDictionary)
+            guard status == errSecSuccess || status == errSecItemNotFound else {
+                throw ServerAPICredentialPersistenceError.keychain(status)
+            }
+            return
+        }
+
+        let attributes: [String: Any] = [
+            kSecValueData as String: Data(token.utf8),
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        let updateStatus = SecItemUpdate(
+            baseQuery as CFDictionary,
+            attributes as CFDictionary
+        )
+        if updateStatus == errSecSuccess {
+            return
+        }
+        guard updateStatus == errSecItemNotFound else {
+            throw ServerAPICredentialPersistenceError.keychain(updateStatus)
+        }
+
+        var item = baseQuery
+        attributes.forEach { item[$0.key] = $0.value }
+        let addStatus = SecItemAdd(item as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw ServerAPICredentialPersistenceError.keychain(addStatus)
+        }
+    }
+
+    private var baseQuery: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecUseDataProtectionKeychain as String: true
+        ]
+    }
+}
+
+struct ServerAPICredentialStore {
+    static let live = Self(
+        keychain: ServerAPIKeychain(),
+        database: ServerAPICredentialDatabase(
+            databaseURL: ServerAPICredentialDatabase.defaultDatabaseURL()
+        )
+    )
+
+    let keychain: ServerAPIKeychain
+    let database: ServerAPICredentialDatabase
+
+    func loadToken() throws -> String? {
+        try keychain.load()
+    }
+
+    func synchronizeVerifier(for token: String?) throws {
+        try database.synchronize(
+            token: ServerAPIAuthentication.normalizedToken(token)
+        )
+    }
+}
+
+private let serverCredentialSQLiteTransientDestructor = unsafeBitCast(
+    -1,
+    to: sqlite3_destructor_type.self
+)
 
 struct ServerAPITokenInfo: Equatable, Sendable {
     let maskedValue: String
@@ -409,7 +680,6 @@ struct NativSettings: Codable, Equatable {
         try container.encodeIfPresent(imageGenerationModelID, forKey: .imageGenerationModelID)
         try container.encodeIfPresent(textToSpeechModelID, forKey: .textToSpeechModelID)
         try container.encodeIfPresent(speechToTextModelID, forKey: .speechToTextModelID)
-        try container.encodeIfPresent(serverAPIKey, forKey: .serverAPIKey)
         try container.encodeIfPresent(huggingFaceToken, forKey: .huggingFaceToken)
         try container.encode(serverHost, forKey: .serverHost)
         try container.encode(serverPort, forKey: .serverPort)
@@ -445,24 +715,81 @@ struct NativSettings: Codable, Equatable {
     }
 
     static func load() -> Self {
-        guard let data = try? Data(contentsOf: storageURL) else {
-            return Self()
+        let storedSettings: Self
+        if let data = try? Data(contentsOf: storageURL),
+           let decoded = try? PropertyListDecoder().decode(Self.self, from: data) {
+            storedSettings = decoded
+        } else {
+            storedSettings = Self()
         }
-        return (try? PropertyListDecoder().decode(Self.self, from: data)) ?? Self()
+
+        var settings = storedSettings
+        let legacyToken = ServerAPIAuthentication.normalizedToken(
+            storedSettings.serverAPIKey
+        )
+
+        do {
+            if let keychainToken = try ServerAPICredentialStore.live.loadToken() {
+                settings.serverAPIKey = keychainToken
+                try? ServerAPICredentialStore.live.synchronizeVerifier(
+                    for: keychainToken
+                )
+                if legacyToken != nil {
+                    try? settings.writePropertyList()
+                }
+            } else if let legacyToken {
+                try ServerAPICredentialStore.live.keychain.save(legacyToken)
+                settings.serverAPIKey = legacyToken
+                try settings.writePropertyList()
+                try? ServerAPICredentialStore.live.synchronizeVerifier(
+                    for: legacyToken
+                )
+            } else {
+                settings.serverAPIKey = nil
+                try? ServerAPICredentialStore.live.synchronizeVerifier(for: nil)
+                if storedSettings.serverAPIKey != nil {
+                    try? settings.writePropertyList()
+                }
+            }
+        } catch {
+            // Keep a legacy token available until it can be migrated without data loss.
+            settings.serverAPIKey = legacyToken
+        }
+
+        return settings
     }
 
     func save() {
+        let settings = normalized()
         do {
-            let url = Self.storageURL
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
+            try ServerAPICredentialStore.live.keychain.save(
+                settings.serverAPIKey
             )
-            let data = try PropertyListEncoder().encode(normalized())
-            try data.write(to: url, options: .atomic)
+            try settings.writePropertyList()
+            try? ServerAPICredentialStore.live.synchronizeVerifier(
+                for: settings.serverAPIKey
+            )
         } catch {
-            // Settings should not prevent the server from running.
+            // Settings should not replace the last recoverable credential.
         }
+    }
+
+    func synchronizeServerAPICredential(
+        databaseURL: URL = ServerAPICredentialDatabase.defaultDatabaseURL()
+    ) throws {
+        try ServerAPICredentialDatabase(databaseURL: databaseURL).synchronize(
+            token: normalized().serverAPIKey
+        )
+    }
+
+    private func writePropertyList() throws {
+        let url = Self.storageURL
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try PropertyListEncoder().encode(normalized())
+        try data.write(to: url, options: .atomic)
     }
 
     func normalized() -> Self {
@@ -555,9 +882,6 @@ struct NativSettings: Codable, Equatable {
         ]
 
         environment["APC_ENABLED"] = settings.prefixCachingEnabled ? "1" : "0"
-        if let serverAPIKey = settings.serverAPIKey {
-            environment["MLX_VLM_SERVER_API_KEY"] = serverAPIKey
-        }
         if let huggingFaceToken = settings.huggingFaceToken {
             environment[HuggingFaceAuthentication.environmentVariableName] = huggingFaceToken
         }

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -176,8 +176,20 @@ public enum Nativ {
         let process = Process()
         process.executableURL = try executableURL()
         process.arguments = arguments
-        var processEnvironment = ProcessInfo.processInfo.environment
-        processEnvironment.merge(environment) { _, newValue in newValue }
+        process.environment = makeProcessEnvironment(overrides: environment)
+        return process
+    }
+
+    static func makeProcessEnvironment(
+        inherited: [String: String] = ProcessInfo.processInfo.environment,
+        overrides: [String: String] = [:]
+    ) -> [String: String] {
+        var processEnvironment = inherited
+        processEnvironment.merge(overrides) { _, newValue in newValue }
+        // The raw server key is handed to the child once over stdin. Remove
+        // both inherited and caller-provided copies of mlx-vlm's legacy
+        // environment credential so it cannot remain in the child process.
+        processEnvironment.removeValue(forKey: "MLX_VLM_SERVER_API_KEY")
         // Xcode enables Metal API validation for the app process and exports
         // these variables to children. The inference server creates and
         // releases many Metal buffers during chunked prefill; running that
@@ -195,8 +207,7 @@ public enum Nativ {
         }
         processEnvironment["PYTHONNOUSERSITE"] = "1"
         processEnvironment["PYTHONUNBUFFERED"] = "1"
-        process.environment = processEnvironment
-        return process
+        return processEnvironment
     }
 
     public static func run(arguments: [String], timeout: TimeInterval = 30) throws -> String {

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -670,7 +670,8 @@ public final class NativProcessController {
     @discardableResult
     public func start(
         arguments: [String] = [],
-        environment: [String: String] = [:]
+        environment: [String: String] = [:],
+        standardInput: Data? = nil
     ) throws -> Process {
         try lock.withLock {
             if process?.isRunning == true {
@@ -680,8 +681,12 @@ public final class NativProcessController {
             let process = try Nativ.makeProcess(arguments: arguments, environment: environment)
             let outputPipe = Pipe()
             let errorPipe = Pipe()
+            let inputPipe = standardInput.map { _ in Pipe() }
             process.standardOutput = outputPipe
             process.standardError = errorPipe
+            if let inputPipe {
+                process.standardInput = inputPipe
+            }
 
             self.outputPipe = outputPipe
             self.errorPipe = errorPipe
@@ -700,7 +705,16 @@ public final class NativProcessController {
 
             do {
                 try process.run()
+                if let standardInput, let inputPipe {
+                    inputPipe.fileHandleForWriting.write(standardInput)
+                    try inputPipe.fileHandleForWriting.close()
+                }
             } catch {
+                if process.isRunning {
+                    process.terminate()
+                }
+                outputPipe.fileHandleForReading.readabilityHandler = nil
+                errorPipe.fileHandleForReading.readabilityHandler = nil
                 self.process = nil
                 self.outputPipe = nil
                 self.errorPipe = nil

--- a/Tests/NativTests/IntegrationServicesTests.swift
+++ b/Tests/NativTests/IntegrationServicesTests.swift
@@ -71,27 +71,69 @@ final class IntegrationServicesTests: XCTestCase {
     }
 
     func testConfiguredServerAPIKeyIsUsedByProfilesAndLaunchEnvironment() throws {
+        let token = "nativ_configured_token"
         manager = IntegrationProfileManager(
             serverBaseURL: serverBaseURL,
-            serverAPIKey: "  nativ_configured_token\n",
+            serverAPIKey: "  \(token)\n",
             homeDirectory: homeDirectory,
             applicationSupportDirectory: applicationSupportDirectory
         )
 
+        XCTAssertEqual(manager.apiKey, token)
+        for tool in IntegrationTool.allCases where !tool.isGuidedSetup {
+            try configure(tool)
+            let configuration = try String(
+                contentsOf: manager.configurationURL(for: tool),
+                encoding: .utf8
+            )
+            XCTAssertFalse(
+                configuration.contains(token),
+                "\(tool.displayName) persisted the raw API key"
+            )
+            XCTAssertTrue(
+                launchCommand(for: tool).contains(token),
+                "\(tool.displayName) did not receive the configured API key"
+            )
+        }
+    }
+
+    func testManagedConfigurationUsesOwnerOnlyPermissions() throws {
         try configure(.pi)
 
-        let root = try json(at: manager.configurationURL(for: .pi))
-        let providers = try XCTUnwrap(root["providers"] as? [String: Any])
-        let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
-        XCTAssertEqual(provider["apiKey"] as? String, "nativ_configured_token")
-        XCTAssertTrue(
-            launchCommand(for: .codex)
-                .contains("export NATIV_API_KEY='nativ_configured_token'")
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: manager.configurationURL(for: .pi).path
         )
-        XCTAssertTrue(
-            launchCommand(for: .goose)
-                .contains("export NATIV_API_KEY='nativ_configured_token'")
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+
+        XCTAssertEqual(permissions.intValue & 0o777, 0o600)
+    }
+
+    func testTerminalLaunchScriptIsOwnerOnlyAndDeletesItselfBeforeRunning() throws {
+        let scriptURL = try manager.prepareTerminalLaunchScript(
+            tool: .codex,
+            executableURL: URL(fileURLWithPath: "/usr/bin/true"),
+            selectedModelID: selectedModel.id,
+            workingDirectory: temporaryRoot
         )
+        let script = try String(contentsOf: scriptURL, encoding: .utf8)
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: scriptURL.path
+        )
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+
+        XCTAssertTrue(script.hasPrefix("#!/bin/zsh\nrm -f -- \"$0\"\n"))
+        XCTAssertTrue(script.contains("export NATIV_API_KEY='nativ'"))
+        XCTAssertTrue(script.contains("exec '/usr/bin/true'"))
+        XCTAssertEqual(permissions.intValue & 0o777, 0o700)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [scriptURL.path]
+        try process.run()
+        process.waitUntilExit()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: scriptURL.path))
     }
 
     func testPiConfigurationAndLaunchCommand() throws {
@@ -111,6 +153,7 @@ final class IntegrationServicesTests: XCTestCase {
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["baseUrl"] as? String, "http://nativ.test:49152/v1")
         XCTAssertEqual(provider["api"] as? String, "openai-completions")
+        XCTAssertEqual(provider["apiKey"] as? String, "NATIV_API_KEY")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
         XCTAssertEqual(models[0]["id"] as? String, selectedModel.id)
@@ -120,7 +163,11 @@ final class IntegrationServicesTests: XCTestCase {
 
         XCTAssertEqual(
             launchCommand(for: .pi),
-            "cd '/tmp/Nativ Project'\n'/tools/pi' '--provider' 'nativ' '--model' 'org/local-model'"
+            """
+            cd '/tmp/Nativ Project'
+            export NATIV_API_KEY='nativ'
+            '/tools/pi' '--provider' 'nativ' '--model' 'org/local-model'
+            """
         )
     }
 
@@ -149,6 +196,9 @@ final class IntegrationServicesTests: XCTestCase {
         )
         XCTAssertFalse(profile.contains(selectedModel.id))
         XCTAssertEqual(profile.components(separatedBy: "# Managed by Nativ.").count - 1, 1)
+        let attributes = try FileManager.default.attributesOfItem(atPath: profileURL.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(permissions.intValue & 0o777, 0o600)
         XCTAssertEqual(
             launchCommand(for: .codex),
             """
@@ -165,7 +215,7 @@ final class IntegrationServicesTests: XCTestCase {
         let configurationURL = manager.configurationURL(for: .claudeCode)
         let root = try json(at: configurationURL)
         let environment = try XCTUnwrap(root["env"] as? [String: Any])
-        XCTAssertEqual(environment["ANTHROPIC_AUTH_TOKEN"] as? String, "nativ")
+        XCTAssertNil(environment["ANTHROPIC_AUTH_TOKEN"])
         XCTAssertEqual(environment["ANTHROPIC_API_KEY"] as? String, "")
         XCTAssertEqual(environment["ANTHROPIC_BASE_URL"] as? String, "http://nativ.test:49152")
         XCTAssertEqual(environment["ANTHROPIC_MODEL"] as? String, selectedModel.id)
@@ -189,6 +239,7 @@ final class IntegrationServicesTests: XCTestCase {
         let configuration = try String(contentsOf: configurationURL, encoding: .utf8)
         XCTAssertTrue(configuration.contains("default: \"org/local-model\""))
         XCTAssertTrue(configuration.contains("base_url: \"http://nativ.test:49152/v1\""))
+        XCTAssertFalse(configuration.contains("api_key:"))
         XCTAssertTrue(configuration.contains("\"org/local-model\":\n        context_length: 32768\n        supports_vision: true"))
         XCTAssertTrue(configuration.contains("\"org/basic-model\":\n        context_length: 131072"))
         XCTAssertEqual(
@@ -200,7 +251,12 @@ final class IntegrationServicesTests: XCTestCase {
         )
         XCTAssertEqual(
             launchCommand(for: .hermes),
-            "cd '/tmp/Nativ Project'\n'/tools/hermes' '-p' 'nativ' 'chat' '--provider' 'custom' '--model' 'org/local-model'"
+            """
+            cd '/tmp/Nativ Project'
+            export OPENAI_API_KEY='nativ'
+            export OPENAI_BASE_URL='http://nativ.test:49152/v1'
+            '/tools/hermes' '-p' 'nativ' 'chat' '--provider' 'custom' '--model' 'org/local-model'
+            """
         )
     }
 
@@ -215,6 +271,7 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertEqual(provider["npm"] as? String, "@ai-sdk/openai-compatible")
         let options = try XCTUnwrap(provider["options"] as? [String: Any])
         XCTAssertEqual(options["baseURL"] as? String, "http://nativ.test:49152/v1")
+        XCTAssertEqual(options["apiKey"] as? String, "{env:NATIV_API_KEY}")
         let models = try XCTUnwrap(provider["models"] as? [String: Any])
         let selected = try XCTUnwrap(models[selectedModel.id] as? [String: Any])
         XCTAssertEqual(selected["attachment"] as? Bool, true)
@@ -229,6 +286,7 @@ final class IntegrationServicesTests: XCTestCase {
             launchCommand(for: .openCode),
             """
             cd '/tmp/Nativ Project'
+            export NATIV_API_KEY='nativ'
             export OPENCODE_CONFIG='\(configurationURL.path)'
             '/tools/opencode' '--model' 'nativ/org/local-model'
             """
@@ -241,10 +299,15 @@ final class IntegrationServicesTests: XCTestCase {
         let configurationURL = manager.configurationURL(for: .aider)
         let contents = try String(contentsOf: configurationURL, encoding: .utf8)
         XCTAssertTrue(contents.contains("OPENAI_API_BASE=http://nativ.test:49152/v1"))
-        XCTAssertTrue(contents.contains("OPENAI_API_KEY=nativ"))
+        XCTAssertFalse(contents.contains("OPENAI_API_KEY="))
         XCTAssertEqual(
             launchCommand(for: .aider),
-            "cd '/tmp/Nativ Project'\n'/tools/aider' '--env-file' '\(configurationURL.path)' '--model' 'openai/org/local-model'"
+            """
+            cd '/tmp/Nativ Project'
+            export OPENAI_API_BASE='http://nativ.test:49152/v1'
+            export OPENAI_API_KEY='nativ'
+            '/tools/aider' '--env-file' '\(configurationURL.path)' '--model' 'openai/org/local-model'
+            """
         )
     }
 
@@ -282,7 +345,7 @@ final class IntegrationServicesTests: XCTestCase {
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["type"] as? String, "openai-compat")
         XCTAssertEqual(provider["base_url"] as? String, "http://nativ.test:49152/v1")
-        XCTAssertEqual(provider["api_key"] as? String, "nativ")
+        XCTAssertEqual(provider["api_key"] as? String, "$NATIV_API_KEY")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
         XCTAssertEqual(models[0]["id"] as? String, selectedModel.id)
@@ -298,6 +361,7 @@ final class IntegrationServicesTests: XCTestCase {
             """
             cd '/tmp/Nativ Project'
             export CRUSH_GLOBAL_CONFIG='\(configurationURL.path)'
+            export NATIV_API_KEY='nativ'
             '/tools/crush'
             """
         )
@@ -308,7 +372,7 @@ final class IntegrationServicesTests: XCTestCase {
 
         let configurationURL = manager.configurationURL(for: .qwenCode)
         let contents = try String(contentsOf: configurationURL, encoding: .utf8)
-        XCTAssertTrue(contents.contains("OPENAI_API_KEY=nativ"))
+        XCTAssertFalse(contents.contains("OPENAI_API_KEY="))
         XCTAssertTrue(contents.contains("OPENAI_BASE_URL=http://nativ.test:49152/v1"))
         XCTAssertTrue(contents.contains("OPENAI_MODEL=org/local-model"))
         XCTAssertEqual(
@@ -333,7 +397,7 @@ final class IntegrationServicesTests: XCTestCase {
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["baseUrl"] as? String, "http://nativ.test:49152/v1")
         XCTAssertEqual(provider["api"] as? String, "openai-completions")
-        XCTAssertEqual(provider["apiKey"] as? String, "nativ")
+        XCTAssertEqual(provider["apiKey"] as? String, "${NATIV_API_KEY}")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
         XCTAssertEqual(models[0]["id"] as? String, selectedModel.id)
@@ -341,7 +405,11 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertNil(models[1]["contextWindow"])
         XCTAssertEqual(
             launchCommand(for: .openClaw),
-            "cd '/tmp/Nativ Project'\n'/tools/openclaw' 'agent' '--model' 'nativ/org/local-model'"
+            """
+            cd '/tmp/Nativ Project'
+            export NATIV_API_KEY='nativ'
+            '/tools/openclaw' 'agent' '--model' 'nativ/org/local-model'
+            """
         )
     }
 
@@ -378,10 +446,14 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertTrue(contents.contains("provider: openai"))
         XCTAssertTrue(contents.contains("apiBase: \"http://nativ.test:49152/v1\""))
         XCTAssertTrue(contents.contains("model: \"org/local-model\""))
-        XCTAssertTrue(contents.contains("apiKey: \"nativ\""))
+        XCTAssertTrue(contents.contains("apiKey: ${{ secrets.NATIV_API_KEY }}"))
         XCTAssertEqual(
             launchCommand(for: .continueDev),
-            "cd '/tmp/Nativ Project'\n'/tools/cn' '--config' '\(configurationURL.path)'"
+            """
+            cd '/tmp/Nativ Project'
+            export NATIV_API_KEY='nativ'
+            '/tools/cn' '--config' '\(configurationURL.path)'
+            """
         )
     }
 

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -86,6 +86,10 @@ final class NativSettingsTests: XCTestCase {
             )
         )
         XCTAssertNil(normalized.launchEnvironment["MLX_VLM_SERVER_API_KEY"])
+        XCTAssertEqual(
+            normalized.launchEnvironment[ServerAPIAuthentication.verifierEnvironmentVariableName],
+            ServerAPICredentialDatabase.verifier(for: "nativ_1234567890abcdef")
+        )
     }
 
     func testBlankServerAPITokenIsOmitted() {
@@ -93,6 +97,10 @@ final class NativSettingsTests: XCTestCase {
 
         XCTAssertNil(settings.serverAPIKey)
         XCTAssertNil(settings.launchEnvironment["MLX_VLM_SERVER_API_KEY"])
+        XCTAssertEqual(
+            settings.launchEnvironment[ServerAPIAuthentication.verifierEnvironmentVariableName],
+            ""
+        )
     }
 
     func testGeneratedServerAPITokenHasNativPrefix() {
@@ -139,6 +147,28 @@ final class NativSettingsTests: XCTestCase {
 
         try database.synchronize(token: nil)
         XCTAssertNil(try database.storedVerifier())
+    }
+
+    func testServerLaunchVerifierSurvivesDatabaseSynchronizationFailure() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "NativServerAPICredentialFailureTests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let settings = NativSettings(serverAPIKey: "nativ_available_at_launch")
+
+        XCTAssertThrowsError(
+            try settings.synchronizeServerAPICredential(databaseURL: directory)
+        )
+        XCTAssertEqual(
+            settings.launchEnvironment[ServerAPIAuthentication.verifierEnvironmentVariableName],
+            ServerAPICredentialDatabase.verifier(for: "nativ_available_at_launch")
+        )
     }
 
     func testServerAuthorizationAddsBearerHeader() {

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -112,6 +112,26 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertTrue(settings.serverAPIKeyStandardInput.isEmpty)
     }
 
+    func testServerProcessRemovesInheritedAndOverriddenLegacyAPIKey() {
+        let environment = Nativ.makeProcessEnvironment(
+            inherited: [
+                "MLX_VLM_SERVER_API_KEY": "inherited_secret",
+                "PATH": "/usr/bin"
+            ],
+            overrides: [
+                "MLX_VLM_SERVER_API_KEY": "override_secret",
+                ServerAPIAuthentication.standardInputEnvironmentVariableName: "1"
+            ]
+        )
+
+        XCTAssertNil(environment["MLX_VLM_SERVER_API_KEY"])
+        XCTAssertEqual(environment["PATH"], "/usr/bin")
+        XCTAssertEqual(
+            environment[ServerAPIAuthentication.standardInputEnvironmentVariableName],
+            "1"
+        )
+    }
+
     func testGeneratedServerAPITokenHasNativPrefix() {
         let token = ServerAPIAuthentication.generateToken()
 

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -87,8 +87,14 @@ final class NativSettingsTests: XCTestCase {
         )
         XCTAssertNil(normalized.launchEnvironment["MLX_VLM_SERVER_API_KEY"])
         XCTAssertEqual(
-            normalized.launchEnvironment[ServerAPIAuthentication.verifierEnvironmentVariableName],
-            ServerAPICredentialDatabase.verifier(for: "nativ_1234567890abcdef")
+            normalized.launchEnvironment[
+                ServerAPIAuthentication.standardInputEnvironmentVariableName
+            ],
+            "1"
+        )
+        XCTAssertEqual(
+            String(data: normalized.serverAPIKeyStandardInput, encoding: .utf8),
+            "nativ_1234567890abcdef"
         )
     }
 
@@ -98,9 +104,12 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertNil(settings.serverAPIKey)
         XCTAssertNil(settings.launchEnvironment["MLX_VLM_SERVER_API_KEY"])
         XCTAssertEqual(
-            settings.launchEnvironment[ServerAPIAuthentication.verifierEnvironmentVariableName],
-            ""
+            settings.launchEnvironment[
+                ServerAPIAuthentication.standardInputEnvironmentVariableName
+            ],
+            "1"
         )
+        XCTAssertTrue(settings.serverAPIKeyStandardInput.isEmpty)
     }
 
     func testGeneratedServerAPITokenHasNativPrefix() {
@@ -149,7 +158,7 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertNil(try database.storedVerifier())
     }
 
-    func testServerLaunchVerifierSurvivesDatabaseSynchronizationFailure() throws {
+    func testServerLaunchCredentialSurvivesDatabaseSynchronizationFailure() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "NativServerAPICredentialFailureTests-\(UUID().uuidString)",
@@ -166,8 +175,8 @@ final class NativSettingsTests: XCTestCase {
             try settings.synchronizeServerAPICredential(databaseURL: directory)
         )
         XCTAssertEqual(
-            settings.launchEnvironment[ServerAPIAuthentication.verifierEnvironmentVariableName],
-            ServerAPICredentialDatabase.verifier(for: "nativ_available_at_launch")
+            String(data: settings.serverAPIKeyStandardInput, encoding: .utf8),
+            "nativ_available_at_launch"
         )
     }
 

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -73,7 +73,7 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertFalse(original.hasSameLaunchConfiguration(as: changed))
     }
 
-    func testServerAPITokenIsNormalizedMaskedAndPassedToServer() {
+    func testServerAPITokenIsNormalizedMaskedAndKeptOutOfServerEnvironment() {
         let settings = NativSettings(serverAPIKey: "  nativ_1234567890abcdef\n")
         let normalized = settings.normalized()
 
@@ -85,10 +85,7 @@ final class NativSettingsTests: XCTestCase {
                 characterCount: 22
             )
         )
-        XCTAssertEqual(
-            normalized.launchEnvironment["MLX_VLM_SERVER_API_KEY"],
-            "nativ_1234567890abcdef"
-        )
+        XCTAssertNil(normalized.launchEnvironment["MLX_VLM_SERVER_API_KEY"])
     }
 
     func testBlankServerAPITokenIsOmitted() {
@@ -103,6 +100,45 @@ final class NativSettingsTests: XCTestCase {
 
         XCTAssertTrue(token.hasPrefix("nativ_"))
         XCTAssertEqual(token, ServerAPIAuthentication.normalizedToken(token))
+    }
+
+    func testServerAPIKeyIsOmittedFromEncodedSettings() throws {
+        let settings = NativSettings(serverAPIKey: "nativ_plaintext_token")
+        let data = try PropertyListEncoder().encode(settings)
+        let propertyList = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil)
+                as? [String: Any]
+        )
+
+        XCTAssertNil(propertyList["serverAPIKey"])
+    }
+
+    func testServerAPIDatabaseStoresOnlyVerifier() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "NativServerAPICredentialTests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let database = ServerAPICredentialDatabase(
+            databaseURL: directory.appendingPathComponent("Analytics.sqlite3")
+        )
+        let token = "nativ_plaintext_token"
+
+        try database.synchronize(token: token)
+
+        let storedVerifier = try XCTUnwrap(database.storedVerifier())
+        XCTAssertEqual(
+            storedVerifier,
+            ServerAPICredentialDatabase.verifier(for: token)
+        )
+        XCTAssertNotEqual(storedVerifier, token)
+
+        try database.synchronize(token: nil)
+        XCTAssertNil(try database.storedVerifier())
     }
 
     func testServerAuthorizationAddsBearerHeader() {


### PR DESCRIPTION
## Summary

- store the server API key in macOS Keychain and persist only its SHA-256 verifier in SQLite
- deliver the Keychain token to the child exactly once through an anonymous standard-input pipe instead of a plist, generated profile, command argument, or process environment variable
- supply that token through mlx-vlm's existing `_server_api_key` source, keeping mlx-vlm's route guard as the single authentication enforcement path
- treat verifier database synchronization as best-effort so an unavailable or unwritable analytics database no longer prevents server startup
- update all managed integrations to reference credentials through their launch environment instead of persisting the raw token in generated profiles
- use the configured API key in guided setup instead of the hard-coded `nativ` value
- write managed configuration files with owner-only permissions and make temporary credential-bearing launch scripts owner-only and self-deleting

Closes #106.

## Security and compatibility

- Nativ does not install authentication middleware or duplicate request validation.
- Current mlx-vlm management endpoints and the upcoming `/v1` inference-router dependency both resolve the same upstream key source.
- The raw server key is absent from Nativ's plist and the mlx-vlm child process environment.
- Database verifier synchronization remains best-effort; the pipe-backed Keychain credential is available even when synchronization fails.
- Managed integration profiles no longer contain the raw API key. The key is injected only into the launched tool process using each integration's supported environment-variable mechanism.

## Validation

- `xcodebuild test -project Nativ.xcodeproj -scheme Nativ -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` — 99 tests passed
- Swift-to-Python process smoke test — piped key accepted; missing and incorrect keys rejected
- bundled FastAPI runtime — current management guard accepts only the piped key
- mlx-vlm-main compatibility simulation — an inference-router dependency captured before the Nativ overlay loads still resolves the piped key and rejects missing/incorrect credentials
- targeted integration and settings suite — 37 tests passed
- `python3 -m py_compile PythonDistribution/Overlay/nativ_server.py`
- `git diff --check`
