### PR TITLE
Per-model configuration profiles

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -235,8 +235,8 @@ struct ChatComposer: View {
             disableThinkingIfUnsupported(modelID: selectedModelID, models: models)
             applyInitialReasoningDefaultIfNeeded(modelID: selectedModelID, models: models)
         }
-        .onChange(of: selectedModelID) { _, modelID in
-            configureReasoningForSelectedModel(modelID: modelID, models: localLibrary.models)
+        .onChange(of: selectedModelID) { oldModelID, newModelID in
+            applyModelConfigOnSwitch(from: oldModelID, to: newModelID, models: localLibrary.models)
         }
         .onDisappear {
             localLibrary.cancel()
@@ -364,6 +364,9 @@ struct ChatComposer: View {
                     return
                 }
                 applyReasoningLevel(level)
+                if let modelID = selectedModelID {
+                    model.settings.rememberProfile(forModel: modelID)
+                }
             }
         )
     }
@@ -388,13 +391,7 @@ struct ChatComposer: View {
             to: localModel,
             for: .language,
             availableModels: localLibrary.models
-        ) {
-            if localModel.capabilities.contains(.reasoning) {
-                applyReasoningLevel(.max)
-            } else {
-                model.settings.thinkingEnabled = false
-            }
-        }
+        ) {}
     }
 
     private func applyReasoningLevel(_ level: ChatReasoningLevel) {
@@ -428,32 +425,47 @@ struct ChatComposer: View {
     ) {
         guard !didApplyInitialReasoningDefault,
               let modelID,
-              let localModel = models.first(where: { $0.repoID == modelID })
+              models.contains(where: { $0.repoID == modelID })
         else {
             return
         }
 
         didApplyInitialReasoningDefault = true
-        if localModel.capabilities.contains(.reasoning) {
-            applyReasoningLevel(.max)
+        if let profile = model.settings.modelProfile(for: modelID) {
+            model.settings.applyProfile(profile)
+        } else {
+            model.settings.rememberProfile(forModel: modelID)
         }
     }
 
-    private func configureReasoningForSelectedModel(
-        modelID: String?,
+    private func applyModelConfigOnSwitch(
+        from oldModelID: String?,
+        to newModelID: String?,
         models: [LocalModel]
     ) {
-        guard let modelID,
-              let localModel = models.first(where: { $0.repoID == modelID })
-        else {
+        if let oldModelID, !oldModelID.isEmpty {
+            model.settings.rememberProfile(forModel: oldModelID)
+        }
+        guard let newModelID, !newModelID.isEmpty else {
             return
         }
+        applyModelConfig(to: newModelID, models: models)
+    }
 
-        if localModel.capabilities.contains(.reasoning) {
+    private func applyModelConfig(to modelID: String, models: [LocalModel]) {
+        if let profile = model.settings.modelProfile(for: modelID) {
+            model.settings.applyProfile(profile)
+            return
+        }
+        let isReasoning = models.first(where: { $0.repoID == modelID })?
+            .capabilities.contains(.reasoning) == true
+        if isReasoning {
             applyReasoningLevel(.max)
         } else {
             model.settings.thinkingEnabled = false
         }
+        model.settings.speculativeDecodingEnabled = false
+        model.settings.rememberProfile(forModel: modelID)
     }
 
     private func provider(for modelID: String) -> LocalModelProvider? {

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -238,6 +238,12 @@ struct ChatComposer: View {
         .onChange(of: selectedModelID) { oldModelID, newModelID in
             applyModelConfigOnSwitch(from: oldModelID, to: newModelID, models: localLibrary.models)
         }
+        .onChange(of: model.settings.currentModelProfile) { _, _ in
+            guard let modelID = selectedModelID, !modelID.isEmpty else {
+                return
+            }
+            model.settings.rememberProfile(forModel: modelID)
+        }
         .onDisappear {
             localLibrary.cancel()
         }
@@ -364,9 +370,6 @@ struct ChatComposer: View {
                     return
                 }
                 applyReasoningLevel(level)
-                if let modelID = selectedModelID {
-                    model.settings.rememberProfile(forModel: modelID)
-                }
             }
         )
     }
@@ -433,6 +436,7 @@ struct ChatComposer: View {
         didApplyInitialReasoningDefault = true
         if let profile = model.settings.modelProfile(for: modelID) {
             model.settings.applyProfile(profile)
+            disableThinkingIfUnsupported(modelID: modelID, models: models)
         } else {
             model.settings.rememberProfile(forModel: modelID)
         }
@@ -455,6 +459,7 @@ struct ChatComposer: View {
     private func applyModelConfig(to modelID: String, models: [LocalModel]) {
         if let profile = model.settings.modelProfile(for: modelID) {
             model.settings.applyProfile(profile)
+            disableThinkingIfUnsupported(modelID: modelID, models: models)
             return
         }
         let isReasoning = models.first(where: { $0.repoID == modelID })?

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -270,6 +270,47 @@ struct ModelPreloadMemoryWarning: Equatable, Identifiable, Sendable {
     }
 }
 
+struct ModelConfigProfile: Codable, Equatable {
+    var thinkingEnabled: Bool
+    var thinkingBudgetEnabled: Bool
+    var thinkingBudget: Int
+    var speculativeDecodingEnabled: Bool
+    var draftModelID: String
+    var draftKind: String
+
+    init(
+        thinkingEnabled: Bool = false,
+        thinkingBudgetEnabled: Bool = false,
+        thinkingBudget: Int = 512,
+        speculativeDecodingEnabled: Bool = false,
+        draftModelID: String = "",
+        draftKind: String = "auto"
+    ) {
+        self.thinkingEnabled = thinkingEnabled
+        self.thinkingBudgetEnabled = thinkingBudgetEnabled
+        self.thinkingBudget = thinkingBudget
+        self.speculativeDecodingEnabled = speculativeDecodingEnabled
+        self.draftModelID = draftModelID
+        self.draftKind = draftKind
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case thinkingEnabled, thinkingBudgetEnabled, thinkingBudget
+        case speculativeDecodingEnabled, draftModelID, draftKind
+    }
+
+    init(from decoder: Decoder) throws {
+        let defaults = ModelConfigProfile()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        thinkingEnabled = try container.decodeIfPresent(Bool.self, forKey: .thinkingEnabled) ?? defaults.thinkingEnabled
+        thinkingBudgetEnabled = try container.decodeIfPresent(Bool.self, forKey: .thinkingBudgetEnabled) ?? defaults.thinkingBudgetEnabled
+        thinkingBudget = try container.decodeIfPresent(Int.self, forKey: .thinkingBudget) ?? defaults.thinkingBudget
+        speculativeDecodingEnabled = try container.decodeIfPresent(Bool.self, forKey: .speculativeDecodingEnabled) ?? defaults.speculativeDecodingEnabled
+        draftModelID = try container.decodeIfPresent(String.self, forKey: .draftModelID) ?? defaults.draftModelID
+        draftKind = try container.decodeIfPresent(String.self, forKey: .draftKind) ?? defaults.draftKind
+    }
+}
+
 struct NativSettings: Codable, Equatable {
     /// Default hub cache location, resolved from the environment.
     /// See `HuggingFaceCache.defaultHubPath`.
@@ -321,6 +362,7 @@ struct NativSettings: Codable, Equatable {
     var prefixCachingEnabled: Bool
     var prefixCacheBlocks: Int
     var prefixCacheBlockSize: Int
+    var modelConfigs: [String: ModelConfigProfile]
 
     init(
         modelSearchPath: String = Self.defaultModelSearchPath,
@@ -362,7 +404,8 @@ struct NativSettings: Codable, Equatable {
         structuredOutputSchema: String = Self.defaultStructuredOutputSchema,
         prefixCachingEnabled: Bool = false,
         prefixCacheBlocks: Int = 2048,
-        prefixCacheBlockSize: Int = 16
+        prefixCacheBlockSize: Int = 16,
+        modelConfigs: [String: ModelConfigProfile] = [:]
     ) {
         self.modelSearchPath = modelSearchPath
         self.additionalModelSearchPaths = additionalModelSearchPaths
@@ -404,6 +447,7 @@ struct NativSettings: Codable, Equatable {
         self.prefixCachingEnabled = prefixCachingEnabled
         self.prefixCacheBlocks = prefixCacheBlocks
         self.prefixCacheBlockSize = prefixCacheBlockSize
+        self.modelConfigs = modelConfigs
     }
 
     enum CodingKeys: String, CodingKey {
@@ -448,6 +492,7 @@ struct NativSettings: Codable, Equatable {
         case prefixCachingEnabled
         case prefixCacheBlocks
         case prefixCacheBlockSize
+        case modelConfigs
     }
 
     init(from decoder: Decoder) throws {
@@ -495,6 +540,7 @@ struct NativSettings: Codable, Equatable {
         prefixCachingEnabled = try container.decodeIfPresent(Bool.self, forKey: .prefixCachingEnabled) ?? defaults.prefixCachingEnabled
         prefixCacheBlocks = try container.decodeIfPresent(Int.self, forKey: .prefixCacheBlocks) ?? defaults.prefixCacheBlocks
         prefixCacheBlockSize = try container.decodeIfPresent(Int.self, forKey: .prefixCacheBlockSize) ?? defaults.prefixCacheBlockSize
+        modelConfigs = try container.decodeIfPresent([String: ModelConfigProfile].self, forKey: .modelConfigs) ?? defaults.modelConfigs
     }
 
     func encode(to encoder: Encoder) throws {
@@ -538,6 +584,38 @@ struct NativSettings: Codable, Equatable {
         try container.encode(prefixCachingEnabled, forKey: .prefixCachingEnabled)
         try container.encode(prefixCacheBlocks, forKey: .prefixCacheBlocks)
         try container.encode(prefixCacheBlockSize, forKey: .prefixCacheBlockSize)
+        try container.encode(modelConfigs, forKey: .modelConfigs)
+    }
+
+    var currentModelProfile: ModelConfigProfile {
+        ModelConfigProfile(
+            thinkingEnabled: thinkingEnabled,
+            thinkingBudgetEnabled: thinkingBudgetEnabled,
+            thinkingBudget: thinkingBudget,
+            speculativeDecodingEnabled: speculativeDecodingEnabled,
+            draftModelID: draftModelID,
+            draftKind: draftKind
+        )
+    }
+
+    func modelProfile(for modelID: String) -> ModelConfigProfile? {
+        modelConfigs[modelID]
+    }
+
+    mutating func rememberProfile(forModel modelID: String) {
+        guard !modelID.isEmpty else {
+            return
+        }
+        modelConfigs[modelID] = currentModelProfile
+    }
+
+    mutating func applyProfile(_ profile: ModelConfigProfile) {
+        thinkingEnabled = profile.thinkingEnabled
+        thinkingBudgetEnabled = profile.thinkingBudgetEnabled
+        thinkingBudget = profile.thinkingBudget
+        speculativeDecodingEnabled = profile.speculativeDecodingEnabled
+        draftModelID = profile.draftModelID
+        draftKind = profile.draftKind
     }
 
     static func load(

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -374,6 +374,75 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertEqual(warning?.estimatedWorkingSetBytes, 90)
     }
 
+    func testRememberProfileCapturesCurrentModelSettings() throws {
+        var settings = NativSettings()
+        settings.thinkingEnabled = true
+        settings.thinkingBudgetEnabled = true
+        settings.thinkingBudget = 1_024
+        settings.speculativeDecodingEnabled = true
+        settings.draftModelID = "org/drafter"
+        settings.draftKind = "mtp"
+
+        settings.rememberProfile(forModel: "org/main")
+
+        let profile = try XCTUnwrap(settings.modelProfile(for: "org/main"))
+        XCTAssertTrue(profile.thinkingEnabled)
+        XCTAssertTrue(profile.thinkingBudgetEnabled)
+        XCTAssertEqual(profile.thinkingBudget, 1_024)
+        XCTAssertTrue(profile.speculativeDecodingEnabled)
+        XCTAssertEqual(profile.draftModelID, "org/drafter")
+        XCTAssertEqual(profile.draftKind, "mtp")
+    }
+
+    func testApplyProfileRestoresSavedValues() {
+        var settings = NativSettings()
+        settings.applyProfile(
+            ModelConfigProfile(
+                thinkingEnabled: false,
+                thinkingBudgetEnabled: true,
+                thinkingBudget: 2_048,
+                speculativeDecodingEnabled: true,
+                draftModelID: "org/drafter",
+                draftKind: "ngram"
+            )
+        )
+
+        XCTAssertFalse(settings.thinkingEnabled)
+        XCTAssertTrue(settings.thinkingBudgetEnabled)
+        XCTAssertEqual(settings.thinkingBudget, 2_048)
+        XCTAssertTrue(settings.speculativeDecodingEnabled)
+        XCTAssertEqual(settings.draftModelID, "org/drafter")
+        XCTAssertEqual(settings.draftKind, "ngram")
+    }
+
+    func testModelConfigsRoundTripThroughCoding() throws {
+        var settings = NativSettings()
+        settings.thinkingEnabled = true
+        settings.draftModelID = "org/drafter"
+        settings.rememberProfile(forModel: "org/main")
+
+        let decoded = try JSONDecoder().decode(
+            NativSettings.self,
+            from: JSONEncoder().encode(settings)
+        )
+
+        let profile = try XCTUnwrap(decoded.modelProfile(for: "org/main"))
+        XCTAssertTrue(profile.thinkingEnabled)
+        XCTAssertEqual(profile.draftModelID, "org/drafter")
+    }
+
+    func testModelProfileIsNilForUnconfiguredModel() {
+        XCTAssertNil(NativSettings().modelProfile(for: "org/never-configured"))
+    }
+
+    func testRememberProfileIgnoresEmptyModelID() {
+        var settings = NativSettings()
+        settings.thinkingEnabled = true
+        settings.rememberProfile(forModel: "")
+
+        XCTAssertTrue(settings.modelConfigs.isEmpty)
+    }
+
     private func temporarySettingsURL() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
Addresses #160, creating a small ModelConfigProfile (thinking on/off + budget, drafter on/off + draft model/kind) that is stored per model ID in NativSettings.modelConfigs and persisted to disk. On model switch, ChatComposer snapshots the outgoing model's settings and restores the incoming model's saved profile (or a capability default with the drafter cleared for never-configured models), and a single observer saves any edit immediately so choices stick. Added a guard that re-disables thinking on models that can't do it, plus five unit tests on the store logic.