### PR TITLE
View > Toggle Sidebar was permanently disabled

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -504,6 +504,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         showMainWindow()
     }
 
+    func toggleSidebar() {
+        controlPanelNavigation.toggleSidebar()
+        showMainWindow()
+    }
+
     private func showMainWindow() {
         mainWindowOpener?()
         NSApplication.shared.activate(ignoringOtherApps: true)

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -52,7 +52,9 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
 final class ControlPanelNavigation: ObservableObject {
     @Published private(set) var requestedTab: ControlPanelTab?
     @Published private(set) var newChatRequest = 0
+    @Published private(set) var toggleSidebarRequest = 0
     private var consumedNewChatRequest = 0
+    private var consumedToggleSidebarRequest = 0
 
     func open(_ tab: ControlPanelTab) {
         requestedTab = tab
@@ -62,11 +64,23 @@ final class ControlPanelNavigation: ObservableObject {
         newChatRequest += 1
     }
 
+    func toggleSidebar() {
+        toggleSidebarRequest += 1
+    }
+
     func consumeNewChatRequest() -> Bool {
         guard consumedNewChatRequest < newChatRequest else {
             return false
         }
         consumedNewChatRequest = newChatRequest
+        return true
+    }
+
+    func consumeToggleSidebarRequest() -> Bool {
+        guard consumedToggleSidebarRequest < toggleSidebarRequest else {
+            return false
+        }
+        consumedToggleSidebarRequest = toggleSidebarRequest
         return true
     }
 }
@@ -290,6 +304,9 @@ struct ControlPanelView: View {
         }
         .onChange(of: navigation.newChatRequest) { _, _ in
             handleNewChatRequest()
+        }
+        .onChange(of: navigation.toggleSidebarRequest) { _, _ in
+            handleToggleSidebarRequest()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.willEnterFullScreenNotification)) { _ in
             isFullScreen = true
@@ -839,6 +856,13 @@ struct ControlPanelView: View {
             return
         }
         createChatSession()
+    }
+
+    private func handleToggleSidebarRequest() {
+        guard navigation.consumeToggleSidebarRequest() else {
+            return
+        }
+        toggleSidebarVisibility()
     }
 
     private func canExportRecent(_ recent: ControlPanelRecentSession) -> Bool {

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -115,7 +115,12 @@ private struct NativApplication: App {
                 .keyboardShortcut("n")
             }
 
-            SidebarCommands()
+            CommandGroup(replacing: .sidebar) {
+                Button("Toggle Sidebar") {
+                    appDelegate.toggleSidebar()
+                }
+                .keyboardShortcut("s", modifiers: [.control, .command])
+            }
 
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {


### PR DESCRIPTION
The View menu's "Show Sidebar" command and its ⌃⌘S keyboard shortcut have never worked — `SidebarCommands()` is SwiftUI's stock API for a real `NavigationSplitView`, but this app's sidebar is a custom `ZStack` and has never had one. The menu item read `enabled: false` unconditionally.

This wires the menu command to the app's actual sidebar-visibility state, mirroring the existing `newChatRequest` pattern used elsewhere in the app. The toolbar sidebar-toggle button (a separate, custom-built control) is unaffected — this only fixes the standards-based menu/keyboard path.

Small, self-contained fix — unrelated to the tool-registry work in the other open PR.
