### PR TITLE
Artifacts: tag embedding model_type client-side before loading

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -303,6 +303,10 @@ struct ControlPanelView: View {
                     cachePath: settings.modelSearchPath,
                     token: model.effectiveHuggingFaceToken
                 ) {
+                    EmbeddingModelPreparer.prepare(
+                        repoID: modelID,
+                        searchPath: settings.modelSearchPath
+                    )
                     embeddingLibrary.scan(
                         path: settings.modelSearchPath,
                         additionalPaths: settings.additionalModelSearchPaths
@@ -323,6 +327,12 @@ struct ControlPanelView: View {
                     )
                     NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
                 }
+            },
+            prepareModel: {
+                EmbeddingModelPreparer.prepare(
+                    repoID: modelID,
+                    searchPath: settings.modelSearchPath
+                )
             }
         )
     }

--- a/Sources/Nativ/Features/Artifacts/ArtifactSemanticSearch.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactSemanticSearch.swift
@@ -12,6 +12,7 @@ struct ArtifactSemanticSearchConfig {
     let insufficientReason: String?
     let onEnable: () -> Void
     var onRemove: () -> Void = {}
+    var prepareModel: () -> Void = {}
 
     var sizeLabel: String {
         ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)

--- a/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
@@ -273,6 +273,7 @@ struct ArtifactsView: View {
             if Task.isCancelled {
                 return
             }
+            await Task.detached { config.prepareModel() }.value
             let matches = await searchIndex.search(query: query, model: config.modelID, client: config.client)
             if Task.isCancelled {
                 return
@@ -286,6 +287,7 @@ struct ArtifactsView: View {
             return
         }
         Task {
+            await Task.detached { config.prepareModel() }.value
             await searchIndex.index(
                 artifacts: store.artifacts,
                 model: config.modelID,

--- a/Sources/Nativ/Features/Artifacts/EmbeddingModelPreparer.swift
+++ b/Sources/Nativ/Features/Artifacts/EmbeddingModelPreparer.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+// Some community embedding checkpoints declare a base generative `model_type`
+// in their config.json (e.g. "qwen3_vl") even though the weights are an
+// embedding model. mlx-vlm would then load them through the generative class,
+// which does not produce pooled embeddings. Before the embedding server reads a
+// downloaded model, rewrite its local config.json to the matching embedding
+// `model_type` so it loads the embedding class. This keeps the model-specific
+// mapping on our side rather than in mlx-vlm.
+enum EmbeddingModelPreparer {
+    // Base generative model_type -> the embedding class mlx-vlm should load.
+    private static let embeddingModelTypes: [String: String] = [
+        "qwen3_vl": "qwen3_vl_embedding"
+    ]
+
+    static func prepare(repoID: String, searchPath: String) {
+        guard let configURL = configURL(repoID: repoID, searchPath: searchPath),
+              let data = try? Data(contentsOf: configURL),
+              var object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let modelType = object["model_type"] as? String,
+              let embeddingType = embeddingModelTypes[modelType]
+        else {
+            return
+        }
+        object["model_type"] = embeddingType
+        guard let updated = try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys]
+        ) else {
+            return
+        }
+        try? updated.write(to: configURL, options: .atomic)
+    }
+
+    private static func configURL(repoID: String, searchPath: String) -> URL? {
+        let root = URL(
+            fileURLWithPath: (searchPath as NSString).expandingTildeInPath,
+            isDirectory: true
+        )
+        let repoDirectory = root.appendingPathComponent(
+            "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+        )
+        let snapshots = repoDirectory.appendingPathComponent("snapshots")
+        let fileManager = FileManager.default
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: snapshots,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+        let newest = entries
+            .filter {
+                (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            }
+            .max { lhs, rhs in
+                let lhsDate = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                let rhsDate = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                return lhsDate < rhsDate
+            }
+        return newest?.appendingPathComponent("config.json")
+    }
+}


### PR DESCRIPTION
Some embedding checkpoints declare a base generative `model_type` (e.g. `qwen3_vl`), so mlx-vlm loads them through the generative class, which does not produce pooled embeddings. Before the embedding server reads a downloaded model, the semantic-search path rewrites its local `config.json` to the matching embedding `model_type`. Keeps the model-specific mapping on the app side instead of in mlx-vlm.

Stacked on #162.

I tried to not hardcode model into codebase, but assuming this is an extra feature, it's easy as swapping the model path if we every want to use a different embeddings model