### PR TITLE
Dictation: fall back to on-device system speech recognition

### DIFF
--- a/Configuration/Nativ-Info.plist
+++ b/Configuration/Nativ-Info.plist
@@ -30,6 +30,8 @@
 	<string>Copyright © 2025 Prince Canuma &amp; contributors</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Nativ records your microphone for dictation, voice notes, and meeting capture.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Nativ uses macOS on-device speech recognition to transcribe dictation before a speech model has been downloaded. Audio stays on your Mac.</string>
 	<key>NSAudioCaptureUsageDescription</key>
 	<string>Nativ records system audio when you start an audio capture.</string>
 	<key>NSScreenCaptureUsageDescription</key>

--- a/Configuration/Nativ-Info.plist
+++ b/Configuration/Nativ-Info.plist
@@ -30,8 +30,6 @@
 	<string>Copyright © 2025 Prince Canuma &amp; contributors</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Nativ records your microphone for dictation, voice notes, and meeting capture.</string>
-	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Nativ uses macOS on-device speech recognition to transcribe dictation before a speech model has been downloaded. Audio stays on your Mac.</string>
 	<key>NSAudioCaptureUsageDescription</key>
 	<string>Nativ records system audio when you start an audio capture.</string>
 	<key>NSScreenCaptureUsageDescription</key>

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */; };
 		7A86AD9E2E640430F47B94D5 /* FileTypeIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677258B04E9BB7CA8B89E11E /* FileTypeIcon.swift */; };
 		802B1F569D3D9FBE951EC8EA /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEC2FFE7F1CFAC59170AC63 /* DashboardViewModel.swift */; };
+		826AB68248F3DD8952284745 /* AppleSpeechTranscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219898F64D1B7C28FA4A1B38 /* AppleSpeechTranscriber.swift */; };
 		86C75AF5CF63104E397339FB /* ArtifactsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3387C33E274E567979F013 /* ArtifactsView.swift */; };
 		8B4DF732A8A6AA5FFBE11982 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BBF79010B8120057237B52 /* StatsView.swift */; };
 		8B86659B490F58DEC1363135 /* NativServerKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; };
@@ -147,6 +148,7 @@
 		F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */; };
 		F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
 		F32A65A75BCD6911505114F4 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
+		F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */; };
 		FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
@@ -240,8 +242,10 @@
 		0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCLIProfile.swift; sourceTree = "<group>"; };
 		141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPrimaryTaskResolver.swift; sourceTree = "<group>"; };
 		1573A2D88784C9D404156D25 /* VoiceDictationExtensionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtensionRuntime.swift; sourceTree = "<group>"; };
+		1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubModelSizeResolver.swift; sourceTree = "<group>"; };
 		1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativAnalyticsStore.swift; sourceTree = "<group>"; };
 		1D4B44C59153CB242FE92D3A /* ImageGenerationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGenerationView.swift; sourceTree = "<group>"; };
+		219898F64D1B7C28FA4A1B38 /* AppleSpeechTranscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSpeechTranscriber.swift; sourceTree = "<group>"; };
 		23155DB5E733D8887D83AFD0 /* VoiceTranscriptInserter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTranscriptInserter.swift; sourceTree = "<group>"; };
 		239C5B241E83468B75C43E5A /* ImageGenerationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGenerationViewModel.swift; sourceTree = "<group>"; };
 		27D63523BA62CC95FDD8D51E /* FnControlShortcutMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FnControlShortcutMonitor.swift; sourceTree = "<group>"; };
@@ -475,6 +479,7 @@
 		4879D4C4839E304DF0C779DC /* VoiceCapture */ = {
 			isa = PBXGroup;
 			children = (
+				219898F64D1B7C28FA4A1B38 /* AppleSpeechTranscriber.swift */,
 				B7E0BD007DAD141D50E1BAA4 /* AudioAnalyticsStore.swift */,
 				820A7EF6D7E1FA0F171A5A59 /* AudioCaptureLibrary.swift */,
 				D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */,
@@ -612,6 +617,7 @@
 		BAC9F35045D83344BC059CB2 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */,
 				E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */,
 				7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */,
 				EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */,
@@ -866,11 +872,11 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				ED4CB78AB93E015D0BE21F7B /* NativExtensionSDK */,
 				1622B274F4DF5A85C2FDB081 /* NativServerKit */,
-				465C23BB3ADA415A5004AAD9 /* Nativ */,
-				7082E254E8272A5E8D13E6F0 /* VoiceDictationExtensionRuntime */,
 				51AD42FA29E71F2450386688 /* NativTests */,
+				7082E254E8272A5E8D13E6F0 /* VoiceDictationExtensionRuntime */,
 			);
 		};
 /* End PBXProject section */
@@ -939,6 +945,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B15353CDE6204176664DB3B2 /* AppDelegate.swift in Sources */,
+				826AB68248F3DD8952284745 /* AppleSpeechTranscriber.swift in Sources */,
 				A9B82EFAD4FD8C57E045721B /* Artifact.swift in Sources */,
 				B63E4B683EE9CA383DBEFADA /* ArtifactPreview.swift in Sources */,
 				582B1E2A148EF3DEE78B11E2 /* ArtifactStore.swift in Sources */,
@@ -970,6 +977,7 @@
 				7A86AD9E2E640430F47B94D5 /* FileTypeIcon.swift in Sources */,
 				B5C7C76E37B11FF2A0A8F584 /* FnControlShortcutMonitor.swift in Sources */,
 				0B11412D6A9FB77B9A204E7C /* Formatting.swift in Sources */,
+				F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */,
 				7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */,
 				B55A6BE5C7B03181E2CD03D6 /* HuggingFaceHub.swift in Sources */,
 				575DCB7EC96DAB35B415434C /* ImageGenerationView.swift in Sources */,

--- a/Sources/Nativ/Features/VoiceCapture/AppleSpeechTranscriber.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AppleSpeechTranscriber.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Speech
+import os
+
+/// On-device dictation through Apple's Speech framework.
+///
+/// This exists so dictation works before any model has been downloaded. Nativ's normal
+/// path needs an installed speech-to-text model *and* a running server; until both are
+/// in place the shortcut records audio and then has nowhere to send it. Apple's
+/// recognizer ships with macOS, needs no weights, and answers in well under a second,
+/// so it covers first launch, a stopped server, and the moment a model is still
+/// downloading.
+///
+/// It is deliberately a fallback rather than an alternative: the bundled MLX models are
+/// more accurate and support far more languages. This just removes the dead end.
+///
+/// **Recognition is pinned on-device.** `SFSpeechRecognizer` will happily stream audio to
+/// Apple's servers when a locale has no local model, which would be the wrong default for
+/// an app whose whole premise is that nothing leaves the Mac. `requiresOnDeviceRecognition`
+/// is set unconditionally and the locale is rejected outright when it has no on-device
+/// support, so a missing local model produces an error rather than a silent upload.
+enum AppleSpeechTranscriber {
+    enum Failure: LocalizedError {
+        case notAuthorized
+        case onDeviceUnavailable(locale: String)
+        case recognizerUnavailable
+        case timedOut
+        case empty
+
+        var errorDescription: String? {
+            switch self {
+            case .notAuthorized:
+                "Nativ is not allowed to use speech recognition."
+            case let .onDeviceUnavailable(locale):
+                "macOS has no on-device speech model for \(locale)."
+            case .recognizerUnavailable:
+                "The system speech recognizer is unavailable."
+            case .timedOut:
+                "The system speech recognizer did not respond."
+            case .empty:
+                "No speech was recognized."
+            }
+        }
+    }
+
+    /// Dictation clips are short and on-device recognition is fast, so anything beyond
+    /// this is a stall rather than slow progress.
+    private static let timeoutSeconds: TimeInterval = 30
+
+    /// Keeps the in-flight recognition task alive and makes completion single-shot.
+    private final class RecognitionTaskHolder: @unchecked Sendable {
+        private let lock = OSAllocatedUnfairLock(initialState: false)
+        var task: SFSpeechRecognitionTask?
+
+        /// True for the first caller only.
+        func claimCompletion() -> Bool {
+            lock.withLock { completed in
+                defer { completed = true }
+                return !completed
+            }
+        }
+    }
+
+    /// Locale used for recognition: the closest supported match to the user's own that
+    /// actually has an on-device model.
+    ///
+    /// Two traps here. `supportedLocales()` returns an unordered `Set`, so picking with
+    /// `first(where:)` yields a different answer between runs — an en-GB user could get
+    /// en-ID one launch and en-AU the next. And `Locale.current.identifier` uses
+    /// underscores (`en_GB`) while the supported list uses hyphens (`en-GB`), so the exact
+    /// match silently never fires. Candidates are therefore normalized, ranked, and
+    /// tie-broken by identifier so the choice is stable.
+    ///
+    /// Ranking also skips locales macOS lists but has no downloaded asset for, because
+    /// on-device recognition is mandatory here — a supported-but-absent locale would fail
+    /// the whole transcription rather than quietly falling back to a neighbouring one.
+    static var preferredLocale: Locale {
+        let current = Locale.current
+        let currentID = normalizedIdentifier(current.identifier)
+        let currentLanguage = current.language.languageCode?.identifier
+        let currentRegion = current.region?.identifier
+
+        func rank(_ locale: Locale) -> Int? {
+            let identifier = normalizedIdentifier(locale.identifier)
+            if identifier == currentID { return 0 }
+            guard let currentLanguage,
+                  locale.language.languageCode?.identifier == currentLanguage
+            else { return identifier == "en-US" ? 3 : nil }
+            return locale.region?.identifier == currentRegion ? 1 : 2
+        }
+
+        let ranked = SFSpeechRecognizer.supportedLocales()
+            .compactMap { locale -> (Locale, Int)? in
+                rank(locale).map { (locale, $0) }
+            }
+            .sorted {
+                $0.1 == $1.1
+                    ? normalizedIdentifier($0.0.identifier) < normalizedIdentifier($1.0.identifier)
+                    : $0.1 < $1.1
+            }
+            .map(\.0)
+
+        return ranked.first(where: hasOnDeviceModel)
+            ?? ranked.first
+            ?? Locale(identifier: "en-US")
+    }
+
+    private static func normalizedIdentifier(_ identifier: String) -> String {
+        identifier.replacingOccurrences(of: "_", with: "-")
+    }
+
+    private static func hasOnDeviceModel(_ locale: Locale) -> Bool {
+        guard let recognizer = SFSpeechRecognizer(locale: locale) else { return false }
+        return recognizer.isAvailable && recognizer.supportsOnDeviceRecognition
+    }
+
+    /// Whether a fallback attempt is worth making.
+    ///
+    /// `notDetermined` counts as available: permission is requested by the first
+    /// transcription, and requiring `authorized` here would deadlock — the fallback would
+    /// never run, so the prompt would never appear, so the status would never leave
+    /// `notDetermined`. A denied or restricted status is permanent until the user changes
+    /// it in System Settings, so it returns false and the caller shows its normal alert
+    /// instead of prompting on every recording.
+    static var isAvailable: Bool {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized, .notDetermined:
+            break
+        case .denied, .restricted:
+            return false
+        @unknown default:
+            return false
+        }
+        return hasOnDeviceModel(preferredLocale)
+    }
+
+    /// Prompts for permission the first time. Safe to call repeatedly; macOS only shows
+    /// the dialog while the status is `notDetermined`.
+    static func requestAuthorization() async -> Bool {
+        if SFSpeechRecognizer.authorizationStatus() == .authorized { return true }
+        return await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status == .authorized)
+            }
+        }
+    }
+
+    /// Transcribes a recorded file. Nativ already writes dictation to disk before
+    /// transcribing, so this takes a URL rather than tapping the microphone — it slots
+    /// into the existing flow without changing how audio is captured.
+    static func transcribe(contentsOf url: URL) async throws -> String {
+        guard await requestAuthorization() else { throw Failure.notAuthorized }
+
+        let locale = preferredLocale
+        guard let recognizer = SFSpeechRecognizer(locale: locale), recognizer.isAvailable else {
+            throw Failure.recognizerUnavailable
+        }
+        guard recognizer.supportsOnDeviceRecognition else {
+            throw Failure.onDeviceUnavailable(
+                locale: locale.localizedString(forIdentifier: locale.identifier)
+                    ?? locale.identifier
+            )
+        }
+
+        let request = SFSpeechURLRecognitionRequest(url: url)
+        request.requiresOnDeviceRecognition = true   // never leaves the Mac
+        request.shouldReportPartialResults = false
+        request.addsPunctuation = true
+        request.taskHint = .dictation
+
+        let transcript: String = try await withCheckedThrowingContinuation { continuation in
+            // The task must be held for the duration of recognition. Discarding the
+            // returned object lets ARC release it, and the result handler then never
+            // fires — the call simply hangs. The holder is captured by both closures
+            // below, which keeps it alive exactly as long as it is needed.
+            let holder = RecognitionTaskHolder()
+
+            func finish(_ result: Result<String, Error>) {
+                // The handler fires for partial results and cancellations as well as the
+                // final result, so resuming must happen at most once.
+                guard holder.claimCompletion() else { return }
+                holder.task?.cancel()
+                holder.task = nil
+                continuation.resume(with: result)
+            }
+
+            // A stalled recognizer would otherwise leave dictation waiting forever, with
+            // the overlay spinning and no way back. Failing here surfaces the normal
+            // "no model / server stopped" alert instead.
+            let timeout = DispatchWorkItem { finish(.failure(Failure.timedOut)) }
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeout)
+
+            holder.task = recognizer.recognitionTask(with: request) { result, error in
+                if let error {
+                    let code = (error as NSError).code
+                    // 216 is "cancelled", which arrives after a successful final result.
+                    if code == 216 { return }
+                    timeout.cancel()
+                    // 1110 is "no speech detected". It is a normal outcome for a recording
+                    // that caught only silence, so it is reported as `.empty` and gets the
+                    // usual no-speech feedback rather than an error alert.
+                    finish(.failure(code == 1110 ? Failure.empty : error))
+                    return
+                }
+                guard let result, result.isFinal else { return }
+                timeout.cancel()
+                finish(.success(result.bestTranscription.formattedString))
+            }
+        }
+
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw Failure.empty }
+        return trimmed
+    }
+
+    /// Model identifier recorded in dictation history, so a transcript produced by the
+    /// fallback is distinguishable from one produced by an MLX model.
+    static let modelIdentifier = "apple-speech (on-device)"
+}

--- a/Sources/Nativ/Features/VoiceCapture/AppleSpeechTranscriber.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AppleSpeechTranscriber.swift
@@ -1,40 +1,37 @@
+import AVFoundation
 import Foundation
 import Speech
-import os
 
-/// On-device dictation through Apple's Speech framework.
+/// On-device dictation through macOS's `SpeechAnalyzer`.
 ///
 /// This exists so dictation works before any model has been downloaded. Nativ's normal
-/// path needs an installed speech-to-text model *and* a running server; until both are
-/// in place the shortcut records audio and then has nowhere to send it. Apple's
-/// recognizer ships with macOS, needs no weights, and answers in well under a second,
-/// so it covers first launch, a stopped server, and the moment a model is still
-/// downloading.
+/// path needs an installed speech-to-text model *and* a running server; until both are in
+/// place the shortcut records audio and then has nowhere to send it. macOS ships its own
+/// speech models, needs no server, and transcribes at roughly 40–70× realtime, so it
+/// covers first launch, a stopped server, and the moment a model is still downloading.
 ///
 /// It is deliberately a fallback rather than an alternative: the bundled MLX models are
 /// more accurate and support far more languages. This just removes the dead end.
 ///
-/// **Recognition is pinned on-device.** `SFSpeechRecognizer` will happily stream audio to
-/// Apple's servers when a locale has no local model, which would be the wrong default for
-/// an app whose whole premise is that nothing leaves the Mac. `requiresOnDeviceRecognition`
-/// is set unconditionally and the locale is rejected outright when it has no on-device
-/// support, so a missing local model produces an error rather than a silent upload.
+/// `SpeechAnalyzer` is the macOS 26 successor to `SFSpeechRecognizer`, which the app's
+/// deployment target lets us require outright. Two things follow. Recognition is on-device
+/// by construction — the framework has no server mode to opt out of, so there is no path
+/// in which audio leaves the Mac — and there is no one-minute ceiling on the audio, which
+/// the older interface enforced by silently transcribing only the tail of a longer
+/// recording and reporting success.
 enum AppleSpeechTranscriber {
     enum Failure: LocalizedError {
-        case notAuthorized
-        case onDeviceUnavailable(locale: String)
-        case recognizerUnavailable
+        case languageUnsupported(String)
+        case modelInstalling(String)
         case timedOut
         case empty
 
         var errorDescription: String? {
             switch self {
-            case .notAuthorized:
-                "Nativ is not allowed to use speech recognition."
-            case let .onDeviceUnavailable(locale):
-                "macOS has no on-device speech model for \(locale)."
-            case .recognizerUnavailable:
-                "The system speech recognizer is unavailable."
+            case let .languageUnsupported(language):
+                "macOS has no on-device speech model for \(language)."
+            case let .modelInstalling(language):
+                "macOS is still downloading its \(language) speech model."
             case .timedOut:
                 "The system speech recognizer did not respond."
             case .empty:
@@ -43,169 +40,42 @@ enum AppleSpeechTranscriber {
         }
     }
 
-    /// Dictation clips are short and on-device recognition is fast, so anything beyond
-    /// this is a stall rather than slow progress.
-    private static let timeoutSeconds: TimeInterval = 30
+    /// Model identifier recorded in dictation history, so a transcript produced by the
+    /// fallback is distinguishable from one produced by an MLX model.
+    static let modelIdentifier = "apple-speech (on-device)"
 
-    /// Keeps the in-flight recognition task alive and makes completion single-shot.
-    private final class RecognitionTaskHolder: @unchecked Sendable {
-        private let lock = OSAllocatedUnfairLock(initialState: false)
-        var task: SFSpeechRecognitionTask?
-
-        /// True for the first caller only.
-        func claimCompletion() -> Bool {
-            lock.withLock { completed in
-                defer { completed = true }
-                return !completed
-            }
-        }
-    }
-
-    /// Locale used for recognition: the closest supported match to the user's own that
-    /// actually has an on-device model.
-    ///
-    /// Two traps here. `supportedLocales()` returns an unordered `Set`, so picking with
-    /// `first(where:)` yields a different answer between runs — an en-GB user could get
-    /// en-ID one launch and en-AU the next. And `Locale.current.identifier` uses
-    /// underscores (`en_GB`) while the supported list uses hyphens (`en-GB`), so the exact
-    /// match silently never fires. Candidates are therefore normalized, ranked, and
-    /// tie-broken by identifier so the choice is stable.
-    ///
-    /// Ranking also skips locales macOS lists but has no downloaded asset for, because
-    /// on-device recognition is mandatory here — a supported-but-absent locale would fail
-    /// the whole transcription rather than quietly falling back to a neighbouring one.
-    static var preferredLocale: Locale {
-        let current = Locale.current
-        let currentID = normalizedIdentifier(current.identifier)
-        let currentLanguage = current.language.languageCode?.identifier
-        let currentRegion = current.region?.identifier
-
-        func rank(_ locale: Locale) -> Int? {
-            let identifier = normalizedIdentifier(locale.identifier)
-            if identifier == currentID { return 0 }
-            guard let currentLanguage,
-                  locale.language.languageCode?.identifier == currentLanguage
-            else { return identifier == "en-US" ? 3 : nil }
-            return locale.region?.identifier == currentRegion ? 1 : 2
-        }
-
-        let ranked = SFSpeechRecognizer.supportedLocales()
-            .compactMap { locale -> (Locale, Int)? in
-                rank(locale).map { (locale, $0) }
-            }
-            .sorted {
-                $0.1 == $1.1
-                    ? normalizedIdentifier($0.0.identifier) < normalizedIdentifier($1.0.identifier)
-                    : $0.1 < $1.1
-            }
-            .map(\.0)
-
-        return ranked.first(where: hasOnDeviceModel)
-            ?? ranked.first
-            ?? Locale(identifier: "en-US")
-    }
-
-    private static func normalizedIdentifier(_ identifier: String) -> String {
-        identifier.replacingOccurrences(of: "_", with: "-")
-    }
-
-    private static func hasOnDeviceModel(_ locale: Locale) -> Bool {
-        guard let recognizer = SFSpeechRecognizer(locale: locale) else { return false }
-        return recognizer.isAvailable && recognizer.supportsOnDeviceRecognition
-    }
-
-    /// Whether a fallback attempt is worth making.
-    ///
-    /// `notDetermined` counts as available: permission is requested by the first
-    /// transcription, and requiring `authorized` here would deadlock — the fallback would
-    /// never run, so the prompt would never appear, so the status would never leave
-    /// `notDetermined`. A denied or restricted status is permanent until the user changes
-    /// it in System Settings, so it returns false and the caller shows its normal alert
-    /// instead of prompting on every recording.
+    /// Whether a fallback attempt is worth making — that is, whether macOS transcribes the
+    /// user's language at all. Whether its model is on disk yet is settled later, once
+    /// there is a recording to transcribe.
     static var isAvailable: Bool {
-        switch SFSpeechRecognizer.authorizationStatus() {
-        case .authorized, .notDetermined:
-            break
-        case .denied, .restricted:
-            return false
-        @unknown default:
-            return false
-        }
-        return hasOnDeviceModel(preferredLocale)
-    }
-
-    /// Prompts for permission the first time. Safe to call repeatedly; macOS only shows
-    /// the dialog while the status is `notDetermined`.
-    static func requestAuthorization() async -> Bool {
-        if SFSpeechRecognizer.authorizationStatus() == .authorized { return true }
-        return await withCheckedContinuation { continuation in
-            SFSpeechRecognizer.requestAuthorization { status in
-                continuation.resume(returning: status == .authorized)
-            }
-        }
+        get async { await transcriber() != nil }
     }
 
     /// Transcribes a recorded file. Nativ already writes dictation to disk before
     /// transcribing, so this takes a URL rather than tapping the microphone — it slots
     /// into the existing flow without changing how audio is captured.
     static func transcribe(contentsOf url: URL) async throws -> String {
-        guard await requestAuthorization() else { throw Failure.notAuthorized }
-
-        let locale = preferredLocale
-        guard let recognizer = SFSpeechRecognizer(locale: locale), recognizer.isAvailable else {
-            throw Failure.recognizerUnavailable
+        guard let transcriber = await transcriber() else {
+            throw Failure.languageUnsupported(displayName(of: .current))
         }
-        guard recognizer.supportsOnDeviceRecognition else {
-            throw Failure.onDeviceUnavailable(
-                locale: locale.localizedString(forIdentifier: locale.identifier)
-                    ?? locale.identifier
-            )
+        guard await isModelInstalled(transcriber) else {
+            throw Failure.modelInstalling(displayName(of: transcriber.locale))
         }
 
-        let request = SFSpeechURLRecognitionRequest(url: url)
-        request.requiresOnDeviceRecognition = true   // never leaves the Mac
-        request.shouldReportPartialResults = false
-        request.addsPunctuation = true
-        request.taskHint = .dictation
-
-        let transcript: String = try await withCheckedThrowingContinuation { continuation in
-            // The task must be held for the duration of recognition. Discarding the
-            // returned object lets ARC release it, and the result handler then never
-            // fires — the call simply hangs. The holder is captured by both closures
-            // below, which keeps it alive exactly as long as it is needed.
-            let holder = RecognitionTaskHolder()
-
-            func finish(_ result: Result<String, Error>) {
-                // The handler fires for partial results and cancellations as well as the
-                // final result, so resuming must happen at most once.
-                guard holder.claimCompletion() else { return }
-                holder.task?.cancel()
-                holder.task = nil
-                continuation.resume(with: result)
+        let analyzer = SpeechAnalyzer(modules: [transcriber.module])
+        let transcript: String
+        do {
+            transcript = try await withTimeout(after: timeout(forAudioAt: url)) {
+                // The results have to be draining before analysis starts, otherwise they
+                // are produced with nothing collecting them.
+                async let collected = transcriber.transcript()
+                _ = try await analyzer.analyzeSequence(from: AVAudioFile(forReading: url))
+                try await analyzer.finalizeAndFinishThroughEndOfInput()
+                return try await collected
             }
-
-            // A stalled recognizer would otherwise leave dictation waiting forever, with
-            // the overlay spinning and no way back. Failing here surfaces the normal
-            // "no model / server stopped" alert instead.
-            let timeout = DispatchWorkItem { finish(.failure(Failure.timedOut)) }
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeout)
-
-            holder.task = recognizer.recognitionTask(with: request) { result, error in
-                if let error {
-                    let code = (error as NSError).code
-                    // 216 is "cancelled", which arrives after a successful final result.
-                    if code == 216 { return }
-                    timeout.cancel()
-                    // 1110 is "no speech detected". It is a normal outcome for a recording
-                    // that caught only silence, so it is reported as `.empty` and gets the
-                    // usual no-speech feedback rather than an error alert.
-                    finish(.failure(code == 1110 ? Failure.empty : error))
-                    return
-                }
-                guard let result, result.isFinal else { return }
-                timeout.cancel()
-                finish(.success(result.bestTranscription.formattedString))
-            }
+        } catch {
+            await analyzer.cancelAndFinishNow()
+            throw error
         }
 
         let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -213,7 +83,153 @@ enum AppleSpeechTranscriber {
         return trimmed
     }
 
-    /// Model identifier recorded in dictation history, so a transcript produced by the
-    /// fallback is distinguishable from one produced by an MLX model.
-    static let modelIdentifier = "apple-speech (on-device)"
+    // MARK: - Choosing a transcriber
+
+    /// A transcription module paired with the code that drains its results.
+    private struct Transcriber {
+        let module: any SpeechModule
+        let locale: Locale
+        /// Collects the module's output. Must be running before analysis begins.
+        let transcript: @Sendable () async throws -> String
+    }
+
+    /// The module that covers the user's language, preferring quality over coverage.
+    ///
+    /// `SpeechTranscriber` is the better recognizer — on a 97 s clip it kept the sentence
+    /// casing and punctuation that `DictationTranscriber` lost — but it covers 45 locales
+    /// to the latter's 54. Dictation therefore picks up what it misses (Czech, Dutch,
+    /// Polish, Russian, Swedish, Arabic, Hebrew and others), which for those users is the
+    /// difference between a fallback and no fallback.
+    ///
+    /// `supportedLocale(equivalentTo:)` does the matching, and does it better than the
+    /// hand-rolled ranking this file used to carry: it is deterministic, and it resolves
+    /// regions macOS has no model for onto ones it does — `en-JP` to `en-GB`, `pt-AO` to
+    /// `pt-PT`, a bare `de` to `de-DE`. A language with no model at all returns nil and
+    /// the caller shows its usual alert, rather than transcribing, say, Welsh with an
+    /// English model and inserting the result at the cursor.
+    private static func transcriber() async -> Transcriber? {
+        if let locale = await SpeechTranscriber.supportedLocale(equivalentTo: .current) {
+            let module = SpeechTranscriber(locale: locale, preset: .transcription)
+            return Transcriber(module: module, locale: locale) {
+                var text = AttributedString()
+                for try await result in module.results where result.isFinal {
+                    text += result.text
+                }
+                return String(text.characters)
+            }
+        }
+
+        if let locale = await DictationTranscriber.supportedLocale(equivalentTo: .current) {
+            let module = DictationTranscriber(locale: locale, preset: .longDictation)
+            return Transcriber(module: module, locale: locale) {
+                var text = AttributedString()
+                for try await result in module.results where result.isFinal {
+                    text += result.text
+                }
+                return String(text.characters)
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - Model assets
+
+    /// Whether the locale's model is ready to use, starting its download if it is not.
+    ///
+    /// macOS usually has the model already — system dictation draws on the same assets —
+    /// but it reports `.supported` rather than `.installed` until the locale is allocated
+    /// to this app, which is what `reserve` does. That call is the whole of the work in
+    /// the common case: nothing is downloaded and the recording transcribes immediately.
+    ///
+    /// When the model genuinely is absent the download runs in the background rather than
+    /// holding the dictation overlay open for an unknown length of time. This recording
+    /// gets the caller's alert; the next one transcribes.
+    private static func isModelInstalled(_ transcriber: Transcriber) async -> Bool {
+        if await AssetInventory.status(forModules: [transcriber.module]) == .installed {
+            return true
+        }
+
+        // Reservations are capped at five locales per app and Nativ only ever asks for the
+        // one being dictated in, so exhausting them would take a deliberate tour through
+        // five languages. Failing here is not fatal either: it costs the guarantee that
+        // macOS keeps the model on disk, not the ability to transcribe with it.
+        _ = try? await AssetInventory.reserve(locale: transcriber.locale)
+        if await AssetInventory.status(forModules: [transcriber.module]) == .installed {
+            return true
+        }
+
+        await ModelInstaller.shared.install(transcriber.module, locale: transcriber.locale)
+        return false
+    }
+
+    /// Downloads a missing speech model, one installation per locale at a time so that
+    /// repeated dictation attempts do not queue duplicate downloads.
+    private actor ModelInstaller {
+        static let shared = ModelInstaller()
+
+        private var installing: Set<String> = []
+
+        func install(_ module: any SpeechModule, locale: Locale) {
+            let key = locale.identifier
+            guard installing.insert(key).inserted else { return }
+
+            Task {
+                do {
+                    let request = try await AssetInventory.assetInstallationRequest(
+                        supporting: [module]
+                    )
+                    if let request {
+                        try await request.downloadAndInstall()
+                        NSLog("Nativ installed the macOS %@ speech model", key)
+                    }
+                } catch {
+                    NSLog(
+                        "Nativ could not install the macOS %@ speech model: %@",
+                        key,
+                        error.localizedDescription
+                    )
+                }
+                finished(key)
+            }
+        }
+
+        private func finished(_ key: String) {
+            installing.remove(key)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Recognition runs far faster than realtime, so a budget of the audio's own duration
+    /// is generous while still ending a stalled recognizer rather than leaving the overlay
+    /// spinning with no way back.
+    private static func timeout(forAudioAt url: URL) -> TimeInterval {
+        guard let file = try? AVAudioFile(forReading: url),
+              file.processingFormat.sampleRate > 0
+        else { return 30 }
+        return max(30, Double(file.length) / file.processingFormat.sampleRate)
+    }
+
+    private static func withTimeout<Success: Sendable>(
+        after seconds: TimeInterval,
+        _ work: @escaping @Sendable () async throws -> Success
+    ) async throws -> Success {
+        try await withThrowingTaskGroup(of: Success.self) { group in
+            group.addTask { try await work() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(seconds))
+                throw Failure.timedOut
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next() else { throw Failure.timedOut }
+            return first
+        }
+    }
+
+    private static func displayName(of locale: Locale) -> String {
+        Locale.current.localizedString(forIdentifier: locale.identifier)
+            ?? locale.language.languageCode?.identifier
+            ?? locale.identifier
+    }
 }

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -389,7 +389,7 @@ final class VoiceCaptureCoordinator {
         overlayTranscriptionID: UUID?,
         unavailableReason: ServerUnavailableReason
     ) async {
-        guard AppleSpeechTranscriber.isAvailable else {
+        guard await AppleSpeechTranscriber.isAvailable else {
             finishOverlayTranscription(overlayTranscriptionID)
             showServerUnavailableAlert(unavailableReason)
             return
@@ -400,6 +400,19 @@ final class VoiceCaptureCoordinator {
             transcript = try await AppleSpeechTranscriber.transcribe(contentsOf: recordingURL)
         } catch AppleSpeechTranscriber.Failure.empty {
             handleEmptyTranscription(recordingURL, overlayTranscriptionID: overlayTranscriptionID)
+            return
+        } catch let AppleSpeechTranscriber.Failure.modelInstalling(language) {
+            // The one failure worth its own message: macOS has the language but not the
+            // model yet, and is now fetching it. Saying so beats an alert about a server
+            // the user may not have been trying to use.
+            finishOverlayTranscription(overlayTranscriptionID)
+            showTranscriptionError(
+                title: "Preparing On-Device Dictation",
+                message: """
+                macOS is downloading its \(language) speech model. Your recording is saved \
+                in Audio — dictate again once it has finished.
+                """
+            )
             return
         } catch {
             NSLog(

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -281,19 +281,20 @@ final class VoiceCaptureCoordinator {
                 self.finishOverlayTranscription(overlayTranscriptionID)
                 return
             }
-            guard let modelID = LocalModelDiscovery.speechToTextModelID(
+            // Both of these are dead ends for the server path. Rather than discarding the
+            // recording, hand it to the on-device system recognizer when that is possible;
+            // the alert is only shown when there is genuinely nothing that can transcribe.
+            let modelID = LocalModelDiscovery.speechToTextModelID(
                 in: installedModels,
                 selectedModelID: requestConfiguration.selectedModelID
-            ) else {
-                self.finishOverlayTranscription(overlayTranscriptionID)
-                self.showMissingSpeechModelAlert()
-                return
-            }
-            guard requestConfiguration.serverIsRunning else {
-                self.finishOverlayTranscription(overlayTranscriptionID)
-                self.showTranscriptionError(
-                    title: "Nativ Server Is Not Running",
-                    message: "Start the Nativ server, then record again to transcribe the audio."
+            )
+            guard let modelID, requestConfiguration.serverIsRunning else {
+                await self.transcribeWithSystemRecognizer(
+                    recordingURL,
+                    target: target,
+                    durationSeconds: durationSeconds,
+                    overlayTranscriptionID: overlayTranscriptionID,
+                    unavailableReason: modelID == nil ? .noSpeechModel : .serverStopped
                 )
                 return
             }
@@ -367,6 +368,86 @@ final class VoiceCaptureCoordinator {
             }
         }
         transcriptionTasks[taskID] = task
+    }
+
+    /// Why the bundled server could not be used for this recording.
+    private enum ServerUnavailableReason {
+        case noSpeechModel
+        case serverStopped
+    }
+
+    /// Last-resort transcription through macOS's on-device recognizer.
+    ///
+    /// Mirrors the server path exactly — same transcript file, same analytics row, same
+    /// cursor insertion — so a fallback transcript behaves like any other. If the system
+    /// recognizer cannot help either, the original alert is shown, leaving the previous
+    /// behaviour intact for anyone it does not cover.
+    private func transcribeWithSystemRecognizer(
+        _ recordingURL: URL,
+        target: VoiceTranscriptInsertionTarget?,
+        durationSeconds: TimeInterval?,
+        overlayTranscriptionID: UUID?,
+        unavailableReason: ServerUnavailableReason
+    ) async {
+        guard AppleSpeechTranscriber.isAvailable else {
+            finishOverlayTranscription(overlayTranscriptionID)
+            showServerUnavailableAlert(unavailableReason)
+            return
+        }
+
+        let transcript: String
+        do {
+            transcript = try await AppleSpeechTranscriber.transcribe(contentsOf: recordingURL)
+        } catch AppleSpeechTranscriber.Failure.empty {
+            handleEmptyTranscription(recordingURL, overlayTranscriptionID: overlayTranscriptionID)
+            return
+        } catch {
+            NSLog(
+                "Nativ on-device transcription failed for %@: %@",
+                recordingURL.lastPathComponent,
+                error.localizedDescription
+            )
+            finishOverlayTranscription(overlayTranscriptionID)
+            showServerUnavailableAlert(unavailableReason)
+            return
+        }
+
+        let transcriptURL = recordingURL
+            .deletingPathExtension()
+            .appendingPathExtension("txt")
+        try? transcript.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        analytics.upsertTranscription(
+            recordingURL: recordingURL,
+            transcript: transcript,
+            durationSeconds: durationSeconds,
+            modelID: AppleSpeechTranscriber.modelIdentifier,
+            applicationName: target?.applicationName
+        )
+
+        let insertedAtCursor = await VoiceTranscriptInserter.insertAtCursor(
+            transcript,
+            target: target
+        )
+        NSLog(
+            "Nativ saved voice transcript to %@ using the on-device system recognizer",
+            transcriptURL.path
+        )
+        finishOverlayTranscription(overlayTranscriptionID)
+        if !insertedAtCursor {
+            showInsertionPermissionAlertIfNeeded()
+        }
+    }
+
+    private func showServerUnavailableAlert(_ reason: ServerUnavailableReason) {
+        switch reason {
+        case .noSpeechModel:
+            showMissingSpeechModelAlert()
+        case .serverStopped:
+            showTranscriptionError(
+                title: "Nativ Server Is Not Running",
+                message: "Start the Nativ server, then record again to transcribe the audio."
+            )
+        }
     }
 
     private func handleEmptyTranscription(


### PR DESCRIPTION
## Summary

Dictation needs an installed speech-to-text model **and** a running server. Until both are true, pressing the shortcut still records — and then hits a dead end, discarding the audio behind a *"download a speech model"* or *"start the server"* alert. That's the first thing a new user tries, and today it does nothing.

macOS ships speech models that need no weights of ours and no server. This uses them **when, and only when, the normal path cannot run** — first launch, a model still downloading, or a stopped server. It stays a fallback: the bundled MLX models are more accurate and cover far more languages. This just removes the dead end.

> Built on `SpeechAnalyzer` (macOS 26). The first commit used `SFSpeechRecognizer`; 9f38912 replaces it following @lucasnewman's review — see the thread. The old interface silently truncated anything past about a minute, which is covered under Verification below.

## What it does

- **`SpeechTranscriber`** does the transcription, with **`DictationTranscriber`** picking up the locales it doesn't cover — 45 vs 54, so the second tier is what gives Czech, Dutch, Polish, Russian, Swedish, Arabic and Hebrew speakers a fallback at all. `SpeechTranscriber` is the better recognizer where both apply: on a 97 s clip it kept sentence casing and punctuation that dictation lost.
- **Locale selection is `supportedLocale(equivalentTo:)`**, which resolves regions macOS has no model for onto ones it does — `en-JP` → `en-GB`, `pt-AO` → `pt-PT`, bare `de` → `de-DE`. A language neither module covers returns nil and the existing alert shows, rather than transcribing e.g. Welsh with an English model and inserting the result at the cursor.
- **Model assets.** macOS normally has the model already — system dictation draws on the same assets — and it only needs allocating to the app via `AssetInventory.reserve`, which downloads nothing. When a model genuinely is absent, the download runs in the background rather than holding the overlay open for an unknown length of time, and that recording gets *"macOS is downloading its \<language\> speech model — your recording is saved in Audio"* instead of an alert about a server the user may not have been trying to start.
- **The timeout scales with the audio length** rather than sitting at a flat 30 s, since recordings are no longer capped at a minute. A stalled recognizer still surfaces the normal alert instead of leaving the overlay spinning.

## Recognition is on-device by construction

`SpeechAnalyzer` has no server mode, so there is no code path in which audio leaves the Mac and nothing to opt out of. That also means no speech-recognition authorization, no permission prompt, and no `NSSpeechRecognitionUsageDescription` — `Configuration/Nativ-Info.plist` is untouched by this PR.

## Behaviour

The fallback reuses the existing success path, so its transcript is written to the `.txt` sidecar, recorded in analytics, and inserted at the cursor exactly like any other. It's attributed as `apple-speech (on-device)` in dictation history so it's distinguishable from an MLX transcript. When macOS can't help either, the original alert is shown unchanged — existing behaviour is preserved for anyone this doesn't cover.

## Verification

Tested on macOS 26 / M5 Max against speech synthesised with `say`, through the shipping code path:

| Input | Latency | Result |
|---|---|---|
| 5.6 s clip | 0.23 s | full transcript |
| 97.4 s clip | 1.29 s | full transcript, 1691 chars |
| 48 kHz stereo float | 0.13 s | full transcript |
| silence | — | `.empty` → normal no-speech feedback |

The 97 s clip is the one worth noting. `SFSpeechRecognizer` doesn't fail past its ~1-minute ceiling on a file — it truncates and reports success. The same recording came back as 659 characters, the *tail* of the audio, with the first minute silently gone and nothing to indicate it. That's the concrete cost of the original approach, and it's why the rewrite is a behaviour fix rather than an API tidy-up.

Three of the four bugs found while building the original `SFSpeechRecognizer` version were artefacts of that API and no longer exist: the authorization deadlock (nothing to authorize), the non-deterministic locale from an unordered `supportedLocales()` set (`supportedLocale(equivalentTo:)` is deterministic), and the released `SFSpeechRecognitionTask` (analysis is awaited, not escaping into a callback). The fourth — silence reported as an error — remains handled, as `.empty` surfacing the normal no-speech feedback.

## Notes

- Deliberately file-based rather than streaming, matching how dictation already records to disk before transcribing — it slots into the existing flow without changing audio capture. Live/partial transcription would be a much larger change and is not attempted here.
- No new dependency; `Speech` is a system framework.
- Happy to put this behind a settings toggle if you'd prefer it opt-in, or to prompt before any model download rather than starting it in the background. I left both automatic because they only activate where the app currently does nothing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
