### PR TITLE
Add a default image model for the Images view

### DIFF
--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
@@ -58,6 +58,7 @@ struct ImageGenerationView: View {
                             turn: turn,
                             activeReferenceID: viewModel.activeReference?.id,
                             isGenerating: viewModel.isGenerating,
+                            progressText: viewModel.statusText,
                             onUseOutput: viewModel.useAsReference,
                             onUseInput: viewModel.useAsReference,
                             onSave: viewModel.save
@@ -196,6 +197,14 @@ private struct ImageGenerationComposer: View {
                 additionalPaths: model.settings.normalized().additionalModelSearchPaths
             )
         }
+        .onChange(of: localLibrary.models) { _, models in
+            viewModel.applyDefaultModel(
+                model.settings.normalized().imageGenerationModelID,
+                installedImageModelIDs: models
+                    .filter { $0.capabilities.contains(.imageGeneration) }
+                    .map(\.repoID)
+            )
+        }
         .onDisappear {
             localLibrary.cancel()
         }
@@ -331,7 +340,10 @@ private struct ImageGenerationComposer: View {
         guard canSubmit else {
             return
         }
-        viewModel.run(using: model)
+        viewModel.run(
+            using: model,
+            modelIsInstalled: imageModels.contains { $0.repoID == viewModel.modelID }
+        )
     }
 
     private func selectImageModel(_ localModel: LocalModel) {
@@ -432,6 +444,7 @@ private struct ImageGenerationTurnView: View {
     let turn: ImageGenerationTurn
     let activeReferenceID: UUID?
     let isGenerating: Bool
+    let progressText: String?
     let onUseOutput: (GeneratedImage) -> Void
     let onUseInput: (ChatImageAttachment) -> Void
     let onSave: (GeneratedImage) -> Void
@@ -487,7 +500,7 @@ private struct ImageGenerationTurnView: View {
         case .inProgress:
             HStack(spacing: 10) {
                 ProgressView().controlSize(.small)
-                Text(turn.isEdit ? "Editing image…" : "Generating image…")
+                Text(progressText ?? (turn.isEdit ? "Editing image…" : "Generating image…"))
                     .foregroundStyle(.secondary)
             }
             .padding(.vertical, 12)

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -151,7 +151,7 @@ struct ImageGenerationTurn: Identifiable, Equatable, Codable, Sendable {
 
 @MainActor
 final class ImageGenerationViewModel: ObservableObject {
-    static let fallbackModelID = "black-forest-labs/FLUX.2-klein-9B-kv"
+    static let fallbackModelID = "mlx-community/flux2-klein-4b-8bit"
 
     @Published var prompt = ""
     @Published var modelID = fallbackModelID
@@ -216,11 +216,17 @@ final class ImageGenerationViewModel: ObservableObject {
         !effectiveReferenceImages.isEmpty
     }
 
-    func applyDefaultModel(_ selectedModelID: String?) {
-        guard let selectedModelID = normalized(selectedModelID) else {
+    func applyDefaultModel(
+        _ selectedModelID: String?,
+        installedImageModelIDs: [String] = []
+    ) {
+        let resolvedModelID = normalized(selectedModelID)
+            ?? installedImageModelIDs.lazy.compactMap(normalized).first
+            ?? Self.fallbackModelID
+        guard modelID != resolvedModelID else {
             return
         }
-        modelID = selectedModelID
+        modelID = resolvedModelID
         persistCurrentSession(updateTimestamp: false)
     }
 
@@ -351,7 +357,7 @@ final class ImageGenerationViewModel: ObservableObject {
         return FileManager.default.fileExists(atPath: url.path) ? url : nil
     }
 
-    func run(using appModel: NativModel) {
+    func run(using appModel: NativModel, modelIsInstalled: Bool = true) {
         guard !isGenerating,
               appModel.isRunning,
               let requestModelID = normalized(modelID),
@@ -395,7 +401,13 @@ final class ImageGenerationViewModel: ObservableObject {
         prompt = ""
         pendingImageAttachments.removeAll()
         isGenerating = true
-        statusText = references.isEmpty ? "Generating image…" : "Editing image…"
+        if modelIsInstalled {
+            statusText = references.isEmpty ? "Generating image…" : "Editing image…"
+        } else {
+            statusText = references.isEmpty
+                ? "Downloading model before generating image…"
+                : "Downloading model before editing image…"
+        }
         persistCurrentSession(updateTimestamp: true)
         bumpScroll()
 
@@ -403,12 +415,24 @@ final class ImageGenerationViewModel: ObservableObject {
         let serverSettings = appModel.settings.normalized()
         let serverBaseURL = serverSettings.serverBaseURL
         let serverAPIKey = serverSettings.serverAPIKey
+        let modelSearchPath = serverSettings.modelSearchPath
+        let huggingFaceToken = appModel.effectiveHuggingFaceToken
         activeTask = Task { @MainActor [weak self, weak appModel] in
             guard let self else {
                 return
             }
 
             do {
+                if !modelIsInstalled {
+                    try await HuggingFaceDownloadManager.shared.downloadIfNeeded(
+                        repoID: requestModelID,
+                        cachePath: modelSearchPath,
+                        token: huggingFaceToken
+                    )
+                    try Task.checkCancellation()
+                    statusText = references.isEmpty ? "Generating image…" : "Editing image…"
+                }
+
                 let outputs = try await ImageGenerationExecutor().run(
                     baseURL: serverBaseURL,
                     apiKey: serverAPIKey,

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -288,6 +288,7 @@ enum HuggingFaceHubError: LocalizedError {
     case requestFailed(Int, String)
     case pythonUnavailable
     case downloadFailed(String)
+    case anotherDownloadInProgress(String)
 
     var errorDescription: String? {
         switch self {
@@ -299,6 +300,8 @@ enum HuggingFaceHubError: LocalizedError {
             "The bundled model downloader is unavailable."
         case .downloadFailed(let message):
             message.isEmpty ? "The model download failed." : message
+        case .anotherDownloadInProgress(let modelID):
+            "Wait for \(modelID) to finish downloading before starting another model download."
         }
     }
 }
@@ -528,8 +531,8 @@ final class HuggingFaceDownloadManager: ObservableObject {
     private var downloadTask: Task<Void, Never>?
     private var activeOperation: HuggingFaceDownloadOperation?
     private var activeCachePath: String?
-    private var activeToken: String?
     private var activeCompletion: (() -> Void)?
+    private var activeWaiters: [UUID: CheckedContinuation<Void, Error>] = [:]
 
     deinit {
         downloadTask?.cancel()
@@ -542,15 +545,61 @@ final class HuggingFaceDownloadManager: ObservableObject {
         onCompletion: @escaping () -> Void
     ) {
         guard downloadingModelID == nil else { return }
-        downloadingModelID = repoID
-        downloadProgress = 0
-        isDownloadPaused = false
-        errorByModelID[repoID] = nil
-        activeCachePath = LocalModelDiscovery.expandedPath(cachePath)
-        activeToken = HuggingFaceAuthentication.normalizedToken(token)
-        activeCompletion = onCompletion
+        do {
+            try startDownload(
+                repoID: repoID,
+                cachePath: cachePath,
+                token: token,
+                onCompletion: onCompletion
+            )
+        } catch {
+            errorByModelID[repoID] =
+                (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
 
-        startActiveDownload()
+    func downloadIfNeeded(
+        repoID: String,
+        cachePath: String,
+        token: String?
+    ) async throws {
+        let expandedCachePath = LocalModelDiscovery.expandedPath(cachePath)
+        if let downloadingModelID {
+            guard downloadingModelID == repoID,
+                  activeCachePath == expandedCachePath
+            else {
+                throw HuggingFaceHubError.anotherDownloadInProgress(downloadingModelID)
+            }
+        } else {
+            do {
+                try startDownload(
+                    repoID: repoID,
+                    cachePath: expandedCachePath,
+                    token: token,
+                    onCompletion: nil
+                )
+            } catch {
+                errorByModelID[repoID] =
+                    (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                throw error
+            }
+        }
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                activeWaiters[waiterID] = continuation
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelWaiter(waiterID)
+            }
+        }
     }
 
     func pauseDownload() {
@@ -569,8 +618,9 @@ final class HuggingFaceDownloadManager: ObservableObject {
         guard let repoID = downloadingModelID, let cachePath = activeCachePath else { return }
         let task = downloadTask
         task?.cancel()
-        downloadTask = nil
+        let waiters = Array(activeWaiters.values)
         clearActiveDownload()
+        waiters.forEach { $0.resume(throwing: CancellationError()) }
 
         Task {
             await task?.value
@@ -580,56 +630,81 @@ final class HuggingFaceDownloadManager: ObservableObject {
         }
     }
 
-    private func startActiveDownload() {
-        guard let repoID = downloadingModelID, let cachePath = activeCachePath else { return }
-
-        let operation: HuggingFaceDownloadOperation
-        do {
-            operation = try HuggingFaceDownloadOperation(
-                repoID: repoID,
-                cachePath: cachePath,
-                token: activeToken
-            ) { progress in
-                Task { @MainActor [weak self] in
-                    guard self?.downloadingModelID == repoID else { return }
-                    self?.downloadProgress = progress
-                }
+    private func startDownload(
+        repoID: String,
+        cachePath: String,
+        token: String?,
+        onCompletion: (() -> Void)?
+    ) throws {
+        let expandedCachePath = LocalModelDiscovery.expandedPath(cachePath)
+        let normalizedToken = HuggingFaceAuthentication.normalizedToken(token)
+        let operation = try HuggingFaceDownloadOperation(
+            repoID: repoID,
+            cachePath: expandedCachePath,
+            token: normalizedToken
+        ) { progress in
+            Task { @MainActor [weak self] in
+                guard self?.downloadingModelID == repoID else { return }
+                self?.downloadProgress = progress
             }
-            activeOperation = operation
-        } catch {
-            errorByModelID[repoID] =
-                (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            clearActiveDownload()
-            return
         }
 
+        downloadingModelID = repoID
+        downloadProgress = 0
+        isDownloadPaused = false
+        errorByModelID[repoID] = nil
+        activeCachePath = expandedCachePath
+        activeCompletion = onCompletion
+        activeOperation = operation
         downloadTask = Task { [weak self] in
             do {
                 try await HuggingFaceSnapshotDownloader.download(operation: operation)
                 guard !Task.isCancelled else { return }
-                self?.downloadProgress = 1
-                let completion = self?.activeCompletion
-                self?.clearActiveDownload()
-                completion?()
+                self?.finishDownload(repoID: repoID, error: nil)
             } catch is CancellationError {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
-                self?.errorByModelID[repoID] =
-                    (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-                self?.clearActiveDownload()
+                self?.finishDownload(repoID: repoID, error: error)
             }
         }
     }
 
+    private func finishDownload(repoID: String, error: Error?) {
+        guard downloadingModelID == repoID else { return }
+        let completion = activeCompletion
+        let waiters = Array(activeWaiters.values)
+        if let error {
+            errorByModelID[repoID] =
+                (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        } else {
+            downloadProgress = 1
+        }
+        clearActiveDownload()
+
+        if let error {
+            waiters.forEach { $0.resume(throwing: error) }
+        } else {
+            NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
+            completion?()
+            waiters.forEach { $0.resume() }
+        }
+    }
+
+    private func cancelWaiter(_ waiterID: UUID) {
+        activeWaiters.removeValue(forKey: waiterID)?
+            .resume(throwing: CancellationError())
+    }
+
     private func clearActiveDownload() {
+        downloadTask = nil
         downloadingModelID = nil
         downloadProgress = 0
         isDownloadPaused = false
         activeOperation = nil
         activeCachePath = nil
-        activeToken = nil
         activeCompletion = nil
+        activeWaiters.removeAll()
     }
 }
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -84,6 +84,9 @@ struct ModelsView: View {
         .task(id: modelScanPath) {
             rescanLocalModels()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
+            rescanLocalModels()
+        }
         .task(id: hubSearchTaskID) {
             guard section == .discover else { return }
             try? await Task.sleep(for: .milliseconds(350))
@@ -378,13 +381,7 @@ struct ModelsView: View {
                                             repoID: hubModel.id,
                                             cachePath: model.settings.modelSearchPath,
                                             token: model.effectiveHuggingFaceToken
-                                        ) {
-                                            rescanLocalModels()
-                                            NotificationCenter.default.post(
-                                                name: .localModelLibraryDidChange,
-                                                object: nil
-                                            )
-                                        }
+                                        ) {}
                                     },
                                     onPauseResume: {
                                         if downloadManager.isDownloadPaused {

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -520,7 +520,6 @@ private struct WelcomeView: View {
             downloadedRecommendedModelID = hubModel.id
             selectedModelID = hubModel.id
             modelLibrary.scan(path: model.settings.modelSearchPath)
-            NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
         }
     }
 }


### PR DESCRIPTION
Uses `mlx-community/flux2-klein-4b-8bit` by default, which supports generation and editing and is ~8gb. Trying to generate an image without a model loaded will first download this model and load it, then generate the image.