### PR TITLE
Keep selection menus open

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677360D86DDAFAB194A995E7 /* Main.swift */; };
 		DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */; };
 		E07244079BF415C89A76AC48 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
+		E407C7F9CE883C978DE7D716 /* PersistentMenuActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */; };
 		E4D299AADEA8470C37256DDE /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
 		E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */; };
 		E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41417C210BF817681A8C6D87 /* IntegrationsView.swift */; };
@@ -175,6 +176,7 @@
 		DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		E46B388273DDFAD7C6C0F4E1 /* IssueReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueReport.swift; sourceTree = "<group>"; };
 		E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSettingsTests.swift; sourceTree = "<group>"; };
+		E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentMenuActionView.swift; sourceTree = "<group>"; };
 		E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceCache.swift; sourceTree = "<group>"; };
 		EE151F7A36DA21A32ABCFD63 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscovery.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */,
 				676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */,
 				BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */,
+				E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */,
 				330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */,
 				5919AB4E9488642C73886266 /* ShellEnvironment.swift */,
 			);
@@ -609,6 +612,7 @@
 				692EA024371CB249BE53DB86 /* NativAnalyticsStore.swift in Sources */,
 				4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */,
 				ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */,
+				E407C7F9CE883C978DE7D716 /* PersistentMenuActionView.swift in Sources */,
 				F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */,
 				5620EDCF472DEF4388E8E526 /* SettingsView.swift in Sources */,
 				C8B10834D4DF407907FCCF6C /* ShellEnvironment.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -623,6 +623,7 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
     func updateNSView(_ button: NSButton, context: Context) {
         context.coordinator.parent = self
         button.isEnabled = isEnabled
+        context.coordinator.updateActionAvailability(isEnabled)
     }
 
     @MainActor
@@ -630,6 +631,10 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
         var parent: ComposerModelPickerMenuControl
 
         private static let menuFont = NSFont.menuFont(ofSize: NSFont.systemFontSize)
+        private weak var modelSummaryItem: NSMenuItem?
+        private weak var secondarySummaryItem: NSMenuItem?
+        private var modelOptionViews = [PersistentMenuActionView]()
+        private var secondaryOptionViews = [PersistentMenuActionView]()
 
         init(parent: ComposerModelPickerMenuControl) {
             self.parent = parent
@@ -638,6 +643,8 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
         @objc func showMenu(_ sender: NSButton) {
             // Build the entire tree before tracking begins. Keeping both submenus
             // alive for the whole session prevents hover-driven view replacement.
+            modelOptionViews.removeAll()
+            secondaryOptionViews.removeAll()
             let menu = makeMenu()
             parent.onTrackingChanged(true)
             defer { parent.onTrackingChanged(false) }
@@ -665,6 +672,7 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
             )
             modelItem.submenu = makeModelMenu()
             menu.addItem(modelItem)
+            modelSummaryItem = modelItem
 
             if let secondarySection = parent.secondarySection {
                 let secondaryItem = NSMenuItem(
@@ -674,6 +682,7 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
                 )
                 secondaryItem.submenu = makeSecondaryMenu(secondarySection)
                 menu.addItem(secondaryItem)
+                secondarySummaryItem = secondaryItem
             }
 
             return menu
@@ -689,9 +698,8 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
                     title: modelMenuLabel(selectedModelID),
                     repoID: selectedModelID,
                     provider: parent.selectedModelProvider,
-                    action: #selector(switchModel(_:))
+                    isSelected: true
                 )
-                item.state = .on
                 menu.addItem(item)
 
                 if !parent.models.isEmpty {
@@ -704,9 +712,8 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
                     title: modelMenuLabel(model.repoID),
                     repoID: model.repoID,
                     provider: model.provider,
-                    action: #selector(selectModel(_:))
+                    isSelected: model.repoID == parent.selectedModelID
                 )
-                item.state = model.repoID == parent.selectedModelID ? .on : .off
                 menu.addItem(item)
             }
 
@@ -726,18 +733,21 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
             menu.autoenablesItems = false
 
             for option in section.options {
-                let item = NSMenuItem(
-                    title: option.title,
-                    action: #selector(selectSecondaryOption(_:)),
-                    keyEquivalent: ""
-                )
-                item.target = self
-                item.representedObject = option.id
-                item.state = option.id == section.selectedID ? .on : .off
-                item.attributedTitle = secondaryOptionTitle(
+                let title = secondaryOptionTitle(
                     option,
                     options: section.options
                 )
+                let item = persistentMenuItem(
+                    title: title,
+                    optionID: option.id,
+                    image: nil,
+                    isSelected: option.id == section.selectedID
+                ) { [weak self] in
+                    self?.selectSecondaryOption(option.id)
+                }
+                if let itemView = item.view as? PersistentMenuActionView {
+                    secondaryOptionViews.append(itemView)
+                }
                 menu.addItem(item)
             }
 
@@ -748,32 +758,68 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
             title: String,
             repoID: String,
             provider: LocalModelProvider?,
-            action: Selector
+            isSelected: Bool
         ) -> NSMenuItem {
-            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
-            item.target = self
-            item.representedObject = repoID
-            item.image = providerImage(provider)
+            let item = persistentMenuItem(
+                title: NSAttributedString(
+                    string: title,
+                    attributes: [.font: Self.menuFont]
+                ),
+                optionID: repoID,
+                image: providerImage(provider),
+                isSelected: isSelected
+            ) { [weak self] in
+                self?.selectModel(repoID)
+            }
+            if let itemView = item.view as? PersistentMenuActionView {
+                modelOptionViews.append(itemView)
+            }
             return item
         }
 
-        @objc private func selectModel(_ sender: NSMenuItem) {
-            guard let repoID = sender.representedObject as? String,
-                  let model = parent.models.first(where: { $0.repoID == repoID })
-            else { return }
-            parent.onSelectModel(model)
+        private func persistentMenuItem(
+            title: NSAttributedString,
+            optionID: String,
+            image: NSImage?,
+            isSelected: Bool,
+            onSelect: @escaping () -> Void
+        ) -> NSMenuItem {
+            let item = NSMenuItem(title: title.string, action: nil, keyEquivalent: "")
+            item.isEnabled = true
+            item.view = PersistentMenuActionView(
+                optionID: optionID,
+                title: title,
+                image: image,
+                isSelected: isSelected,
+                onSelect: onSelect
+            )
+            return item
         }
 
-        @objc private func switchModel(_ sender: NSMenuItem) {
-            guard let repoID = sender.representedObject as? String else { return }
-            parent.onSwitchModel(repoID)
-        }
+        private func selectModel(_ repoID: String) {
+            modelOptionViews.forEach { $0.isSelected = $0.optionID == repoID }
+            modelSummaryItem?.title = "Model   \(modelMenuLabel(repoID))"
 
-        @objc private func selectSecondaryOption(_ sender: NSMenuItem) {
-            guard let optionID = sender.representedObject as? String else {
-                return
+            if let model = parent.models.first(where: { $0.repoID == repoID }) {
+                parent.onSelectModel(model)
+            } else {
+                parent.onSwitchModel(repoID)
             }
-            parent.secondarySection?.onSelect(optionID)
+        }
+
+        private func selectSecondaryOption(_ optionID: String) {
+            guard let section = parent.secondarySection,
+                  let option = section.options.first(where: { $0.id == optionID })
+            else { return }
+
+            secondaryOptionViews.forEach { $0.isSelected = $0.optionID == optionID }
+            secondarySummaryItem?.title = "\(section.title)   \(option.title)"
+            section.onSelect(optionID)
+        }
+
+        func updateActionAvailability(_ isEnabled: Bool) {
+            modelOptionViews.forEach { $0.isActionEnabled = isEnabled }
+            secondaryOptionViews.forEach { $0.isActionEnabled = isEnabled }
         }
 
         private func modelMenuLabel(_ modelID: String) -> String {

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -119,95 +119,47 @@ struct SystemMonitorView: View {
     }
 
     private var menuBarControl: some View {
-        Menu {
-            Section("Menu bar") {
-                Toggle(
-                    isOn: Binding(
-                        get: { menuBarPreferences.items.isEmpty },
-                        set: { isEnabled in
-                            if isEnabled {
-                                menuBarPreferences.useNativIcon()
-                            }
-                        }
-                    )
-                ) {
-                    Label(
-                        "Nativ icon",
-                        systemImage: SystemMenuBarMetric.nativ.systemImage
-                    )
-                }
-            }
+        HStack(spacing: 8) {
+            Image(systemName: "menubar.rectangle")
+                .foregroundStyle(Color.accentColor)
 
-            ForEach(
-                SystemMenuBarMetric.allCases.filter { $0 != .nativ }
-            ) { metric in
-                Section(metric.title) {
-                    ForEach(metric.menuBarStyles) { style in
-                        Toggle(
-                            isOn: Binding(
-                                get: {
-                                    menuBarPreferences.contains(
-                                        metric: metric,
-                                        style: style
-                                    )
-                                },
-                                set: { isEnabled in
-                                    menuBarPreferences.setEnabled(
-                                        isEnabled,
-                                        metric: metric,
-                                        style: style
-                                    )
-                                }
-                            )
-                        ) {
-                            Label(style.title, systemImage: style.systemImage)
-                        }
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "menubar.rectangle")
-                    .foregroundStyle(Color.accentColor)
+            Text("Customize Menu Bar")
+                .foregroundStyle(.primary)
 
-                Text("Customize Menu Bar")
-                    .foregroundStyle(.primary)
+            Text("\(menuBarItemCount)")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.white)
+                .frame(minWidth: 18, minHeight: 18)
+                .background(Color.accentColor, in: Capsule())
 
-                Text("\(menuBarItemCount)")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(.white)
-                    .frame(minWidth: 18, minHeight: 18)
-                    .background(Color.accentColor, in: Capsule())
-
-                Image(systemName: "chevron.down")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(.secondary)
-            }
-            .font(.callout.weight(.semibold))
-            .padding(.horizontal, 11)
-            .frame(height: 34)
-            .background {
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .fill(
-                        Color.accentColor.opacity(
-                            isMenuBarControlHovered ? 0.14 : 0.07
-                        )
-                    )
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .stroke(
-                        Color.accentColor.opacity(
-                            isMenuBarControlHovered ? 0.65 : 0.32
-                        ),
-                        lineWidth: 1
-                    )
-            }
-            .contentShape(.rect)
+            Image(systemName: "chevron.down")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.secondary)
         }
-        .menuStyle(.button)
-        .buttonStyle(.plain)
-        .menuIndicator(.hidden)
+        .font(.callout.weight(.semibold))
+        .padding(.horizontal, 11)
+        .frame(height: 34)
+        .background {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(
+                    Color.accentColor.opacity(
+                        isMenuBarControlHovered ? 0.14 : 0.07
+                    )
+                )
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .stroke(
+                    Color.accentColor.opacity(
+                        isMenuBarControlHovered ? 0.65 : 0.32
+                    ),
+                    lineWidth: 1
+                )
+        }
+        .contentShape(.rect)
+        .overlay {
+            MenuBarCustomizationMenuControl(preferences: menuBarPreferences)
+        }
         .fixedSize()
         .onHover { isHovered in
             withAnimation(.easeOut(duration: 0.12)) {
@@ -1998,6 +1950,153 @@ private enum SystemMonitorFormat {
 
     static func integer(_ value: UInt64) -> String {
         value.formatted()
+    }
+}
+
+private struct MenuBarCustomizationMenuControl: NSViewRepresentable {
+    @ObservedObject var preferences: SystemMenuBarPreferences
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(preferences: preferences)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton()
+        button.isBordered = false
+        button.title = ""
+        button.image = nil
+        button.focusRingType = .none
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.showMenu(_:))
+        button.setAccessibilityLabel("Customize Menu Bar")
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.preferences = preferences
+        context.coordinator.refreshSelection()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var preferences: SystemMenuBarPreferences
+
+        private static let menuFont = NSFont.menuFont(ofSize: NSFont.systemFontSize)
+        private var optionViews = [PersistentMenuActionView]()
+
+        init(preferences: SystemMenuBarPreferences) {
+            self.preferences = preferences
+        }
+
+        @objc func showMenu(_ sender: NSButton) {
+            optionViews.removeAll()
+            let menu = makeMenu()
+            menu.update()
+            menu.popUp(
+                positioning: nil,
+                at: NSPoint(
+                    x: -8,
+                    y: sender.isFlipped
+                        ? sender.bounds.minY - menu.size.height - 4
+                        : sender.bounds.maxY + menu.size.height + 4
+                ),
+                in: sender
+            )
+        }
+
+        func refreshSelection() {
+            for optionView in optionViews {
+                if optionView.optionID == SystemMenuBarMetric.nativ.rawValue {
+                    optionView.isSelected = preferences.items.isEmpty
+                    continue
+                }
+                guard let item = SystemMenuBarItem(id: optionView.optionID) else {
+                    continue
+                }
+                optionView.isSelected = preferences.contains(
+                    metric: item.metric,
+                    style: item.style
+                )
+            }
+        }
+
+        private func makeMenu() -> NSMenu {
+            let menu = NSMenu()
+            menu.autoenablesItems = false
+
+            menu.addItem(.sectionHeader(title: "Menu bar"))
+            menu.addItem(menuItem(
+                title: "Nativ icon",
+                systemImage: SystemMenuBarMetric.nativ.systemImage,
+                optionID: SystemMenuBarMetric.nativ.rawValue,
+                isSelected: preferences.items.isEmpty
+            ) { [weak self] in
+                self?.preferences.useNativIcon()
+                self?.refreshSelection()
+            })
+
+            for metric in SystemMenuBarMetric.allCases where metric != .nativ {
+                menu.addItem(.separator())
+                menu.addItem(.sectionHeader(title: metric.title))
+
+                for style in metric.menuBarStyles {
+                    let item = SystemMenuBarItem(metric: metric, style: style)
+                    menu.addItem(menuItem(
+                        title: style.title,
+                        systemImage: style.systemImage,
+                        optionID: item.id,
+                        isSelected: preferences.contains(metric: metric, style: style)
+                    ) { [weak self] in
+                        guard let self else { return }
+                        let isSelected = self.preferences.contains(
+                            metric: metric,
+                            style: style
+                        )
+                        self.preferences.setEnabled(
+                            !isSelected,
+                            metric: metric,
+                            style: style
+                        )
+                        self.refreshSelection()
+                    })
+                }
+            }
+
+            return menu
+        }
+
+        private func menuItem(
+            title: String,
+            systemImage: String,
+            optionID: String,
+            isSelected: Bool,
+            onSelect: @escaping () -> Void
+        ) -> NSMenuItem {
+            let configuration = NSImage.SymbolConfiguration(
+                pointSize: NSFont.systemFontSize,
+                weight: .regular
+            )
+            let image = NSImage(
+                systemSymbolName: systemImage,
+                accessibilityDescription: title
+            )?.withSymbolConfiguration(configuration)
+            let attributedTitle = NSAttributedString(
+                string: title,
+                attributes: [.font: Self.menuFont]
+            )
+            let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+            let itemView = PersistentMenuActionView(
+                optionID: optionID,
+                title: attributedTitle,
+                image: image,
+                isSelected: isSelected,
+                onSelect: onSelect
+            )
+            item.view = itemView
+            item.isEnabled = true
+            optionViews.append(itemView)
+            return item
+        }
     }
 }
 

--- a/Sources/Nativ/Utilities/PersistentMenuActionView.swift
+++ b/Sources/Nativ/Utilities/PersistentMenuActionView.swift
@@ -1,0 +1,197 @@
+import AppKit
+
+/// A menu row whose embedded control performs an action without ending the
+/// enclosing menu's tracking session.
+@MainActor
+final class PersistentMenuActionView: NSView {
+    let optionID: String
+
+    var isSelected: Bool {
+        didSet {
+            guard oldValue != isSelected else { return }
+            updateSelection()
+        }
+    }
+
+    var isActionEnabled: Bool {
+        get { actionButton.isEnabled }
+        set {
+            actionButton.isEnabled = newValue
+            alphaValue = newValue ? 1 : 0.5
+            updateAppearance()
+        }
+    }
+
+    private let normalTitle: NSAttributedString
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let selectionImage = NSImageView()
+    private let optionImage = NSImageView()
+    private let actionButton = NSButton()
+    private let onSelect: () -> Void
+    private var trackingArea: NSTrackingArea?
+    private var isHovered = false {
+        didSet {
+            guard oldValue != isHovered else { return }
+            updateAppearance()
+        }
+    }
+
+    init(
+        optionID: String,
+        title: NSAttributedString,
+        image: NSImage?,
+        isSelected: Bool,
+        onSelect: @escaping () -> Void
+    ) {
+        self.optionID = optionID
+        self.normalTitle = title
+        self.isSelected = isSelected
+        self.onSelect = onSelect
+
+        let titleWidth = title.size().width.rounded(.up)
+        let imageWidth: CGFloat = image == nil ? 0 : 22
+        super.init(frame: NSRect(
+            x: 0,
+            y: 0,
+            width: max(180, titleWidth + imageWidth + 48),
+            height: 22
+        ))
+
+        autoresizingMask = [.width]
+
+        selectionImage.imageScaling = .scaleProportionallyDown
+        selectionImage.translatesAutoresizingMaskIntoConstraints = false
+
+        optionImage.image = image
+        optionImage.imageScaling = .scaleProportionallyDown
+        optionImage.isHidden = image == nil
+        optionImage.translatesAutoresizingMaskIntoConstraints = false
+
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        actionButton.title = ""
+        actionButton.isBordered = false
+        actionButton.isTransparent = true
+        actionButton.target = self
+        actionButton.action = #selector(performSelection)
+        actionButton.translatesAutoresizingMaskIntoConstraints = false
+        actionButton.setAccessibilityLabel(title.string)
+        actionButton.setAccessibilityRole(.button)
+
+        addSubview(selectionImage)
+        addSubview(optionImage)
+        addSubview(titleLabel)
+        addSubview(actionButton)
+
+        let titleLeadingAnchor = image == nil
+            ? selectionImage.trailingAnchor
+            : optionImage.trailingAnchor
+
+        NSLayoutConstraint.activate([
+            selectionImage.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 9),
+            selectionImage.centerYAnchor.constraint(equalTo: centerYAnchor),
+            selectionImage.widthAnchor.constraint(equalToConstant: 13),
+            selectionImage.heightAnchor.constraint(equalToConstant: 13),
+
+            optionImage.leadingAnchor.constraint(
+                equalTo: selectionImage.trailingAnchor,
+                constant: 5
+            ),
+            optionImage.centerYAnchor.constraint(equalTo: centerYAnchor),
+            optionImage.widthAnchor.constraint(equalToConstant: 16),
+            optionImage.heightAnchor.constraint(equalToConstant: 16),
+
+            titleLabel.leadingAnchor.constraint(equalTo: titleLeadingAnchor, constant: 7),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -10),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            actionButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+            actionButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+            actionButton.topAnchor.constraint(equalTo: topAnchor),
+            actionButton.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        updateSelection()
+        updateAppearance()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard isHovered, isActionEnabled else { return }
+
+        NSColor.selectedContentBackgroundColor.setFill()
+        NSBezierPath(
+            roundedRect: bounds.insetBy(dx: 5, dy: 1),
+            xRadius: 5,
+            yRadius: 5
+        ).fill()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.activeAlways, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        self.trackingArea = trackingArea
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+    }
+
+    private func updateSelection() {
+        selectionImage.image = isSelected
+            ? NSImage(systemSymbolName: "checkmark", accessibilityDescription: "Selected")
+            : nil
+        actionButton.setAccessibilityValue(isSelected ? "Selected" : "Not selected")
+    }
+
+    private func updateAppearance() {
+        let isHighlighted = isHovered && isActionEnabled
+        selectionImage.contentTintColor = isHighlighted
+            ? .selectedMenuItemTextColor
+            : .labelColor
+        if optionImage.image?.isTemplate == true {
+            optionImage.contentTintColor = isHighlighted
+                ? .selectedMenuItemTextColor
+                : .labelColor
+        }
+
+        guard isHighlighted else {
+            titleLabel.attributedStringValue = normalTitle
+            needsDisplay = true
+            return
+        }
+
+        let highlightedTitle = NSMutableAttributedString(attributedString: normalTitle)
+        highlightedTitle.addAttribute(
+            .foregroundColor,
+            value: NSColor.selectedMenuItemTextColor,
+            range: NSRange(location: 0, length: highlightedTitle.length)
+        )
+        titleLabel.attributedStringValue = highlightedTitle
+        needsDisplay = true
+    }
+
+    @objc private func performSelection() {
+        guard isActionEnabled else { return }
+        onSelect()
+    }
+}


### PR DESCRIPTION
## What changed

- Keep the chat model and reasoning menus open after selecting an option.
- Keep the menu bar customization menu open while toggling metrics and display styles.
- Update checkmarks and selected-value summaries in place.
- Share the persistent AppKit menu-row behavior through `PersistentMenuActionView`.

## Why

The model and menu bar customization pickers previously used ordinary menu actions. AppKit and SwiftUI ended menu tracking after every selection, forcing users to reopen the menu for each additional choice.

This change uses embedded menu controls that apply the selection without ending the active menu session. The menus still dismiss through the normal outside-click or cancellation behavior.

## User impact

Users can switch models or reasoning levels and configure several menu bar items without repeatedly reopening the relevant menu.

## Validation

- Debug macOS build succeeds.
- Full test suite passes: 108 tests, 0 failures.
- `git diff --check` passes.