### PR TITLE
Include downloaded image models in the Models installed list

### DIFF
--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -316,7 +316,7 @@ enum LocalModelDiscovery {
             }
 
             guard let snapshotURL = preferredSnapshotURL(for: repoURL, fileManager: fileManager),
-                  isLikelyMLXModelSnapshot(snapshotURL, fileManager: fileManager)
+                  isLikelyMLXModelSnapshot(snapshotURL, model: repoID, fileManager: fileManager)
             else {
                 return nil
             }
@@ -550,7 +550,7 @@ enum LocalModelDiscovery {
         return ref.isEmpty ? nil : ref
     }
 
-    private static func isLikelyMLXModelSnapshot(_ snapshotURL: URL, fileManager: FileManager) -> Bool {
+    private static func isLikelyMLXModelSnapshot(_ snapshotURL: URL, model: String = "", fileManager: FileManager) -> Bool {
         let configURL = snapshotURL.appendingPathComponent("config.json")
         let tokenizerConfigURL = snapshotURL.appendingPathComponent("tokenizer_config.json")
         let modelIndexURL = snapshotURL.appendingPathComponent("model_index.json")
@@ -580,7 +580,7 @@ enum LocalModelDiscovery {
         // backend manifest and its family-specific layout checks decide
         // whether such a snapshot is complete and loadable.
         return MLXImageModelResolver.shared.isSupportedImageModel(
-            model: "",
+            model: model,
             at: snapshotURL,
             fileManager: fileManager
         )


### PR DESCRIPTION
Flux model downloaded for img gen page doesn't show in Models page, under the list of installed models, this pr fixes that. By this, people do have the choice to delete the model if need be.