### PR TITLE
Add "Sort by Size" to the model selection menu

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -7,6 +7,7 @@ enum HuggingFaceModelSort: String, CaseIterable, Hashable, Identifiable, Sendabl
     case trending = "trendingScore"
     case likes
     case recentlyUpdated = "lastModified"
+    case size
 
     var id: String { rawValue }
 
@@ -16,6 +17,7 @@ enum HuggingFaceModelSort: String, CaseIterable, Hashable, Identifiable, Sendabl
         case .trending: "Trending"
         case .likes: "Likes"
         case .recentlyUpdated: "Recently Updated"
+        case .size: "Size"
         }
     }
 
@@ -25,6 +27,7 @@ enum HuggingFaceModelSort: String, CaseIterable, Hashable, Identifiable, Sendabl
         case .trending: "flame"
         case .likes: "heart"
         case .recentlyUpdated: "clock.arrow.circlepath"
+        case .size: "internaldrive"
         }
     }
 
@@ -34,8 +37,18 @@ enum HuggingFaceModelSort: String, CaseIterable, Hashable, Identifiable, Sendabl
         case .trending: "trending"
         case .likes: "likes"
         case .recentlyUpdated: "modified"
+        case .size: "downloads"
         }
     }
+
+    /// The Hugging Face search API can't sort by model size, so `.size` fetches by
+    /// downloads and the results are re-sorted client-side.
+    var apiValue: String {
+        self == .size ? Self.downloads.rawValue : rawValue
+    }
+
+    /// Whether results are re-sorted client-side by model size.
+    var sortsBySize: Bool { self == .size }
 }
 
 struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
@@ -322,7 +335,7 @@ private struct HuggingFaceHubClient: Sendable {
 
         var queryItems = [
             URLQueryItem(name: "filter", value: "safetensors"),
-            URLQueryItem(name: "sort", value: sort.rawValue),
+            URLQueryItem(name: "sort", value: sort.apiValue),
             URLQueryItem(name: "direction", value: "-1"),
             URLQueryItem(name: "limit", value: "50")
         ]
@@ -401,6 +414,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
     private let client = HuggingFaceHubClient()
     private var searchTask: Task<Void, Never>?
     private var buffer: [HuggingFaceModel] = []
+    private var activeSort: HuggingFaceModelSort = .downloads
     private var nextPageURL: URL?
     private let pageSize = 24
     private let maximumPageCount = 5
@@ -417,6 +431,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
         buffer = []
         nextPageURL = nil
         pageNumber = 1
+        activeSort = sort
 
         searchTask = Task { [weak self] in
             guard let self else { return }
@@ -510,9 +525,24 @@ final class HuggingFaceModelLibrary: ObservableObject {
     }
 
     private func slice(forPage number: Int) -> [HuggingFaceModel] {
+        let ordered = orderedBuffer
         let start = (number - 1) * pageSize
-        guard start < buffer.count else { return [] }
-        return Array(buffer[start..<min(start + pageSize, buffer.count)])
+        guard start < ordered.count else { return [] }
+        return Array(ordered[start..<min(start + pageSize, ordered.count)])
+    }
+
+    /// The buffered results in display order. Hugging Face can't sort by size, so the
+    /// `.size` sort re-orders the fetched results locally (smallest first; models whose
+    /// size is unknown go last).
+    private var orderedBuffer: [HuggingFaceModel] {
+        guard activeSort.sortsBySize else { return buffer }
+        return buffer.sorted { lhs, rhs in
+            switch (lhs.sizeBytes, rhs.sizeBytes) {
+            case let (lhsSize?, rhsSize?): return lhsSize < rhsSize
+            case (nil, _): return false
+            case (_, nil): return true
+            }
+        }
     }
 
     func cancel() {

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -41,12 +41,6 @@ enum HuggingFaceModelSort: String, CaseIterable, Hashable, Identifiable, Sendabl
         }
     }
 
-    /// The Hugging Face search API can't sort by model size, so `.size` fetches by
-    /// downloads and the results are re-sorted client-side.
-    var apiValue: String {
-        self == .size ? Self.downloads.rawValue : rawValue
-    }
-
     /// Whether results are re-sorted client-side by model size.
     var sortsBySize: Bool { self == .size }
 }
@@ -335,7 +329,7 @@ private struct HuggingFaceHubClient: Sendable {
 
         var queryItems = [
             URLQueryItem(name: "filter", value: "safetensors"),
-            URLQueryItem(name: "sort", value: sort.apiValue),
+            URLQueryItem(name: "sort", value: sort.rawValue),
             URLQueryItem(name: "direction", value: "-1"),
             URLQueryItem(name: "limit", value: "50")
         ]
@@ -531,9 +525,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
         return Array(ordered[start..<min(start + pageSize, ordered.count)])
     }
 
-    /// The buffered results in display order. Hugging Face can't sort by size, so the
-    /// `.size` sort re-orders the fetched results locally (smallest first; models whose
-    /// size is unknown go last).
+    /// Buffered results in display order; `.size` re-sorts locally (smallest first).
     private var orderedBuffer: [HuggingFaceModel] {
         guard activeSort.sortsBySize else { return buffer }
         return buffer.sorted { lhs, rhs in


### PR DESCRIPTION
Resolves Blaizzy/nativ#120.

Adds a **Size** option to the Discover "Sort by" menu so users can quickly find models that fit their hardware (RAM/VRAM).

**How:** Hugging Face's search API doesn't support sorting by model size, so `.size` fetches by downloads (a valid API sort) and re-sorts the fetched results **client-side** by size — smallest first, with unknown sizes last — using the `safetensors` size metadata the search already requests (`expand[]=safetensors`). Pagination re-orders the accumulated buffer, so paging stays consistent.

**Scope:** one new enum case (`HuggingFaceModelSort.size`) + an `orderedBuffer` in `HuggingFaceModelLibrary`; the sort picker picks it up automatically via `allCases`.