### PR TITLE
Bump mlx-vlm minimum to 0.6.8

### DIFF
--- a/PythonDistribution/Requirements/mlx-vlm-server-macos-arm64.txt
+++ b/PythonDistribution/Requirements/mlx-vlm-server-macos-arm64.txt
@@ -32,7 +32,7 @@ miniaudio==1.71
 mlx-audio==0.4.3
 mlx-lm==0.31.3
 mlx-metal>=0.32.0
-mlx-vlm>=0.6.5
+mlx-vlm>=0.6.8
 mlx>=0.32.0
 multidict==6.7.1
 multiprocess==0.70.19


### PR DESCRIPTION
## Summary

- Raise the embedded server requirement from `mlx-vlm>=0.6.5` to `mlx-vlm>=0.6.8`.
- Invalidate the embedded Python distribution build stamp so new builds resolve the updated minimum version.

## Why

The embedded distribution cache keys off the requirements file contents. Because the previous lower bound remained unchanged, incremental builds could continue reusing a bundle containing mlx-vlm 0.6.7 even after 0.6.8 became available.

## Impact

Clean builds and release builds now embed mlx-vlm 0.6.8 or newer.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -derivedDataPath build/VersionBumpDerivedData CODE_SIGNING_ALLOWED=NO build`
- Confirmed the resulting `Nativ.app` reports embedded `mlx-vlm` version `0.6.8`.
- `git diff --check`