### PR TITLE
Fix Discover sort-by-size (invalid Hugging Face API parameter)

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -43,6 +43,10 @@ enum HuggingFaceModelSort: String, CaseIterable, Hashable, Identifiable, Sendabl
 
     /// Whether results are re-sorted client-side by model size.
     var sortsBySize: Bool { self == .size }
+
+    var apiSortValue: String {
+        self == .size ? "downloads" : rawValue
+    }
 }
 
 struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
@@ -329,7 +333,7 @@ private struct HuggingFaceHubClient: Sendable {
 
         var queryItems = [
             URLQueryItem(name: "filter", value: "safetensors"),
-            URLQueryItem(name: "sort", value: sort.rawValue),
+            URLQueryItem(name: "sort", value: sort.apiSortValue),
             URLQueryItem(name: "direction", value: "-1"),
             URLQueryItem(name: "limit", value: "50")
         ]


### PR DESCRIPTION
Sorting the Discover list by **Size** sent `sort=size` to the Hugging Face API, which rejects it (`Invalid sort parameter: size`) — so the list showed **0 results** with a "Hugging Face is unavailable" error.

The Hub API has no `size` sort; results are already re-sorted client-side by size (`orderedBuffer`, gated on `sortsBySize`). This sends a valid ordering (`downloads`) for the Size option and lets the existing client-side re-sort produce the size ordering.

I used to get this:
<img width="937" height="188" alt="Screenshot 2026-07-30 at 4 51 37 PM" src="https://github.com/user-attachments/assets/0c3551a5-32ad-407f-8910-ea6ca0dc15d2" />

