### PR TITLE
Add drag-and-drop pinning, reordering, and bulk actions to the chat s…

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -234,6 +234,7 @@ struct ControlPanelView: View {
     @State private var isPinnedDropTargeted = false
     @State private var isSessionsDropTargeted = false
     @State private var reorderTargetID: ControlPanelRecentSession.ID?
+    @State private var reorderInsertAfter = false
     @State private var pendingDeleteRecent: ControlPanelRecentSession?
     @State private var isConfirmingBulkDelete = false
 
@@ -533,17 +534,18 @@ struct ControlPanelView: View {
             } else {
                 ForEach(pinnedSessions) { recent in
                     VStack(alignment: .leading, spacing: 0) {
-                        pinnedInsertionLine(visible: reorderTargetID == recent.id)
+                        pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter)
                         draggableRow(recent, isPinnedRow: true)
+                        pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter)
                     }
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(dropHighlight(isTargeted: isPinnedDropTargeted))
-        .dropDestination(for: String.self) { items, _ in
-            handlePinDrop(items)
-        } isTargeted: { isPinnedDropTargeted = $0 }
+        .onDrop(of: [.text], isTargeted: $isPinnedDropTargeted) { providers in
+            loadDropString(providers) { _ = handlePinDrop([$0]) }
+        }
     }
 
     private var sessionsSection: some View {
@@ -555,14 +557,18 @@ struct ControlPanelView: View {
                 .padding(.bottom, 4)
 
             ForEach(unpinnedSessions) { recent in
-                draggableRow(recent, isPinnedRow: false)
+                VStack(alignment: .leading, spacing: 0) {
+                    pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter)
+                    draggableRow(recent, isPinnedRow: false)
+                    pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(dropHighlight(isTargeted: isSessionsDropTargeted))
-        .dropDestination(for: String.self) { items, _ in
-            handleUnpinDrop(items)
-        } isTargeted: { isSessionsDropTargeted = $0 }
+        .onDrop(of: [.text], isTargeted: $isSessionsDropTargeted) { providers in
+            loadDropString(providers) { _ = handleUnpinDrop([$0]) }
+        }
     }
 
     private var emptyPinnedHint: some View {
@@ -586,27 +592,75 @@ struct ControlPanelView: View {
         isPinnedRow: Bool
     ) -> some View {
         if let payload = recent.dragPayload, !isSelectingRecents {
-            if isPinnedRow {
-                recentSessionRow(recent)
-                    .draggable(payload) { dragPreview(recent) }
-                    .dropDestination(for: String.self) { items, _ in
-                        let handled = handlePinnedRowDrop(items, target: recent)
-                        reorderTargetID = nil
-                        return handled
-                    } isTargeted: { targeted in
-                        if targeted {
-                            reorderTargetID = recent.id
-                        } else if reorderTargetID == recent.id {
-                            reorderTargetID = nil
-                        }
+            recentSessionRow(recent)
+                .onDrag {
+                    NSItemProvider(object: payload as NSString)
+                } preview: {
+                    dragPreview(recent)
+                }
+                .onDrop(of: [.text], delegate: RowReorderDropDelegate(
+                    targetID: recent.id,
+                    setTarget: { id, after in
+                        reorderTargetID = id
+                        reorderInsertAfter = after
+                    },
+                    onDrop: { draggedPayload, after in
+                        handleRowDrop(
+                            draggedPayload: draggedPayload,
+                            target: recent,
+                            insertAfter: after,
+                            isPinnedRow: isPinnedRow
+                        )
                     }
-            } else {
-                recentSessionRow(recent)
-                    .draggable(payload) { dragPreview(recent) }
-            }
+                ))
         } else {
             recentSessionRow(recent)
         }
+    }
+
+    private func handleRowDrop(
+        draggedPayload: String,
+        target: ControlPanelRecentSession,
+        insertAfter: Bool,
+        isPinnedRow: Bool
+    ) {
+        guard let draggedID = UUID(uuidString: draggedPayload),
+              chat.sessions.contains(where: { $0.id == draggedID }),
+              let targetID = target.chatID,
+              draggedID != targetID
+        else {
+            return
+        }
+        var order = (isPinnedRow ? pinnedSessions : unpinnedSessions).compactMap(\.chatID)
+        order.removeAll { $0 == draggedID }
+        if let index = order.firstIndex(of: targetID) {
+            order.insert(draggedID, at: insertAfter ? index + 1 : index)
+        } else {
+            order.append(draggedID)
+        }
+        withAnimation(.snappy(duration: 0.2)) {
+            if isPinnedRow {
+                chat.applyPinnedOrder(order)
+            } else {
+                chat.applySessionOrder(order)
+            }
+        }
+    }
+
+    @discardableResult
+    private func loadDropString(
+        _ providers: [NSItemProvider],
+        _ handler: @escaping (String) -> Void
+    ) -> Bool {
+        guard let provider = providers.first else {
+            return false
+        }
+        provider.loadObject(ofClass: NSString.self) { object, _ in
+            if let string = object as? String, !string.isEmpty {
+                DispatchQueue.main.async { handler(string) }
+            }
+        }
+        return true
     }
 
     private func pinnedInsertionLine(visible: Bool) -> some View {
@@ -927,7 +981,7 @@ struct ControlPanelView: View {
     }
 
     private var unpinnedSessions: [ControlPanelRecentSession] {
-        recentSessions.filter { !$0.pinned }
+        recentSessions.filter { !$0.pinned }.sorted(by: ControlPanelRecentSession.sessionSort)
     }
 
     @ViewBuilder
@@ -999,28 +1053,6 @@ struct ControlPanelView: View {
             return false
         }
         order.append(draggedID)
-        withAnimation(.snappy(duration: 0.2)) {
-            chat.applyPinnedOrder(order)
-        }
-        return true
-    }
-
-    private func handlePinnedRowDrop(
-        _ items: [String],
-        target: ControlPanelRecentSession
-    ) -> Bool {
-        guard let draggedID = draggedChatID(from: items),
-              let targetID = target.chatID,
-              draggedID != targetID else {
-            return false
-        }
-        var order = pinnedSessions.compactMap(\.chatID)
-        order.removeAll { $0 == draggedID }
-        if let targetIndex = order.firstIndex(of: targetID) {
-            order.insert(draggedID, at: targetIndex)
-        } else {
-            order.append(draggedID)
-        }
         withAnimation(.snappy(duration: 0.2)) {
             chat.applyPinnedOrder(order)
         }
@@ -2691,6 +2723,42 @@ private enum ControlPanelSidebarSelection: Hashable {
     case imageGeneration(UUID)
 }
 
+private struct RowReorderDropDelegate: DropDelegate {
+    let targetID: ControlPanelRecentSession.ID
+    let setTarget: (ControlPanelRecentSession.ID?, Bool) -> Void
+    let onDrop: (String, Bool) -> Void
+    private let rowHeight: CGFloat = 30
+
+    func dropEntered(info: DropInfo) {
+        setTarget(targetID, info.location.y > rowHeight / 2)
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        setTarget(targetID, info.location.y > rowHeight / 2)
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) {
+        setTarget(nil, false)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let insertAfter = info.location.y > rowHeight / 2
+        setTarget(nil, false)
+        guard let provider = info.itemProviders(for: [.text]).first else {
+            return false
+        }
+        provider.loadObject(ofClass: NSString.self) { object, _ in
+            if let string = object as? String, !string.isEmpty {
+                DispatchQueue.main.async {
+                    onDrop(string, insertAfter)
+                }
+            }
+        }
+        return true
+    }
+}
+
 private struct ControlPanelRecentSession: Identifiable, Equatable {
     enum ID: Hashable {
         case chat(UUID)
@@ -2703,6 +2771,7 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
     let updatedAt: Date
     let pinned: Bool
     let pinnedOrder: Int?
+    let sessionOrder: Int?
 
     init(chat session: ChatSessionSummary) {
         id = .chat(session.id)
@@ -2711,6 +2780,7 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
         updatedAt = session.updatedAt
         pinned = session.isPinned
         pinnedOrder = session.pinnedOrder
+        sessionOrder = session.sessionOrder
     }
 
     init(imageGeneration session: ImageGenerationSessionSummary) {
@@ -2720,6 +2790,7 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
         updatedAt = session.updatedAt
         pinned = false
         pinnedOrder = nil
+        sessionOrder = nil
     }
 
     var chatID: UUID? {
@@ -2772,6 +2843,19 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
         case (_?, nil):
             return true
         case (nil, _?):
+            return false
+        case (nil, nil):
+            return recencySort(lhs, rhs)
+        }
+    }
+
+    static func sessionSort(_ lhs: ControlPanelRecentSession, _ rhs: ControlPanelRecentSession) -> Bool {
+        switch (lhs.sessionOrder, rhs.sessionOrder) {
+        case let (left?, right?):
+            return left == right ? recencySort(lhs, rhs) : left < right
+        case (nil, _?):
+            return true
+        case (_?, nil):
             return false
         case (nil, nil):
             return recencySort(lhs, rhs)

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -533,11 +533,13 @@ struct ControlPanelView: View {
                 emptyPinnedHint
             } else {
                 ForEach(pinnedSessions) { recent in
-                    VStack(alignment: .leading, spacing: 0) {
-                        pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter)
-                        draggableRow(recent, isPinnedRow: true)
-                        pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter)
-                    }
+                    draggableRow(recent, isPinnedRow: true)
+                        .overlay(alignment: .top) {
+                            pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter && isPinnedDropTargeted)
+                        }
+                        .overlay(alignment: .bottom) {
+                            pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter && isPinnedDropTargeted)
+                        }
                 }
             }
         }
@@ -557,11 +559,13 @@ struct ControlPanelView: View {
                 .padding(.bottom, 4)
 
             ForEach(unpinnedSessions) { recent in
-                VStack(alignment: .leading, spacing: 0) {
-                    pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter)
-                    draggableRow(recent, isPinnedRow: false)
-                    pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter)
-                }
+                draggableRow(recent, isPinnedRow: false)
+                    .overlay(alignment: .top) {
+                        pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter && isSessionsDropTargeted)
+                    }
+                    .overlay(alignment: .bottom) {
+                        pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter && isSessionsDropTargeted)
+                    }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -601,8 +605,10 @@ struct ControlPanelView: View {
                 .onDrop(of: [.text], delegate: RowReorderDropDelegate(
                     targetID: recent.id,
                     setTarget: { id, after in
-                        reorderTargetID = id
-                        reorderInsertAfter = after
+                        if reorderTargetID != id || reorderInsertAfter != after {
+                            reorderTargetID = id
+                            reorderInsertAfter = after
+                        }
                     },
                     onDrop: { draggedPayload, after in
                         handleRowDrop(

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -233,6 +233,9 @@ struct ControlPanelView: View {
     @State private var selectedRecentIDs: Set<ControlPanelRecentSession.ID> = []
     @State private var isPinnedDropTargeted = false
     @State private var isSessionsDropTargeted = false
+    @State private var reorderTargetID: ControlPanelRecentSession.ID?
+    @State private var pendingDeleteRecent: ControlPanelRecentSession?
+    @State private var isConfirmingBulkDelete = false
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -390,6 +393,35 @@ struct ControlPanelView: View {
                 isFullScreen: isFullScreen
             )
         )
+        .alert(
+            "Delete chat?",
+            isPresented: Binding(
+                get: { pendingDeleteRecent != nil },
+                set: { if !$0 { pendingDeleteRecent = nil } }
+            ),
+            presenting: pendingDeleteRecent
+        ) { recent in
+            Button("Delete", role: .destructive) {
+                deleteRecentSession(recent)
+                pendingDeleteRecent = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDeleteRecent = nil
+            }
+        } message: { recent in
+            Text("“\(recent.title)” will be permanently deleted.")
+        }
+        .alert(
+            "Delete \(selectedRecentIDs.count) chats?",
+            isPresented: $isConfirmingBulkDelete
+        ) {
+            Button("Delete", role: .destructive) {
+                bulkDeleteSelected()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("The selected chats will be permanently deleted.")
+        }
     }
 
     private var resizableSidebar: some View {
@@ -500,7 +532,10 @@ struct ControlPanelView: View {
                 emptyPinnedHint
             } else {
                 ForEach(pinnedSessions) { recent in
-                    draggableRow(recent, isPinnedRow: true)
+                    VStack(alignment: .leading, spacing: 0) {
+                        pinnedInsertionLine(visible: reorderTargetID == recent.id)
+                        draggableRow(recent, isPinnedRow: true)
+                    }
                 }
             }
         }
@@ -555,7 +590,15 @@ struct ControlPanelView: View {
                 recentSessionRow(recent)
                     .draggable(payload)
                     .dropDestination(for: String.self) { items, _ in
-                        handlePinnedRowDrop(items, target: recent)
+                        let handled = handlePinnedRowDrop(items, target: recent)
+                        reorderTargetID = nil
+                        return handled
+                    } isTargeted: { targeted in
+                        if targeted {
+                            reorderTargetID = recent.id
+                        } else if reorderTargetID == recent.id {
+                            reorderTargetID = nil
+                        }
                     }
             } else {
                 recentSessionRow(recent)
@@ -564,6 +607,15 @@ struct ControlPanelView: View {
         } else {
             recentSessionRow(recent)
         }
+    }
+
+    private func pinnedInsertionLine(visible: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 1)
+            .fill(Color.accentColor)
+            .frame(height: 2)
+            .padding(.horizontal, 8)
+            .opacity(visible ? 1 : 0)
+            .animation(.easeOut(duration: 0.12), value: visible)
     }
 
     private var bulkSelectionBar: some View {
@@ -593,7 +645,7 @@ struct ControlPanelView: View {
             .disabled(!hasSelectedChats)
 
             Button(role: .destructive) {
-                bulkDeleteSelected()
+                isConfirmingBulkDelete = true
             } label: {
                 Image(systemName: "trash")
                     .frame(width: 24, height: 22)
@@ -876,7 +928,7 @@ struct ControlPanelView: View {
                 applySidebarSelection(recent.selection)
             },
             onDelete: {
-                deleteRecentSession(recent)
+                pendingDeleteRecent = recent
             },
             onCopyConversation: {
                 copyRecentConversation(recent)

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -229,6 +229,10 @@ struct ControlPanelView: View {
     @State private var isFullScreen = false
     @State private var windowControlsRefreshTrigger = 0
     @State private var isNewChatHovering = false
+    @State private var isSelectingRecents = false
+    @State private var selectedRecentIDs: Set<ControlPanelRecentSession.ID> = []
+    @State private var isPinnedDropTargeted = false
+    @State private var isSessionsDropTargeted = false
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -350,34 +354,16 @@ struct ControlPanelView: View {
                 .padding(.horizontal, 10)
                 .padding(.bottom, 10)
 
+            if isSelectingRecents {
+                bulkSelectionBar
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 8)
+            }
+
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    sidebarPinnedHeader
-                        .padding(.leading, 17)
-                        .padding(.trailing, 10)
-                        .padding(.bottom, 4)
-
-                    if pinnedSessions.isEmpty {
-                        Label("Shift-click a chat to pin", systemImage: "pin")
-                            .font(.system(size: 13))
-                            .foregroundStyle(.secondary.opacity(0.6))
-                            .padding(.horizontal, 17)
-                            .padding(.vertical, 6)
-                    } else {
-                        ForEach(pinnedSessions) { recent in
-                            recentSessionRow(recent)
-                        }
-                    }
-
-                    sidebarRecentsHeader
-                        .padding(.leading, 17)
-                        .padding(.trailing, 10)
-                        .padding(.top, 12)
-                        .padding(.bottom, 4)
-
-                    ForEach(unpinnedSessions) { recent in
-                        recentSessionRow(recent)
-                    }
+                    pinnedSection
+                    sessionsSection
                 }
                 .padding(.horizontal, 10)
                 .padding(.bottom, 8)
@@ -503,6 +489,135 @@ struct ControlPanelView: View {
         }
     }
 
+    private var pinnedSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sidebarPinnedHeader
+                .padding(.leading, 17)
+                .padding(.trailing, 10)
+                .padding(.bottom, 4)
+
+            if pinnedSessions.isEmpty {
+                emptyPinnedHint
+            } else {
+                ForEach(pinnedSessions) { recent in
+                    draggableRow(recent, isPinnedRow: true)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(dropHighlight(isTargeted: isPinnedDropTargeted))
+        .dropDestination(for: String.self) { items, _ in
+            handlePinDrop(items)
+        } isTargeted: { isPinnedDropTargeted = $0 }
+    }
+
+    private var sessionsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sidebarRecentsHeader
+                .padding(.leading, 17)
+                .padding(.trailing, 10)
+                .padding(.top, 12)
+                .padding(.bottom, 4)
+
+            ForEach(unpinnedSessions) { recent in
+                draggableRow(recent, isPinnedRow: false)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(dropHighlight(isTargeted: isSessionsDropTargeted))
+        .dropDestination(for: String.self) { items, _ in
+            handleUnpinDrop(items)
+        } isTargeted: { isSessionsDropTargeted = $0 }
+    }
+
+    private var emptyPinnedHint: some View {
+        Label("Drag a chat here to pin", systemImage: "pin")
+            .font(.system(size: 13))
+            .foregroundStyle(.secondary.opacity(0.6))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 17)
+            .padding(.vertical, 10)
+            .contentShape(.rect)
+    }
+
+    private func dropHighlight(isTargeted: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(Color.accentColor.opacity(isTargeted ? 0.08 : 0))
+    }
+
+    @ViewBuilder
+    private func draggableRow(
+        _ recent: ControlPanelRecentSession,
+        isPinnedRow: Bool
+    ) -> some View {
+        if let payload = recent.dragPayload, !isSelectingRecents {
+            if isPinnedRow {
+                recentSessionRow(recent)
+                    .draggable(payload)
+                    .dropDestination(for: String.self) { items, _ in
+                        handlePinnedRowDrop(items, target: recent)
+                    }
+            } else {
+                recentSessionRow(recent)
+                    .draggable(payload)
+            }
+        } else {
+            recentSessionRow(recent)
+        }
+    }
+
+    private var bulkSelectionBar: some View {
+        HStack(spacing: 6) {
+            Text(bulkSelectionTitle)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 0)
+
+            Button {
+                bulkTogglePinSelected()
+            } label: {
+                Image(systemName: allSelectedChatsPinned ? "pin.slash" : "pin")
+                    .frame(width: 24, height: 22)
+            }
+            .help(allSelectedChatsPinned ? "Unpin selected" : "Pin selected")
+            .disabled(!hasSelectedChats)
+
+            Button {
+                bulkExportSelected()
+            } label: {
+                Image(systemName: "square.and.arrow.up")
+                    .frame(width: 24, height: 22)
+            }
+            .help("Export selected")
+            .disabled(!hasSelectedChats)
+
+            Button(role: .destructive) {
+                bulkDeleteSelected()
+            } label: {
+                Image(systemName: "trash")
+                    .frame(width: 24, height: 22)
+            }
+            .help("Delete selected")
+            .disabled(selectedRecentIDs.isEmpty)
+
+            Button("Done") {
+                withAnimation(.snappy(duration: 0.2)) {
+                    exitSelectMode()
+                }
+            }
+            .font(.system(size: 12, weight: .medium))
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.secondary.opacity(0.08))
+        )
+    }
+
     private var sidebarPinnedHeader: some View {
         HStack(spacing: 8) {
             Text("Pinned")
@@ -520,6 +635,21 @@ struct ControlPanelView: View {
                 .foregroundStyle(.secondary.opacity(0.7))
 
             Spacer(minLength: 0)
+
+            Button {
+                withAnimation(.snappy(duration: 0.2)) {
+                    enterSelectMode()
+                }
+            } label: {
+                Image(systemName: "checklist")
+                    .font(.system(size: 14, weight: .medium))
+                    .frame(width: 26, height: 28)
+                    .foregroundStyle(Color.secondary.opacity(0.7))
+            }
+            .buttonStyle(.plain)
+            .disabled(isSelectingRecents || recentSessions.isEmpty)
+            .help("Select multiple")
+            .opacity(isSelectingRecents ? 0 : 1)
 
             Button {
                 withAnimation(.snappy(duration: 0.2)) {
@@ -719,7 +849,9 @@ struct ControlPanelView: View {
     }
 
     private var pinnedSessions: [ControlPanelRecentSession] {
-        recentSessions.filter(\.pinned)
+        recentSessions
+            .filter(\.pinned)
+            .sorted(by: ControlPanelRecentSession.pinnedSort)
     }
 
     private var unpinnedSessions: [ControlPanelRecentSession] {
@@ -735,6 +867,11 @@ struct ControlPanelView: View {
             isSelectionDisabled: isRecentSelectionDisabled(recent),
             isDeleteDisabled: isRecentDeleteDisabled(recent),
             canExport: canExportRecent(recent),
+            isSelecting: isSelectingRecents,
+            isChecked: selectedRecentIDs.contains(recent.id),
+            onToggleSelect: {
+                toggleRecentSelection(recent)
+            },
             onSelect: {
                 applySidebarSelection(recent.selection)
             },
@@ -769,6 +906,177 @@ struct ControlPanelView: View {
         withAnimation(.snappy(duration: 0.2)) {
             chat.setPinned(sessionID, pinned: !recent.pinned)
         }
+    }
+
+    private func draggedChatID(from items: [String]) -> UUID? {
+        for item in items {
+            if let id = UUID(uuidString: item),
+               chat.sessions.contains(where: { $0.id == id }) {
+                return id
+            }
+        }
+        return nil
+    }
+
+    private func handlePinDrop(_ items: [String]) -> Bool {
+        guard let draggedID = draggedChatID(from: items) else {
+            return false
+        }
+        var order = pinnedSessions.compactMap(\.chatID)
+        guard !order.contains(draggedID) else {
+            return false
+        }
+        order.append(draggedID)
+        withAnimation(.snappy(duration: 0.2)) {
+            chat.applyPinnedOrder(order)
+        }
+        return true
+    }
+
+    private func handlePinnedRowDrop(
+        _ items: [String],
+        target: ControlPanelRecentSession
+    ) -> Bool {
+        guard let draggedID = draggedChatID(from: items),
+              let targetID = target.chatID,
+              draggedID != targetID else {
+            return false
+        }
+        var order = pinnedSessions.compactMap(\.chatID)
+        order.removeAll { $0 == draggedID }
+        if let targetIndex = order.firstIndex(of: targetID) {
+            order.insert(draggedID, at: targetIndex)
+        } else {
+            order.append(draggedID)
+        }
+        withAnimation(.snappy(duration: 0.2)) {
+            chat.applyPinnedOrder(order)
+        }
+        return true
+    }
+
+    private func handleUnpinDrop(_ items: [String]) -> Bool {
+        guard let draggedID = draggedChatID(from: items),
+              pinnedSessions.contains(where: { $0.chatID == draggedID }) else {
+            return false
+        }
+        withAnimation(.snappy(duration: 0.2)) {
+            chat.setPinned(draggedID, pinned: false)
+        }
+        return true
+    }
+
+    private func enterSelectMode() {
+        selectedRecentIDs = []
+        isSelectingRecents = true
+    }
+
+    private func exitSelectMode() {
+        isSelectingRecents = false
+        selectedRecentIDs = []
+    }
+
+    private func toggleRecentSelection(_ recent: ControlPanelRecentSession) {
+        if selectedRecentIDs.contains(recent.id) {
+            selectedRecentIDs.remove(recent.id)
+        } else {
+            selectedRecentIDs.insert(recent.id)
+        }
+    }
+
+    private var selectedChats: [ControlPanelRecentSession] {
+        recentSessions.filter { $0.isChat && selectedRecentIDs.contains($0.id) }
+    }
+
+    private var hasSelectedChats: Bool {
+        !selectedChats.isEmpty
+    }
+
+    private var allSelectedChatsPinned: Bool {
+        hasSelectedChats && selectedChats.allSatisfy(\.pinned)
+    }
+
+    private var bulkSelectionTitle: String {
+        let count = selectedRecentIDs.count
+        return count == 0 ? "Select chats" : "\(count) selected"
+    }
+
+    private func bulkTogglePinSelected() {
+        let shouldPin = !allSelectedChatsPinned
+        let ids = selectedChats.compactMap(\.chatID)
+        guard !ids.isEmpty else {
+            return
+        }
+        withAnimation(.snappy(duration: 0.2)) {
+            for id in ids {
+                chat.setPinned(id, pinned: shouldPin)
+            }
+            exitSelectMode()
+        }
+    }
+
+    private func bulkExportSelected() {
+        let chats = selectedChats
+        guard !chats.isEmpty else {
+            return
+        }
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Export"
+        guard panel.runModal() == .OK, let directory = panel.url else {
+            return
+        }
+        for recent in chats {
+            guard case .chat(let sessionID) = recent.selection,
+                  let text = chat.conversationText(for: sessionID) else {
+                continue
+            }
+            let url = uniqueExportURL(in: directory, title: recent.title)
+            try? text.write(to: url, atomically: true, encoding: .utf8)
+        }
+        exitSelectMode()
+    }
+
+    private func uniqueExportURL(in directory: URL, title: String) -> URL {
+        let separators = CharacterSet(charactersIn: "/:")
+        let sanitized = title.components(separatedBy: separators).joined(separator: "-")
+        let base = sanitized.isEmpty ? "Chat" : sanitized
+        var candidate = directory.appendingPathComponent("\(base).txt")
+        var counter = 2
+        while FileManager.default.fileExists(atPath: candidate.path) {
+            candidate = directory.appendingPathComponent("\(base) \(counter).txt")
+            counter += 1
+        }
+        return candidate
+    }
+
+    private func bulkDeleteSelected() {
+        let targets = recentSessions.filter { selectedRecentIDs.contains($0.id) }
+        guard !targets.isEmpty else {
+            return
+        }
+        let affectsDisplayed = targets.contains { isDisplayedRecent($0) }
+        let removedIDs = selectedRecentIDs
+        withAnimation(.snappy(duration: 0.2)) {
+            for recent in targets {
+                switch recent.selection {
+                case .chat(let sessionID):
+                    chat.deleteSession(sessionID)
+                case .imageGeneration(let sessionID):
+                    imageGeneration.deleteSession(sessionID)
+                case .tab:
+                    break
+                }
+            }
+            exitSelectMode()
+        }
+        guard affectsDisplayed else {
+            return
+        }
+        let survivor = recentSessions.first { !removedIDs.contains($0.id) }
+        applySidebarSelection(survivor?.selection ?? .tab(selectedTab))
     }
 
     private func renameRecentSession(_ recent: ControlPanelRecentSession, to newTitle: String) {
@@ -2322,6 +2630,7 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
     let createdAt: Date
     let updatedAt: Date
     let pinned: Bool
+    let pinnedOrder: Int?
 
     init(chat session: ChatSessionSummary) {
         id = .chat(session.id)
@@ -2329,6 +2638,7 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
         createdAt = session.createdAt
         updatedAt = session.updatedAt
         pinned = session.isPinned
+        pinnedOrder = session.pinnedOrder
     }
 
     init(imageGeneration session: ImageGenerationSessionSummary) {
@@ -2337,6 +2647,18 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
         createdAt = session.createdAt
         updatedAt = session.updatedAt
         pinned = false
+        pinnedOrder = nil
+    }
+
+    var chatID: UUID? {
+        if case .chat(let sessionID) = id {
+            return sessionID
+        }
+        return nil
+    }
+
+    var dragPayload: String? {
+        chatID?.uuidString
     }
 
     var selection: ControlPanelSidebarSelection {
@@ -2370,6 +2692,19 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
         }
         return lhs.updatedAt > rhs.updatedAt
     }
+
+    static func pinnedSort(_ lhs: ControlPanelRecentSession, _ rhs: ControlPanelRecentSession) -> Bool {
+        switch (lhs.pinnedOrder, rhs.pinnedOrder) {
+        case let (left?, right?):
+            return left == right ? recencySort(lhs, rhs) : left < right
+        case (_?, nil):
+            return true
+        case (nil, _?):
+            return false
+        case (nil, nil):
+            return recencySort(lhs, rhs)
+        }
+    }
 }
 
 private struct ControlPanelRecentSessionRow: View {
@@ -2379,6 +2714,9 @@ private struct ControlPanelRecentSessionRow: View {
     let isSelectionDisabled: Bool
     let isDeleteDisabled: Bool
     let canExport: Bool
+    let isSelecting: Bool
+    let isChecked: Bool
+    let onToggleSelect: () -> Void
     let onSelect: () -> Void
     let onDelete: () -> Void
     let onCopyConversation: () -> Void
@@ -2415,8 +2753,8 @@ private struct ControlPanelRecentSessionRow: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 Button {
-                    if NSEvent.modifierFlags.contains(.shift), recent.isChat {
-                        onTogglePin()
+                    if isSelecting {
+                        onToggleSelect()
                     } else if isSelected, recent.isChat {
                         beginRename()
                     } else {
@@ -2424,10 +2762,17 @@ private struct ControlPanelRecentSessionRow: View {
                     }
                 } label: {
                     HStack(spacing: 7) {
-                        Circle()
-                            .fill(isCurrent ? Color.accentColor : Color.clear)
-                            .frame(width: 5, height: 5)
-                            .accessibilityHidden(true)
+                        if isSelecting {
+                            Image(systemName: isChecked ? "checkmark.circle.fill" : "circle")
+                                .font(.system(size: 13))
+                                .foregroundStyle(isChecked ? Color.accentColor : Color.secondary)
+                                .accessibilityLabel(isChecked ? "Selected" : "Not selected")
+                        } else {
+                            Circle()
+                                .fill(isCurrent ? Color.accentColor : Color.clear)
+                                .frame(width: 5, height: 5)
+                                .accessibilityHidden(true)
+                        }
 
                         if let badgeSystemImage = recent.badgeSystemImage {
                             Image(systemName: badgeSystemImage)
@@ -2452,11 +2797,25 @@ private struct ControlPanelRecentSessionRow: View {
                     .contentShape(.rect)
                 }
                 .buttonStyle(.plain)
-                .disabled(isSelectionDisabled)
+                .disabled(isSelectionDisabled && !isSelecting)
                 .help(recent.title)
             }
 
-            if isHovering {
+            if isHovering, !isSelecting {
+                Menu {
+                    rowMenuContents
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.caption)
+                        .frame(width: 24, height: 20)
+                        .contentShape(.rect)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .foregroundStyle(.secondary)
+                .help("Actions")
+
                 Button(role: .destructive, action: onDelete) {
                     Image(systemName: "trash")
                         .font(.caption)
@@ -2475,53 +2834,58 @@ private struct ControlPanelRecentSessionRow: View {
                 .onHover { isDeleteHovering = $0 }
             }
         }
-        .sidebarRowSelectionStyle(isSelected: isSelected)
-        .opacity(isSelectionDisabled && !isCurrent ? 0.55 : 1)
+        .sidebarRowSelectionStyle(isSelected: isSelecting ? isChecked : isSelected)
+        .opacity(isSelectionDisabled && !isCurrent && !isSelecting ? 0.55 : 1)
         .onHover { isHovering = $0 }
         .animation(.easeInOut, value: isHovering)
         .contextMenu {
-            Button {
-                onNewChat()
-            } label: {
-                Label("New", systemImage: "square.and.pencil")
-            }
+            rowMenuContents
+        }
+    }
 
-            if recent.isChat {
-                Divider()
+    @ViewBuilder
+    private var rowMenuContents: some View {
+        Button {
+            onNewChat()
+        } label: {
+            Label("New", systemImage: "square.and.pencil")
+        }
 
-                Button {
-                    beginRename()
-                } label: {
-                    Label("Rename", systemImage: "pencil")
-                }
-
-                Button {
-                    onTogglePin()
-                } label: {
-                    Label(
-                        recent.pinned ? "Unpin" : "Pin",
-                        systemImage: recent.pinned ? "pin.slash" : "pin"
-                    )
-                }
-            }
-
+        if recent.isChat {
             Divider()
 
-            if canExport {
-                Button {
-                    onExportFile()
-                } label: {
-                    Label("Export", systemImage: "square.and.arrow.up")
-                }
+            Button {
+                beginRename()
+            } label: {
+                Label("Rename", systemImage: "pencil")
             }
 
-            Button(role: .destructive) {
-                onDelete()
+            Button {
+                onTogglePin()
             } label: {
-                Label("Delete", systemImage: "trash")
+                Label(
+                    recent.pinned ? "Unpin" : "Pin",
+                    systemImage: recent.pinned ? "pin.slash" : "pin"
+                )
             }
-            .disabled(isDeleteDisabled)
         }
+
+        Divider()
+
+        if canExport {
+            Button {
+                onExportFile()
+            } label: {
+                Label("Export", systemImage: "square.and.arrow.up")
+            }
+        }
+
+        Button(role: .destructive) {
+            onDelete()
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+        .disabled(isDeleteDisabled)
     }
 
     private func beginRename() {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -588,7 +588,7 @@ struct ControlPanelView: View {
         if let payload = recent.dragPayload, !isSelectingRecents {
             if isPinnedRow {
                 recentSessionRow(recent)
-                    .draggable(payload)
+                    .draggable(payload) { dragPreview(recent) }
                     .dropDestination(for: String.self) { items, _ in
                         let handled = handlePinnedRowDrop(items, target: recent)
                         reorderTargetID = nil
@@ -602,7 +602,7 @@ struct ControlPanelView: View {
                     }
             } else {
                 recentSessionRow(recent)
-                    .draggable(payload)
+                    .draggable(payload) { dragPreview(recent) }
             }
         } else {
             recentSessionRow(recent)
@@ -616,6 +616,26 @@ struct ControlPanelView: View {
             .padding(.horizontal, 8)
             .opacity(visible ? 1 : 0)
             .animation(.easeOut(duration: 0.12), value: visible)
+    }
+
+    private func dragPreview(_ recent: ControlPanelRecentSession) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "bubble.left")
+                .font(.system(size: 11))
+            Text(recent.title)
+                .font(.system(size: 13, weight: .medium))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(.regularMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.35), lineWidth: 1)
+        )
     }
 
     private var bulkSelectionBar: some View {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -638,12 +638,12 @@ struct ControlPanelView: View {
         } else {
             order.append(draggedID)
         }
-        withAnimation(.snappy(duration: 0.2)) {
-            if isPinnedRow {
-                chat.applyPinnedOrder(order)
-            } else {
-                chat.applySessionOrder(order)
-            }
+        reorderTargetID = nil
+        reorderInsertAfter = false
+        if isPinnedRow {
+            chat.applyPinnedOrder(order)
+        } else {
+            chat.applySessionOrder(order)
         }
     }
 
@@ -669,7 +669,6 @@ struct ControlPanelView: View {
             .frame(height: 2)
             .padding(.horizontal, 8)
             .opacity(visible ? 1 : 0)
-            .animation(.easeOut(duration: 0.12), value: visible)
     }
 
     private func dragPreview(_ recent: ControlPanelRecentSession) -> some View {
@@ -1029,9 +1028,7 @@ struct ControlPanelView: View {
         guard case .chat(let sessionID) = recent.selection else {
             return
         }
-        withAnimation(.snappy(duration: 0.2)) {
-            chat.setPinned(sessionID, pinned: !recent.pinned)
-        }
+        chat.setPinned(sessionID, pinned: !recent.pinned)
     }
 
     private func draggedChatID(from items: [String]) -> UUID? {
@@ -1053,9 +1050,9 @@ struct ControlPanelView: View {
             return false
         }
         order.append(draggedID)
-        withAnimation(.snappy(duration: 0.2)) {
-            chat.applyPinnedOrder(order)
-        }
+        reorderTargetID = nil
+        reorderInsertAfter = false
+        chat.applyPinnedOrder(order)
         return true
     }
 
@@ -1064,9 +1061,9 @@ struct ControlPanelView: View {
               pinnedSessions.contains(where: { $0.chatID == draggedID }) else {
             return false
         }
-        withAnimation(.snappy(duration: 0.2)) {
-            chat.setPinned(draggedID, pinned: false)
-        }
+        reorderTargetID = nil
+        reorderInsertAfter = false
+        chat.setPinned(draggedID, pinned: false)
         return true
     }
 
@@ -1111,12 +1108,10 @@ struct ControlPanelView: View {
         guard !ids.isEmpty else {
             return
         }
-        withAnimation(.snappy(duration: 0.2)) {
-            for id in ids {
-                chat.setPinned(id, pinned: shouldPin)
-            }
-            exitSelectMode()
+        for id in ids {
+            chat.setPinned(id, pinned: shouldPin)
         }
+        exitSelectMode()
     }
 
     private func bulkExportSelected() {

--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -11,6 +11,7 @@ struct ChatSession: Identifiable, Equatable, Codable {
     var updatedAt: Date
     var messages: [ChatTranscriptMessage]
     var pinned: Bool?
+    var pinnedOrder: Int?
 
     var summary: ChatSessionSummary {
         ChatSessionSummary(
@@ -19,7 +20,8 @@ struct ChatSession: Identifiable, Equatable, Codable {
             createdAt: createdAt,
             updatedAt: updatedAt,
             messageCount: messages.count,
-            isPinned: pinned ?? false
+            isPinned: pinned ?? false,
+            pinnedOrder: pinnedOrder
         )
     }
 
@@ -100,6 +102,7 @@ struct ChatSessionSummary: Identifiable, Equatable {
     let updatedAt: Date
     let messageCount: Int
     let isPinned: Bool
+    let pinnedOrder: Int?
 
     static func recencySort(_ lhs: ChatSessionSummary, _ rhs: ChatSessionSummary) -> Bool {
         if lhs.updatedAt == rhs.updatedAt {

--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -12,6 +12,7 @@ struct ChatSession: Identifiable, Equatable, Codable {
     var messages: [ChatTranscriptMessage]
     var pinned: Bool?
     var pinnedOrder: Int?
+    var sessionOrder: Int?
 
     var summary: ChatSessionSummary {
         ChatSessionSummary(
@@ -21,7 +22,8 @@ struct ChatSession: Identifiable, Equatable, Codable {
             updatedAt: updatedAt,
             messageCount: messages.count,
             isPinned: pinned ?? false,
-            pinnedOrder: pinnedOrder
+            pinnedOrder: pinnedOrder,
+            sessionOrder: sessionOrder
         )
     }
 
@@ -103,6 +105,7 @@ struct ChatSessionSummary: Identifiable, Equatable {
     let messageCount: Int
     let isPinned: Bool
     let pinnedOrder: Int?
+    let sessionOrder: Int?
 
     static func recencySort(_ lhs: ChatSessionSummary, _ rhs: ChatSessionSummary) -> Bool {
         if lhs.updatedAt == rhs.updatedAt {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -353,12 +353,35 @@ final class ChatViewModel: ObservableObject {
         guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
             return
         }
+        let order = pinned ? nextPinnedOrder() : nil
         storedSessions[index].pinned = pinned
+        storedSessions[index].pinnedOrder = order
         if currentSession?.id == sessionID {
             currentSession?.pinned = pinned
+            currentSession?.pinnedOrder = order
         }
         sessionStore.saveSession(storedSessions[index])
         refreshSessionList()
+    }
+
+    func applyPinnedOrder(_ orderedSessionIDs: [UUID]) {
+        for (order, sessionID) in orderedSessionIDs.enumerated() {
+            guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
+                continue
+            }
+            storedSessions[index].pinned = true
+            storedSessions[index].pinnedOrder = order
+            if currentSession?.id == sessionID {
+                currentSession?.pinned = true
+                currentSession?.pinnedOrder = order
+            }
+            sessionStore.saveSession(storedSessions[index])
+        }
+        refreshSessionList()
+    }
+
+    private func nextPinnedOrder() -> Int {
+        (storedSessions.compactMap(\.pinnedOrder).max() ?? -1) + 1
     }
 
     func deleteSession(_ sessionID: UUID) {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -380,6 +380,24 @@ final class ChatViewModel: ObservableObject {
         refreshSessionList()
     }
 
+    func applySessionOrder(_ orderedSessionIDs: [UUID]) {
+        for (order, sessionID) in orderedSessionIDs.enumerated() {
+            guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
+                continue
+            }
+            storedSessions[index].pinned = false
+            storedSessions[index].pinnedOrder = nil
+            storedSessions[index].sessionOrder = order
+            if currentSession?.id == sessionID {
+                currentSession?.pinned = false
+                currentSession?.pinnedOrder = nil
+                currentSession?.sessionOrder = order
+            }
+            sessionStore.saveSession(storedSessions[index])
+        }
+        refreshSessionList()
+    }
+
     private func nextPinnedOrder() -> Int {
         (storedSessions.compactMap(\.pinnedOrder).max() ?? -1) + 1
     }


### PR DESCRIPTION

Replace shift-click pinning with drag-and-drop for pinning, unpinning, and reordering pinned chats, backed by a persisted pinnedOrder so the arrangement survives restarts. Add a per-row actions menu (shared with the right-click menu) and a multi-select mode for bulk pin, export, and delete.


edit: video below


https://github.com/user-attachments/assets/6eee77d1-b1ce-4aba-bfa1-c27a16808357

