### PR TITLE
Improve sidebar collapse performance

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -95,6 +95,7 @@ private enum ControlPanelLayout {
     static let windowControlsCenterY =
         windowControlsTopPadding + (windowControlsHeight / 2)
     static let sidebarTransitionDuration: TimeInterval = 0.2
+    static let sidebarTransitionSettleDuration: Duration = .milliseconds(225)
 }
 
 extension Color {
@@ -207,6 +208,9 @@ struct ControlPanelView: View {
     @State private var sidebarWidth = ControlPanelLayout.sidebarIdealWidth
     @State private var sidebarDragStartWidth: CGFloat?
     @State private var isSidebarVisuallyVisible = true
+    @State private var detailTransitionOffset: CGFloat = 0
+    @State private var isSidebarTransitioning = false
+    @State private var sidebarTransitionGeneration = 0
     @State private var isModelConfigurationVisible = false
     @State private var isFullScreen = false
     @State private var windowControlsRefreshTrigger = 0
@@ -229,6 +233,7 @@ struct ControlPanelView: View {
                         maxHeight: .infinity
                     )
                     .clipped()
+                    .offset(x: detailTransitionOffset)
             }
             .animation(nil, value: splitColumnVisibility)
 
@@ -263,9 +268,9 @@ struct ControlPanelView: View {
                 ControlPanelWindowControls(refreshTrigger: windowControlsRefreshTrigger)
                 ControlPanelCollapseButtons(
                     showsModelConfigurationButton: showsModelConfigurationToggle,
-                    sidebarHelp: splitColumnVisibility == .detailOnly
-                        ? "Show Sidebar"
-                        : "Hide Sidebar",
+                    sidebarHelp: isSidebarVisuallyVisible
+                        ? "Hide Sidebar"
+                        : "Show Sidebar",
                     modelConfigurationHelp: isModelConfigurationVisible
                         ? "Hide model configuration"
                         : "Show model configuration",
@@ -392,7 +397,10 @@ struct ControlPanelView: View {
             .frame(width: sidebarWidth)
             .background {
                 Group {
-                    if isFullScreen {
+                    if isSidebarTransitioning {
+                        Rectangle()
+                            .fill(Color(nsColor: .windowBackgroundColor))
+                    } else if isFullScreen {
                         Rectangle()
                             .fill(.regularMaterial)
                     } else {
@@ -512,15 +520,29 @@ struct ControlPanelView: View {
     }
 
     private func toggleSidebarVisibility() {
-        let newVisibility: NavigationSplitViewVisibility =
-            splitColumnVisibility == .detailOnly ? .all : .detailOnly
+        let willShowSidebar = !isSidebarVisuallyVisible
+        sidebarTransitionGeneration &+= 1
+        let transitionGeneration = sidebarTransitionGeneration
         var transaction = Transaction()
         transaction.disablesAnimations = true
         withTransaction(transaction) {
-            splitColumnVisibility = newVisibility
+            isSidebarTransitioning = true
+            splitColumnVisibility = willShowSidebar ? .all : .detailOnly
+            detailTransitionOffset = willShowSidebar ? -sidebarWidth : sidebarWidth
         }
         withAnimation(.snappy(duration: ControlPanelLayout.sidebarTransitionDuration)) {
-            isSidebarVisuallyVisible = newVisibility != .detailOnly
+            isSidebarVisuallyVisible = willShowSidebar
+            detailTransitionOffset = 0
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: ControlPanelLayout.sidebarTransitionSettleDuration)
+            guard sidebarTransitionGeneration == transitionGeneration else { return }
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                isSidebarTransitioning = false
+            }
         }
     }
 

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -1263,7 +1263,7 @@ private final class ControlPanelSurfaceReaderView: NSView {
             updateCornerCorrectionTimer()
             return
         }
-        configureGlassSurface()
+        correctCachedSurfaceCorners()
     }
 
     private func configureGlassSurface(adjustsConstraints: Bool = true) {
@@ -1375,7 +1375,9 @@ private final class ControlPanelSurfaceReaderView: NSView {
             liveResizeCornerCorrectionTimer = timer
         }
 
-        scheduleEndLiveSidebarResizeCornerCorrection()
+        if !isTrackingSidebarTransition {
+            scheduleEndLiveSidebarResizeCornerCorrection()
+        }
     }
 
     private func scheduleEndLiveSidebarResizeCornerCorrection() {
@@ -1395,7 +1397,7 @@ private final class ControlPanelSurfaceReaderView: NSView {
 
     @objc
     private func correctLiveSidebarResizeCorners(_ timer: Timer) {
-        configureGlassSurface(adjustsConstraints: false)
+        correctCachedSurfaceCorners()
     }
 
     private func endLiveSidebarResizeCornerCorrection() {
@@ -1403,6 +1405,24 @@ private final class ControlPanelSurfaceReaderView: NSView {
         liveResizeCornerCorrectionTimer = nil
         liveResizeStopWorkItem = nil
         configureGlassSurface(adjustsConstraints: false)
+    }
+
+    private func correctCachedSurfaceCorners() {
+        guard #available(macOS 26.0, *) else { return }
+
+        // Full surface discovery walks the surrounding AppKit hierarchy. Keep
+        // animated corrections local to the already discovered sidebar views.
+        if let glassSurface = glassSurface as? NSGlassEffectView {
+            setCornerRadiusToZero(on: glassSurface)
+            configureFullSizeGlassLayers(in: glassSurface)
+        }
+
+        if let sidebarBackdropView {
+            setBackdropCornerRadiusToZero(
+                on: sidebarBackdropView,
+                key: "punchOutCornerRadius"
+            )
+        }
     }
 
     private func observeSidebarResizing(above view: NSView) {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -530,7 +530,7 @@ struct ControlPanelView: View {
             splitColumnVisibility = willShowSidebar ? .all : .detailOnly
             detailTransitionOffset = willShowSidebar ? -sidebarWidth : sidebarWidth
         }
-        withAnimation(.snappy(duration: ControlPanelLayout.sidebarTransitionDuration)) {
+        withAnimation(.smooth(duration: ControlPanelLayout.sidebarTransitionDuration)) {
             isSidebarVisuallyVisible = willShowSidebar
             detailTransitionOffset = 0
         }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -547,9 +547,7 @@ struct ControlPanelView: View {
     }
 
     private func toggleModelConfigurationVisibility() {
-        withAnimation(.snappy(duration: 0.2)) {
-            isModelConfigurationVisible.toggle()
-        }
+        isModelConfigurationVisible.toggle()
     }
 
     private var showsModelConfigurationToggle: Bool {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -1263,7 +1263,7 @@ private final class ControlPanelSurfaceReaderView: NSView {
             updateCornerCorrectionTimer()
             return
         }
-        correctCachedSurfaceCorners()
+        configureGlassSurface()
     }
 
     private func configureGlassSurface(adjustsConstraints: Bool = true) {
@@ -1375,9 +1375,7 @@ private final class ControlPanelSurfaceReaderView: NSView {
             liveResizeCornerCorrectionTimer = timer
         }
 
-        if !isTrackingSidebarTransition {
-            scheduleEndLiveSidebarResizeCornerCorrection()
-        }
+        scheduleEndLiveSidebarResizeCornerCorrection()
     }
 
     private func scheduleEndLiveSidebarResizeCornerCorrection() {
@@ -1397,7 +1395,7 @@ private final class ControlPanelSurfaceReaderView: NSView {
 
     @objc
     private func correctLiveSidebarResizeCorners(_ timer: Timer) {
-        correctCachedSurfaceCorners()
+        configureGlassSurface(adjustsConstraints: false)
     }
 
     private func endLiveSidebarResizeCornerCorrection() {
@@ -1405,24 +1403,6 @@ private final class ControlPanelSurfaceReaderView: NSView {
         liveResizeCornerCorrectionTimer = nil
         liveResizeStopWorkItem = nil
         configureGlassSurface(adjustsConstraints: false)
-    }
-
-    private func correctCachedSurfaceCorners() {
-        guard #available(macOS 26.0, *) else { return }
-
-        // Full surface discovery walks the surrounding AppKit hierarchy. Keep
-        // animated corrections local to the already discovered sidebar views.
-        if let glassSurface = glassSurface as? NSGlassEffectView {
-            setCornerRadiusToZero(on: glassSurface)
-            configureFullSizeGlassLayers(in: glassSurface)
-        }
-
-        if let sidebarBackdropView {
-            setBackdropCornerRadiusToZero(
-                on: sidebarBackdropView,
-                key: "punchOutCornerRadius"
-            )
-        }
     }
 
     private func observeSidebarResizing(above view: NSView) {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -95,7 +95,6 @@ private enum ControlPanelLayout {
     static let windowControlsCenterY =
         windowControlsTopPadding + (windowControlsHeight / 2)
     static let sidebarTransitionDuration: TimeInterval = 0.2
-    static let sidebarTransitionSettleDuration: Duration = .milliseconds(250)
 }
 
 extension Color {
@@ -207,27 +206,41 @@ struct ControlPanelView: View {
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .all
     @State private var sidebarWidth = ControlPanelLayout.sidebarIdealWidth
     @State private var sidebarDragStartWidth: CGFloat?
-    @State private var isSidebarTransitioning = false
-    @State private var sidebarTransitionGeneration = 0
+    @State private var isSidebarVisuallyVisible = true
     @State private var isModelConfigurationVisible = false
     @State private var isFullScreen = false
     @State private var windowControlsRefreshTrigger = 0
     @State private var isNewChatHovering = false
 
     var body: some View {
-        HStack(spacing: 0) {
-            if splitColumnVisibility != .detailOnly {
-                resizableSidebar
-                    .transition(.move(edge: .leading).combined(with: .opacity))
-            }
+        ZStack(alignment: .leading) {
+            HStack(spacing: 0) {
+                Color.clear
+                    .frame(
+                        width: splitColumnVisibility == .detailOnly
+                            ? 0
+                            : sidebarWidth
+                    )
 
-            detail
-                .frame(
-                    minWidth: ControlPanelLayout.detailMinimumWidth,
-                    maxWidth: .infinity,
-                    maxHeight: .infinity
+                detail
+                    .frame(
+                        minWidth: ControlPanelLayout.detailMinimumWidth,
+                        maxWidth: .infinity,
+                        maxHeight: .infinity
+                    )
+                    .clipped()
+            }
+            .animation(nil, value: splitColumnVisibility)
+
+            resizableSidebar
+                .compositingGroup()
+                .offset(
+                    x: isSidebarVisuallyVisible
+                        ? 0
+                        : -(sidebarWidth + 5)
                 )
-                .clipped()
+                .allowsHitTesting(isSidebarVisuallyVisible)
+                .accessibilityHidden(!isSidebarVisuallyVisible)
         }
         .toolbarVisibility(.hidden, for: .windowToolbar)
         .ignoresSafeArea(.container, edges: .top)
@@ -369,8 +382,7 @@ struct ControlPanelView: View {
         .navigationTitle("Nativ")
         .background(
             ControlPanelSurfaceReader(
-                isFullScreen: isFullScreen,
-                isSidebarTransitioning: isSidebarTransitioning
+                isFullScreen: isFullScreen
             )
         )
     }
@@ -502,9 +514,13 @@ struct ControlPanelView: View {
     private func toggleSidebarVisibility() {
         let newVisibility: NavigationSplitViewVisibility =
             splitColumnVisibility == .detailOnly ? .all : .detailOnly
-        beginSidebarTransition()
-        withAnimation(.snappy(duration: ControlPanelLayout.sidebarTransitionDuration)) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
             splitColumnVisibility = newVisibility
+        }
+        withAnimation(.snappy(duration: ControlPanelLayout.sidebarTransitionDuration)) {
+            isSidebarVisuallyVisible = newVisibility != .detailOnly
         }
     }
 
@@ -786,18 +802,6 @@ struct ControlPanelView: View {
         }
     }
 
-    private func beginSidebarTransition() {
-        sidebarTransitionGeneration &+= 1
-        let generation = sidebarTransitionGeneration
-        isSidebarTransitioning = true
-
-        Task { @MainActor in
-            try? await Task.sleep(for: ControlPanelLayout.sidebarTransitionSettleDuration)
-            guard sidebarTransitionGeneration == generation else { return }
-            isSidebarTransitioning = false
-        }
-    }
-
     private func createRecentSession() {
         if selectedTab == .imageGeneration {
             imageGeneration.createSession()
@@ -1036,22 +1040,15 @@ private final class FooterControlTrackingNSView: NSView {
 
 private struct ControlPanelSurfaceReader: NSViewRepresentable {
     let isFullScreen: Bool
-    let isSidebarTransitioning: Bool
 
     func makeNSView(context: Context) -> ControlPanelSurfaceReaderView {
         let view = ControlPanelSurfaceReaderView()
-        view.update(
-            isFullScreen: isFullScreen,
-            isSidebarTransitioning: isSidebarTransitioning
-        )
+        view.update(isFullScreen: isFullScreen)
         return view
     }
 
     func updateNSView(_ view: ControlPanelSurfaceReaderView, context: Context) {
-        view.update(
-            isFullScreen: isFullScreen,
-            isSidebarTransitioning: isSidebarTransitioning
-        )
+        view.update(isFullScreen: isFullScreen)
     }
 }
 
@@ -1077,7 +1074,6 @@ private final class ControlPanelSurfaceReaderView: NSView {
     private var liveResizeStopWorkItem: DispatchWorkItem?
     private var localMouseEventMonitor: Any?
     private var isFullScreen = false
-    private var isTrackingSidebarTransition = false
 
     deinit {
         cornerCorrectionTimer?.invalidate()
@@ -1119,20 +1115,11 @@ private final class ControlPanelSurfaceReaderView: NSView {
         }
     }
 
-    func update(
-        isFullScreen: Bool,
-        isSidebarTransitioning: Bool
-    ) {
+    func update(isFullScreen: Bool) {
         self.isFullScreen = isFullScreen
         updateCornerCorrectionTimer()
 
-        if isSidebarTransitioning {
-            isTrackingSidebarTransition = true
-            beginLiveSidebarResizeCornerCorrection()
-        } else if isTrackingSidebarTransition {
-            isTrackingSidebarTransition = false
-            endLiveSidebarResizeCornerCorrection()
-        } else if liveResizeCornerCorrectionTimer == nil {
+        if liveResizeCornerCorrectionTimer == nil {
             configureGlassSurface()
         }
     }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -94,7 +94,8 @@ private enum ControlPanelLayout {
     static let windowControlsHeight: CGFloat = 28
     static let windowControlsCenterY =
         windowControlsTopPadding + (windowControlsHeight / 2)
-    static let coordinateSpaceName = "ControlPanelLayout"
+    static let sidebarTransitionDuration: TimeInterval = 0.2
+    static let sidebarTransitionSettleDuration: Duration = .milliseconds(250)
 }
 
 extension Color {
@@ -206,9 +207,8 @@ struct ControlPanelView: View {
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .all
     @State private var sidebarWidth = ControlPanelLayout.sidebarIdealWidth
     @State private var sidebarDragStartWidth: CGFloat?
-    @State private var detailLeadingEdge = ControlPanelLayout.sidebarIdealWidth
-    @State private var expandedDetailLeadingEdge = ControlPanelLayout.sidebarIdealWidth
     @State private var isSidebarTransitioning = false
+    @State private var sidebarTransitionGeneration = 0
     @State private var isModelConfigurationVisible = false
     @State private var isFullScreen = false
     @State private var windowControlsRefreshTrigger = 0
@@ -231,7 +231,6 @@ struct ControlPanelView: View {
         }
         .toolbarVisibility(.hidden, for: .windowToolbar)
         .ignoresSafeArea(.container, edges: .top)
-        .coordinateSpace(name: ControlPanelLayout.coordinateSpaceName)
         .frame(minWidth: 1040, minHeight: 600)
         .overlay(alignment: .top) {
             if selectedTab != .models, let failure = model.modelLoadFailure {
@@ -273,9 +272,6 @@ struct ControlPanelView: View {
         }
         .onChange(of: navigation.newChatRequest) { _, _ in
             handleNewChatRequest()
-        }
-        .onChange(of: splitColumnVisibility) { _, newVisibility in
-            beginSidebarTransition(to: newVisibility)
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.willEnterFullScreenNotification)) { _ in
             isFullScreen = true
@@ -427,11 +423,9 @@ struct ControlPanelView: View {
                         max(proposedWidth, ControlPanelLayout.sidebarMinimumWidth),
                         ControlPanelLayout.sidebarMaximumWidth
                     )
-                    expandedDetailLeadingEdge = sidebarWidth
                 }
                 .onEnded { _ in
                     sidebarDragStartWidth = nil
-                    expandedDetailLeadingEdge = sidebarWidth
                     NSCursor.arrow.set()
                 }
         )
@@ -508,8 +502,8 @@ struct ControlPanelView: View {
     private func toggleSidebarVisibility() {
         let newVisibility: NavigationSplitViewVisibility =
             splitColumnVisibility == .detailOnly ? .all : .detailOnly
-        beginSidebarTransition(to: newVisibility)
-        withAnimation(.snappy(duration: 0.2)) {
+        beginSidebarTransition()
+        withAnimation(.snappy(duration: ControlPanelLayout.sidebarTransitionDuration)) {
             splitColumnVisibility = newVisibility
         }
     }
@@ -745,11 +739,6 @@ struct ControlPanelView: View {
         } message: {
             Text(model.modelPreloadMemoryWarning?.message ?? "")
         }
-        .onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.frame(in: .named(ControlPanelLayout.coordinateSpaceName)).minX
-        } action: { leadingEdge in
-            updateDetailLeadingEdge(leadingEdge)
-        }
     }
 
     private func applySidebarSelection(_ selection: ControlPanelSidebarSelection) {
@@ -783,15 +772,9 @@ struct ControlPanelView: View {
     }
 
     private var detailTitleLeadingInset: CGFloat {
-        guard isSidebarTransitioning else {
-            return splitColumnVisibility == .detailOnly
-                ? ControlPanelLayout.collapsedSidebarTitleClearance
-                : 0
-        }
-
-        let expandedLeadingEdge = max(expandedDetailLeadingEdge, 1)
-        let visibleFraction = min(max(detailLeadingEdge / expandedLeadingEdge, 0), 1)
-        return ControlPanelLayout.collapsedSidebarTitleClearance * (1 - visibleFraction)
+        splitColumnVisibility == .detailOnly
+            ? ControlPanelLayout.collapsedSidebarTitleClearance
+            : 0
     }
 
     private var detailExtendsIntoTitlebar: Bool {
@@ -803,32 +786,15 @@ struct ControlPanelView: View {
         }
     }
 
-    private func beginSidebarTransition(to visibility: NavigationSplitViewVisibility) {
-        if visibility == .detailOnly {
-            expandedDetailLeadingEdge = sidebarWidth
-        }
+    private func beginSidebarTransition() {
+        sidebarTransitionGeneration &+= 1
+        let generation = sidebarTransitionGeneration
         isSidebarTransitioning = true
-    }
 
-    private func updateDetailLeadingEdge(_ leadingEdge: CGFloat) {
-        var transaction = Transaction()
-        transaction.animation = nil
-        withTransaction(transaction) {
-            detailLeadingEdge = max(0, leadingEdge)
-
-            if isSidebarTransitioning {
-                if splitColumnVisibility == .detailOnly {
-                    if detailLeadingEdge <= 0.5 {
-                        isSidebarTransitioning = false
-                    }
-                } else if detailLeadingEdge >= expandedDetailLeadingEdge - 0.5 {
-                    expandedDetailLeadingEdge = detailLeadingEdge
-                    isSidebarTransitioning = false
-                }
-            } else if splitColumnVisibility != .detailOnly,
-                      detailLeadingEdge >= ControlPanelLayout.sidebarMinimumWidth {
-                expandedDetailLeadingEdge = detailLeadingEdge
-            }
+        Task { @MainActor in
+            try? await Task.sleep(for: ControlPanelLayout.sidebarTransitionSettleDuration)
+            guard sidebarTransitionGeneration == generation else { return }
+            isSidebarTransitioning = false
         }
     }
 
@@ -1093,6 +1059,8 @@ private var controlPanelBackdropCornerRadiusObservationContext = 0
 
 @MainActor
 private final class ControlPanelSurfaceReaderView: NSView {
+    private static let liveCornerCorrectionInterval: TimeInterval = 1 / 30
+
     private weak var glassSurface: NSView?
     private weak var sidebarBackdropView: NSView?
     private weak var observedSplitView: NSSplitView?
@@ -1109,6 +1077,7 @@ private final class ControlPanelSurfaceReaderView: NSView {
     private var liveResizeStopWorkItem: DispatchWorkItem?
     private var localMouseEventMonitor: Any?
     private var isFullScreen = false
+    private var isTrackingSidebarTransition = false
 
     deinit {
         cornerCorrectionTimer?.invalidate()
@@ -1145,7 +1114,9 @@ private final class ControlPanelSurfaceReaderView: NSView {
 
     override func layout() {
         super.layout()
-        configureGlassSurface()
+        if liveResizeCornerCorrectionTimer == nil {
+            configureGlassSurface()
+        }
     }
 
     func update(
@@ -1156,8 +1127,12 @@ private final class ControlPanelSurfaceReaderView: NSView {
         updateCornerCorrectionTimer()
 
         if isSidebarTransitioning {
+            isTrackingSidebarTransition = true
             beginLiveSidebarResizeCornerCorrection()
-        } else {
+        } else if isTrackingSidebarTransition {
+            isTrackingSidebarTransition = false
+            endLiveSidebarResizeCornerCorrection()
+        } else if liveResizeCornerCorrectionTimer == nil {
             configureGlassSurface()
         }
     }
@@ -1387,11 +1362,10 @@ private final class ControlPanelSurfaceReaderView: NSView {
     }
 
     private func beginLiveSidebarResizeCornerCorrection() {
-        configureGlassSurface(adjustsConstraints: false)
-
         if liveResizeCornerCorrectionTimer == nil {
+            configureGlassSurface(adjustsConstraints: false)
             let timer = Timer(
-                timeInterval: 1 / 120,
+                timeInterval: Self.liveCornerCorrectionInterval,
                 target: self,
                 selector: #selector(correctLiveSidebarResizeCorners(_:)),
                 userInfo: nil,

--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -7,6 +7,7 @@ private enum ModelConfigurationLayoutMetrics {
     static let contentMinimumWidth: CGFloat = 420
     static let contentMinimumWidthWithConfiguration: CGFloat = 360
     static let configurationWidth: CGFloat = 320
+    static let transitionDuration: TimeInterval = 0.2
 }
 
 struct ModelConfigurationLayout<Content: View>: View {
@@ -25,33 +26,51 @@ struct ModelConfigurationLayout<Content: View>: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            content
-                .frame(
-                    minWidth: isConfigurationVisible
-                        ? ModelConfigurationLayoutMetrics.contentMinimumWidthWithConfiguration
-                        : ModelConfigurationLayoutMetrics.contentMinimumWidth,
-                    maxWidth: .infinity,
-                    maxHeight: .infinity
-                )
-                .clipped()
+        ZStack(alignment: .trailing) {
+            HStack(spacing: 0) {
+                content
+                    .frame(
+                        minWidth: isConfigurationVisible
+                            ? ModelConfigurationLayoutMetrics.contentMinimumWidthWithConfiguration
+                            : ModelConfigurationLayoutMetrics.contentMinimumWidth,
+                        maxWidth: .infinity,
+                        maxHeight: .infinity
+                    )
+                    .clipped()
 
-            if isConfigurationVisible {
-                ModelConfigurationView(
-                    settings: $model.settings,
-                    settingsRequireRestart: model.settingsRequireRestart,
-                    onReset: model.resetSettings
-                )
-                .frame(width: ModelConfigurationLayoutMetrics.configurationWidth)
-                .ignoresSafeArea(.container, edges: .top)
-                .overlay(alignment: .leading) {
-                    Rectangle()
-                        .fill(Color(nsColor: .separatorColor))
-                        .frame(width: 1)
-                        .ignoresSafeArea(.container, edges: [.top, .bottom])
-                }
-                .transition(.move(edge: .trailing).combined(with: .opacity))
+                Color.clear
+                    .frame(
+                        width: isConfigurationVisible
+                            ? ModelConfigurationLayoutMetrics.configurationWidth
+                            : 0
+                    )
             }
+            .animation(nil, value: isConfigurationVisible)
+
+            ModelConfigurationView(
+                settings: $model.settings,
+                settingsRequireRestart: model.settingsRequireRestart,
+                onReset: model.resetSettings
+            )
+            .frame(width: ModelConfigurationLayoutMetrics.configurationWidth)
+            .ignoresSafeArea(.container, edges: .top)
+            .overlay(alignment: .leading) {
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor))
+                    .frame(width: 1)
+                    .ignoresSafeArea(.container, edges: [.top, .bottom])
+            }
+            .offset(
+                x: isConfigurationVisible
+                    ? 0
+                    : ModelConfigurationLayoutMetrics.configurationWidth + 5
+            )
+            .allowsHitTesting(isConfigurationVisible)
+            .accessibilityHidden(!isConfigurationVisible)
+            .animation(
+                .smooth(duration: ModelConfigurationLayoutMetrics.transitionDuration),
+                value: isConfigurationVisible
+            )
         }
     }
 }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -305,7 +305,7 @@ struct ChatView: View {
 
     private var transcript: some View {
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 12) {
                 if chat.visibleMessages.isEmpty {
                     if chat.messages.isEmpty {
                         ChatEmptyTranscriptView(

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -305,7 +305,7 @@ struct ChatView: View {
 
     private var transcript: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+            LazyVStack(alignment: .leading, spacing: 12) {
                 if chat.visibleMessages.isEmpty {
                     if chat.messages.isEmpty {
                         ChatEmptyTranscriptView(

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -103,10 +103,7 @@ struct DeveloperView: View {
 
     private var runtimeGrid: some View {
         LazyVGrid(
-            columns: Array(
-                repeating: GridItem(.flexible(minimum: 165), spacing: 10),
-                count: 4
-            ),
+            columns: [GridItem(.adaptive(minimum: 165), spacing: 10)],
             alignment: .leading,
             spacing: 10
         ) {

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -545,10 +545,10 @@ private struct IntegrationDetailView: View {
                         missingToolPanel
                     } else {
                         modelPanel
+                        actionBar
                         projectPanel
                         launchCommandPanel
                         configurationPanel
-                        actionBar
                     }
                 }
                 .frame(maxWidth: 760)


### PR DESCRIPTION
## Summary

- keep the 200 ms sidebar slide while making the detail-column width change atomic
- animate the sidebar as one composited surface so its glass backing and menu stay synchronized
- remove per-frame detail-geometry state feedback and transition bookkeeping
- reduce live resize corner correction to 30 Hz and skip redundant glass reconfiguration while it is active

## Root cause

The sidebar transition animated the root `HStack` width, forcing the complete active detail tree to be measured and placed on every animation frame. Dashboard charts/cards and the Developer diagnostics/log hierarchy made that repeated main-thread layout especially visible. Geometry observations also wrote the changing detail edge back into root state during the transition.

The visual sidebar is now independent from layout: a stable spacer switches between zero and the chosen sidebar width without animation, while only one composited sidebar surface slides. This preserves the interaction animation without repeatedly resizing the active page or allowing the glass backing to move ahead of the menu.

## Impact

Sidebar collapse and expansion remain animated, Dashboard and Developer avoid page-wide layout work on every transition frame, and manual sidebar drag resizing remains unchanged. Chat transcript rendering is left on its existing eager stack, preserving the rendering behavior restored for #93.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -derivedDataPath build/XcodeDerivedData CODE_SIGNING_ALLOWED=NO build`
- profiled repeated Dashboard and Developer toggles and confirmed the original hot path was SwiftUI layout measurement/placement
- launched the rebuilt Debug app and exercised collapse, expansion, rapid reversal, Dashboard, and Developer states
