### PR TITLE
Persist added model source folders across restarts

### DIFF
--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -799,13 +799,17 @@ struct ModelsView: View {
         guard panel.runModal() == .OK, let url = panel.url else {
             return
         }
-        model.settings.additionalModelSearchPaths.append(
+        var settings = model.settings
+        settings.additionalModelSearchPaths.append(
             (url.path as NSString).abbreviatingWithTildeInPath
         )
+        model.settings = settings
     }
 
     private func removeModelSourceFolder(_ path: String) {
-        model.settings.additionalModelSearchPaths.removeAll { $0 == path }
+        var settings = model.settings
+        settings.additionalModelSearchPaths.removeAll { $0 == path }
+        model.settings = settings
     }
 
     private func abbreviatedPath(_ path: String) -> String {


### PR DESCRIPTION
handles #135 when model paths saved in models page does not presist after restart

fix is to use same copy-then-reassign pattern as the rest of the app, so didSet → save() runs:

```Swift
var settings = model.settings
settings.additionalModelSearchPaths.append(…)
model.settings = settings
```

No new storage, additionalModelSearchPaths is already encoded/decoded in NativSettings, this just ensures the write is actually saved.