### PR TITLE
Warn when attaching images to a non-vision model

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -154,7 +154,21 @@ struct ChatComposer: View {
                             }
                         }
                         .padding(.vertical, 1)
+                        .opacity(modelLacksVision ? 0.5 : 1)
                     }
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                }
+
+                if !viewModel.pendingImageAttachments.isEmpty, modelLacksVision {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("The current model can't see images — load a vision model to use them.")
+                            .foregroundStyle(.secondary)
+                        Spacer(minLength: 0)
+                    }
+                    .font(.system(size: 11))
                     .padding(.horizontal, 12)
                     .padding(.bottom, 8)
                 }
@@ -280,6 +294,11 @@ struct ChatComposer: View {
             return value
         }
         return "\(value), loading \(percentage) percent"
+    }
+
+    private var modelLacksVision: Bool {
+        guard let model = selectedLocalModel else { return false }
+        return !model.capabilities.contains(.vision)
     }
 
     private var selectedLocalModel: LocalModel? {


### PR DESCRIPTION
Looks like this:

<img width="709" height="204" alt="Screenshot 2026-08-01 at 10 55 52 AM" src="https://github.com/user-attachments/assets/13f5da1e-c92e-441f-b944-bc97dc0eff97" />
