### PR TITLE
docs: fix spelling of 'Glamourous' → 'Glamorous' in INTEGRATIONS.md

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -80,7 +80,7 @@ Extensible on-machine AI agent.
 
 ## Crush
 
-Glamourous terminal coding agent.
+Glamorous terminal coding agent.
 
 - Config: a `crush.json` with an `openai-compat` provider `nativ`
   (`base_url: http://127.0.0.1:8080/v1`, `api_key: nativ`); large and small models set to `nativ`.


### PR DESCRIPTION
Fixes a spelling error on line 83 of INTEGRATIONS.md: "Glamourous" should be "Glamorous". The adjective form drops the 'u' from the noun "glamour" in both US and UK English.