### PR TITLE
Fix release extension bundle identifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           cat > Configuration/Signing.local.xcconfig <<EOF
           NATIV_BUNDLE_IDENTIFIER = $APP_BUNDLE_ID
           NATIV_SERVER_KIT_BUNDLE_IDENTIFIER = $FRAMEWORK_BUNDLE_ID
+          NATIV_VOICE_EXTENSION_BUNDLE_IDENTIFIER = ${APP_BUNDLE_ID}.VoiceDictationExtension
           DEVELOPMENT_TEAM = $APPLE_TEAM_ID
           EOF
 


### PR DESCRIPTION
## Summary

Fixes the macOS release workflow so the bundled voice-dictation ExtensionKit runtime receives a bundle identifier prefixed by the parent app bundle identifier.

## Root cause

The release workflow configured `NATIV_BUNDLE_IDENTIFIER` and `NATIV_SERVER_KIT_BUNDLE_IDENTIFIER`, but omitted `NATIV_VOICE_EXTENSION_BUNDLE_IDENTIFIER`. The extension therefore used the development default `dev.local.Nativ.VoiceDictationExtension` while the release app used `io.github.blaizzy.nativ`. Xcode rejected the archive during `ValidateEmbeddedBinary`.

## Fix

The workflow now sets `NATIV_VOICE_EXTENSION_BUNDLE_IDENTIFIER` to `${APP_BUNDLE_ID}.VoiceDictationExtension`.

## Validation

- Reproduced the failing bundle identifiers from [release run #30846517077](https://github.com/Blaizzy/nativ/actions/runs/30846517077/job/91796027064).
- Verified Xcode resolves the release app and extension identifiers with the required prefix.
- Passed YAML parsing, shell syntax checks, and `git diff --check`.