### PR TITLE
Improve sidebar title / icon alignment

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -181,6 +181,16 @@ private struct ModelsDownloadArrow: View {
     }
 }
 
+private struct SidebarNavigationLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(spacing: 8) {
+            configuration.icon
+                .frame(width: 24, alignment: .center)
+            configuration.title
+        }
+    }
+}
+
 private struct GlobalModelLoadFailureBanner: View {
     let failure: ModelLoadFailure
     let onOpenModels: () -> Void
@@ -588,6 +598,7 @@ struct ControlPanelView: View {
         } label: {
             HStack(spacing: 8) {
                 Label(tab.rawValue, systemImage: tab.systemImage)
+                    .labelStyle(SidebarNavigationLabelStyle())
                 Spacer(minLength: 0)
                 if tab == .models {
                     HStack(spacing: 6) {
@@ -619,6 +630,7 @@ struct ControlPanelView: View {
             applySidebarSelection(selection)
         } label: {
             Label(contribution.title, systemImage: contribution.systemImage)
+                .labelStyle(SidebarNavigationLabelStyle())
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(.rect)
         }


### PR DESCRIPTION
I noticed the titles have a ragged edge, which is especially poor with the new Audio item. This ensures a fixed width for the icons to align the titles.

Before:
<img width="327" height="451" alt="Screenshot 2026-08-03 at 8 08 24 AM" src="https://github.com/user-attachments/assets/d4998351-ef71-4979-a4d1-b1fed52bddda" />

After:
<img width="282" height="371" alt="Screenshot 2026-08-03 at 8 28 27 AM" src="https://github.com/user-attachments/assets/b3989f09-aba3-424b-a586-a0c2dc237731" />
