### PR TITLE
Dictation improvements

### DIFF
--- a/Docs/Extensions.md
+++ b/Docs/Extensions.md
@@ -116,6 +116,9 @@ The host only renders contributions for extensions that are installed, enabled, 
 have an available host adapter or runtime. Removing Audio therefore removes its page
 from navigation and stops its global shortcuts immediately.
 
+Included extensions are enabled by default unless their manifest sets
+`enabledByDefault` to `false`. External extensions always start disabled.
+
 ## Permissions and host services
 
 Permissions are declared up front and enforced again by the XPC broker:

--- a/Extensions/VoiceDictation/Manifest.json
+++ b/Extensions/VoiceDictation/Manifest.json
@@ -38,11 +38,6 @@
         "id": "com.nativ.voice-dictation.retranscribe",
         "title": "Retranscribe",
         "defaultShortcut": "Fn+R"
-      },
-      {
-        "id": "com.nativ.voice-dictation.hands-free",
-        "title": "Hands-free",
-        "defaultShortcut": "Option"
       }
     ],
     "settings": [

--- a/Extensions/VoiceDictation/Manifest.json
+++ b/Extensions/VoiceDictation/Manifest.json
@@ -8,6 +8,7 @@
   "developer": "Nativ",
   "systemImage": "waveform.badge.mic",
   "included": true,
+  "enabledByDefault": false,
   "runtime": "extensionFoundation",
   "extensionPoint": "com.nativ.extension",
   "runtimeBundleIdentifier": "dev.local.Nativ.VoiceDictationExtension",

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -134,6 +134,11 @@ private enum ControlPanelLayout {
     static let sidebarTransitionSettleDuration: Duration = .milliseconds(225)
 }
 
+private enum ControlPanelOnboarding {
+    static let extensionsBadgeDismissedKey =
+        "nativ.control-panel.extensions-new-badge-dismissed.v1"
+}
+
 extension Color {
     static let nativMainContentBackground = Color(
         nsColor: NSColor(name: NSColor.Name("NativMainContentBackground")) { appearance in
@@ -239,6 +244,8 @@ struct ControlPanelView: View {
     @StateObject private var systemMonitor = SystemMonitorStore()
     @StateObject private var launchAtLogin = LaunchAtLoginController()
     @ObservedObject private var downloads = HuggingFaceDownloadManager.shared
+    @AppStorage(ControlPanelOnboarding.extensionsBadgeDismissedKey)
+    private var isExtensionsBadgeDismissed = false
     @State private var sidebarSelection: ControlPanelSidebarSelection = .tab(.chat)
     @State private var selectedTab: ControlPanelTab = .chat
     @State private var hoveredFooterControl: FooterControl?
@@ -588,6 +595,14 @@ struct ControlPanelView: View {
         } label: {
             HStack(spacing: 8) {
                 Label(tab.rawValue, systemImage: tab.systemImage)
+                if tab == .extensions, !isExtensionsBadgeDismissed {
+                    Text("NEW")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.accentColor, in: Capsule())
+                }
                 Spacer(minLength: 0)
                 if tab == .models {
                     HStack(spacing: 6) {
@@ -1728,6 +1743,9 @@ struct ControlPanelView: View {
     private func applySidebarSelection(_ selection: ControlPanelSidebarSelection) {
         switch selection {
         case .tab(let tab):
+            if tab == .extensions {
+                isExtensionsBadgeDismissed = true
+            }
             if tab == .chat, chat.currentSessionID == nil {
                 chat.createSession()
             } else if tab == .imageGeneration,
@@ -3776,7 +3794,6 @@ private struct SidebarRowSelectionStyle: ViewModifier {
             .foregroundStyle(Color.primary)
             .contentShape(.rect)
             .onHover { isHovering = $0 }
-            .animation(.easeInOut, value: isHovering)
     }
 
     private var backgroundColor: Color {

--- a/Sources/Nativ/Features/Extensions/ExtensionsView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsView.swift
@@ -267,7 +267,7 @@ struct ExtensionsView: View {
 
             FlowLayout(spacing: 8) {
                 ForEach(record.manifest.permissions, id: \.self) { permission in
-                    permissionBadge(permission)
+                    permissionBadge(permission, extensionIsEnabled: record.isEnabled)
                 }
             }
         }
@@ -275,10 +275,13 @@ struct ExtensionsView: View {
 
     @ViewBuilder
     private func permissionBadge(
-        _ permission: NativExtensionPermission
+        _ permission: NativExtensionPermission,
+        extensionIsEnabled: Bool
     ) -> some View {
         let status = manager.permissionStatus(permission)
-        let actionTitle = manager.permissionActionTitle(permission)
+        let actionTitle = extensionIsEnabled
+            ? manager.permissionActionTitle(permission)
+            : nil
         if let actionTitle {
             Button {
                 manager.requestPermission(permission)

--- a/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
+++ b/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
@@ -211,9 +211,15 @@ final class NativExtensionManager: ObservableObject {
               !record.isRemoved else {
             return
         }
+        let shouldRequestMicrophone = enabled
+            && !record.isEnabled
+            && record.manifest.permissions.contains(.microphone)
         stateStore.set(enabled ? .enabled : .disabled, for: extensionID)
         rebuildRecords()
         reconcileLifecycle()
+        if shouldRequestMicrophone {
+            requestPermission(.microphone)
+        }
     }
 
     func remove(extensionID: String) {
@@ -240,12 +246,17 @@ final class NativExtensionManager: ObservableObject {
     }
 
     func restore(extensionID: String) {
-        guard records.contains(where: { $0.id == extensionID }) else {
+        guard let record = records.first(where: { $0.id == extensionID }),
+              record.isRemoved else {
             return
         }
+        let shouldRequestMicrophone = record.manifest.permissions.contains(.microphone)
         stateStore.set(.enabled, for: extensionID)
         rebuildRecords()
         reconcileLifecycle()
+        if shouldRequestMicrophone {
+            requestPermission(.microphone)
+        }
     }
 
     func installPackage(at sourceURL: URL) {

--- a/Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
+++ b/Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
@@ -31,7 +31,7 @@ final class NativExtensionStateStore {
     }
 
     func state(for manifest: NativExtensionManifest) -> NativExtensionInstallState {
-        states[manifest.id] ?? (manifest.included ? .enabled : .disabled)
+        states[manifest.id] ?? (manifest.isEnabledByDefault ? .enabled : .disabled)
     }
 
     func set(_ state: NativExtensionInstallState, for extensionID: String) {

--- a/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
+++ b/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
@@ -130,11 +130,6 @@ final class VoiceDictationExtension: NativHostExtension {
                     title: "Retranscribe",
                     defaultShortcut: "Fn+R"
                 ),
-                .init(
-                    id: "com.nativ.voice-dictation.hands-free",
-                    title: "Hands-free",
-                    defaultShortcut: "Command+Option"
-                ),
             ],
             settings: [
                 .init(id: "com.nativ.voice-dictation.model", title: "Speech-to-text model"),

--- a/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
+++ b/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
@@ -100,6 +100,7 @@ final class VoiceDictationExtension: NativHostExtension {
         developer: "Nativ",
         systemImage: "waveform.badge.mic",
         included: true,
+        enabledByDefault: false,
         runtime: .extensionFoundation,
         runtimeBundleIdentifier: "dev.local.Nativ.VoiceDictationExtension",
         contributions: .init(
@@ -132,7 +133,7 @@ final class VoiceDictationExtension: NativHostExtension {
                 .init(
                     id: "com.nativ.voice-dictation.hands-free",
                     title: "Hands-free",
-                    defaultShortcut: "Option"
+                    defaultShortcut: "Command+Option"
                 ),
             ],
             settings: [

--- a/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
@@ -284,6 +284,50 @@ final class AudioAnalyticsStore: ObservableObject {
         save()
     }
 
+    func deleteDictation(
+        withID recordID: String,
+        recordingsDirectory: URL?,
+        fileManager: FileManager = .default
+    ) {
+        guard records.contains(where: {
+            $0.id == recordID && $0.resolvedKind == .dictation
+        }) else {
+            return
+        }
+        if let recordingsDirectory {
+            Self.deleteDictationFiles(
+                withID: recordID,
+                in: recordingsDirectory,
+                fileManager: fileManager
+            )
+        }
+        records.removeAll { $0.id == recordID }
+        save()
+    }
+
+    func deleteAllDictations(
+        recordingsDirectory: URL?,
+        fileManager: FileManager = .default
+    ) {
+        let recordIDs = records.compactMap { record in
+            record.resolvedKind == .dictation ? record.id : nil
+        }
+        guard !recordIDs.isEmpty else {
+            return
+        }
+        if let recordingsDirectory {
+            for recordID in recordIDs {
+                Self.deleteDictationFiles(
+                    withID: recordID,
+                    in: recordingsDirectory,
+                    fileManager: fileManager
+                )
+            }
+        }
+        records.removeAll { $0.resolvedKind == .dictation }
+        save()
+    }
+
     func importTranscripts(in directory: URL) {
         guard let urls = try? FileManager.default.contentsOfDirectory(
             at: directory,
@@ -364,6 +408,19 @@ final class AudioAnalyticsStore: ObservableObject {
             forKeys: [.contentModificationDateKey, .creationDateKey]
         )
         return values?.contentModificationDate ?? values?.creationDate
+    }
+
+    private static func deleteDictationFiles(
+        withID recordID: String,
+        in directory: URL,
+        fileManager: FileManager
+    ) {
+        for pathExtension in ["txt", "wav"] {
+            let url = directory
+                .appendingPathComponent(recordID)
+                .appendingPathExtension(pathExtension)
+            try? fileManager.removeItem(at: url)
+        }
     }
 
     private func load() {

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -147,7 +147,7 @@ final class AudioCaptureLibrary: ObservableObject {
         activeIncludesSystemAudio = kind == .meeting && includeSystemAudio
         inputLevel = 0
 
-        guard await Self.requestMicrophoneAccess() else {
+        guard Self.hasMicrophoneAccess() else {
             fail(AudioCaptureLibraryError.microphonePermissionRequired)
             return
         }
@@ -655,17 +655,8 @@ final class AudioCaptureLibrary: ObservableObject {
         recordingOverlay.update(level: level, elapsed: elapsed)
     }
 
-    private static func requestMicrophoneAccess() async -> Bool {
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .authorized:
-            return true
-        case .denied, .restricted:
-            return false
-        case .notDetermined:
-            return await AVCaptureDevice.requestAccess(for: .audio)
-        @unknown default:
-            return false
-        }
+    private static func hasMicrophoneAccess() -> Bool {
+        AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
     }
 
     private static func makeOutputURL(

--- a/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
@@ -14,7 +14,7 @@ final class AudioInputLevelMonitor: ObservableObject {
         stop()
         errorMessage = nil
 
-        guard await Self.requestMicrophoneAccess() else {
+        guard Self.hasMicrophoneAccess() else {
             errorMessage = "Microphone access is required to test this input."
             return
         }
@@ -114,16 +114,7 @@ final class AudioInputLevelMonitor: ObservableObject {
         return pow(min(1, rootMeanSquare * 8), 0.65)
     }
 
-    private static func requestMicrophoneAccess() async -> Bool {
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .authorized:
-            true
-        case .denied, .restricted:
-            false
-        case .notDetermined:
-            await AVCaptureDevice.requestAccess(for: .audio)
-        @unknown default:
-            false
-        }
+    private static func hasMicrophoneAccess() -> Bool {
+        AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
     }
 }

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -1680,16 +1680,35 @@ struct AudioView: View {
             }
 
             VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Hands-free")
+                            .font(.callout.weight(.medium))
+                        Text(
+                            shortcuts.isHandsFreeEnabled
+                                ? "Press once to start; press again to transcribe."
+                                : "Hold while speaking; release to transcribe."
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+
+                    Spacer(minLength: 16)
+
+                    Toggle("Hands-free", isOn: $shortcuts.isHandsFreeEnabled)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+                .padding(10)
+                .background(
+                    Color.primary.opacity(0.035),
+                    in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+                )
+
                 shortcutRow(
-                    title: "Record while held",
+                    title: "Dictation shortcut",
                     shortcut: shortcuts.recordShortcut,
                     kind: .record
-                )
-                shortcutRow(
-                    title: "Hands-free toggle",
-                    subtitle: "Press once to start; press again to transcribe.",
-                    shortcut: shortcuts.handsFreeShortcut,
-                    kind: .handsFree
                 )
                 shortcutRow(
                     title: "Retry recent audio",
@@ -1852,8 +1871,6 @@ struct AudioView: View {
                     switch kind {
                     case .record:
                         shortcuts.resetRecordShortcut()
-                    case .handsFree:
-                        shortcuts.resetHandsFreeShortcut()
                     case .retry:
                         shortcuts.resetRetryShortcut()
                     }
@@ -2038,7 +2055,6 @@ struct AudioView: View {
     private func apply(_ shortcut: VoiceShortcut, to kind: AudioShortcutKind) {
         let assignments: [(AudioShortcutKind, VoiceShortcut)] = [
             (.record, shortcuts.recordShortcut),
-            (.handsFree, shortcuts.handsFreeShortcut),
             (.retry, shortcuts.retryShortcut),
         ]
         guard !assignments.contains(where: {
@@ -2052,8 +2068,6 @@ struct AudioView: View {
         switch kind {
         case .record:
             shortcuts.recordShortcut = shortcut
-        case .handsFree:
-            shortcuts.handsFreeShortcut = shortcut
         case .retry:
             shortcuts.retryShortcut = shortcut
         }
@@ -2116,15 +2130,13 @@ private struct AudioInputLevelMeterView: View {
 
 private enum AudioShortcutKind: String, Identifiable {
     case record
-    case handsFree
     case retry
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .record: "Record shortcut"
-        case .handsFree: "Hands-free shortcut"
+        case .record: "Dictation shortcut"
         case .retry: "Retry shortcut"
         }
     }

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -62,6 +62,8 @@ struct AudioView: View {
     @State private var editingShortcut: AudioShortcutKind?
     @State private var shortcutConflict: String?
     @State private var destination: AudioDestination = .record
+    @State private var pendingDeleteDictation: AudioTranscriptionRecord?
+    @State private var isConfirmingClearAllDictations = false
 
     let titleLeadingInset: CGFloat
     let onOpenSpeechModels: () -> Void
@@ -174,6 +176,35 @@ struct AudioView: View {
             }
         } message: {
             Text(captureLibrary.lastErrorMessage ?? "Audio capture failed.")
+        }
+        .alert(
+            "Delete dictation?",
+            isPresented: Binding(
+                get: { pendingDeleteDictation != nil },
+                set: { if !$0 { pendingDeleteDictation = nil } }
+            ),
+            presenting: pendingDeleteDictation
+        ) { record in
+            Button("Delete", role: .destructive) {
+                deleteDictation(record)
+                pendingDeleteDictation = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDeleteDictation = nil
+            }
+        } message: { _ in
+            Text("The transcript and any retained audio will be permanently deleted.")
+        }
+        .alert(
+            "Clear all recent dictations?",
+            isPresented: $isConfirmingClearAllDictations
+        ) {
+            Button("Clear All", role: .destructive) {
+                clearAllDictations()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("All locally stored dictation transcripts and retained dictation audio will be permanently deleted.")
         }
     }
 
@@ -1725,6 +1756,15 @@ struct AudioView: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
+                Button("Clear All", role: .destructive) {
+                    isConfirmingClearAllDictations = true
+                }
+                .buttonStyle(.plain)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.red)
+                .disabled(dictationRecords.isEmpty)
+                .help("Delete all recent dictations")
+
                 TextField("Search transcripts", text: $searchText)
                     .textFieldStyle(.roundedBorder)
                     .frame(width: 240)
@@ -1748,7 +1788,10 @@ struct AudioView: View {
                 LazyVStack(spacing: 0) {
                     ForEach(Array(filteredRecords.prefix(30).enumerated()), id: \.element.id) {
                         index, record in
-                        AudioTranscriptRow(record: record)
+                        AudioTranscriptRow(
+                            record: record,
+                            onDelete: { pendingDeleteDictation = record }
+                        )
                         if index < min(filteredRecords.count, 30) - 1 {
                             Divider()
                         }
@@ -1877,16 +1920,19 @@ struct AudioView: View {
     }
 
     private var filteredRecords: [AudioTranscriptionRecord] {
-        let dictations = analytics.records.filter { $0.resolvedKind == .dictation }
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {
-            return dictations
+            return dictationRecords
         }
-        return dictations.filter { record in
+        return dictationRecords.filter { record in
             record.transcript.localizedCaseInsensitiveContains(query)
                 || record.applicationName?.localizedCaseInsensitiveContains(query) == true
                 || record.modelID?.localizedCaseInsensitiveContains(query) == true
         }
+    }
+
+    private var dictationRecords: [AudioTranscriptionRecord] {
+        analytics.records.filter { $0.resolvedKind == .dictation }
     }
 
     private var captureRecords: [AudioTranscriptionRecord] {
@@ -1978,6 +2024,20 @@ struct AudioView: View {
             return
         }
         analytics.importTranscripts(in: directory)
+    }
+
+    private func deleteDictation(_ record: AudioTranscriptionRecord) {
+        analytics.deleteDictation(
+            withID: record.id,
+            recordingsDirectory: try? VoiceAudioRecorder.recordingsDirectory
+        )
+    }
+
+    private func clearAllDictations() {
+        analytics.deleteAllDictations(
+            recordingsDirectory: try? VoiceAudioRecorder.recordingsDirectory
+        )
+        searchText = ""
     }
 
     private func apply(_ shortcut: VoiceShortcut, to kind: AudioShortcutKind) {
@@ -2229,7 +2289,9 @@ private struct InlineEditableAudioTitle: View {
 
 private struct AudioTranscriptRow: View {
     let record: AudioTranscriptionRecord
+    let onDelete: () -> Void
     @State private var copied = false
+    @State private var isDeleteHovering = false
 
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
@@ -2259,22 +2321,43 @@ private struct AudioTranscriptRow: View {
 
             Spacer(minLength: 12)
 
-            Button {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(record.transcript, forType: .string)
-                copied = true
-                Task {
-                    try? await Task.sleep(for: .seconds(1.5))
-                    copied = false
+            HStack(spacing: 4) {
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(record.transcript, forType: .string)
+                    copied = true
+                    Task {
+                        try? await Task.sleep(for: .seconds(1.5))
+                        copied = false
+                    }
+                } label: {
+                    Label(
+                        copied ? "Copied" : "Copy",
+                        systemImage: copied ? "checkmark" : "doc.on.doc"
+                    )
                 }
-            } label: {
-                Label(
-                    copied ? "Copied" : "Copy",
-                    systemImage: copied ? "checkmark" : "doc.on.doc"
-                )
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(role: .destructive, action: onDelete) {
+                    Image(systemName: "trash")
+                        .font(.caption)
+                        .frame(width: 26, height: 20)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(
+                                    isDeleteHovering
+                                        ? Color.red.opacity(0.13)
+                                        : Color.clear
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(isDeleteHovering ? Color.red : Color.secondary)
+                .help("Delete dictation")
+                .accessibilityLabel("Delete dictation")
+                .onHover { isDeleteHovering = $0 }
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
         }
         .padding(.vertical, 12)
     }

--- a/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
@@ -104,7 +104,6 @@ private let voiceHotKeyHandler: EventHandlerUPP = { _, event, userData in
 final class FnControlShortcutMonitor {
     var onChange: ((Bool) -> Void)?
     var onRetry: (() -> Void)?
-    var onHandsFreeToggle: (() -> Void)?
 
     private var localMonitor: Any?
     private var globalMonitor: Any?
@@ -113,15 +112,14 @@ final class FnControlShortcutMonitor {
     private var recordIsHeld = false
     private var retryModifierIsHeld = false
     private var retryState = FnRetryShortcutState()
-    private var handsFreeModifierState = VoiceModifierToggleShortcutState()
-    private var handsFreeKeyState = FnRetryShortcutState()
+    private var recordModifierToggleState = VoiceModifierToggleShortcutState()
+    private var recordKeyToggleState = FnRetryShortcutState()
     private var hotKeys: [UInt32: EventHotKeyRef] = [:]
     private var hotKeyEventHandler: EventHandlerRef?
     private let preferences: VoiceShortcutPreferences
     private let hotKeySignature = OSType(0x4E_41_54_56)
     private let recordHotKeyID: UInt32 = 1
     private let retryHotKeyID: UInt32 = 2
-    private let handsFreeHotKeyID: UInt32 = 3
 
     init(preferences: VoiceShortcutPreferences? = nil) {
         self.preferences = preferences ?? .shared
@@ -182,8 +180,8 @@ final class FnControlShortcutMonitor {
         retryModifierIsHeld = false
         uninstallHotKeys()
         retryState = FnRetryShortcutState()
-        handsFreeModifierState.reset()
-        handsFreeKeyState = FnRetryShortcutState()
+        recordModifierToggleState.reset()
+        recordKeyToggleState = FnRetryShortcutState()
     }
 
     func resynchronizeAfterModalInteraction() {
@@ -191,8 +189,8 @@ final class FnControlShortcutMonitor {
         recordIsHeld = false
         retryModifierIsHeld = false
         retryState = FnRetryShortcutState()
-        handsFreeModifierState.reset()
-        handsFreeKeyState = FnRetryShortcutState()
+        recordModifierToggleState.reset()
+        recordKeyToggleState = FnRetryShortcutState()
 
         if recordWasHeld {
             onChange?(false)
@@ -232,7 +230,7 @@ final class FnControlShortcutMonitor {
                 )
             )
         case .keyDown:
-            handsFreeModifierState.noteKeyDown()
+            recordModifierToggleState.noteKeyDown()
         default:
             break
         }
@@ -240,10 +238,20 @@ final class FnControlShortcutMonitor {
 
     private func consume(_ activeModifiers: VoiceShortcutModifiers) {
         if preferences.recordShortcut.keyCode == nil {
-            let isHeld =
-                activeModifiers == preferences.recordShortcut.modifiers
-                && !activeModifiers.isEmpty
-            updateRecordState(isHeld)
+            if preferences.isHandsFreeEnabled {
+                if recordModifierToggleState.update(
+                    activeModifiers: activeModifiers,
+                    shortcutModifiers: preferences.recordShortcut.modifiers
+                ) {
+                    onChange?(true)
+                }
+            } else {
+                recordModifierToggleState.reset()
+                let isHeld =
+                    activeModifiers == preferences.recordShortcut.modifiers
+                    && !activeModifiers.isEmpty
+                updateRecordState(isHeld)
+            }
         }
 
         if preferences.retryShortcut.keyCode == nil {
@@ -254,15 +262,6 @@ final class FnControlShortcutMonitor {
                 onRetry?()
             }
             retryModifierIsHeld = isHeld
-        }
-
-        if preferences.handsFreeShortcut.keyCode == nil,
-           handsFreeModifierState.update(
-               activeModifiers: activeModifiers,
-               shortcutModifiers: preferences.handsFreeShortcut.modifiers
-           )
-        {
-            onHandsFreeToggle?()
         }
     }
 
@@ -279,14 +278,16 @@ final class FnControlShortcutMonitor {
 
         switch id {
         case recordHotKeyID:
-            updateRecordState(isPressed)
+            if preferences.isHandsFreeEnabled {
+                if recordKeyToggleState.update(isPressed: isPressed) {
+                    onChange?(true)
+                }
+            } else {
+                updateRecordState(isPressed)
+            }
         case retryHotKeyID:
             if retryState.update(isPressed: isPressed) {
                 onRetry?()
-            }
-        case handsFreeHotKeyID:
-            if handsFreeKeyState.update(isPressed: isPressed) {
-                onHandsFreeToggle?()
             }
         default:
             break
@@ -307,8 +308,8 @@ final class FnControlShortcutMonitor {
         }
         retryModifierIsHeld = false
         retryState = FnRetryShortcutState()
-        handsFreeModifierState.reset()
-        handsFreeKeyState = FnRetryShortcutState()
+        recordModifierToggleState.reset()
+        recordKeyToggleState = FnRetryShortcutState()
         uninstallHotKeys()
         installHotKeys()
         consumeCurrentModifierFlags()
@@ -322,7 +323,6 @@ final class FnControlShortcutMonitor {
         let keyedShortcuts = [
             (recordHotKeyID, preferences.recordShortcut),
             (retryHotKeyID, preferences.retryShortcut),
-            (handsFreeHotKeyID, preferences.handsFreeShortcut),
         ].filter { $0.1.keyCode != nil }
         guard !keyedShortcuts.isEmpty else {
             return

--- a/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
@@ -247,6 +247,13 @@ final class VoiceAudioRecorder {
         return recordingURL
     }
 
+    func discard() {
+        if let recordingURL = stop() {
+            try? FileManager.default.removeItem(at: recordingURL)
+        }
+        lastRecordingDuration = nil
+    }
+
     private func updateMeter(level: Float, elapsed: TimeInterval) {
         guard isRecording else {
             return

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -42,6 +42,9 @@ final class VoiceCaptureCoordinator {
         shortcutMonitor.onHandsFreeToggle = { [weak self] in
             self?.toggleHandsFreeCapture()
         }
+        overlay.setDictationCancelAction { [weak self] in
+            self?.cancelCapture()
+        }
         recorder.onMeterUpdate = { [weak self] level, elapsed in
             self?.overlay.update(level: level, elapsed: elapsed)
         }
@@ -118,7 +121,7 @@ final class VoiceCaptureCoordinator {
             guard let self else {
                 return
             }
-            let isAuthorized = await Self.requestMicrophoneAccess()
+            let isAuthorized = Self.hasMicrophoneAccess()
             guard !Task.isCancelled, self.isShortcutHeld else {
                 return
             }
@@ -159,6 +162,17 @@ final class VoiceCaptureCoordinator {
             return
         }
         activeOverlayTranscriptionID = nil
+        overlay.hide()
+    }
+
+    private func cancelCapture() {
+        permissionTask?.cancel()
+        permissionTask = nil
+        recorder.discard()
+        activeOverlayTranscriptionID = nil
+        insertionTarget = nil
+        isShortcutHeld = false
+        isHandsFreeMode = false
         overlay.hide()
     }
 
@@ -488,16 +502,7 @@ final class VoiceCaptureCoordinator {
         }
     }
 
-    private static func requestMicrophoneAccess() async -> Bool {
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .authorized:
-            true
-        case .notDetermined:
-            await AVCaptureDevice.requestAccess(for: .audio)
-        case .denied, .restricted:
-            false
-        @unknown default:
-            false
-        }
+    private static func hasMicrophoneAccess() -> Bool {
+        AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
     }
 }

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -39,9 +39,6 @@ final class VoiceCaptureCoordinator {
         shortcutMonitor.onRetry = { [weak self] in
             self?.retryLastTranscription()
         }
-        shortcutMonitor.onHandsFreeToggle = { [weak self] in
-            self?.toggleHandsFreeCapture()
-        }
         overlay.setDictationCancelAction { [weak self] in
             self?.cancelCapture()
         }
@@ -85,29 +82,32 @@ final class VoiceCaptureCoordinator {
     }
 
     private func handleShortcutChange(_ isHeld: Bool) {
-        guard !isHandsFreeMode else {
-            return
-        }
-        isShortcutHeld = isHeld
-        if isHeld {
-            beginCapture()
-        } else {
-            endCapture()
-        }
-    }
-
-    private func toggleHandsFreeCapture() {
         if isHandsFreeMode {
+            guard isHeld else {
+                return
+            }
             isHandsFreeMode = false
             isShortcutHeld = false
             endCapture()
             return
         }
 
-        guard !isShortcutHeld, !recorder.isRecording else {
+        if isShortcutHeld {
+            guard !isHeld else {
+                return
+            }
+            isShortcutHeld = false
+            endCapture()
             return
         }
-        isHandsFreeMode = true
+
+        guard isHeld else {
+            return
+        }
+
+        if VoiceShortcutPreferences.shared.isHandsFreeEnabled {
+            isHandsFreeMode = true
+        }
         isShortcutHeld = true
         beginCapture()
     }

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureOverlay.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureOverlay.swift
@@ -65,6 +65,7 @@ final class VoiceCaptureOverlayModel: ObservableObject {
     var completeAudioCapture: (() -> Void)?
     var restartAudioCapture: (() -> Void)?
     var deleteAudioCapture: (() -> Void)?
+    var cancelDictation: (() -> Void)?
 
     func beginActivation(presentation: Presentation = .dictation) {
         let now = Date()
@@ -85,8 +86,8 @@ final class VoiceCaptureOverlayModel: ObservableObject {
 
 @MainActor
 final class VoiceCaptureOverlayController {
-    private static let waveformPanelSize = NSSize(width: 184, height: 58)
-    private static let floatingIslandPanelSize = NSSize(width: 128, height: 52)
+    private static let waveformPanelSize = NSSize(width: 210, height: 58)
+    private static let floatingIslandPanelSize = NSSize(width: 140, height: 52)
     private static let floatingAudioCapturePanelSize = NSSize(width: 226, height: 52)
     private static let verticalAudioCapturePanelSize = NSSize(width: 72, height: 258)
     private let model: VoiceCaptureOverlayModel
@@ -128,6 +129,10 @@ final class VoiceCaptureOverlayController {
         model.completeAudioCapture = complete
         model.restartAudioCapture = restart
         model.deleteAudioCapture = delete
+    }
+
+    func setDictationCancelAction(_ action: @escaping () -> Void) {
+        model.cancelDictation = action
     }
 
     private static func makePanel<Content: View>(
@@ -198,7 +203,8 @@ final class VoiceCaptureOverlayController {
         }
         activeSoundStyle = soundPreferences.selectedStyle
         model.islandStyle = activeStyle
-        islandPanel.ignoresMouseEvents = presentation.audioCaptureKind == nil
+        waveformPanel.ignoresMouseEvents = presentation.audioCaptureKind != nil
+        islandPanel.ignoresMouseEvents = false
         islandPanel.isMovable = activeStyle == .verticalRecorder
         islandPanel.isMovableByWindowBackground = activeStyle == .verticalRecorder
         waveformPanel.clearPinnedFrame()
@@ -1152,11 +1158,18 @@ private struct VoiceCaptureOverlayView: View {
                             )
                             .foregroundStyle(.white.opacity(0.68))
                             .frame(width: 34, alignment: .trailing)
+
+                        if !isAudioCapture {
+                            VoiceCaptureDictationCancelButton(
+                                action: model.cancelDictation
+                            )
+                            .disabled(!canCancelDictation)
+                        }
                     }
                 }
             }
             .padding(.horizontal, isAudioCapture ? 10 : 14)
-            .frame(width: 184, height: 52)
+            .frame(width: isAudioCapture ? 184 : 210, height: 52)
             .background {
                 Capsule()
                     .fill(Color.black.opacity(0.94))
@@ -1168,7 +1181,7 @@ private struct VoiceCaptureOverlayView: View {
             .opacity(1 - finishProgress)
         }
         .padding(.vertical, 3)
-        .accessibilityElement(children: .ignore)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
     }
 
@@ -1204,6 +1217,10 @@ private struct VoiceCaptureOverlayView: View {
 
     private var isAudioCapture: Bool {
         model.presentation.audioCaptureKind != nil
+    }
+
+    private var canCancelDictation: Bool {
+        !isAudioCapture && (model.state == .preparing || model.state == .recording)
     }
 
     private var indicatorColor: Color {
@@ -1395,7 +1412,7 @@ private struct VoiceCaptureIslandView: View {
                 floatingIsland
             }
         }
-        .accessibilityElement(children: .ignore)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
     }
 
@@ -1431,11 +1448,16 @@ private struct VoiceCaptureIslandView: View {
 
                 if model.presentation.audioCaptureKind != nil {
                     VoiceCaptureRecordingControls(model: model)
+                } else {
+                    VoiceCaptureDictationCancelButton(
+                        action: model.cancelDictation
+                    )
+                    .disabled(!canCancelDictation)
                 }
             }
             .padding(.horizontal, model.presentation.audioCaptureKind == nil ? 15 : 12)
             .frame(
-                width: model.presentation.audioCaptureKind == nil ? 128 : 226,
+                width: model.presentation.audioCaptureKind == nil ? 140 : 226,
                 height: 46
             )
             .background {
@@ -1458,6 +1480,11 @@ private struct VoiceCaptureIslandView: View {
     private var formattedElapsed: String {
         let seconds = max(0, Int(model.elapsed))
         return String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
+
+    private var canCancelDictation: Bool {
+        model.presentation.audioCaptureKind == nil
+            && (model.state == .preparing || model.state == .recording)
     }
 
     private var feedbackText: String {
@@ -1689,7 +1716,7 @@ struct VoiceCaptureNotchIslandView: View {
     }
 
     private var rightContent: some View {
-        HStack(spacing: 7) {
+        HStack(spacing: model.presentation.audioCaptureKind == nil ? 3 : 7) {
             if model.state == .failed {
                 Text("Mic")
                     .font(.system(size: 10, weight: .semibold))
@@ -1706,6 +1733,11 @@ struct VoiceCaptureNotchIslandView: View {
                         tint: .red,
                         action: model.completeAudioCapture
                     )
+                } else {
+                    VoiceCaptureDictationCancelButton(
+                        action: model.cancelDictation
+                    )
+                    .disabled(!canCancelDictation)
                 }
             }
         }
@@ -1719,6 +1751,11 @@ struct VoiceCaptureNotchIslandView: View {
     private var formattedElapsed: String {
         let seconds = max(0, Int(model.elapsed))
         return String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
+
+    private var canCancelDictation: Bool {
+        model.presentation.audioCaptureKind == nil
+            && (model.state == .preparing || model.state == .recording)
     }
 }
 
@@ -1884,7 +1921,7 @@ private struct VoiceCaptureWideNotchView: View {
     }
 
     private var rightContent: some View {
-        HStack(spacing: 7) {
+        HStack(spacing: model.presentation.audioCaptureKind == nil ? 5 : 7) {
             if model.state == .failed {
                 Text("Mic")
                     .font(.system(size: 10, weight: .semibold))
@@ -1901,6 +1938,11 @@ private struct VoiceCaptureWideNotchView: View {
                         tint: .red,
                         action: model.completeAudioCapture
                     )
+                } else {
+                    VoiceCaptureDictationCancelButton(
+                        action: model.cancelDictation
+                    )
+                    .disabled(!canCancelDictation)
                 }
             }
         }
@@ -1909,6 +1951,11 @@ private struct VoiceCaptureWideNotchView: View {
     private var formattedElapsed: String {
         let seconds = max(0, Int(model.elapsed))
         return String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
+
+    private var canCancelDictation: Bool {
+        model.presentation.audioCaptureKind == nil
+            && (model.state == .preparing || model.state == .recording)
     }
 }
 
@@ -1961,6 +2008,25 @@ private struct VoiceCaptureActionButton: View {
         .buttonStyle(.plain)
         .help(title)
         .accessibilityLabel(title)
+    }
+}
+
+private struct VoiceCaptureDictationCancelButton: View {
+    let action: (() -> Void)?
+
+    var body: some View {
+        Button {
+            action?()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.52))
+                .frame(width: 18, height: 18)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Cancel dictation")
+        .accessibilityLabel("Cancel dictation")
     }
 }
 

--- a/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
@@ -87,6 +87,11 @@ struct VoiceShortcut: Codable, Equatable, Sendable {
     static let handsFreeDefault = VoiceShortcut(
         keyCode: nil,
         keyDisplay: nil,
+        modifiers: [.command, .option]
+    )
+    static let legacyHandsFreeDefault = VoiceShortcut(
+        keyCode: nil,
+        keyDisplay: nil,
         modifiers: [.option]
     )
 
@@ -178,9 +183,12 @@ final class VoiceShortcutPreferences: ObservableObject {
         {
             recordShortcut = payload.recordShortcut
             retryShortcut = payload.retryShortcut
-            handsFreeShortcut = payload.handsFreeShortcut.flatMap {
+            let storedHandsFreeShortcut = payload.handsFreeShortcut.flatMap {
                 $0.isValid ? $0 : nil
             } ?? .handsFreeDefault
+            handsFreeShortcut = storedHandsFreeShortcut == .legacyHandsFreeDefault
+                ? .handsFreeDefault
+                : storedHandsFreeShortcut
         } else {
             recordShortcut = .recordDefault
             retryShortcut = .retryDefault

--- a/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
@@ -84,16 +84,6 @@ struct VoiceShortcut: Codable, Equatable, Sendable {
         keyDisplay: "R",
         modifiers: [.function]
     )
-    static let handsFreeDefault = VoiceShortcut(
-        keyCode: nil,
-        keyDisplay: nil,
-        modifiers: [.command, .option]
-    )
-    static let legacyHandsFreeDefault = VoiceShortcut(
-        keyCode: nil,
-        keyDisplay: nil,
-        modifiers: [.option]
-    )
 
     var displayName: String {
         let parts = modifiers.displayParts + (keyDisplay.map { [$0] } ?? [])
@@ -157,14 +147,14 @@ final class VoiceShortcutPreferences: ObservableObject {
     @Published var retryShortcut: VoiceShortcut {
         didSet { preferencesDidChange() }
     }
-    @Published var handsFreeShortcut: VoiceShortcut {
+    @Published var isHandsFreeEnabled: Bool {
         didSet { preferencesDidChange() }
     }
 
     private struct Payload: Codable {
         let recordShortcut: VoiceShortcut
         let retryShortcut: VoiceShortcut
-        let handsFreeShortcut: VoiceShortcut?
+        let isHandsFreeEnabled: Bool?
     }
 
     private let defaults: UserDefaults
@@ -183,16 +173,11 @@ final class VoiceShortcutPreferences: ObservableObject {
         {
             recordShortcut = payload.recordShortcut
             retryShortcut = payload.retryShortcut
-            let storedHandsFreeShortcut = payload.handsFreeShortcut.flatMap {
-                $0.isValid ? $0 : nil
-            } ?? .handsFreeDefault
-            handsFreeShortcut = storedHandsFreeShortcut == .legacyHandsFreeDefault
-                ? .handsFreeDefault
-                : storedHandsFreeShortcut
+            isHandsFreeEnabled = payload.isHandsFreeEnabled ?? true
         } else {
             recordShortcut = .recordDefault
             retryShortcut = .retryDefault
-            handsFreeShortcut = .handsFreeDefault
+            isHandsFreeEnabled = true
         }
     }
 
@@ -204,15 +189,11 @@ final class VoiceShortcutPreferences: ObservableObject {
         retryShortcut = .retryDefault
     }
 
-    func resetHandsFreeShortcut() {
-        handsFreeShortcut = .handsFreeDefault
-    }
-
     private func preferencesDidChange() {
         let payload = Payload(
             recordShortcut: recordShortcut,
             retryShortcut: retryShortcut,
-            handsFreeShortcut: handsFreeShortcut
+            isHandsFreeEnabled: isHandsFreeEnabled
         )
         if let data = try? JSONEncoder().encode(payload) {
             defaults.set(data, forKey: storageKey)

--- a/Sources/NativExtensionSDK/NativExtensionManifest.swift
+++ b/Sources/NativExtensionSDK/NativExtensionManifest.swift
@@ -113,6 +113,7 @@ public struct NativExtensionManifest: Codable, Hashable, Identifiable, Sendable 
     public let developer: String
     public let systemImage: String
     public let included: Bool
+    public let enabledByDefault: Bool?
     public let runtime: NativExtensionRuntimeKind
     public let extensionPoint: String
     public let runtimeBundleIdentifier: String?
@@ -129,6 +130,7 @@ public struct NativExtensionManifest: Codable, Hashable, Identifiable, Sendable 
         developer: String,
         systemImage: String,
         included: Bool,
+        enabledByDefault: Bool? = nil,
         runtime: NativExtensionRuntimeKind,
         extensionPoint: String = "com.nativ.extension",
         runtimeBundleIdentifier: String? = nil,
@@ -144,11 +146,16 @@ public struct NativExtensionManifest: Codable, Hashable, Identifiable, Sendable 
         self.developer = developer
         self.systemImage = systemImage
         self.included = included
+        self.enabledByDefault = enabledByDefault
         self.runtime = runtime
         self.extensionPoint = extensionPoint
         self.runtimeBundleIdentifier = runtimeBundleIdentifier
         self.contributions = contributions
         self.permissions = permissions
+    }
+
+    public var isEnabledByDefault: Bool {
+        included && (enabledByDefault ?? true)
     }
 }
 

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -87,6 +87,94 @@ final class AudioAnalyticsStoreTests: XCTestCase {
         XCTAssertNil(store.records.first?.durationSeconds)
     }
 
+    func testDeletesDictationFilesAndPersistedRecord() throws {
+        let recordingURL = temporaryDirectory.appendingPathComponent("dictation.wav")
+        let transcriptURL = temporaryDirectory.appendingPathComponent("dictation.txt")
+        try Data([0x00]).write(to: recordingURL)
+        try "Delete this transcript".write(
+            to: transcriptURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        store.upsertTranscription(
+            recordingURL: recordingURL,
+            transcript: "Delete this transcript",
+            durationSeconds: 2,
+            modelID: "local-asr",
+            applicationName: "Notes"
+        )
+
+        store.deleteDictation(
+            withID: "dictation",
+            recordingsDirectory: temporaryDirectory
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recordingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: transcriptURL.path))
+        XCTAssertTrue(store.records.isEmpty)
+        store.importTranscripts(in: temporaryDirectory)
+        XCTAssertTrue(store.records.isEmpty)
+        let reloaded = AudioAnalyticsStore(
+            storageURL: temporaryDirectory.appendingPathComponent("analytics.json")
+        )
+        XCTAssertTrue(reloaded.records.isEmpty)
+    }
+
+    func testDeletesAllDictationsWithoutDeletingSavedRecordings() throws {
+        let dictationURL = temporaryDirectory.appendingPathComponent("dictation.wav")
+        let dictationTranscriptURL = temporaryDirectory
+            .appendingPathComponent("dictation.txt")
+        try Data([0x00]).write(to: dictationURL)
+        try "Delete this dictation".write(
+            to: dictationTranscriptURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        store.upsertTranscription(
+            recordingURL: dictationURL,
+            transcript: "Delete this dictation",
+            durationSeconds: 2,
+            modelID: "local-asr",
+            applicationName: nil
+        )
+
+        let meetingURL = temporaryDirectory.appendingPathComponent("meeting.m4a")
+        let meetingTranscriptURL = temporaryDirectory
+            .appendingPathComponent("meeting.txt")
+        try Data([0x00]).write(to: meetingURL)
+        try "Keep this recording".write(
+            to: meetingTranscriptURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        store.upsertTranscription(
+            recordingURL: meetingURL,
+            transcript: "Keep this recording",
+            durationSeconds: 30,
+            modelID: "local-asr",
+            applicationName: nil,
+            kind: .meeting,
+            title: "Planning",
+            persistAudioReference: true
+        )
+
+        store.deleteAllDictations(recordingsDirectory: temporaryDirectory)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dictationURL.path))
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dictationTranscriptURL.path)
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: meetingURL.path))
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: meetingTranscriptURL.path)
+        )
+        XCTAssertEqual(store.records.map(\.id), ["meeting"])
+        let reloaded = AudioAnalyticsStore(
+            storageURL: temporaryDirectory.appendingPathComponent("analytics.json")
+        )
+        XCTAssertEqual(reloaded.records.map(\.id), ["meeting"])
+    }
+
     func testPersistsMeetingAudioTranscriptAndSummaryMetadata() throws {
         let recordingURL = temporaryDirectory.appendingPathComponent("meeting.m4a")
         try Data([0x00]).write(to: recordingURL)
@@ -573,7 +661,10 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
     func testDefaultsMatchExistingVoiceCommands() {
         XCTAssertEqual(VoiceShortcut.recordDefault.displayName, "Fn + Control")
         XCTAssertEqual(VoiceShortcut.retryDefault.displayName, "Fn + R")
-        XCTAssertEqual(VoiceShortcut.handsFreeDefault.displayName, "Option")
+        XCTAssertEqual(
+            VoiceShortcut.handsFreeDefault.displayName,
+            "Option + Command"
+        )
     }
 
     func testConvertsSystemModifierFlagsForGlobalPolling() {
@@ -611,6 +702,30 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
         XCTAssertEqual(restored.recordShortcut, shortcut)
         XCTAssertEqual(restored.retryShortcut, .retryDefault)
         XCTAssertEqual(restored.handsFreeShortcut, handsFreeShortcut)
+    }
+
+    func testMigratesLegacyBareOptionHandsFreeDefault() throws {
+        struct LegacyDefaultPayload: Codable {
+            let recordShortcut: VoiceShortcut
+            let retryShortcut: VoiceShortcut
+            let handsFreeShortcut: VoiceShortcut
+        }
+
+        let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let payload = LegacyDefaultPayload(
+            recordShortcut: .recordDefault,
+            retryShortcut: .retryDefault,
+            handsFreeShortcut: .legacyHandsFreeDefault
+        )
+        defaults.set(
+            try JSONEncoder().encode(payload),
+            forKey: "voiceShortcutPreferences.v1"
+        )
+
+        let restored = VoiceShortcutPreferences(defaults: defaults)
+        XCTAssertEqual(restored.handsFreeShortcut, .handsFreeDefault)
     }
 
     func testAddsHandsFreeDefaultToLegacyPreferences() throws {

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -661,9 +661,13 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
     func testDefaultsMatchExistingVoiceCommands() {
         XCTAssertEqual(VoiceShortcut.recordDefault.displayName, "Fn + Control")
         XCTAssertEqual(VoiceShortcut.retryDefault.displayName, "Fn + R")
-        XCTAssertEqual(
-            VoiceShortcut.handsFreeDefault.displayName,
-            "Option + Command"
+
+        let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertTrue(
+            VoiceShortcutPreferences(defaults: defaults).isHandsFreeEnabled
         )
     }
 
@@ -689,23 +693,18 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
             keyDisplay: "B",
             modifiers: [.command, .shift]
         )
-        let handsFreeShortcut = VoiceShortcut(
-            keyCode: 49,
-            keyDisplay: "Space",
-            modifiers: [.option]
-        )
         preferences?.recordShortcut = shortcut
-        preferences?.handsFreeShortcut = handsFreeShortcut
+        preferences?.isHandsFreeEnabled = false
         preferences = nil
 
         let restored = VoiceShortcutPreferences(defaults: defaults)
         XCTAssertEqual(restored.recordShortcut, shortcut)
         XCTAssertEqual(restored.retryShortcut, .retryDefault)
-        XCTAssertEqual(restored.handsFreeShortcut, handsFreeShortcut)
+        XCTAssertFalse(restored.isHandsFreeEnabled)
     }
 
-    func testMigratesLegacyBareOptionHandsFreeDefault() throws {
-        struct LegacyDefaultPayload: Codable {
+    func testRetiresLegacyHandsFreeShortcutAndDefaultsModeOn() throws {
+        struct LegacyPayload: Codable {
             let recordShortcut: VoiceShortcut
             let retryShortcut: VoiceShortcut
             let handsFreeShortcut: VoiceShortcut
@@ -714,10 +713,14 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
         let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let payload = LegacyDefaultPayload(
+        let payload = LegacyPayload(
             recordShortcut: .recordDefault,
             retryShortcut: .retryDefault,
-            handsFreeShortcut: .legacyHandsFreeDefault
+            handsFreeShortcut: VoiceShortcut(
+                keyCode: 49,
+                keyDisplay: "Space",
+                modifiers: [.option]
+            )
         )
         defaults.set(
             try JSONEncoder().encode(payload),
@@ -725,10 +728,12 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
         )
 
         let restored = VoiceShortcutPreferences(defaults: defaults)
-        XCTAssertEqual(restored.handsFreeShortcut, .handsFreeDefault)
+        XCTAssertEqual(restored.recordShortcut, .recordDefault)
+        XCTAssertEqual(restored.retryShortcut, .retryDefault)
+        XCTAssertTrue(restored.isHandsFreeEnabled)
     }
 
-    func testAddsHandsFreeDefaultToLegacyPreferences() throws {
+    func testAddsHandsFreeModeDefaultToLegacyPreferences() throws {
         struct LegacyPayload: Codable {
             let recordShortcut: VoiceShortcut
             let retryShortcut: VoiceShortcut
@@ -754,6 +759,6 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
         let restored = VoiceShortcutPreferences(defaults: defaults)
         XCTAssertEqual(restored.recordShortcut, customRecord)
         XCTAssertEqual(restored.retryShortcut, .retryDefault)
-        XCTAssertEqual(restored.handsFreeShortcut, .handsFreeDefault)
+        XCTAssertTrue(restored.isHandsFreeEnabled)
     }
 }

--- a/Tests/NativTests/NativExtensionTests.swift
+++ b/Tests/NativTests/NativExtensionTests.swift
@@ -30,6 +30,13 @@ final class NativExtensionManifestTests: XCTestCase {
             manifest.contributions.sidebar.map(\.id),
             ["com.nativ.voice-dictation.audio"]
         )
+        XCTAssertEqual(
+            manifest.contributions.shortcuts.map(\.id),
+            [
+                "com.nativ.voice-dictation.transcribe",
+                "com.nativ.voice-dictation.retranscribe",
+            ]
+        )
         XCTAssertTrue(manifest.permissions.contains(.systemAudioCapture))
     }
 

--- a/Tests/NativTests/NativExtensionTests.swift
+++ b/Tests/NativTests/NativExtensionTests.swift
@@ -25,6 +25,7 @@ final class NativExtensionManifestTests: XCTestCase {
         XCTAssertEqual(manifest.id, "com.nativ.voice-dictation")
         XCTAssertEqual(manifest.displayName, "Audio")
         XCTAssertTrue(manifest.included)
+        XCTAssertEqual(manifest.enabledByDefault, false)
         XCTAssertEqual(
             manifest.contributions.sidebar.map(\.id),
             ["com.nativ.voice-dictation.audio"]
@@ -211,6 +212,15 @@ final class NativExtensionStateStoreTests: XCTestCase {
         XCTAssertEqual(store.state(for: makeManifest(included: false)), .disabled)
     }
 
+    func testIncludedExtensionCanDefaultToDisabled() {
+        let store = NativExtensionStateStore(defaults: defaults)
+
+        XCTAssertEqual(
+            store.state(for: makeManifest(included: true, enabledByDefault: false)),
+            .disabled
+        )
+    }
+
     func testRemovedTombstoneSurvivesStoreRecreation() {
         let key = "state.\(UUID().uuidString)"
         let manifest = makeManifest(included: true)
@@ -232,7 +242,10 @@ final class NativExtensionStateStoreTests: XCTestCase {
         XCTAssertEqual(store.state(for: manifest), .enabled)
     }
 
-    private func makeManifest(included: Bool) -> NativExtensionManifest {
+    private func makeManifest(
+        included: Bool,
+        enabledByDefault: Bool? = nil
+    ) -> NativExtensionManifest {
         NativExtensionManifest(
             id: "com.example.extension",
             version: "1.0.0",
@@ -242,6 +255,7 @@ final class NativExtensionStateStoreTests: XCTestCase {
             developer: "Example",
             systemImage: "puzzlepiece.extension",
             included: included,
+            enabledByDefault: enabledByDefault,
             runtime: .extensionFoundation,
             runtimeBundleIdentifier: "com.example.extension.runtime"
         )


### PR DESCRIPTION
1) Use option + command for hands-free to avoid accidental activations when e.g. option-clicking
2) Allow dismissing dictation from the global overlay widget
3) Allow deleting individual transcripts or clearing all from the library
4) Show a "NEW" badge on the Extensions tab to allow for feature discovery for new and existing users, ask for mic permissions when enabling the dictation extension