### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -513,8 +513,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				1622B274F4DF5A85C2FDB081 /* NativServerKit */,
+				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				51AD42FA29E71F2450386688 /* NativTests */,
 			);
 		};
@@ -756,7 +756,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Configuration/Nativ-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Nativ;
@@ -766,7 +766,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(NATIV_BUNDLE_IDENTIFIER)";
 				SDKROOT = macosx;
 			};
@@ -779,7 +779,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Configuration/Nativ-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Nativ;
@@ -789,7 +789,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(NATIV_BUNDLE_IDENTIFIER)";
 				SDKROOT = macosx;
 			};

--- a/project.yml
+++ b/project.yml
@@ -84,8 +84,8 @@ targets:
         INFOPLIST_FILE: Configuration/Nativ-Info.plist
         INFOPLIST_KEY_CFBundleDisplayName: Nativ
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.utilities
-        MARKETING_VERSION: 0.0.1
-        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: 0.1.0
+        CURRENT_PROJECT_VERSION: 2
   NativTests:
     type: bundle.unit-test
     platform: macOS


### PR DESCRIPTION
## Summary

- bump the Nativ marketing version from `0.0.1` to `0.1.0`
- bump the app build number from `1` to `2`
- regenerate `Nativ.xcodeproj` from `project.yml`

## Impact

Debug and Release builds now report version `0.1.0` (build `2`). Release tags continue to use the `v0.1.0` form.

## Validation

- regenerated the project with `make xcode-generate`
- verified Debug and Release version settings
- ran `git diff --check`