### PR TITLE
Apply per-model configuration on the API path

### DIFF
--- a/PythonDistribution/Overlay/nativ_server.py
+++ b/PythonDistribution/Overlay/nativ_server.py
@@ -799,6 +799,46 @@ def resolve_thinking_enabled(payload: dict[str, Any]) -> bool:
     return bool(base.get_server_enable_thinking())
 
 
+def _load_per_model_configs() -> dict[str, Any]:
+    raw = os.environ.get("NATIV_MODEL_CONFIGS")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+_PER_MODEL_CONFIGS = _load_per_model_configs()
+
+
+def apply_per_model_request_defaults(payload: dict[str, Any]) -> bool:
+    model_id = payload.get("model")
+    if not isinstance(model_id, str):
+        return False
+    profile = _PER_MODEL_CONFIGS.get(model_id)
+    if not isinstance(profile, dict):
+        return False
+
+    changed = False
+    thinking_enabled = profile.get("thinkingEnabled")
+    if "enable_thinking" not in payload and isinstance(thinking_enabled, bool):
+        payload["enable_thinking"] = thinking_enabled
+        changed = True
+
+    thinking_budget = profile.get("thinkingBudget")
+    if (
+        "thinking_budget" not in payload
+        and profile.get("thinkingBudgetEnabled") is True
+        and isinstance(thinking_budget, int)
+    ):
+        payload["thinking_budget"] = thinking_budget
+        changed = True
+
+    return changed
+
+
 def parse_request_observation(request: Request, payload: dict[str, Any]) -> RequestObservation:
     image_count = 0
     audio_count = 0
@@ -1164,6 +1204,16 @@ def install_metrics_overlay() -> None:
             payload = json.loads(body.decode("utf-8")) if body else {}
         except json.JSONDecodeError:
             payload = {}
+
+        if isinstance(payload, dict) and apply_per_model_request_defaults(payload):
+            body = json.dumps(payload).encode("utf-8")
+            request._body = body
+
+            async def _receive() -> dict[str, Any]:
+                return {"type": "http.request", "body": body, "more_body": False}
+
+            request._receive = _receive
+
         observation = parse_request_observation(request, payload)
         TRACKER.record_started(observation)
         metrics_capture: dict[str, Any] = {}

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -783,7 +783,22 @@ struct NativSettings: Codable, Equatable {
             environment["APC_NUM_BLOCKS"] = "\(settings.prefixCacheBlocks)"
             environment["APC_BLOCK_SIZE"] = "\(settings.prefixCacheBlockSize)"
         }
+        if let modelConfigsJSON = encodedModelConfigs {
+            environment["NATIV_MODEL_CONFIGS"] = modelConfigsJSON
+        }
         return environment
+    }
+
+    var encodedModelConfigs: String? {
+        guard !modelConfigs.isEmpty else {
+            return nil
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(modelConfigs) else {
+            return nil
+        }
+        return String(decoding: data, as: UTF8.self)
     }
 
     var launchArguments: [String] {

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -443,6 +443,26 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertTrue(settings.modelConfigs.isEmpty)
     }
 
+    func testModelConfigsAreExportedToServerLaunchEnvironment() throws {
+        var settings = NativSettings()
+        settings.thinkingEnabled = true
+        settings.thinkingBudgetEnabled = true
+        settings.thinkingBudget = 1_024
+        settings.rememberProfile(forModel: "org/main")
+
+        let json = try XCTUnwrap(settings.launchEnvironment["NATIV_MODEL_CONFIGS"])
+        let decoded = try JSONDecoder().decode(
+            [String: ModelConfigProfile].self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(decoded["org/main"]?.thinkingEnabled, true)
+        XCTAssertEqual(decoded["org/main"]?.thinkingBudget, 1_024)
+    }
+
+    func testLaunchEnvironmentOmitsModelConfigsWhenEmpty() {
+        XCTAssertNil(NativSettings().launchEnvironment["NATIV_MODEL_CONFIGS"])
+    }
+
     private func temporarySettingsURL() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
This PR makes the server apply a model's own saved configuration when that model is named in an API request, instead of inheriting whatever settings were last active globally. On the server side, a new middleware step reads the requested model and fills in its saved enable_thinking/thinking_budget from a per-model config map whenever the client omits them

tested it, and on a live endpoint, when a request names a model, the server now applies that model's saved thinking setting when the client omits it, an explicit client value always overrides it, unrelated models are left alone, and a missing/broken config safely falls back to normal behavior.

this is for text models, but if needed for other model types, can open a pr for that as well; such as img-gen knobs like steps, guidance, size, sampler