### PR TITLE
Make Return activate the default button in confirmation dialogs

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -318,6 +318,7 @@ struct ControlPanelView: View {
             Button("OK", role: .cancel) {
                 launchAtLogin.errorMessage = nil
             }
+            .keyboardShortcut(.defaultAction)
         } message: {
             Text(launchAtLogin.errorMessage ?? "An unknown error occurred.")
         }
@@ -769,6 +770,7 @@ struct ControlPanelView: View {
             Button("Load Anyway") {
                 model.confirmPendingModelPreloadSwitch()
             }
+            .keyboardShortcut(.defaultAction)
             Button("Cancel", role: .cancel) {
                 model.cancelPendingModelPreloadSwitch()
             }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -2170,6 +2170,7 @@ private struct ChatImageAttachmentView: View {
         .accessibilityLabel(attachment.filename)
         .alert("Couldn’t Save Image", isPresented: $showsSaveError) {
             Button("OK", role: .cancel) {}
+                .keyboardShortcut(.defaultAction)
         } message: {
             Text(saveErrorMessage ?? "The image could not be saved.")
         }

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -697,6 +697,7 @@ private struct ServerAPIAuthenticationPanel: View {
             Button("Remove Token", role: .destructive) {
                 onSetToken(nil)
             }
+            .keyboardShortcut(.defaultAction)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(
@@ -1140,6 +1141,7 @@ private struct HuggingFaceAuthenticationPanel: View {
             Button(logoutConfirmationAction, role: .destructive) {
                 performLogout()
             }
+            .keyboardShortcut(.defaultAction)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(logoutConfirmationMessage)
@@ -1154,6 +1156,7 @@ private struct HuggingFaceAuthenticationPanel: View {
             Button("OK", role: .cancel) {
                 managementError = nil
             }
+            .keyboardShortcut(.defaultAction)
         } message: {
             Text(managementError ?? "An unknown error occurred.")
         }

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -373,6 +373,7 @@ struct IntegrationsView: View {
             set: { if !$0 { viewModel.errorMessage = nil } }
         )) {
             Button("OK", role: .cancel) { viewModel.errorMessage = nil }
+                .keyboardShortcut(.defaultAction)
         } message: {
             Text(viewModel.errorMessage ?? "Unknown error")
         }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1058,6 +1058,7 @@ private struct InstalledModelRow: View {
         .modelRowBackground(isHighlighted: isSelected, isHovered: isHovered)
         .alert("Model isn’t supported", isPresented: $showsUnsupportedModelInformation) {
             Button("OK", role: .cancel) {}
+                .keyboardShortcut(.defaultAction)
         } message: {
             Text(
                 "\(localModel.repoID) is installed in your Hugging Face cache, but Nativ can’t use it for chat, image generation, text-to-speech, or speech-to-text."
@@ -1065,6 +1066,7 @@ private struct InstalledModelRow: View {
         }
         .alert("Delete \(modelName(localModel.repoID))?", isPresented: $showsDeleteConfirmation) {
             Button("Delete Model", role: .destructive, action: onDelete)
+                .keyboardShortcut(.defaultAction)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This permanently removes \(localModel.repoID) from the local Hugging Face cache.")


### PR DESCRIPTION
One fearture is to allow the submit button to work on like small pop ups that show, such as these:

I think it's just something natural most people do, so would be nice
<img width="334" height="176" alt="Screenshot 2026-07-28 at 7 44 33 AM" src="https://github.com/user-attachments/assets/1b4616a5-db0f-4841-b2e3-f1dbc340e033" />
