### PR TITLE
Support concurrent model downloads

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -117,17 +117,30 @@ extension Color {
 /// A small pulsing download arrow shown at the trailing edge of the Models sidebar row
 /// while a model is downloading.
 private struct ModelsDownloadArrow: View {
+    let count: Int
     @State private var pulse = false
 
     var body: some View {
-        Image(systemName: "arrow.down.circle.fill")
-            .font(.caption)
-            .foregroundStyle(.tint)
-            .opacity(pulse ? 0.4 : 1.0)
-            .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: pulse)
-            .onAppear { pulse = true }
-            .help("A model is downloading")
-            .accessibilityLabel("A model is downloading")
+        HStack(spacing: 4) {
+            Image(systemName: "arrow.down.circle.fill")
+                .font(.caption)
+                .foregroundStyle(.tint)
+                .opacity(pulse ? 0.4 : 1.0)
+                .animation(
+                    .easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: pulse)
+                .onAppear { pulse = true }
+            if count > 0 {
+                Text("\(count)")
+                    .font(.caption2.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(.tint)
+            }
+        }
+        .help(helpText)
+        .accessibilityLabel(helpText)
+    }
+
+    private var helpText: String {
+        count == 1 ? "A model is downloading" : "\(count) models are downloading"
     }
 }
 
@@ -447,8 +460,8 @@ struct ControlPanelView: View {
                                         .foregroundStyle(.secondary)
                                         .frame(width: 34, alignment: .trailing)
                                 }
-                                if downloads.downloadingModelID != nil {
-                                    ModelsDownloadArrow()
+                                if downloads.activeCount > 0 {
+                                    ModelsDownloadArrow(count: downloads.activeCount)
                                 }
                             }
                         }

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -426,6 +426,7 @@ final class ImageGenerationViewModel: ObservableObject {
                 if !modelIsInstalled {
                     try await HuggingFaceDownloadManager.shared.downloadIfNeeded(
                         repoID: requestModelID,
+                        sizeBytes: nil,
                         cachePath: modelSearchPath,
                         token: huggingFaceToken
                     )

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -548,31 +548,98 @@ final class HuggingFaceModelLibrary: ObservableObject {
 final class HuggingFaceDownloadManager: ObservableObject {
     static let shared = HuggingFaceDownloadManager()
 
-    @Published private(set) var downloadingModelID: String?
-    @Published private(set) var downloadProgress = 0.0
-    @Published private(set) var isDownloadPaused = false
+    enum DownloadState: Equatable {
+        case downloading
+        case paused
+        case queued
+    }
+
+    struct ActiveDownload: Identifiable, Equatable {
+        let modelID: String
+        let sizeBytes: Int64?
+        var progress: Double
+        var state: DownloadState
+
+        var id: String { modelID }
+    }
+
+    private final class DownloadContext {
+        let modelID: String
+        let cachePath: String
+        let token: String?
+        var onCompletion: (() -> Void)?
+        var operation: HuggingFaceDownloadOperation?
+        var task: Task<Void, Never>?
+        var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+
+        init(modelID: String, cachePath: String, token: String?, onCompletion: (() -> Void)?) {
+            self.modelID = modelID
+            self.cachePath = cachePath
+            self.token = token
+            self.onCompletion = onCompletion
+        }
+    }
+
+    @Published private(set) var downloads: [ActiveDownload] = []
     @Published private(set) var errorByModelID: [String: String] = [:]
 
-    private var downloadTask: Task<Void, Never>?
-    private var activeOperation: HuggingFaceDownloadOperation?
-    private var activeCachePath: String?
-    private var activeCompletion: (() -> Void)?
-    private var activeWaiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private let maxConcurrentDownloads = 3
+    private var contexts: [String: DownloadContext] = [:]
 
     deinit {
-        downloadTask?.cancel()
+        contexts.values.forEach { $0.task?.cancel() }
+    }
+
+    var activeCount: Int { downloads.count }
+
+    var reservedBytes: Int64 {
+        downloads.reduce(Int64(0)) { total, download in
+            guard let sizeBytes = download.sizeBytes else { return total }
+            let remaining = Double(sizeBytes) * (1 - download.progress)
+            guard remaining > 0 else { return total }
+            return total + Int64(remaining)
+        }
+    }
+
+    func isDownloading(_ modelID: String) -> Bool {
+        contexts[modelID] != nil
+    }
+
+    func progress(for modelID: String) -> Double {
+        downloads.first { $0.modelID == modelID }?.progress ?? 0
+    }
+
+    func isPaused(for modelID: String) -> Bool {
+        downloads.first { $0.modelID == modelID }?.state == .paused
+    }
+
+    func state(for modelID: String) -> DownloadState? {
+        downloads.first { $0.modelID == modelID }?.state
+    }
+
+    func capacityBlocker(sizeBytes: Int64?, cachePath: String) -> String? {
+        guard let sizeBytes, sizeBytes > 0 else { return nil }
+        let path = LocalModelDiscovery.expandedPath(cachePath)
+        guard let freeBytes = Self.freeDiskBytes(atPath: path) else { return nil }
+        let availableBytes = max(freeBytes - reservedBytes, 0)
+        guard sizeBytes > availableBytes else { return nil }
+        let needed = ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
+        let available = ByteCountFormatter.string(fromByteCount: availableBytes, countStyle: .file)
+        return "Needs \(needed) but only \(available) is free after reserving space for in-progress downloads."
     }
 
     func download(
         repoID: String,
+        sizeBytes: Int64?,
         cachePath: String,
         token: String?,
         onCompletion: @escaping () -> Void
     ) {
-        guard downloadingModelID == nil else { return }
+        guard contexts[repoID] == nil else { return }
         do {
-            try startDownload(
+            try enqueue(
                 repoID: repoID,
+                sizeBytes: sizeBytes,
                 cachePath: cachePath,
                 token: token,
                 onCompletion: onCompletion
@@ -585,20 +652,20 @@ final class HuggingFaceDownloadManager: ObservableObject {
 
     func downloadIfNeeded(
         repoID: String,
+        sizeBytes: Int64?,
         cachePath: String,
         token: String?
     ) async throws {
         let expandedCachePath = LocalModelDiscovery.expandedPath(cachePath)
-        if let downloadingModelID {
-            guard downloadingModelID == repoID,
-                  activeCachePath == expandedCachePath
-            else {
-                throw HuggingFaceHubError.anotherDownloadInProgress(downloadingModelID)
+        if let context = contexts[repoID] {
+            guard context.cachePath == expandedCachePath else {
+                throw HuggingFaceHubError.anotherDownloadInProgress(repoID)
             }
         } else {
             do {
-                try startDownload(
+                try enqueue(
                     repoID: repoID,
+                    sizeBytes: sizeBytes,
                     cachePath: expandedCachePath,
                     token: token,
                     onCompletion: nil
@@ -614,74 +681,100 @@ final class HuggingFaceDownloadManager: ObservableObject {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation {
                 (continuation: CheckedContinuation<Void, Error>) in
-                guard !Task.isCancelled else {
+                guard !Task.isCancelled, let context = contexts[repoID] else {
                     continuation.resume(throwing: CancellationError())
                     return
                 }
-                activeWaiters[waiterID] = continuation
+                context.waiters[waiterID] = continuation
             }
         } onCancel: {
             Task { @MainActor [weak self] in
-                self?.cancelWaiter(waiterID)
+                self?.cancelWaiter(waiterID, modelID: repoID)
             }
         }
     }
 
-    func pauseDownload() {
-        guard downloadingModelID != nil, !isDownloadPaused else { return }
-        activeOperation?.pause()
-        isDownloadPaused = true
+    func pauseDownload(_ modelID: String) {
+        guard let context = contexts[modelID], state(for: modelID) == .downloading else { return }
+        context.operation?.pause()
+        setState(modelID, .paused)
     }
 
-    func resumeDownload() {
-        guard downloadingModelID != nil, isDownloadPaused else { return }
-        activeOperation?.resume()
-        isDownloadPaused = false
+    func resumeDownload(_ modelID: String) {
+        guard let context = contexts[modelID], state(for: modelID) == .paused else { return }
+        context.operation?.resume()
+        setState(modelID, .downloading)
     }
 
-    func removeDownload() {
-        guard let repoID = downloadingModelID, let cachePath = activeCachePath else { return }
-        let task = downloadTask
+    func removeDownload(_ modelID: String) {
+        guard let context = contexts[modelID] else { return }
+        let task = context.task
+        let cachePath = context.cachePath
+        let hadOperation = context.operation != nil
         task?.cancel()
-        let waiters = Array(activeWaiters.values)
-        clearActiveDownload()
+        let waiters = Array(context.waiters.values)
+        removeContext(modelID)
         waiters.forEach { $0.resume(throwing: CancellationError()) }
+        startNextIfPossible()
 
+        guard hadOperation else { return }
         Task {
             await task?.value
             await Task.detached(priority: .utility) {
-                HuggingFaceSnapshotDownloader.removeDownload(repoID: repoID, cachePath: cachePath)
+                HuggingFaceSnapshotDownloader.removeDownload(repoID: modelID, cachePath: cachePath)
             }.value
         }
     }
 
-    private func startDownload(
+    private func enqueue(
         repoID: String,
+        sizeBytes: Int64?,
         cachePath: String,
         token: String?,
         onCompletion: (() -> Void)?
     ) throws {
         let expandedCachePath = LocalModelDiscovery.expandedPath(cachePath)
-        let normalizedToken = HuggingFaceAuthentication.normalizedToken(token)
+        let context = DownloadContext(
+            modelID: repoID,
+            cachePath: expandedCachePath,
+            token: token,
+            onCompletion: onCompletion
+        )
+        contexts[repoID] = context
+        errorByModelID[repoID] = nil
+
+        if runningCount < maxConcurrentDownloads {
+            downloads.append(
+                ActiveDownload(modelID: repoID, sizeBytes: sizeBytes, progress: 0, state: .downloading)
+            )
+            do {
+                try startDownload(context)
+            } catch {
+                removeContext(repoID)
+                throw error
+            }
+        } else {
+            downloads.append(
+                ActiveDownload(modelID: repoID, sizeBytes: sizeBytes, progress: 0, state: .queued)
+            )
+        }
+    }
+
+    private func startDownload(_ context: DownloadContext) throws {
+        let repoID = context.modelID
+        let normalizedToken = HuggingFaceAuthentication.normalizedToken(context.token)
         let operation = try HuggingFaceDownloadOperation(
             repoID: repoID,
-            cachePath: expandedCachePath,
+            cachePath: context.cachePath,
             token: normalizedToken
         ) { progress in
             Task { @MainActor [weak self] in
-                guard self?.downloadingModelID == repoID else { return }
-                self?.downloadProgress = progress
+                self?.updateProgress(repoID, progress)
             }
         }
 
-        downloadingModelID = repoID
-        downloadProgress = 0
-        isDownloadPaused = false
-        errorByModelID[repoID] = nil
-        activeCachePath = expandedCachePath
-        activeCompletion = onCompletion
-        activeOperation = operation
-        downloadTask = Task { [weak self] in
+        context.operation = operation
+        context.task = Task { [weak self] in
             do {
                 try await HuggingFaceSnapshotDownloader.download(operation: operation)
                 guard !Task.isCancelled else { return }
@@ -696,16 +789,15 @@ final class HuggingFaceDownloadManager: ObservableObject {
     }
 
     private func finishDownload(repoID: String, error: Error?) {
-        guard downloadingModelID == repoID else { return }
-        let completion = activeCompletion
-        let waiters = Array(activeWaiters.values)
+        guard let context = contexts[repoID] else { return }
+        let completion = context.onCompletion
+        let waiters = Array(context.waiters.values)
         if let error {
             errorByModelID[repoID] =
                 (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-        } else {
-            downloadProgress = 1
         }
-        clearActiveDownload()
+        removeContext(repoID)
+        startNextIfPossible()
 
         if let error {
             waiters.forEach { $0.resume(throwing: error) }
@@ -716,20 +808,61 @@ final class HuggingFaceDownloadManager: ObservableObject {
         }
     }
 
-    private func cancelWaiter(_ waiterID: UUID) {
-        activeWaiters.removeValue(forKey: waiterID)?
+    private func startNextIfPossible() {
+        while runningCount < maxConcurrentDownloads,
+              let next = downloads.first(where: { $0.state == .queued }) {
+            guard let context = contexts[next.modelID] else {
+                removeContext(next.modelID)
+                continue
+            }
+            setState(next.modelID, .downloading)
+            do {
+                try startDownload(context)
+            } catch {
+                let waiters = Array(context.waiters.values)
+                errorByModelID[next.modelID] =
+                    (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                removeContext(next.modelID)
+                waiters.forEach { $0.resume(throwing: error) }
+            }
+        }
+    }
+
+    private var runningCount: Int {
+        downloads.reduce(0) { $1.state == .queued ? $0 : $0 + 1 }
+    }
+
+    private func updateProgress(_ modelID: String, _ progress: Double) {
+        guard contexts[modelID] != nil,
+              let index = downloads.firstIndex(where: { $0.modelID == modelID })
+        else {
+            return
+        }
+        downloads[index].progress = progress
+    }
+
+    private func setState(_ modelID: String, _ state: DownloadState) {
+        guard let index = downloads.firstIndex(where: { $0.modelID == modelID }) else { return }
+        downloads[index].state = state
+    }
+
+    private func removeContext(_ modelID: String) {
+        contexts.removeValue(forKey: modelID)
+        downloads.removeAll { $0.modelID == modelID }
+    }
+
+    private func cancelWaiter(_ waiterID: UUID, modelID: String) {
+        contexts[modelID]?.waiters.removeValue(forKey: waiterID)?
             .resume(throwing: CancellationError())
     }
 
-    private func clearActiveDownload() {
-        downloadTask = nil
-        downloadingModelID = nil
-        downloadProgress = 0
-        isDownloadPaused = false
-        activeOperation = nil
-        activeCachePath = nil
-        activeCompletion = nil
-        activeWaiters.removeAll()
+    private static func freeDiskBytes(atPath path: String) -> Int64? {
+        guard let attributes = try? FileManager.default.attributesOfFileSystem(forPath: path),
+              let freeBytes = attributes[.systemFreeSize] as? Int64
+        else {
+            return nil
+        }
+        return freeBytes
     }
 }
 

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -551,7 +551,6 @@ final class HuggingFaceDownloadManager: ObservableObject {
     enum DownloadState: Equatable {
         case downloading
         case paused
-        case queued
     }
 
     struct ActiveDownload: Identifiable, Equatable {
@@ -583,7 +582,6 @@ final class HuggingFaceDownloadManager: ObservableObject {
     @Published private(set) var downloads: [ActiveDownload] = []
     @Published private(set) var errorByModelID: [String: String] = [:]
 
-    private let maxConcurrentDownloads = 3
     private var contexts: [String: DownloadContext] = [:]
 
     deinit {
@@ -710,14 +708,11 @@ final class HuggingFaceDownloadManager: ObservableObject {
         guard let context = contexts[modelID] else { return }
         let task = context.task
         let cachePath = context.cachePath
-        let hadOperation = context.operation != nil
         task?.cancel()
         let waiters = Array(context.waiters.values)
         removeContext(modelID)
         waiters.forEach { $0.resume(throwing: CancellationError()) }
-        startNextIfPossible()
 
-        guard hadOperation else { return }
         Task {
             await task?.value
             await Task.detached(priority: .utility) {
@@ -742,21 +737,14 @@ final class HuggingFaceDownloadManager: ObservableObject {
         )
         contexts[repoID] = context
         errorByModelID[repoID] = nil
-
-        if runningCount < maxConcurrentDownloads {
-            downloads.append(
-                ActiveDownload(modelID: repoID, sizeBytes: sizeBytes, progress: 0, state: .downloading)
-            )
-            do {
-                try startDownload(context)
-            } catch {
-                removeContext(repoID)
-                throw error
-            }
-        } else {
-            downloads.append(
-                ActiveDownload(modelID: repoID, sizeBytes: sizeBytes, progress: 0, state: .queued)
-            )
+        downloads.append(
+            ActiveDownload(modelID: repoID, sizeBytes: sizeBytes, progress: 0, state: .downloading)
+        )
+        do {
+            try startDownload(context)
+        } catch {
+            removeContext(repoID)
+            throw error
         }
     }
 
@@ -797,7 +785,6 @@ final class HuggingFaceDownloadManager: ObservableObject {
                 (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
         }
         removeContext(repoID)
-        startNextIfPossible()
 
         if let error {
             waiters.forEach { $0.resume(throwing: error) }
@@ -806,30 +793,6 @@ final class HuggingFaceDownloadManager: ObservableObject {
             completion?()
             waiters.forEach { $0.resume() }
         }
-    }
-
-    private func startNextIfPossible() {
-        while runningCount < maxConcurrentDownloads,
-              let next = downloads.first(where: { $0.state == .queued }) {
-            guard let context = contexts[next.modelID] else {
-                removeContext(next.modelID)
-                continue
-            }
-            setState(next.modelID, .downloading)
-            do {
-                try startDownload(context)
-            } catch {
-                let waiters = Array(context.waiters.values)
-                errorByModelID[next.modelID] =
-                    (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-                removeContext(next.modelID)
-                waiters.forEach { $0.resume(throwing: error) }
-            }
-        }
-    }
-
-    private var runningCount: Int {
-        downloads.reduce(0) { $1.state == .queued ? $0 : $0 + 1 }
     }
 
     private func updateProgress(_ modelID: String, _ progress: Double) {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -121,37 +121,22 @@ struct ModelsView: View {
 
     @ViewBuilder
     private var activeDownloadBanner: some View {
-        if let modelID = downloadManager.downloadingModelID {
-            HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(NativFormatting.truncateModelName(
-                        modelID.split(separator: "/").last.map(String.init) ?? modelID,
-                        maxLength: 44
-                    ))
-                    .font(.callout.weight(.semibold))
-                    .lineLimit(1)
-                    Text(downloadManager.isDownloadPaused
-                        ? "Download paused"
-                        : "Downloading… \(Int((downloadManager.downloadProgress * 100).rounded()))%")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-                Spacer(minLength: 12)
-                Button(downloadManager.isDownloadPaused ? "Resume" : "Pause") {
-                    if downloadManager.isDownloadPaused {
-                        downloadManager.resumeDownload()
-                    } else {
-                        downloadManager.pauseDownload()
-                    }
-                }
-                Button("Cancel", role: .destructive) {
-                    downloadManager.removeDownload()
+        if !downloadManager.downloads.isEmpty {
+            VStack(spacing: 0) {
+                ForEach(downloadManager.downloads) { download in
+                    ActiveDownloadBannerRow(
+                        download: download,
+                        onPauseResume: {
+                            if download.state == .paused {
+                                downloadManager.resumeDownload(download.modelID)
+                            } else {
+                                downloadManager.pauseDownload(download.modelID)
+                            }
+                        },
+                        onCancel: { downloadManager.removeDownload(download.modelID) }
+                    )
                 }
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
-            .background(Color.accentColor.opacity(0.08))
             Divider()
         }
     }
@@ -364,34 +349,31 @@ struct ModelsView: View {
                                 HubModelRow(
                                     model: hubModel,
                                     isInstalled: installedModelIDs.contains(hubModel.id),
-                                    isDownloading: downloadManager.downloadingModelID
-                                        == hubModel.id,
-                                    downloadProgress: downloadManager.downloadingModelID
-                                        == hubModel.id
-                                        ? downloadManager.downloadProgress
-                                        : 0,
-                                    isDownloadPaused: downloadManager.downloadingModelID
-                                        == hubModel.id
-                                        && downloadManager.isDownloadPaused,
-                                    anotherDownloadIsActive: downloadManager.downloadingModelID
-                                        != nil,
+                                    isDownloading: downloadManager.isDownloading(hubModel.id),
+                                    downloadProgress: downloadManager.progress(for: hubModel.id),
+                                    isDownloadPaused: downloadManager.isPaused(for: hubModel.id),
+                                    downloadBlockedReason: downloadManager.capacityBlocker(
+                                        sizeBytes: hubModel.sizeBytes,
+                                        cachePath: model.settings.modelSearchPath
+                                    ),
                                     downloadError: downloadManager.errorByModelID[hubModel.id],
                                     onDownload: {
                                         downloadManager.download(
                                             repoID: hubModel.id,
+                                            sizeBytes: hubModel.sizeBytes,
                                             cachePath: model.settings.modelSearchPath,
                                             token: model.effectiveHuggingFaceToken
                                         ) {}
                                     },
                                     onPauseResume: {
-                                        if downloadManager.isDownloadPaused {
-                                            downloadManager.resumeDownload()
+                                        if downloadManager.isPaused(for: hubModel.id) {
+                                            downloadManager.resumeDownload(hubModel.id)
                                         } else {
-                                            downloadManager.pauseDownload()
+                                            downloadManager.pauseDownload(hubModel.id)
                                         }
                                     },
                                     onRemoveDownload: {
-                                        downloadManager.removeDownload()
+                                        downloadManager.removeDownload(hubModel.id)
                                     }
                                 )
                             }
@@ -1102,13 +1084,55 @@ private struct InstalledModelRow: View {
     }
 }
 
+private struct ActiveDownloadBannerRow: View {
+    let download: HuggingFaceDownloadManager.ActiveDownload
+    let onPauseResume: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(NativFormatting.truncateModelName(
+                    download.modelID.split(separator: "/").last.map(String.init) ?? download.modelID,
+                    maxLength: 44
+                ))
+                .font(.callout.weight(.semibold))
+                .lineLimit(1)
+                Text(statusText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Spacer(minLength: 12)
+            if download.state != .queued {
+                Button(download.state == .paused ? "Resume" : "Pause", action: onPauseResume)
+            }
+            Button("Cancel", role: .destructive, action: onCancel)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .background(Color.accentColor.opacity(0.08))
+    }
+
+    private var statusText: String {
+        switch download.state {
+        case .downloading:
+            "Downloading… \(Int((download.progress * 100).rounded()))%"
+        case .paused:
+            "Download paused"
+        case .queued:
+            "Queued"
+        }
+    }
+}
+
 private struct HubModelRow: View {
     let model: HuggingFaceModel
     let isInstalled: Bool
     let isDownloading: Bool
     let downloadProgress: Double
     let isDownloadPaused: Bool
-    let anotherDownloadIsActive: Bool
+    let downloadBlockedReason: String?
     let downloadError: String?
     let onDownload: () -> Void
     let onPauseResume: () -> Void
@@ -1194,12 +1218,8 @@ private struct HubModelRow: View {
                         Label("Download", systemImage: "arrow.down.circle")
                     }
                         .buttonStyle(.borderedProminent)
-                        .disabled(anotherDownloadIsActive || model.isPrivate)
-                    .help(
-                        model.isGated
-                            ? "Gated models require Hugging Face authentication."
-                            : "Download to the configured cache"
-                    )
+                        .disabled(downloadBlockedReason != nil || model.isPrivate)
+                    .help(downloadHelp)
                         .fixedSize()
                 }
             }
@@ -1213,6 +1233,15 @@ private struct HubModelRow: View {
         }
         .padding(14)
         .modelRowBackground(isHighlighted: false)
+    }
+
+    private var downloadHelp: String {
+        if let downloadBlockedReason {
+            return downloadBlockedReason
+        }
+        return model.isGated
+            ? "Gated models require Hugging Face authentication."
+            : "Download to the configured cache"
     }
 }
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1104,9 +1104,7 @@ private struct ActiveDownloadBannerRow: View {
                     .monospacedDigit()
             }
             Spacer(minLength: 12)
-            if download.state != .queued {
-                Button(download.state == .paused ? "Resume" : "Pause", action: onPauseResume)
-            }
+            Button(download.state == .paused ? "Resume" : "Pause", action: onPauseResume)
             Button("Cancel", role: .destructive, action: onCancel)
         }
         .padding(.horizontal, 20)
@@ -1120,8 +1118,6 @@ private struct ActiveDownloadBannerRow: View {
             "Downloading… \(Int((download.progress * 100).rounded()))%"
         case .paused:
             "Download paused"
-        case .queued:
-            "Queued"
         }
     }
 }

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -169,7 +169,7 @@ private struct WelcomeView: View {
                                 Image(systemName: "arrow.clockwise")
                             }
                             .buttonStyle(.borderless)
-                            .disabled(downloadManager.downloadingModelID != nil)
+                            .disabled(downloadManager.activeCount > 0)
                             .help("Refresh installed models")
                         }
                     }
@@ -226,10 +226,10 @@ private struct WelcomeView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
                 .keyboardShortcut(.defaultAction)
-                .disabled(downloadManager.downloadingModelID != nil)
-                .help(downloadManager.downloadingModelID == nil
+                .disabled(downloadManager.activeCount > 0)
+                .help(downloadManager.activeCount == 0
                     ? "Continue setup"
-                    : "Finish or cancel the model download before continuing")
+                    : "Finish or cancel the model downloads before continuing")
             }
         }
     }
@@ -279,15 +279,16 @@ private struct WelcomeView: View {
                         model: hubModel,
                         isDownloaded: downloadedRecommendedModelID == hubModel.id,
                         isSelected: selectedModelID == hubModel.id,
-                        isDownloading: downloadManager.downloadingModelID == hubModel.id,
-                        downloadProgress: downloadManager.downloadingModelID == hubModel.id
-                            ? downloadManager.downloadProgress
-                            : 0,
-                        anotherDownloadIsActive: downloadManager.downloadingModelID != nil,
+                        isDownloading: downloadManager.isDownloading(hubModel.id),
+                        downloadProgress: downloadManager.progress(for: hubModel.id),
+                        downloadBlockedReason: downloadManager.capacityBlocker(
+                            sizeBytes: hubModel.sizeBytes,
+                            cachePath: model.settings.modelSearchPath
+                        ),
                         downloadError: downloadManager.errorByModelID[hubModel.id],
                         onSelect: { selectedModelID = hubModel.id },
                         onDownload: { downloadRecommendedModel(hubModel) },
-                        onCancel: { downloadManager.removeDownload() }
+                        onCancel: { downloadManager.removeDownload(hubModel.id) }
                     )
                 }
             }
@@ -514,6 +515,7 @@ private struct WelcomeView: View {
         selectedModelID = nil
         downloadManager.download(
             repoID: hubModel.id,
+            sizeBytes: hubModel.sizeBytes,
             cachePath: model.settings.modelSearchPath,
             token: model.effectiveHuggingFaceToken
         ) {
@@ -707,7 +709,7 @@ private struct WelcomeDownloadModelRow: View {
     let isSelected: Bool
     let isDownloading: Bool
     let downloadProgress: Double
-    let anotherDownloadIsActive: Bool
+    let downloadBlockedReason: String?
     let downloadError: String?
     let onSelect: () -> Void
     let onDownload: () -> Void
@@ -773,8 +775,8 @@ private struct WelcomeDownloadModelRow: View {
                     Button("Download", action: onDownload)
                         .buttonStyle(.bordered)
                         .controlSize(.small)
-                        .disabled(anotherDownloadIsActive)
-                        .help("Download \(model.id) to the configured cache")
+                        .disabled(downloadBlockedReason != nil)
+                        .help(downloadBlockedReason ?? "Download \(model.id) to the configured cache")
                 }
             }
 


### PR DESCRIPTION
Replace the single-download HuggingFaceDownloadManager with a queue that runs up to a user's device suffices. Each download tracks its own operation, task, progress, state (downloading/paused/queued) and waiters, keyed by model ID; extra requests are queued FIFO and started as active slots free up on completion or cancel. Pause (SIGSTOP), resume (SIGCONT) and cancel now target an individual model.

Add a cumulative disk gate: capacityBlocker compares a model's size against free space minus reservedBytes (the remaining bytes of every in-flight download), so a download is only offered when it still fits.

Update all consumers: the sidebar arrow shows the active count, the Models banner lists one row per download with per-model controls, and hub rows drive their state per model while disabling downloads that no longer fit on disk.