### PR TITLE
Add Buzz as a guided-setup integration

### DIFF
--- a/Sources/Nativ/Assets.xcassets/IntegrationLogo-buzz.imageset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/IntegrationLogo-buzz.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "filename": "buzz.svg",
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/Sources/Nativ/Assets.xcassets/IntegrationLogo-buzz.imageset/buzz.svg
+++ b/Sources/Nativ/Assets.xcassets/IntegrationLogo-buzz.imageset/buzz.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Buzz">
+  <rect width="512" height="512" rx="96" fill="#0b0b0b"/>
+  <path d="M256 75 334 120v90l-78 45-78-45v-90z" fill="#ffd84d"/>
+  <path d="M178 210 256 255v90l-78 45-78-45v-90z" fill="#ffbd24"/>
+  <path d="M334 210 412 255v90l-78 45-78-45v-90z" fill="#ffb000"/>
+  <path d="M256 300 334 345v90l-78 45-78-45v-90z" fill="#ff8a00"/>
+  <path d="M256 105 306 134l-50 29-50-29z" fill="#ffe680" opacity=".75"/>
+  <path d="M178 240 228 269l-50 29-50-29z" fill="#ffe680" opacity=".55"/>
+  <path d="M334 240 384 269l-50 29-50-29z" fill="#ffe680" opacity=".55"/>
+</svg>

--- a/Sources/Nativ/Features/Integrations/IntegrationServices.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationServices.swift
@@ -107,7 +107,7 @@ struct IntegrationProfileManager {
         case .codex, .hermes, .aider, .qwenCode, .continueDev:
             guard let text = String(data: data, encoding: .utf8) else { return false }
             return text.contains(Self.providerID) && text.contains(openAIBaseURL)
-        case .vscode, .cursor, .jetbrains:
+        case .vscode, .cursor, .jetbrains, .buzz:
             return false
         case .cline:
             return false
@@ -157,7 +157,7 @@ struct IntegrationProfileManager {
             try configureZed(models: models)
         case .continueDev:
             try configureContinue(selectedModelID: selectedModelID, models: models)
-        case .vscode, .cursor, .jetbrains:
+        case .vscode, .cursor, .jetbrains, .buzz:
             break
         case .cline:
             break
@@ -248,6 +248,8 @@ struct IntegrationProfileManager {
             return integrationsSupportURL.appendingPathComponent("cursor-guided.json")
         case .jetbrains:
             return integrationsSupportURL.appendingPathComponent("jetbrains-guided.json")
+        case .buzz:
+            return integrationsSupportURL.appendingPathComponent("buzz-guided.json")
         }
     }
 
@@ -661,7 +663,7 @@ struct IntegrationProfileManager {
             return (["."], ["NATIV_API_KEY": apiKey])
         case .continueDev:
             return (["--config", configurationURL(for: tool).path], [:])
-        case .vscode, .cursor, .jetbrains:
+        case .vscode, .cursor, .jetbrains, .buzz:
             return ([], [:])
         case .cline:
             return ([], [:])

--- a/Sources/Nativ/Features/Integrations/IntegrationTypes.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationTypes.swift
@@ -17,6 +17,7 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
     case cline
     case cursor
     case jetbrains
+    case buzz
 
     var id: String { rawValue }
 
@@ -38,6 +39,7 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
         case .cline: "Cline"
         case .cursor: "Cursor"
         case .jetbrains: "JetBrains"
+        case .buzz: "Buzz"
         }
     }
 
@@ -59,6 +61,7 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
         case .cline: "cline"
         case .cursor: "cursor"
         case .jetbrains: "jetbrains"
+        case .buzz: "buzz"
         }
     }
 
@@ -82,6 +85,7 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
         case .cline: "OpenAI-compatible provider in the Cline extension"
         case .cursor: "OpenAI-compatible endpoint in Cursor's AI panel"
         case .jetbrains: "OpenAI-compatible endpoint in JetBrains AI Assistant"
+        case .buzz: "Self-hostable workspace for people and AI agents"
         }
     }
 
@@ -103,6 +107,7 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
         case .cline: URL(string: "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev")!
         case .cursor: URL(string: "https://docs.cursor.com/settings/models")!
         case .jetbrains: URL(string: "https://www.jetbrains.com/help/ai-assistant/configure-openai-compatible-models.html")!
+        case .buzz: URL(string: "https://github.com/block/buzz")!
         }
     }
 
@@ -119,6 +124,7 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
         case .cline: true
         case .cursor: true
         case .jetbrains: true
+        case .buzz: true
         default: false
         }
     }
@@ -161,6 +167,13 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
                 "Under Providers & API keys, add an \u{201C}OpenAI Compatible\u{201D} provider with the Base URL and API key shown above.",
                 "Select your model, then use it from the AI Assistant chat."
             ]
+        case .buzz:
+            [
+                "Start Nativ's server and load a model from the Models page.",
+                "Install Buzz from github.com/block/buzz, then set the variables below where its agent runs.",
+                "Set BUZZ_AGENT_PROVIDER to \u{201C}openai\u{201D}, OPENAI_COMPAT_BASE_URL to the Base URL above, and OPENAI_COMPAT_API_KEY to the API key above.",
+                "Set OPENAI_COMPAT_MODEL to your model ID, then start Buzz \u{2014} its agent will use your local model."
+            ]
         default:
             []
         }
@@ -172,6 +185,7 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
         case .cline: "Cline runs inside VS Code and compatible editors."
         case .cursor: "Only Cursor's chat/AI panel honors a custom OpenAI endpoint \u{2014} Tab and inline edits stay on Cursor's own models."
         case .jetbrains: "Requires the AI Assistant plugin (recent JetBrains IDE versions)."
+        case .buzz: "These variables configure Buzz's agent runtime; set them where Buzz runs its agent."
         default: nil
         }
     }

--- a/Sources/Nativ/IntegrationLogos/LICENSES.txt
+++ b/Sources/Nativ/IntegrationLogos/LICENSES.txt
@@ -12,5 +12,6 @@ Qwen Code mark: https://github.com/QwenLM/qwen-code/blob/main/packages/chrome-ex
 OpenClaw mark: https://github.com/openclaw/openclaw/blob/main/apps/ios/Sources/Assets.xcassets/AppIcon.appiconset/258.png
 Zed mark: https://github.com/zed-industries/zed/blob/main/assets/images/zed_logo.svg
 Continue mark: https://github.com/continuedev/continue/blob/main/extensions/intellij/src/main/resources/META-INF/pluginIcon.svg
+Buzz mark: https://github.com/block/buzz/blob/main/desktop/public/buzz.svg
 
 All product names, logos, and trademarks remain the property of their respective owners.

--- a/Tests/NativTests/IntegrationServicesTests.swift
+++ b/Tests/NativTests/IntegrationServicesTests.swift
@@ -17,7 +17,8 @@ final class IntegrationServicesTests: XCTestCase {
         .vscode,
         .cline,
         .cursor,
-        .jetbrains
+        .jetbrains,
+        .buzz
     ]
 
     private var temporaryRoot: URL!
@@ -383,6 +384,21 @@ final class IntegrationServicesTests: XCTestCase {
             launchCommand(for: .continueDev),
             "cd '/tmp/Nativ Project'\n'/tools/cn' '--config' '\(configurationURL.path)'"
         )
+    }
+
+    func testBuzzIsGuidedSetupWithoutManagedConfiguration() throws {
+        XCTAssertTrue(IntegrationTool.buzz.isGuidedSetup)
+        XCTAssertNotNil(IntegrationTool.buzz.guidedSetupCaveat)
+
+        let steps = IntegrationTool.buzz.guidedSetupSteps.joined(separator: "\n")
+        XCTAssertFalse(steps.isEmpty)
+        XCTAssertTrue(steps.contains("BUZZ_AGENT_PROVIDER"))
+        XCTAssertTrue(steps.contains("OPENAI_COMPAT_BASE_URL"))
+        XCTAssertTrue(steps.contains("OPENAI_COMPAT_MODEL"))
+
+        try configure(.buzz)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: manager.configurationURL(for: .buzz).path))
+        XCTAssertEqual(launchCommand(for: .buzz), "cd '/tmp/Nativ Project'\n'/tools/buzz'")
     }
 
     private func configure(_ tool: IntegrationTool) throws {


### PR DESCRIPTION
same integration as before, thought it'd best to include it in the readme, but included since we already have blocks' goose. 

env based like claudecode or codex is risky, safe to let user follow instructions, and we can update if things change with buzz