### PR TITLE
Chat: drag files from Finder + paste images into the composer

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -90,6 +90,7 @@ struct ChatComposer: View {
     let onSend: (Bool) -> Void
     @State private var editorContentHeight: CGFloat = 0
     @State private var didApplyInitialReasoningDefault = false
+    @State private var isDropTargeted = false
     private let textInset = EdgeInsets(top: 14, leading: 14, bottom: 10, trailing: 14)
     private let editorMinimumHeight: CGFloat = 64
     private let editorMaximumHeight: CGFloat = 120
@@ -216,7 +217,16 @@ struct ChatComposer: View {
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
                     .stroke(Color(nsColor: .separatorColor), lineWidth: 0.75)
             }
+            .overlay {
+                if isDropTargeted {
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .strokeBorder(Color.accentColor, lineWidth: 2)
+                }
+            }
             .shadow(color: .black.opacity(0.08), radius: 12, x: 0, y: 4)
+            .dropDestination(for: URL.self) { urls, _ in
+                viewModel.attachImages(fromURLs: urls)
+            } isTargeted: { isDropTargeted = $0 }
         }
         .padding(.vertical, 18)
         .task(id: modelScanKey) {

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -90,7 +90,6 @@ struct ChatComposer: View {
     let onSend: (Bool) -> Void
     @State private var editorContentHeight: CGFloat = 0
     @State private var didApplyInitialReasoningDefault = false
-    @State private var isDropTargeted = false
     private let textInset = EdgeInsets(top: 14, leading: 14, bottom: 10, trailing: 14)
     private let editorMinimumHeight: CGFloat = 64
     private let editorMaximumHeight: CGFloat = 120
@@ -217,16 +216,7 @@ struct ChatComposer: View {
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
                     .stroke(Color(nsColor: .separatorColor), lineWidth: 0.75)
             }
-            .overlay {
-                if isDropTargeted {
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .strokeBorder(Color.accentColor, lineWidth: 2)
-                }
-            }
             .shadow(color: .black.opacity(0.08), radius: 12, x: 0, y: 4)
-            .dropDestination(for: URL.self) { urls, _ in
-                viewModel.attachImages(fromURLs: urls)
-            } isTargeted: { isDropTargeted = $0 }
         }
         .padding(.vertical, 18)
         .task(id: modelScanKey) {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -24,6 +24,7 @@ struct ChatView: View {
     let conversationWidthReduction: CGFloat
     @State private var transcriptScrollPosition = ScrollPosition(edge: .bottom)
     @State private var composerHeight: CGFloat = 0
+    @State private var isDropTargeted = false
     @State private var followsLatestMessage = true
     @State private var isUserScrollingTranscript = false
 
@@ -68,8 +69,42 @@ struct ChatView: View {
                         }
                     }
             }
+            .dropDestination(for: URL.self) { urls, _ in
+                chat.attachImages(fromURLs: urls)
+            } isTargeted: { isDropTargeted = $0 }
+            .overlay {
+                if isDropTargeted {
+                    dropOverlay
+                        .allowsHitTesting(false)
+                        .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: 0.15), value: isDropTargeted)
         }
         .background(Color.nativMainContentBackground)
+    }
+
+    private var dropOverlay: some View {
+        ZStack {
+            Color(nsColor: .windowBackgroundColor).opacity(0.72)
+            VStack(spacing: 14) {
+                Image(systemName: "plus")
+                    .font(.system(size: 34, weight: .semibold))
+                Text("Drop files here")
+                    .font(.system(size: 15, weight: .medium))
+            }
+            .foregroundStyle(.secondary)
+            .padding(44)
+            .frame(maxWidth: 320)
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .strokeBorder(
+                        Color.secondary.opacity(0.55),
+                        style: StrokeStyle(lineWidth: 2, dash: [8, 6])
+                    )
+            )
+        }
+        .ignoresSafeArea()
     }
 
     private var selectedModelID: String? {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -667,6 +667,16 @@ final class ChatViewModel: ObservableObject {
         return true
     }
 
+    @discardableResult
+    func attachImages(fromURLs urls: [URL]) -> Bool {
+        let attachments = urls.compactMap { try? ChatImageAttachment(contentsOf: $0) }
+        guard !attachments.isEmpty else {
+            return false
+        }
+        pendingImageAttachments.append(contentsOf: attachments)
+        return true
+    }
+
     func pasteImageFromClipboard() {
         attachImages(from: .general)
     }


### PR DESCRIPTION
Drag image files from Finder onto the chat composer to stage them as attachments (with a drop highlight). 
