### PR TITLE
Fix v0.2.0 launch (drop unused keychain entitlement) and version repo…

### DIFF
--- a/Configuration/Nativ.entitlements
+++ b/Configuration/Nativ.entitlements
@@ -2,9 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	</array>
 </dict>
 </plist>

--- a/project.yml
+++ b/project.yml
@@ -85,7 +85,7 @@ targets:
         INFOPLIST_FILE: Configuration/Nativ-Info.plist
         INFOPLIST_KEY_CFBundleDisplayName: Nativ
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.utilities
-        MARKETING_VERSION: 0.1.0
+        MARKETING_VERSION: 0.2.0
         CURRENT_PROJECT_VERSION: 2
   NativTests:
     type: bundle.unit-test


### PR DESCRIPTION
patches the release issue for #183, #184 and #185

fixes the v0.2.0 release bugs by dropping the unused keychain-access-groups entitlement, which OS was rejecting and
bumping MARKETING_VERSION to 0.2.0 so app stops misreporting itself as 0.1.0 in Settings and Sparkle 

