### PR TITLE
Improve page responsiveness and background work

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -12,63 +12,27 @@ struct ChatQueuedPrompt: Identifiable, Equatable {
     let position: Int
 }
 
-struct ChatView: View {
-    private enum Layout {
-        static let conversationMaxWidth: CGFloat = 680
-        static let horizontalPadding: CGFloat = 32
-    }
+private struct ChatSessionBootstrap {
+    let sessions: [ChatSession]
+}
 
+struct ChatView: View {
     @ObservedObject var model: NativModel
-    @ObservedObject var chat: ChatViewModel
+    let chat: ChatViewModel
     @Binding var showsConfiguration: Bool
     let conversationWidthReduction: CGFloat
-    @State private var transcriptScrollPosition = ScrollPosition(edge: .bottom)
-    @State private var composerHeight: CGFloat = 0
     @State private var isDropTargeted = false
-    @State private var followsLatestMessage = true
-    @State private var isUserScrollingTranscript = false
 
     var body: some View {
         ModelConfigurationLayout(
             model: model,
             isConfigurationVisible: $showsConfiguration
         ) {
-            VStack(spacing: 0) {
-                transcript
-                    .overlay(alignment: .bottom) {
-                        ChatComposer(
-                            model: model,
-                            viewModel: chat,
-                            unavailableReason: unavailableReason,
-                            canCompose: canCompose,
-                            canSend: canSend,
-                            onSend: { languageModelSupportsTools in
-                                chat.send(
-                                    using: model,
-                                    languageModelSupportsTools: languageModelSupportsTools
-                                )
-                            }
-                        )
-                        .frame(
-                            maxWidth: Layout.conversationMaxWidth
-                                - conversationWidthReduction
-                        )
-                        .frame(maxWidth: .infinity)
-                        .padding(.horizontal, Layout.horizontalPadding)
-                        .onGeometryChange(for: CGFloat.self) { proxy in
-                            proxy.size.height
-                        } action: { height in
-                            let isInitialMeasurement = composerHeight == 0
-                            composerHeight = height
-                            if isInitialMeasurement {
-                                Task { @MainActor in
-                                    try? await Task.sleep(for: .milliseconds(50))
-                                    transcriptScrollPosition.scrollTo(edge: .bottom)
-                                }
-                            }
-                        }
-                    }
-            }
+            ChatTranscriptView(
+                model: model,
+                chat: chat,
+                conversationWidthReduction: conversationWidthReduction
+            )
             .dropDestination(for: URL.self) { urls, _ in
                 chat.attachImages(fromURLs: urls)
             } isTargeted: { isDropTargeted = $0 }
@@ -106,31 +70,27 @@ struct ChatView: View {
         }
         .ignoresSafeArea()
     }
+}
+
+private struct ChatTranscriptView: View {
+    private enum Layout {
+        static let conversationMaxWidth: CGFloat = 680
+        static let horizontalPadding: CGFloat = 32
+    }
+
+    @ObservedObject var model: NativModel
+    @ObservedObject var chat: ChatViewModel
+    let conversationWidthReduction: CGFloat
+    @State private var transcriptScrollPosition = ScrollPosition(edge: .bottom)
+    @State private var composerHeight: CGFloat = 0
+    @State private var followsLatestMessage = true
+    @State private var isUserScrollingTranscript = false
 
     private var selectedModelID: String? {
         model.settings.normalized().languageModelID
     }
 
-    private var canSend: Bool {
-        !model.isModelLoading
-            && model.settings.structuredOutputValidationError == nil
-            && chat.canSend(isRunning: model.isRunning, selectedModelID: selectedModelID)
-    }
-
-    private var canCompose: Bool {
-        model.isRunning
-            && !model.isModelLoading
-            && selectedModelID?.isEmpty == false
-            && model.settings.structuredOutputValidationError == nil
-    }
-
-    private var unavailableReason: String? {
-        model.modelLoadingStatusText
-            ?? chat.unavailableReason(isRunning: model.isRunning, selectedModelID: selectedModelID)
-            ?? model.settings.structuredOutputValidationError
-    }
-
-    private var transcript: some View {
+    var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 12) {
                 if chat.visibleMessages.isEmpty {
@@ -155,16 +115,30 @@ struct ChatView: View {
                     }
                 }
             }
-            .frame(
-                maxWidth: Layout.conversationMaxWidth
-                    - conversationWidthReduction
-            )
+            .frame(maxWidth: Layout.conversationMaxWidth - conversationWidthReduction)
             .frame(maxWidth: .infinity)
             .padding(.horizontal, Layout.horizontalPadding)
             .padding(.top, 18)
             .padding(.bottom, max(18, composerHeight))
         }
         .scrollPosition($transcriptScrollPosition)
+        .overlay(alignment: .bottom) {
+            ChatComposerContainer(
+                model: model,
+                chat: chat,
+                conversationWidthReduction: conversationWidthReduction,
+                onHeightChange: { height in
+                    let isInitialMeasurement = composerHeight == 0
+                    composerHeight = height
+                    if isInitialMeasurement {
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .milliseconds(50))
+                            transcriptScrollPosition.scrollTo(edge: .bottom)
+                        }
+                    }
+                }
+            )
+        }
         .onScrollPhaseChange { _, newPhase, context in
             switch newPhase {
             case .tracking, .interacting:
@@ -175,9 +149,7 @@ struct ChatView: View {
                     followsLatestMessage = false
                 }
             case .idle:
-                guard isUserScrollingTranscript else {
-                    return
-                }
+                guard isUserScrollingTranscript else { return }
                 isUserScrollingTranscript = false
                 followsLatestMessage = isAtTranscriptBottom(context.geometry)
             case .animating:
@@ -194,9 +166,7 @@ struct ChatView: View {
             transcriptScrollPosition.scrollTo(edge: .bottom)
         }
         .onChange(of: chat.scrollTargetMessageID) { _, target in
-            guard let target else {
-                return
-            }
+            guard let target else { return }
             followsLatestMessage = false
             DispatchQueue.main.async {
                 transcriptScrollPosition.scrollTo(id: target, anchor: .center)
@@ -211,6 +181,48 @@ struct ChatView: View {
 
     private func isAtTranscriptBottom(_ geometry: ScrollGeometry) -> Bool {
         geometry.visibleRect.maxY >= geometry.contentSize.height - 8
+    }
+}
+
+private struct ChatComposerContainer: View {
+    @ObservedObject var model: NativModel
+    @ObservedObject var chat: ChatViewModel
+    let conversationWidthReduction: CGFloat
+    let onHeightChange: (CGFloat) -> Void
+
+    private var selectedModelID: String? {
+        model.settings.normalized().languageModelID
+    }
+
+    var body: some View {
+        ChatComposer(
+            model: model,
+            viewModel: chat,
+            unavailableReason: model.modelLoadingStatusText
+                ?? chat.unavailableReason(isRunning: model.isRunning, selectedModelID: selectedModelID)
+                ?? model.settings.structuredOutputValidationError,
+            canCompose: model.isRunning
+                && !model.isModelLoading
+                && selectedModelID?.isEmpty == false
+                && model.settings.structuredOutputValidationError == nil,
+            canSend: !model.isModelLoading
+                && model.settings.structuredOutputValidationError == nil
+                && chat.canSend(isRunning: model.isRunning, selectedModelID: selectedModelID),
+            onSend: { languageModelSupportsTools in
+                chat.send(
+                    using: model,
+                    languageModelSupportsTools: languageModelSupportsTools
+                )
+            }
+        )
+        .frame(maxWidth: 680 - conversationWidthReduction)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 32)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            onHeightChange(height)
+        }
     }
 }
 
@@ -238,8 +250,10 @@ final class ChatViewModel: ObservableObject {
     @Published private(set) var sendingStartedAt: Date?
     @Published private(set) var scrollToken = 0
     @Published var scrollTargetMessageID: UUID?
+    @Published private(set) var isLoadingSessions = true
 
     private let sessionStore = ChatSessionStore()
+    private var sessionLoadTask: Task<Void, Never>?
     private var activeTask: Task<Void, Never>?
     private var activeRequestID: UUID?
     private var activeAssistantMessageID: UUID?
@@ -256,18 +270,31 @@ final class ChatViewModel: ObservableObject {
     private let toolConsentGate = ChatToolConsentGate()
 
     init() {
-        storedSessions = sessionStore.loadSessions()
         folders = sessionStore.loadFolders()
-        pruneRedundantEmptySessions()
-        if let latestSession = storedSessions.sorted(by: ChatSession.recencySort).first {
-            applyCurrentSession(latestSession)
-        } else {
-            createSession()
+        let now = Date()
+        applyCurrentSession(
+            ChatSession(
+                id: UUID(),
+                title: ChatSession.timestampTitle(for: now),
+                createdAt: now,
+                updatedAt: now,
+                messages: []
+            )
+        )
+
+        let loadTask = Task.detached(priority: .userInitiated) {
+            ChatSessionBootstrap(sessions: ChatSessionStore().loadSessions())
+        }
+        sessionLoadTask = Task { @MainActor [weak self] in
+            let bootstrap = await loadTask.value
+            guard let self, !Task.isCancelled else { return }
+            finishLoadingSessions(bootstrap)
         }
     }
 
     deinit {
         activeTask?.cancel()
+        sessionLoadTask?.cancel()
     }
 
     var isCurrentSessionSending: Bool {
@@ -1521,6 +1548,39 @@ final class ChatViewModel: ObservableObject {
         ) ? normalizedForLoad(session.messages) : session.messages
         refreshSessionList()
         bumpScroll()
+    }
+
+    private func finishLoadingSessions(_ bootstrap: ChatSessionBootstrap) {
+        let localSession = currentSession
+        let localSessionHasWork = localSession.map { session in
+            !session.messages.isEmpty
+                || !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || !pendingImageAttachments.isEmpty
+                || activeRequestID != nil
+        } == true
+
+        storedSessions = bootstrap.sessions
+        if localSessionHasWork, let localSession {
+            upsertStoredSession(localSession)
+        }
+
+        pruneRedundantEmptySessions()
+        isLoadingSessions = false
+
+        guard !localSessionHasWork else {
+            refreshSessionList()
+            return
+        }
+
+        if let latestSession = storedSessions.sorted(by: ChatSession.recencySort).first {
+            applyCurrentSession(latestSession)
+        } else if let localSession {
+            storedSessions = [localSession]
+            sessionStore.saveSession(localSession)
+            refreshSessionList()
+        } else {
+            createSession()
+        }
     }
 
     private func normalizedForLoad(_ messages: [ChatTranscriptMessage]) -> [ChatTranscriptMessage] {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -132,7 +132,7 @@ struct ChatView: View {
 
     private var transcript: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+            LazyVStack(alignment: .leading, spacing: 12) {
                 if chat.visibleMessages.isEmpty {
                     if chat.messages.isEmpty {
                         ChatEmptyTranscriptView(
@@ -150,6 +150,7 @@ struct ChatView: View {
                             onConfirmToolConsent: chat.confirmToolConsent,
                             onDenyToolConsent: chat.denyToolConsent
                         )
+                        .equatable()
                         .id(message.id)
                     }
                 }
@@ -216,7 +217,7 @@ struct ChatView: View {
 @MainActor
 final class ChatViewModel: ObservableObject {
     private static let liveDecodeRateRefreshInterval: TimeInterval = 0.25
-    private static let streamFlushInterval: TimeInterval = 1.0 / 30.0
+    private static let streamFlushInterval: TimeInterval = 1.0 / 15.0
 
     private struct QueuedChatRequest {
         let id: UUID
@@ -1630,7 +1631,7 @@ final class ChatViewModel: ObservableObject {
     }
 }
 
-private struct ChatMessageRow: View {
+private struct ChatMessageRow: View, Equatable {
     private static let maximumUserBubbleWidth: CGFloat = 560
 
     let message: ChatTranscriptMessage
@@ -1638,6 +1639,10 @@ private struct ChatMessageRow: View {
     let onDenyToolConsent: (UUID) -> Void
     @State private var didCopyResponse = false
     @State private var isHoveringMessage = false
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.message == rhs.message
+    }
 
     var body: some View {
         VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 4) {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -92,7 +92,7 @@ private struct ChatTranscriptView: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 12) {
                 if chat.visibleMessages.isEmpty {
                     if chat.messages.isEmpty {
                         ChatEmptyTranscriptView(

--- a/Sources/Nativ/Features/Dashboard/DashboardViewModel.swift
+++ b/Sources/Nativ/Features/Dashboard/DashboardViewModel.swift
@@ -252,62 +252,64 @@ final class DashboardViewModel: ObservableObject {
 
         let task = Task.detached(priority: .userInitiated) {
             let store = NativAnalyticsStore(databaseURL: databaseURL)
-            let displayGranularity = Self.displayGranularity(
-                for: range,
-                store: store,
-                modelID: selectedModelID
-            )
-            let summary = store.fetchSummary(
-                range: range.analyticsRange,
-                modelID: selectedModelID,
-                granularityOverride: displayGranularity
-            )
-            let rawBuckets = store.fetchBuckets(
-                range: range.analyticsRange,
-                modelID: selectedModelID,
-                granularityOverride: displayGranularity
-            )
-            let rawActivityBuckets = store.fetchBuckets(
-                range: range.analyticsRange,
-                modelID: selectedModelID,
-                granularityOverride: .hour
-            )
-            let ttftEvents = store.fetchTTFTEvents(
-                range: range.analyticsRange,
-                modelID: selectedModelID
-            )
-            let recentRequestEvents = store.fetchRecentRequestEvents(
-                range: range.analyticsRange,
-                modelID: selectedModelID,
-                limit: 10
-            )
-            let knownModelIDs = store.fetchKnownModelIDs()
-            let points = Self.bucketPoints(
-                from: rawBuckets,
-                ttftEvents: ttftEvents,
-                range: range,
-                granularity: displayGranularity
-            )
-            let activityPoints = Self.activityPoints(from: rawActivityBuckets)
-            let modelPerformance = Self.modelPerformance(from: rawBuckets)
-            let servedModelIDs = Set(modelPerformance.map(\.modelID))
-            let modelBuckets = rawBuckets.filter { servedModelIDs.contains($0.modelID) }
-            let leadingModelIDs = Set(modelPerformance.prefix(12).map(\.modelID))
-            let modelTokenPoints = Self.modelTokenPoints(
-                from: modelBuckets,
-                bucketDates: points.map(\.bucketStart),
-                leadingModelIDs: leadingModelIDs,
-                groupsRemainingModels: modelPerformance.count > 12
-            )
-            return DashboardSnapshot(
-                summary: summary,
-                points: points,
-                activityPoints: activityPoints,
-                modelPerformance: modelPerformance,
-                modelTokenPoints: modelTokenPoints,
-                knownModelIDs: knownModelIDs,
-                recentRequestEvents: recentRequestEvents
-            )
+            return store.withReadSnapshot {
+                let displayGranularity = Self.displayGranularity(
+                    for: range,
+                    store: store,
+                    modelID: selectedModelID
+                )
+                let summary = store.fetchSummary(
+                    range: range.analyticsRange,
+                    modelID: selectedModelID,
+                    granularityOverride: displayGranularity
+                )
+                let rawBuckets = store.fetchBuckets(
+                    range: range.analyticsRange,
+                    modelID: selectedModelID,
+                    granularityOverride: displayGranularity
+                )
+                let rawActivityBuckets = store.fetchBuckets(
+                    range: range.analyticsRange,
+                    modelID: selectedModelID,
+                    granularityOverride: .hour
+                )
+                let ttftEvents = store.fetchTTFTEvents(
+                    range: range.analyticsRange,
+                    modelID: selectedModelID
+                )
+                let recentRequestEvents = store.fetchRecentRequestEvents(
+                    range: range.analyticsRange,
+                    modelID: selectedModelID,
+                    limit: 10
+                )
+                let knownModelIDs = store.fetchKnownModelIDs()
+                let points = Self.bucketPoints(
+                    from: rawBuckets,
+                    ttftEvents: ttftEvents,
+                    range: range,
+                    granularity: displayGranularity
+                )
+                let activityPoints = Self.activityPoints(from: rawActivityBuckets)
+                let modelPerformance = Self.modelPerformance(from: rawBuckets)
+                let servedModelIDs = Set(modelPerformance.map(\.modelID))
+                let modelBuckets = rawBuckets.filter { servedModelIDs.contains($0.modelID) }
+                let leadingModelIDs = Set(modelPerformance.prefix(12).map(\.modelID))
+                let modelTokenPoints = Self.modelTokenPoints(
+                    from: modelBuckets,
+                    bucketDates: points.map(\.bucketStart),
+                    leadingModelIDs: leadingModelIDs,
+                    groupsRemainingModels: modelPerformance.count > 12
+                )
+                return DashboardSnapshot(
+                    summary: summary,
+                    points: points,
+                    activityPoints: activityPoints,
+                    modelPerformance: modelPerformance,
+                    modelTokenPoints: modelTokenPoints,
+                    knownModelIDs: knownModelIDs,
+                    recentRequestEvents: recentRequestEvents
+                )
+            }
         }
         historyLoadTask = task
 

--- a/Sources/Nativ/Features/Dashboard/NativAnalyticsStore.swift
+++ b/Sources/Nativ/Features/Dashboard/NativAnalyticsStore.swift
@@ -207,9 +207,15 @@ struct NativAnalyticsTTFTEvent: Sendable {
 
 final class NativAnalyticsStore {
     private let databaseURL: URL
+    // Keep one read connection for a dashboard snapshot. Opening a connection
+    // for every metric query repeats schema setup and WAL configuration, and
+    // makes one reload look like several independent database passes.
+    private let connection: SQLiteConnection?
 
     init(databaseURL: URL = NativAnalyticsStore.defaultDatabaseURL()) {
-        self.databaseURL = databaseURL.standardizedFileURL
+        let standardizedURL = databaseURL.standardizedFileURL
+        self.databaseURL = standardizedURL
+        self.connection = try? SQLiteConnection(url: standardizedURL)
     }
 
     static func defaultDatabaseURL() -> URL {
@@ -223,12 +229,25 @@ final class NativAnalyticsStore {
             .appendingPathComponent("Analytics.sqlite3")
     }
 
+    /// Runs a group of dashboard reads against one consistent SQLite snapshot.
+    /// The connection is shared by all fetch methods on this store, so a reload
+    /// does not repeatedly open/configure the database or observe mixed writes.
+    func withReadSnapshot<Result>(_ work: () -> Result) -> Result {
+        guard let connection else {
+            return work()
+        }
+
+        try? connection.execute("BEGIN TRANSACTION;")
+        defer { try? connection.execute("COMMIT;") }
+        return work()
+    }
+
     func fetchSummary(
         range: NativAnalyticsRange = .allTime,
         modelID: String? = nil,
         granularityOverride: NativAnalyticsGranularity? = nil
     ) -> NativHistoricalAnalyticsSummary {
-        guard let connection = try? SQLiteConnection(url: databaseURL) else {
+        guard let connection else {
             return .empty
         }
 
@@ -375,7 +394,7 @@ final class NativAnalyticsStore {
         modelID: String? = nil,
         granularityOverride: NativAnalyticsGranularity? = nil
     ) -> [NativAnalyticsBucketPoint] {
-        guard let connection = try? SQLiteConnection(url: databaseURL) else {
+        guard let connection else {
             return []
         }
 
@@ -502,7 +521,7 @@ final class NativAnalyticsStore {
         granularity: NativAnalyticsGranularity,
         modelID: String? = nil
     ) -> (start: Date, end: Date)? {
-        guard let connection = try? SQLiteConnection(url: databaseURL) else {
+        guard let connection else {
             return nil
         }
 
@@ -542,7 +561,7 @@ final class NativAnalyticsStore {
         modelID: String? = nil,
         limit: Int = 10
     ) -> [NativAnalyticsRequestEvent] {
-        guard let connection = try? SQLiteConnection(url: databaseURL) else {
+        guard let connection else {
             return []
         }
 
@@ -632,7 +651,7 @@ final class NativAnalyticsStore {
         range: NativAnalyticsRange,
         modelID: String? = nil
     ) -> [NativAnalyticsTTFTEvent] {
-        guard let connection = try? SQLiteConnection(url: databaseURL) else {
+        guard let connection else {
             return []
         }
 
@@ -673,7 +692,7 @@ final class NativAnalyticsStore {
     }
 
     func fetchKnownModelIDs() -> [String] {
-        guard let connection = try? SQLiteConnection(url: databaseURL) else {
+        guard let connection else {
             return []
         }
 

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -113,10 +113,28 @@ final class IntegrationsViewModel: ObservableObject {
     func refreshStatuses() {
         guard !isRefreshingStatuses else { return }
         isRefreshingStatuses = true
+        let baseURL = integrationServerBaseURL
+        let apiKey = serverAPIKey
         Task {
-            var refreshed: [IntegrationTool: IntegrationToolStatus] = [:]
-            for tool in IntegrationTool.allCases {
-                refreshed[tool] = await profiles.status(for: tool)
+            let refreshed = await withTaskGroup(
+                of: (IntegrationTool, IntegrationToolStatus).self,
+                returning: [IntegrationTool: IntegrationToolStatus].self
+            ) { group in
+                for tool in IntegrationTool.allCases {
+                    group.addTask {
+                        let profile = IntegrationProfileManager(
+                            serverBaseURL: baseURL,
+                            serverAPIKey: apiKey
+                        )
+                        return (tool, await profile.status(for: tool))
+                    }
+                }
+
+                var statuses: [IntegrationTool: IntegrationToolStatus] = [:]
+                for await (tool, status) in group {
+                    statuses[tool] = status
+                }
+                return statuses
             }
             statuses = refreshed
             isRefreshingStatuses = false

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -59,6 +59,13 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
     let isPrivate: Bool
     let isGated: Bool
     let safetensors: HuggingFaceSafetensors?
+    // These values are used by every visible row. Resolve them once while the
+    // response is decoded instead of repeating string parsing, provider lookup,
+    // and memory estimation during every SwiftUI body pass while scrolling.
+    let provider: LocalModelProvider?
+    let sizeBytes: Int64?
+    let capabilities: Set<LocalModelCapability>
+    let memoryEstimate: LocalModelMemoryEstimate?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -90,27 +97,38 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         } else {
             isGated = false
         }
+
+        provider = LocalModelProviderResolver.resolve(repoID: id, modelType: nil, architectures: [])
+        sizeBytes = safetensors?.sizeBytes
+        capabilities = Self.resolveCapabilities(
+            pipelineTag: pipelineTag,
+            libraryName: libraryName,
+            tags: tags
+        )
+        memoryEstimate = Self.resolveMemoryEstimate(
+            repoID: id,
+            safetensors: safetensors,
+            sizeBytes: sizeBytes,
+            capabilities: capabilities
+        )
     }
 
-    var provider: LocalModelProvider? {
-        LocalModelProviderResolver.resolve(repoID: id, modelType: nil, architectures: [])
-    }
-
-    var sizeBytes: Int64? {
-        safetensors?.sizeBytes
-    }
-
-    var memoryEstimate: LocalModelMemoryEstimate? {
+    private static func resolveMemoryEstimate(
+        repoID: String,
+        safetensors: HuggingFaceSafetensors?,
+        sizeBytes: Int64?,
+        capabilities: Set<LocalModelCapability>
+    ) -> LocalModelMemoryEstimate? {
         guard let safetensors,
               safetensors.hasOnlyKnownDataTypes,
-              let sizeBytes = safetensors.sizeBytes,
+              let sizeBytes,
               sizeBytes > 0
         else {
             return nil
         }
 
-        let parameterCount = LocalModelDiscovery.parameterCount(from: id)
-        let quantizationBits = LocalModelDiscovery.quantizationBits(from: id)
+        let parameterCount = LocalModelDiscovery.parameterCount(from: repoID)
+        let quantizationBits = LocalModelDiscovery.quantizationBits(from: repoID)
         var estimatedModelBytes = Double(sizeBytes)
 
         // Packed integer summaries and explicitly quantized repositories need a
@@ -154,7 +172,11 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         )
     }
 
-    var capabilities: Set<LocalModelCapability> {
+    private static func resolveCapabilities(
+        pipelineTag: String?,
+        libraryName: String?,
+        tags: [String]
+    ) -> Set<LocalModelCapability> {
         let pipeline = pipelineTag?.lowercased() ?? ""
         let descriptors = ([pipelineTag, libraryName].compactMap { $0 } + tags)
             .joined(separator: " ")
@@ -587,6 +609,8 @@ final class HuggingFaceDownloadManager: ObservableObject {
     @Published private(set) var errorByModelID: [String: String] = [:]
 
     private var contexts: [String: DownloadContext] = [:]
+    private var progressUpdateTimes: [String: Date] = [:]
+    private var freeDiskCache: [String: (timestamp: Date, bytes: Int64?)] = [:]
 
     deinit {
         contexts.values.forEach { $0.task?.cancel() }
@@ -622,7 +646,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     func capacityBlocker(sizeBytes: Int64?, cachePath: String) -> String? {
         guard let sizeBytes, sizeBytes > 0 else { return nil }
         let path = LocalModelDiscovery.expandedPath(cachePath)
-        guard let freeBytes = Self.freeDiskBytes(atPath: path) else { return nil }
+        guard let freeBytes = cachedFreeDiskBytes(atPath: path) else { return nil }
         let availableBytes = max(freeBytes - reservedBytes, 0)
         guard sizeBytes > availableBytes else { return nil }
         let needed = ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
@@ -805,7 +829,22 @@ final class HuggingFaceDownloadManager: ObservableObject {
         else {
             return
         }
-        downloads[index].progress = progress
+        let clampedProgress = min(max(progress, 0), 1)
+        let previousProgress = downloads[index].progress
+        let now = Date()
+        let lastUpdate = progressUpdateTimes[modelID] ?? .distantPast
+
+        // Python reports byte progress frequently. Coalesce those reports on
+        // the main actor so a download does not invalidate every visible row
+        // (and the scroll view) for tiny, visually indistinguishable changes.
+        guard clampedProgress >= 1
+            || clampedProgress - previousProgress >= 0.01
+            || now.timeIntervalSince(lastUpdate) >= 0.10
+        else {
+            return
+        }
+        downloads[index].progress = clampedProgress
+        progressUpdateTimes[modelID] = now
     }
 
     private func setState(_ modelID: String, _ state: DownloadState) {
@@ -816,6 +855,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     private func removeContext(_ modelID: String) {
         contexts.removeValue(forKey: modelID)
         downloads.removeAll { $0.modelID == modelID }
+        progressUpdateTimes.removeValue(forKey: modelID)
     }
 
     private func cancelWaiter(_ waiterID: UUID, modelID: String) {
@@ -830,6 +870,16 @@ final class HuggingFaceDownloadManager: ObservableObject {
             return nil
         }
         return freeBytes
+    }
+
+    private func cachedFreeDiskBytes(atPath path: String) -> Int64? {
+        let now = Date()
+        if let cached = freeDiskCache[path], now.timeIntervalSince(cached.timestamp) < 1 {
+            return cached.bytes
+        }
+        let bytes = Self.freeDiskBytes(atPath: path)
+        freeDiskCache[path] = (timestamp: now, bytes: bytes)
+        return bytes
     }
 }
 
@@ -917,7 +967,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
                 total = float(expected_bytes or self.total or 0)
                 value = float(self.n or 0)
                 progress = min(max(value / total, 0.0), 1.0) if total > 0 else 0.0
-                if abs(progress - self._mlx_last_progress) >= 0.002 or progress >= 1.0:
+                if abs(progress - self._mlx_last_progress) >= 0.01 or progress >= 1.0:
                     self._mlx_last_progress = progress
                     print(f"__MLX_PROGRESS__:{progress:.6f}", flush=True)
 

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -231,23 +231,80 @@ struct LocalModelConfigurationMetadata: Equatable, Sendable {
 }
 
 enum LocalModelDiscovery {
+    private actor ScanCache {
+        struct Key: Hashable, Sendable {
+            let path: String
+            let additionalPaths: [String]
+        }
+
+        private struct Entry: Sendable {
+            let models: [LocalModel]
+            let expiresAt: Date
+        }
+
+        private var entries: [Key: Entry] = [:]
+        private var inFlight: [Key: Task<[LocalModel], Error>] = [:]
+
+        func scan(key: Key) async throws -> [LocalModel] {
+            let now = Date()
+            entries = entries.filter { $0.value.expiresAt > now }
+            if let entry = entries[key] {
+                return entry.models
+            }
+
+            if let task = inFlight[key] {
+                return try await task.value
+            }
+
+            let task = Task.detached(priority: .userInitiated) {
+                try LocalModelDiscovery.performScan(
+                    path: key.path,
+                    additionalPaths: key.additionalPaths
+                )
+            }
+            inFlight[key] = task
+
+            do {
+                let models = try await task.value
+                entries[key] = Entry(
+                    models: models,
+                    expiresAt: Date().addingTimeInterval(2)
+                )
+                inFlight.removeValue(forKey: key)
+                return models
+            } catch {
+                inFlight.removeValue(forKey: key)
+                throw error
+            }
+        }
+    }
+
+    private static let scanCache = ScanCache()
+
     static func scan(path: String, additionalPaths: [String] = []) async throws -> [LocalModel] {
         let expandedPath = Self.expandedPath(path)
         let expandedAdditionalPaths = additionalPaths.map(Self.expandedPath)
-        return try await Task.detached(priority: .userInitiated) {
-            let externalModels = Self.scanAdditionalPathsSynchronously(
-                expandedAdditionalPaths,
-                fileManager: FileManager.default
-            )
-            do {
-                return Self.sortedByDisplayName(try Self.scanSynchronously(path: expandedPath) + externalModels)
-            } catch {
-                guard !externalModels.isEmpty else {
-                    throw error
-                }
-                return Self.sortedByDisplayName(externalModels)
+        return try await scanCache.scan(
+            key: ScanCache.Key(path: expandedPath, additionalPaths: expandedAdditionalPaths)
+        )
+    }
+
+    private static func performScan(
+        path: String,
+        additionalPaths: [String]
+    ) throws -> [LocalModel] {
+        let externalModels = Self.scanAdditionalPathsSynchronously(
+            additionalPaths,
+            fileManager: FileManager.default
+        )
+        do {
+            return Self.sortedByDisplayName(try Self.scanSynchronously(path: path) + externalModels)
+        } catch {
+            guard !externalModels.isEmpty else {
+                throw error
             }
-        }.value
+            return Self.sortedByDisplayName(externalModels)
+        }
     }
 
     static func delete(repoID: String, path: String) async throws {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -56,7 +56,10 @@ struct ModelsView: View {
     var speechModelDiscoveryRequest = 0
     @StateObject private var localLibrary = LocalModelLibrary()
     @StateObject private var hubLibrary = HuggingFaceModelLibrary()
-    @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
+    // Keep download progress observation in the banner and individual rows.
+    // Observing the manager here invalidates the entire Models view for every
+    // progress tick, which makes Discover scroll janky during downloads.
+    private var downloadManager: HuggingFaceDownloadManager { .shared }
     @State private var section: ModelsPageSection = .installed
     @State private var typeFilter: ModelsTypeFilter = .all
     @State private var localQuery = ""
@@ -144,24 +147,7 @@ struct ModelsView: View {
 
     @ViewBuilder
     private var activeDownloadBanner: some View {
-        if !downloadManager.downloads.isEmpty {
-            VStack(spacing: 0) {
-                ForEach(downloadManager.downloads) { download in
-                    ActiveDownloadBannerRow(
-                        download: download,
-                        onPauseResume: {
-                            if download.state == .paused {
-                                downloadManager.resumeDownload(download.modelID)
-                            } else {
-                                downloadManager.pauseDownload(download.modelID)
-                            }
-                        },
-                        onCancel: { downloadManager.removeDownload(download.modelID) }
-                    )
-                }
-            }
-            Divider()
-        }
+        ActiveDownloadBannerView()
     }
 
     private var pageHeader: some View {
@@ -369,17 +355,10 @@ struct ModelsView: View {
                             )
                         } else {
                             ForEach(filteredHubModels) { hubModel in
-                                HubModelRow(
+                                HubModelRowContainer(
                                     model: hubModel,
                                     isInstalled: installedModelIDs.contains(hubModel.id),
-                                    isDownloading: downloadManager.isDownloading(hubModel.id),
-                                    downloadProgress: downloadManager.progress(for: hubModel.id),
-                                    isDownloadPaused: downloadManager.isPaused(for: hubModel.id),
-                                    downloadBlockedReason: downloadManager.capacityBlocker(
-                                        sizeBytes: hubModel.sizeBytes,
-                                        cachePath: model.settings.modelSearchPath
-                                    ),
-                                    downloadError: downloadManager.errorByModelID[hubModel.id],
+                                    cachePath: model.settings.modelSearchPath,
                                     onDownload: {
                                         downloadManager.download(
                                             repoID: hubModel.id,
@@ -1152,7 +1131,33 @@ private struct ActiveDownloadBannerRow: View {
     }
 }
 
-private struct HubModelRow: View {
+private struct ActiveDownloadBannerView: View {
+    @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
+
+    @ViewBuilder
+    var body: some View {
+        if !downloadManager.downloads.isEmpty {
+            VStack(spacing: 0) {
+                ForEach(downloadManager.downloads) { download in
+                    ActiveDownloadBannerRow(
+                        download: download,
+                        onPauseResume: {
+                            if download.state == .paused {
+                                downloadManager.resumeDownload(download.modelID)
+                            } else {
+                                downloadManager.pauseDownload(download.modelID)
+                            }
+                        },
+                        onCancel: { downloadManager.removeDownload(download.modelID) }
+                    )
+                }
+            }
+            Divider()
+        }
+    }
+}
+
+private struct HubModelRow: View, Equatable {
     let model: HuggingFaceModel
     let isInstalled: Bool
     let isDownloading: Bool
@@ -1163,6 +1168,18 @@ private struct HubModelRow: View {
     let onDownload: () -> Void
     let onPauseResume: () -> Void
     let onRemoveDownload: () -> Void
+
+    static func == (lhs: HubModelRow, rhs: HubModelRow) -> Bool {
+        // Actions are intentionally excluded: they do not affect rendering,
+        // while closures are recreated whenever the parent view is rebuilt.
+        lhs.model == rhs.model
+            && lhs.isInstalled == rhs.isInstalled
+            && lhs.isDownloading == rhs.isDownloading
+            && lhs.downloadProgress == rhs.downloadProgress
+            && lhs.isDownloadPaused == rhs.isDownloadPaused
+            && lhs.downloadBlockedReason == rhs.downloadBlockedReason
+            && lhs.downloadError == rhs.downloadError
+    }
 
     private var memoryFitWarning: String? {
         if let estimate = model.memoryEstimate, !estimate.isUsable {
@@ -1289,6 +1306,38 @@ private struct HubModelRow: View {
         return model.isGated
             ? "Gated models require Hugging Face authentication."
             : "Download to the configured cache"
+    }
+}
+
+/// Keeps download progress observation local to the affected row. The parent
+/// Discover view remains stable while a download reports progress.
+private struct HubModelRowContainer: View {
+    @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
+
+    let model: HuggingFaceModel
+    let isInstalled: Bool
+    let cachePath: String
+    let onDownload: () -> Void
+    let onPauseResume: () -> Void
+    let onRemoveDownload: () -> Void
+
+    var body: some View {
+        HubModelRow(
+            model: model,
+            isInstalled: isInstalled,
+            isDownloading: downloadManager.isDownloading(model.id),
+            downloadProgress: downloadManager.progress(for: model.id),
+            isDownloadPaused: downloadManager.isPaused(for: model.id),
+            downloadBlockedReason: downloadManager.capacityBlocker(
+                sizeBytes: model.sizeBytes,
+                cachePath: cachePath
+            ),
+            downloadError: downloadManager.errorByModelID[model.id],
+            onDownload: onDownload,
+            onPauseResume: onPauseResume,
+            onRemoveDownload: onRemoveDownload
+        )
+        .equatable()
     }
 }
 

--- a/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
@@ -84,6 +84,10 @@ final class AudioAnalyticsStore: ObservableObject {
 
     private let storageURL: URL
     private let calendar: Calendar
+    private var cachedWordCounts: [String: Int] = [:]
+    private var cachedTotalWords = 0
+    private var cachedAverageWordsPerMinute: Double?
+    private var cachedEstimatedTimeSaved: TimeInterval = 0
 
     init(
         storageURL: URL? = nil,
@@ -95,35 +99,56 @@ final class AudioAnalyticsStore: ObservableObject {
     }
 
     var totalWords: Int {
-        records.reduce(0) { $0 + $1.wordCount }
+        cachedTotalWords
     }
 
     var averageWordsPerMinute: Double? {
+        cachedAverageWordsPerMinute
+    }
+
+    var estimatedTimeSaved: TimeInterval {
+        cachedEstimatedTimeSaved
+    }
+
+    var currentStreak: Int {
+        calculateCurrentStreak()
+    }
+
+    private func wordCount(for record: AudioTranscriptionRecord) -> Int {
+        cachedWordCounts[record.id] ?? record.wordCount
+    }
+
+    private func rebuildDerivedMetrics() {
+        cachedWordCounts = Dictionary(
+            uniqueKeysWithValues: records.map { ($0.id, $0.wordCount) }
+        )
+        cachedTotalWords = records.reduce(0) { $0 + wordCount(for: $1) }
+
         let timed = records.compactMap { record -> (Int, TimeInterval)? in
             guard let duration = record.durationSeconds, duration > 0 else {
                 return nil
             }
-            return (record.wordCount, duration)
+            return (wordCount(for: record), duration)
         }
         let duration = timed.reduce(0) { $0 + $1.1 }
-        guard duration > 0 else {
-            return nil
+        if duration > 0 {
+            cachedAverageWordsPerMinute = Double(timed.reduce(0) { $0 + $1.0 }) / (duration / 60)
+        } else {
+            cachedAverageWordsPerMinute = nil
         }
-        return Double(timed.reduce(0) { $0 + $1.0 }) / (duration / 60)
-    }
 
-    var estimatedTimeSaved: TimeInterval {
-        records.reduce(0) { result, record in
+        cachedEstimatedTimeSaved = records.reduce(0) { result, record in
             guard let duration = record.durationSeconds else {
                 return result
             }
             let estimatedTypingDuration =
-                Double(record.wordCount) / Self.assumedTypingWordsPerMinute * 60
+                Double(wordCount(for: record)) / Self.assumedTypingWordsPerMinute * 60
             return result + max(0, estimatedTypingDuration - duration)
         }
+
     }
 
-    var currentStreak: Int {
+    private func calculateCurrentStreak() -> Int {
         let activeDays = Set(records.map { calendar.startOfDay(for: $0.recordedAt) })
         guard !activeDays.isEmpty else {
             return 0
@@ -159,7 +184,7 @@ final class AudioAnalyticsStore: ObservableObject {
             }
             return AudioDailyUsage(
                 date: date,
-                words: matching.reduce(0) { $0 + $1.wordCount },
+                words: matching.reduce(0) { $0 + self.wordCount(for: $1) },
                 sessions: matching.count
             )
         }
@@ -206,6 +231,7 @@ final class AudioAnalyticsStore: ObservableObject {
         records.removeAll { $0.id == id }
         records.append(record)
         records.sort { $0.recordedAt > $1.recordedAt }
+        rebuildDerivedMetrics()
         save()
     }
 
@@ -247,6 +273,7 @@ final class AudioAnalyticsStore: ObservableObject {
         records.removeAll { $0.id == recordID }
         records.append(record)
         records.sort { $0.recordedAt > $1.recordedAt }
+        rebuildDerivedMetrics()
         save()
     }
 
@@ -273,6 +300,7 @@ final class AudioAnalyticsStore: ObservableObject {
         records.removeAll { $0.id == recordID }
         records.append(record)
         records.sort { $0.recordedAt > $1.recordedAt }
+        rebuildDerivedMetrics()
         save()
     }
 
@@ -281,6 +309,7 @@ final class AudioAnalyticsStore: ObservableObject {
             return
         }
         records.removeAll { $0.id == recordID }
+        rebuildDerivedMetrics()
         save()
     }
 
@@ -336,6 +365,7 @@ final class AudioAnalyticsStore: ObservableObject {
             return
         }
         records.sort { $0.recordedAt > $1.recordedAt }
+        rebuildDerivedMetrics()
         save()
     }
 
@@ -374,9 +404,11 @@ final class AudioAnalyticsStore: ObservableObject {
               )
         else {
             records = []
+            rebuildDerivedMetrics()
             return
         }
         records = decoded.sorted { $0.recordedAt > $1.recordedAt }
+        rebuildDerivedMetrics()
     }
 
     private func save() {

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -50,7 +50,7 @@ final class AudioCaptureLibrary: ObservableObject {
     @Published private(set) var phase: AudioCapturePhase = .idle
     @Published private(set) var activeKind: AudioRecordKind?
     @Published private(set) var elapsed: TimeInterval = 0
-    @Published private(set) var inputLevel: Float = 0
+    let meterState = AudioInputLevelState()
     @Published private(set) var activeIncludesSystemAudio = false
     @Published private(set) var processingRecordIDs = Set<String>()
     @Published var lastErrorMessage: String?
@@ -143,7 +143,7 @@ final class AudioCaptureLibrary: ObservableObject {
         phase = .preparing
         shouldSummarizeCurrentCapture = automaticallySummarize
         activeIncludesSystemAudio = kind == .meeting && includeSystemAudio
-        inputLevel = 0
+        meterState.update(0)
         lastMeterPublishAt = .distantPast
 
         guard await Self.requestMicrophoneAccess() else {
@@ -616,7 +616,7 @@ final class AudioCaptureLibrary: ObservableObject {
         phase = .idle
         activeKind = nil
         elapsed = 0
-        inputLevel = 0
+        meterState.update(0)
         activeIncludesSystemAudio = false
         activeBackend = nil
         captureStartedAt = nil
@@ -634,7 +634,7 @@ final class AudioCaptureLibrary: ObservableObject {
                 }
                 self.elapsed = Date().timeIntervalSince(captureStartedAt)
                 self.updateRecordingOverlay(
-                    level: self.inputLevel,
+                    level: self.meterState.level,
                     elapsed: self.elapsed
                 )
             }
@@ -661,7 +661,7 @@ final class AudioCaptureLibrary: ObservableObject {
             return
         }
         lastMeterPublishAt = now
-        inputLevel = level
+        meterState.update(level)
         self.elapsed = elapsed
         updateRecordingOverlay(level: level, elapsed: elapsed)
     }

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -67,6 +67,7 @@ final class AudioCaptureLibrary: ObservableObject {
     private var shouldSummarizeCurrentCapture = false
     private var activeBackend: ActiveAudioCaptureBackend?
     private var activeTask: Task<Void, Never>?
+    private var lastMeterPublishAt = Date.distantPast
 
     init(analytics: AudioAnalyticsStore? = nil) {
         self.analytics = analytics ?? .shared
@@ -91,16 +92,13 @@ final class AudioCaptureLibrary: ObservableObject {
             guard let self else {
                 return
             }
-            self.inputLevel = level
-            self.elapsed = elapsed
-            self.updateRecordingOverlay(level: level, elapsed: elapsed)
+            self.publishMeter(level: level, elapsed: elapsed)
         }
         meetingRecorder.onMicrophoneLevelUpdate = { [weak self] level in
             guard let self else {
                 return
             }
-            self.inputLevel = level
-            self.updateRecordingOverlay(level: level, elapsed: self.elapsed)
+            self.publishMeter(level: level, elapsed: self.elapsed)
         }
     }
 
@@ -146,6 +144,7 @@ final class AudioCaptureLibrary: ObservableObject {
         shouldSummarizeCurrentCapture = automaticallySummarize
         activeIncludesSystemAudio = kind == .meeting && includeSystemAudio
         inputLevel = 0
+        lastMeterPublishAt = .distantPast
 
         guard await Self.requestMicrophoneAccess() else {
             fail(AudioCaptureLibraryError.microphonePermissionRequired)
@@ -622,6 +621,7 @@ final class AudioCaptureLibrary: ObservableObject {
         activeBackend = nil
         captureStartedAt = nil
         shouldSummarizeCurrentCapture = false
+        lastMeterPublishAt = .distantPast
         activeTask = nil
     }
 
@@ -653,6 +653,17 @@ final class AudioCaptureLibrary: ObservableObject {
             return
         }
         recordingOverlay.update(level: level, elapsed: elapsed)
+    }
+
+    private func publishMeter(level: Float, elapsed: TimeInterval) {
+        let now = Date()
+        guard now.timeIntervalSince(lastMeterPublishAt) >= 1.0 / 15.0 else {
+            return
+        }
+        lastMeterPublishAt = now
+        inputLevel = level
+        self.elapsed = elapsed
+        updateRecordingOverlay(level: level, elapsed: elapsed)
     }
 
     private static func requestMicrophoneAccess() async -> Bool {

--- a/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
@@ -3,12 +3,15 @@ import Foundation
 
 @MainActor
 final class AudioInputLevelMonitor: ObservableObject {
+    private static let publishInterval: TimeInterval = 1.0 / 15.0
+
     @Published private(set) var level: Float = 0
     @Published private(set) var isMonitoring = false
     @Published private(set) var errorMessage: String?
 
     private var audioEngine: AVAudioEngine?
     private var smoothedLevel: Float = 0
+    private var lastPublishedAt = Date.distantPast
 
     func start(deviceUniqueID: String?) async {
         stop()
@@ -75,6 +78,7 @@ final class AudioInputLevelMonitor: ObservableObject {
         audioEngine = nil
         isMonitoring = false
         smoothedLevel = 0
+        lastPublishedAt = .distantPast
         level = 0
         if resetError {
             errorMessage = nil
@@ -86,6 +90,11 @@ final class AudioInputLevelMonitor: ObservableObject {
             return
         }
         smoothedLevel = (smoothedLevel * 0.65) + (newLevel * 0.35)
+        let now = Date()
+        guard now.timeIntervalSince(lastPublishedAt) >= Self.publishInterval else {
+            return
+        }
+        lastPublishedAt = now
         level = smoothedLevel
     }
 

--- a/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
@@ -2,10 +2,19 @@ import AVFoundation
 import Foundation
 
 @MainActor
+final class AudioInputLevelState: ObservableObject {
+    @Published private(set) var level: Float = 0
+
+    func update(_ level: Float) {
+        self.level = max(0, min(1, level))
+    }
+}
+
+@MainActor
 final class AudioInputLevelMonitor: ObservableObject {
     private static let publishInterval: TimeInterval = 1.0 / 15.0
 
-    @Published private(set) var level: Float = 0
+    let meterState = AudioInputLevelState()
     @Published private(set) var isMonitoring = false
     @Published private(set) var errorMessage: String?
 
@@ -79,7 +88,7 @@ final class AudioInputLevelMonitor: ObservableObject {
         isMonitoring = false
         smoothedLevel = 0
         lastPublishedAt = .distantPast
-        level = 0
+        meterState.update(0)
         if resetError {
             errorMessage = nil
         }
@@ -95,7 +104,7 @@ final class AudioInputLevelMonitor: ObservableObject {
             return
         }
         lastPublishedAt = now
-        level = smoothedLevel
+        meterState.update(smoothedLevel)
     }
 
     private nonisolated static func normalizedLevel(

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -97,11 +97,7 @@ struct AudioView: View {
         }
         .background(Color.nativMainContentBackground)
         .onAppear {
-            refreshLocalModels()
-            importExistingTranscripts()
-            inputDevices.refresh()
-            inputVolume.refresh(deviceUniqueID: inputDevices.effectiveDeviceID)
-            startInputMonitoringIfNeeded()
+            handleViewAppear()
         }
         .onChange(of: model.settings.modelSearchPath) { _, _ in
             refreshLocalModels()
@@ -125,12 +121,7 @@ struct AudioView: View {
             }
         }
         .onChange(of: destination) { _, destination in
-            if destination == .record {
-                inputVolume.refresh(deviceUniqueID: inputDevices.effectiveDeviceID)
-                startInputMonitoringIfNeeded()
-            } else {
-                inputLevelMonitor.stop()
-            }
+            handleDestinationChange(destination)
         }
         .onDisappear {
             inputLevelMonitor.stop()
@@ -1952,6 +1943,39 @@ struct AudioView: View {
             return "\(Int((seconds / 60).rounded())) min"
         }
         return String(format: "%.1f hr", seconds / 3_600)
+    }
+
+    private func handleViewAppear() {
+        switch destination {
+        case .record:
+            refreshLocalModels()
+            inputDevices.refresh()
+            inputVolume.refresh(deviceUniqueID: inputDevices.effectiveDeviceID)
+            startInputMonitoringIfNeeded()
+        case .model:
+            refreshLocalModels()
+        case .overview, .history:
+            importExistingTranscripts()
+        case .animation, .shortcuts:
+            break
+        }
+    }
+
+    private func handleDestinationChange(_ destination: AudioDestination) {
+        switch destination {
+        case .record:
+            refreshLocalModels()
+            inputVolume.refresh(deviceUniqueID: inputDevices.effectiveDeviceID)
+            startInputMonitoringIfNeeded()
+        case .model:
+            refreshLocalModels()
+            inputLevelMonitor.stop()
+        case .overview, .history:
+            importExistingTranscripts()
+            inputLevelMonitor.stop()
+        case .animation, .shortcuts:
+            inputLevelMonitor.stop()
+        }
     }
 
     private func refreshLocalModels() {

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -737,40 +737,11 @@ struct AudioView: View {
     }
 
     private var inputLevelMeter: some View {
-        HStack(spacing: 8) {
-            ForEach(0..<16, id: \.self) { index in
-                let threshold = Float(index + 1) / 16
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(
-                        displayedInputLevel >= threshold
-                            ? inputSegmentColor(at: index)
-                            : Color.secondary.opacity(0.18)
-                    )
-                    .frame(width: 12, height: 30)
-                    .animation(.linear(duration: 0.08), value: displayedInputLevel)
-            }
-        }
-        .frame(maxWidth: 312, alignment: .leading)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Microphone input level")
-        .accessibilityValue("\(Int(displayedInputLevel * 100)) percent")
-    }
-
-    private var displayedInputLevel: Float {
-        captureLibrary.phase == .recording
-            ? captureLibrary.inputLevel
-            : inputLevelMonitor.level
-    }
-
-    private func inputSegmentColor(at index: Int) -> Color {
-        switch index {
-        case 0..<11:
-            .accentColor
-        case 11..<14:
-            .orange
-        default:
-            .red
-        }
+        AudioInputLevelMeterView(
+            captureMeter: captureLibrary.meterState,
+            monitorMeter: inputLevelMonitor.meterState,
+            isRecording: captureLibrary.phase == .recording
+        )
     }
 
     private var audioInputStatus: String {
@@ -2039,6 +2010,47 @@ struct AudioView: View {
             return String(format: "%d:%02d:%02d", hours, minutes, seconds)
         }
         return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+private struct AudioInputLevelMeterView: View {
+    @ObservedObject var captureMeter: AudioInputLevelState
+    @ObservedObject var monitorMeter: AudioInputLevelState
+    let isRecording: Bool
+
+    private var displayedLevel: Float {
+        isRecording ? captureMeter.level : monitorMeter.level
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(0..<16, id: \.self) { index in
+                let threshold = Float(index + 1) / 16
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(
+                        displayedLevel >= threshold
+                            ? segmentColor(at: index)
+                            : Color.secondary.opacity(0.18)
+                    )
+                    .frame(width: 12, height: 30)
+                    .animation(.linear(duration: 0.08), value: displayedLevel)
+            }
+        }
+        .frame(maxWidth: 312, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Microphone input level")
+        .accessibilityValue("\(Int(displayedLevel * 100)) percent")
+    }
+
+    private func segmentColor(at index: Int) -> Color {
+        switch index {
+        case 0..<11:
+            .accentColor
+        case 11..<14:
+            .orange
+        default:
+            .red
+        }
     }
 }
 

--- a/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
@@ -121,6 +121,8 @@ enum VoiceAudioRetention {
 
 @MainActor
 final class VoiceAudioRecorder {
+    private static let meterPublishInterval: TimeInterval = 1.0 / 15.0
+
     var onMeterUpdate: ((Float, TimeInterval) -> Void)?
 
     private(set) var isRecording = false
@@ -129,6 +131,7 @@ final class VoiceAudioRecorder {
     private var recordingWriter: VoiceAudioRecordingWriter?
     private var recordingURL: URL?
     private var smoothedLevel: Float = 0
+    private var lastMeterUpdateElapsed = -Double.infinity
 
     static var recordingsDirectory: URL {
         get throws {
@@ -219,6 +222,7 @@ final class VoiceAudioRecorder {
         isRecording = true
         lastRecordingDuration = nil
         smoothedLevel = 0
+        lastMeterUpdateElapsed = -Double.infinity
         return outputURL
     }
 
@@ -237,6 +241,7 @@ final class VoiceAudioRecorder {
         isRecording = false
         lastRecordingDuration = duration
         smoothedLevel = 0
+        lastMeterUpdateElapsed = -Double.infinity
         onMeterUpdate?(0, duration)
 
         guard duration > 0 else {
@@ -253,6 +258,10 @@ final class VoiceAudioRecorder {
         }
         let shapedLevel = pow(max(0, min(1, level)), 0.72)
         smoothedLevel = (smoothedLevel * 0.68) + (shapedLevel * 0.32)
+        guard elapsed - lastMeterUpdateElapsed >= Self.meterPublishInterval else {
+            return
+        }
+        lastMeterUpdateElapsed = elapsed
         onMeterUpdate?(smoothedLevel, elapsed)
     }
 


### PR DESCRIPTION
## Summary

- coalesce and briefly cache duplicate local-model scans
- reduce SwiftUI chat row work and stream flush frequency
- isolate chat transcript and composer updates from the parent chat page
- load chat history off the main actor during initial page construction
- throttle audio meter UI publications while preserving smoothing
- isolate high-frequency audio meter state so it does not refresh the full Audio page
- cache audio analytics aggregates and reuse one SQLite connection/read snapshot for dashboard reloads
- avoid unnecessary model/transcript work when switching audio pages
- refresh integration statuses concurrently instead of serially waiting on each executable

## Benchmarks

Compared with `origin/main` (`4028b46`) using identical local synthetic workloads:

| Workload | `origin/main` | Optimized | Improvement |
| --- | ---: | ---: | ---: |
| 100 repeated local-model scans | 70.3 ms | 0.77 ms | ~92x faster |
| 40 dashboard read batches | 69.1 ms | 5.8 ms | ~12x faster |

The model-scan benchmark exercises cache/coalescing. The dashboard benchmark exercises connection reuse across six analytics reads per reload. Interactive SwiftUI/audio frame timing still needs Instruments on a production device; `xctrace` was unavailable in the benchmark environment.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -derivedDataPath build/NativDevelopmentDerivedData CODE_SIGNING_ALLOWED=NO build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -derivedDataPath build/NativDevelopmentDerivedData CODE_SIGNING_ALLOWED=NO test` (207 tests passed)
