### PR TITLE
Settings never persisted across a relaunch on unsigned debug builds

### DIFF
--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -575,10 +575,10 @@ struct NativSettings: Codable, Equatable {
         let settings = normalized()
         do {
             try credentialStore.save(settings.serverAPIKey)
-            try settings.writePropertyList(to: url)
         } catch {
             // Do not replace the last recoverable credential on failure.
         }
+        try? settings.writePropertyList(to: url)
     }
 
     private func writePropertyList(to url: URL) throws {

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -148,6 +148,25 @@ final class NativSettingsTests: XCTestCase {
         )
     }
 
+    func testSavingWritesPropertyListEvenWhenCredentialStoreFails() throws {
+        let url = temporarySettingsURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let credentialStore = TestServerAPICredentialStore(
+            saveError: TestCredentialStoreError.unavailable
+        )
+
+        NativSettings(languageModelID: "org/model").save(
+            to: url,
+            credentialStore: credentialStore
+        )
+
+        XCTAssertEqual(
+            try propertyList(at: url)["languageModelID"] as? String,
+            "org/model",
+            "a Keychain failure must not block persisting the rest of settings to disk"
+        )
+    }
+
     func testLoadingMigratesLegacyServerAPIKeyIntoCredentialStore() throws {
         let url = temporarySettingsURL()
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }


### PR DESCRIPTION
`NativSettings.save()` ran the Keychain write and the property-list write in the same `do`/`catch` block. On an unsigned or ad-hoc-signed build (no `keychain-access-groups` entitlement), the Keychain write throws `errSecMissingEntitlement`, which silently aborted the plist write too — meaning **no settings change survived an app relaunch** in that build configuration, not just newly-added items.

Likely low-impact for properly signed/notarized distribution builds (which do have the entitlement), but real for anyone building and running Nativ locally without signing — which is presumably common for contributors.

Fix: decouple the two writes so a recoverable-credential failure can't block the rest of settings from being written to disk.

Found and fixed while testing an unrelated feature; small, self-contained, unrelated to the other open PRs.
