### PR TITLE
Sidebar: collapsible sections plus a collapse-all toggle

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -563,6 +563,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         showMainWindow()
     }
 
+    func toggleAllSidebarSections() {
+        controlPanelNavigation.collapseAllSections()
+        showMainWindow()
+    }
+
     func increaseChatFontSize() {
         stepChatFontSize(by: 1)
     }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -64,8 +64,10 @@ final class ControlPanelNavigation: ObservableObject {
     @Published private(set) var newChatRequest = 0
     @Published private(set) var toggleSidebarRequest = 0
     @Published private(set) var speechModelDiscoveryRequest = 0
+    @Published private(set) var collapseAllSectionsRequest = 0
     private var consumedNewChatRequest = 0
     private var consumedToggleSidebarRequest = 0
+    private var consumedCollapseAllSectionsRequest = 0
 
     func open(_ tab: ControlPanelTab) {
         requestedExtensionPageID = nil
@@ -90,6 +92,10 @@ final class ControlPanelNavigation: ObservableObject {
         toggleSidebarRequest += 1
     }
 
+    func collapseAllSections() {
+        collapseAllSectionsRequest += 1
+    }
+
     func consumeNewChatRequest() -> Bool {
         guard consumedNewChatRequest < newChatRequest else {
             return false
@@ -103,6 +109,14 @@ final class ControlPanelNavigation: ObservableObject {
             return false
         }
         consumedToggleSidebarRequest = toggleSidebarRequest
+        return true
+    }
+
+    func consumeCollapseAllSectionsRequest() -> Bool {
+        guard consumedCollapseAllSectionsRequest < collapseAllSectionsRequest else {
+            return false
+        }
+        consumedCollapseAllSectionsRequest = collapseAllSectionsRequest
         return true
     }
 }
@@ -382,6 +396,9 @@ struct ControlPanelView: View {
         .onChange(of: navigation.toggleSidebarRequest) { _, _ in
             handleToggleSidebarRequest()
         }
+        .onChange(of: navigation.collapseAllSectionsRequest) { _, _ in
+            handleCollapseAllSectionsRequest()
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.willEnterFullScreenNotification)) { _ in
             isFullScreen = true
         }
@@ -647,27 +664,32 @@ struct ControlPanelView: View {
 
             headerDivider
 
-            if pinnedSessions.isEmpty && pinnedFolders.isEmpty {
-                emptyPinnedHint
-            } else {
-                ForEach(pinnedFolders) { folder in
-                    folderView(folder, dropTargeted: isPinnedDropTargeted)
-                }
-                ForEach(pinnedSessions) { recent in
-                    draggableRow(recent, isPinnedRow: true)
-                        .overlay(alignment: .top) {
-                            pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter && isPinnedDropTargeted)
-                        }
-                        .overlay(alignment: .bottom) {
-                            pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter && isPinnedDropTargeted)
-                        }
+            if !model.settings.sidebarPinnedCollapsed {
+                if pinnedSessions.isEmpty && pinnedFolders.isEmpty {
+                    emptyPinnedHint
+                } else {
+                    ForEach(pinnedFolders) { folder in
+                        folderView(folder, dropTargeted: isPinnedDropTargeted)
+                    }
+                    ForEach(pinnedSessions) { recent in
+                        draggableRow(recent, isPinnedRow: true)
+                            .overlay(alignment: .top) {
+                                pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter && isPinnedDropTargeted)
+                            }
+                            .overlay(alignment: .bottom) {
+                                pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter && isPinnedDropTargeted)
+                            }
+                    }
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(dropHighlight(isTargeted: isPinnedDropTargeted))
         .onDrop(of: [.text], isTargeted: $isPinnedDropTargeted) { providers in
-            loadDropString(providers) { handlePinnedDrop($0) }
+            loadDropString(providers) { payload in
+                revealSidebarSection(\.sidebarPinnedCollapsed)
+                handlePinnedDrop(payload)
+            }
         }
     }
 
@@ -681,20 +703,25 @@ struct ControlPanelView: View {
 
             headerDivider
 
-            ForEach(ungroupedSessions) { recent in
-                draggableRow(recent, isPinnedRow: false)
-                    .overlay(alignment: .top) {
-                        pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter && isSessionsDropTargeted)
-                    }
-                    .overlay(alignment: .bottom) {
-                        pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter && isSessionsDropTargeted)
-                    }
+            if !model.settings.sidebarSessionsCollapsed {
+                ForEach(ungroupedSessions) { recent in
+                    draggableRow(recent, isPinnedRow: false)
+                        .overlay(alignment: .top) {
+                            pinnedInsertionLine(visible: reorderTargetID == recent.id && !reorderInsertAfter && isSessionsDropTargeted)
+                        }
+                        .overlay(alignment: .bottom) {
+                            pinnedInsertionLine(visible: reorderTargetID == recent.id && reorderInsertAfter && isSessionsDropTargeted)
+                        }
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(dropHighlight(isTargeted: isSessionsDropTargeted))
         .onDrop(of: [.text], isTargeted: $isSessionsDropTargeted) { providers in
-            loadDropString(providers) { _ = handleSessionsDrop([$0]) }
+            loadDropString(providers) { payload in
+                revealSidebarSection(\.sidebarSessionsCollapsed)
+                _ = handleSessionsDrop([payload])
+            }
         }
     }
 
@@ -708,11 +735,13 @@ struct ControlPanelView: View {
 
             headerDivider
 
-            if chat.folders.isEmpty {
-                emptyFoldersHint
-            } else {
-                ForEach(unpinnedFolders) { folder in
-                    folderView(folder, dropTargeted: isFoldersDropTargeted)
+            if !model.settings.sidebarFoldersCollapsed {
+                if chat.folders.isEmpty {
+                    emptyFoldersHint
+                } else {
+                    ForEach(unpinnedFolders) { folder in
+                        folderView(folder, dropTargeted: isFoldersDropTargeted)
+                    }
                 }
             }
         }
@@ -968,6 +997,17 @@ struct ControlPanelView: View {
             Spacer(minLength: 0)
 
             Button {
+                toggleAllSidebarSections()
+            } label: {
+                Image(systemName: allSidebarSectionsCollapsed ? "rectangle.expand.vertical" : "rectangle.compress.vertical")
+                    .font(.system(size: 14, weight: .medium))
+                    .frame(width: 26, height: 28)
+                    .foregroundStyle(Color.secondary.opacity(0.7))
+            }
+            .buttonStyle(.plain)
+            .help(allSidebarSectionsCollapsed ? "Expand all sections" : "Collapse all sections")
+
+            Button {
                 withAnimation(.snappy(duration: 0.2)) {
                     enterSelectMode()
                 }
@@ -1057,26 +1097,56 @@ struct ControlPanelView: View {
             .padding(.bottom, 6)
     }
 
-    private var sidebarPinnedHeader: some View {
+    private func sidebarSectionHeader<Trailing: View>(
+        title: String,
+        isCollapsed: Bool,
+        onToggle: @escaping () -> Void,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
         HStack(spacing: 8) {
-            Text("Pinned")
-                .font(.system(size: 15, weight: .regular))
-                .foregroundStyle(.secondary.opacity(0.7))
+            HStack(spacing: 8) {
+                Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 12)
 
-            Spacer(minLength: 0)
+                Text(title)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundStyle(.secondary.opacity(0.7))
+
+                Spacer(minLength: 0)
+            }
+            .contentShape(.rect)
+            .onTapGesture {
+                withAnimation(.snappy(duration: 0.2)) {
+                    onToggle()
+                }
+            }
+            .help(isCollapsed ? "Expand \(title)" : "Collapse \(title)")
+
+            trailing()
+        }
+    }
+
+    private var sidebarPinnedHeader: some View {
+        sidebarSectionHeader(
+            title: "Pinned",
+            isCollapsed: model.settings.sidebarPinnedCollapsed,
+            onToggle: { model.settings.sidebarPinnedCollapsed.toggle() }
+        ) {
+            EmptyView()
         }
     }
 
     private var sidebarFoldersHeader: some View {
-        HStack(spacing: 8) {
-            Text("Folders")
-                .font(.system(size: 15, weight: .regular))
-                .foregroundStyle(.secondary.opacity(0.7))
-
-            Spacer(minLength: 0)
-
+        sidebarSectionHeader(
+            title: "Folders",
+            isCollapsed: model.settings.sidebarFoldersCollapsed,
+            onToggle: { model.settings.sidebarFoldersCollapsed.toggle() }
+        ) {
             Button {
                 withAnimation(.snappy(duration: 0.2)) {
+                    model.settings.sidebarFoldersCollapsed = false
                     _ = chat.createFolder(name: "New Folder")
                 }
             } label: {
@@ -1091,12 +1161,34 @@ struct ControlPanelView: View {
     }
 
     private var sidebarRecentsHeader: some View {
-        HStack(spacing: 8) {
-            Text("Sessions")
-                .font(.system(size: 15, weight: .regular))
-                .foregroundStyle(.secondary.opacity(0.7))
+        sidebarSectionHeader(
+            title: "Sessions",
+            isCollapsed: model.settings.sidebarSessionsCollapsed,
+            onToggle: { model.settings.sidebarSessionsCollapsed.toggle() }
+        ) {
+            EmptyView()
+        }
+    }
 
-            Spacer(minLength: 0)
+    private var allSidebarSectionsCollapsed: Bool {
+        model.settings.allSidebarSectionsCollapsed
+            && !chat.folders.contains { !$0.isCollapsed }
+    }
+
+    private func revealSidebarSection(_ keyPath: WritableKeyPath<NativSettings, Bool>) {
+        guard model.settings[keyPath: keyPath] else {
+            return
+        }
+        withAnimation(.snappy(duration: 0.2)) {
+            model.settings[keyPath: keyPath] = false
+        }
+    }
+
+    private func toggleAllSidebarSections() {
+        let shouldCollapse = !allSidebarSectionsCollapsed
+        withAnimation(.snappy(duration: 0.2)) {
+            model.settings.setAllSidebarSectionsCollapsed(shouldCollapse)
+            chat.setAllFoldersCollapsed(shouldCollapse)
         }
     }
 
@@ -1820,6 +1912,13 @@ struct ControlPanelView: View {
             return
         }
         toggleSidebarVisibility()
+    }
+
+    private func handleCollapseAllSectionsRequest() {
+        guard navigation.consumeCollapseAllSectionsRequest() else {
+            return
+        }
+        toggleAllSidebarSections()
     }
 
     private func canExportRecent(_ recent: ControlPanelRecentSession) -> Bool {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -997,17 +997,6 @@ struct ControlPanelView: View {
             Spacer(minLength: 0)
 
             Button {
-                toggleAllSidebarSections()
-            } label: {
-                Image(systemName: allSidebarSectionsCollapsed ? "rectangle.expand.vertical" : "rectangle.compress.vertical")
-                    .font(.system(size: 14, weight: .medium))
-                    .frame(width: 26, height: 28)
-                    .foregroundStyle(Color.secondary.opacity(0.7))
-            }
-            .buttonStyle(.plain)
-            .help(allSidebarSectionsCollapsed ? "Expand all sections" : "Collapse all sections")
-
-            Button {
                 withAnimation(.snappy(duration: 0.2)) {
                     enterSelectMode()
                 }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -481,6 +481,16 @@ final class ChatViewModel: ObservableObject {
         sessionStore.saveFolders(folders)
     }
 
+    func setAllFoldersCollapsed(_ collapsed: Bool) {
+        guard folders.contains(where: { $0.isCollapsed != collapsed }) else {
+            return
+        }
+        for index in folders.indices {
+            folders[index].isCollapsed = collapsed
+        }
+        sessionStore.saveFolders(folders)
+    }
+
     func moveSession(_ sessionID: UUID, toFolder folderID: UUID?) {
         guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
             return

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -123,6 +123,11 @@ private struct NativApplication: App {
             }
 
             CommandGroup(after: .sidebar) {
+                Button("Collapse All Sections") {
+                    appDelegate.toggleAllSidebarSections()
+                }
+                .keyboardShortcut(".", modifiers: [.command, .option])
+
                 Button("Increase Chat Font Size") {
                     appDelegate.increaseChatFontSize()
                 }

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -363,6 +363,9 @@ struct NativSettings: Codable, Equatable {
     var prefixCacheBlocks: Int
     var prefixCacheBlockSize: Int
     var chatFontScale: Double
+    var sidebarPinnedCollapsed: Bool
+    var sidebarFoldersCollapsed: Bool
+    var sidebarSessionsCollapsed: Bool
     var modelConfigs: [String: ModelConfigProfile]
 
     init(
@@ -407,6 +410,9 @@ struct NativSettings: Codable, Equatable {
         prefixCacheBlocks: Int = 2048,
         prefixCacheBlockSize: Int = 16,
         chatFontScale: Double = Self.defaultChatFontScale,
+        sidebarPinnedCollapsed: Bool = false,
+        sidebarFoldersCollapsed: Bool = false,
+        sidebarSessionsCollapsed: Bool = false,
         modelConfigs: [String: ModelConfigProfile] = [:]
     ) {
         self.modelSearchPath = modelSearchPath
@@ -450,6 +456,9 @@ struct NativSettings: Codable, Equatable {
         self.prefixCacheBlocks = prefixCacheBlocks
         self.prefixCacheBlockSize = prefixCacheBlockSize
         self.chatFontScale = chatFontScale
+        self.sidebarPinnedCollapsed = sidebarPinnedCollapsed
+        self.sidebarFoldersCollapsed = sidebarFoldersCollapsed
+        self.sidebarSessionsCollapsed = sidebarSessionsCollapsed
         self.modelConfigs = modelConfigs
     }
 
@@ -496,6 +505,9 @@ struct NativSettings: Codable, Equatable {
         case prefixCacheBlocks
         case prefixCacheBlockSize
         case chatFontScale
+        case sidebarPinnedCollapsed
+        case sidebarFoldersCollapsed
+        case sidebarSessionsCollapsed
         case modelConfigs
     }
 
@@ -545,6 +557,9 @@ struct NativSettings: Codable, Equatable {
         prefixCacheBlocks = try container.decodeIfPresent(Int.self, forKey: .prefixCacheBlocks) ?? defaults.prefixCacheBlocks
         prefixCacheBlockSize = try container.decodeIfPresent(Int.self, forKey: .prefixCacheBlockSize) ?? defaults.prefixCacheBlockSize
         chatFontScale = try container.decodeIfPresent(Double.self, forKey: .chatFontScale) ?? defaults.chatFontScale
+        sidebarPinnedCollapsed = try container.decodeIfPresent(Bool.self, forKey: .sidebarPinnedCollapsed) ?? defaults.sidebarPinnedCollapsed
+        sidebarFoldersCollapsed = try container.decodeIfPresent(Bool.self, forKey: .sidebarFoldersCollapsed) ?? defaults.sidebarFoldersCollapsed
+        sidebarSessionsCollapsed = try container.decodeIfPresent(Bool.self, forKey: .sidebarSessionsCollapsed) ?? defaults.sidebarSessionsCollapsed
         modelConfigs = try container.decodeIfPresent([String: ModelConfigProfile].self, forKey: .modelConfigs) ?? defaults.modelConfigs
     }
 
@@ -590,6 +605,9 @@ struct NativSettings: Codable, Equatable {
         try container.encode(prefixCacheBlocks, forKey: .prefixCacheBlocks)
         try container.encode(prefixCacheBlockSize, forKey: .prefixCacheBlockSize)
         try container.encode(chatFontScale, forKey: .chatFontScale)
+        try container.encode(sidebarPinnedCollapsed, forKey: .sidebarPinnedCollapsed)
+        try container.encode(sidebarFoldersCollapsed, forKey: .sidebarFoldersCollapsed)
+        try container.encode(sidebarSessionsCollapsed, forKey: .sidebarSessionsCollapsed)
         try container.encode(modelConfigs, forKey: .modelConfigs)
     }
 
@@ -745,6 +763,16 @@ struct NativSettings: Codable, Equatable {
 
     mutating func resetChatFontScale() {
         chatFontScale = Self.defaultChatFontScale
+    }
+
+    var allSidebarSectionsCollapsed: Bool {
+        sidebarPinnedCollapsed && sidebarFoldersCollapsed && sidebarSessionsCollapsed
+    }
+
+    mutating func setAllSidebarSectionsCollapsed(_ collapsed: Bool) {
+        sidebarPinnedCollapsed = collapsed
+        sidebarFoldersCollapsed = collapsed
+        sidebarSessionsCollapsed = collapsed
     }
 
     func hasSameLaunchConfiguration(as other: Self) -> Bool {

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -401,6 +401,48 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertEqual(extreme.normalized().chatFontScale, NativSettings.maxChatFontScale)
     }
 
+    func testSidebarSectionCollapseRoundTrips() throws {
+        var settings = NativSettings()
+        XCTAssertFalse(settings.sidebarPinnedCollapsed)
+        XCTAssertFalse(settings.sidebarFoldersCollapsed)
+        XCTAssertFalse(settings.sidebarSessionsCollapsed)
+        XCTAssertFalse(settings.allSidebarSectionsCollapsed)
+
+        settings.sidebarPinnedCollapsed = true
+        settings.sidebarSessionsCollapsed = true
+        let decoded = try JSONDecoder().decode(
+            NativSettings.self,
+            from: JSONEncoder().encode(settings)
+        )
+        XCTAssertTrue(decoded.sidebarPinnedCollapsed)
+        XCTAssertFalse(decoded.sidebarFoldersCollapsed)
+        XCTAssertTrue(decoded.sidebarSessionsCollapsed)
+        XCTAssertFalse(decoded.allSidebarSectionsCollapsed)
+    }
+
+    func testSetAllSidebarSectionsCollapsedTogglesEveryFlag() {
+        var settings = NativSettings()
+        settings.setAllSidebarSectionsCollapsed(true)
+        XCTAssertTrue(settings.sidebarPinnedCollapsed)
+        XCTAssertTrue(settings.sidebarFoldersCollapsed)
+        XCTAssertTrue(settings.sidebarSessionsCollapsed)
+        XCTAssertTrue(settings.allSidebarSectionsCollapsed)
+
+        settings.setAllSidebarSectionsCollapsed(false)
+        XCTAssertFalse(settings.sidebarPinnedCollapsed)
+        XCTAssertFalse(settings.sidebarFoldersCollapsed)
+        XCTAssertFalse(settings.sidebarSessionsCollapsed)
+        XCTAssertFalse(settings.allSidebarSectionsCollapsed)
+    }
+
+    func testSidebarSectionCollapseDefaultsToExpandedForExistingInstalls() throws {
+        let legacyJSON = Data(#"{"serverHost":"127.0.0.1","serverPort":8080}"#.utf8)
+        let decoded = try JSONDecoder().decode(NativSettings.self, from: legacyJSON)
+        XCTAssertFalse(decoded.sidebarPinnedCollapsed)
+        XCTAssertFalse(decoded.sidebarFoldersCollapsed)
+        XCTAssertFalse(decoded.sidebarSessionsCollapsed)
+    }
+
     func testRememberProfileCapturesCurrentModelSettings() throws {
         var settings = NativSettings()
         settings.thinkingEnabled = true


### PR DESCRIPTION
The Pinned, Folders, and Sessions headers were static text, so the only thing that collapsed in the sidebar was an individual folder. Give each section a chevron matching the folder one, and add a single control that folds every section and folder at once.

Section state lives in NativSettings (three Bools, decoded with decodeIfPresent so existing installs default to expanded) and persists via the existing settings didSet. Per-folder state keeps using ChatFolder.isCollapsed; setAllFoldersCollapsed writes all folders with one saveFolders call.

The three headers now share one sidebarSectionHeader builder rather than repeating the chevron, with the Folders "new folder" button passed in as a trailing slot. Dropping a chat onto a collapsed Pinned or Sessions section expands it first, so the moved chat stays visible.

Collapse-all is reachable from the sidebar action bar and from a Collapse All Sections menu item, routed through ControlPanelNavigation's existing request-counter pattern.

looks like:


https://github.com/user-attachments/assets/01d48482-ce25-49e4-b597-0de873a9956d



