### PR TITLE
Add meeting transcription suggestions

### DIFF
--- a/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
+++ b/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
@@ -30,6 +30,7 @@ final class VoiceDictationExtension: NativHostExtension {
             context.showMainWindow()
         }
         coordinator.start()
+        audioCaptureLibrary.start()
         isActive = true
     }
 

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -15,7 +15,7 @@ enum AudioCapturePreferences {
         UserDefaults.standard.register(defaults: [
             automaticallySummarizeKey: true,
             includeSystemAudioKey: true,
-            suggestMeetingTranscriptionKey: true,
+            suggestMeetingTranscriptionKey: false,
         ])
     }
 

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -1,8 +1,36 @@
 import AppKit
 import AVFoundation
+import CoreAudio
+import Darwin
 import Foundation
 import NativServerKit
 import ScreenCaptureKit
+
+enum AudioCapturePreferences {
+    static let automaticallySummarizeKey = "audio.capture.automaticallySummarize"
+    static let includeSystemAudioKey = "audio.capture.includeSystemAudio"
+    static let suggestMeetingTranscriptionKey = "audio.capture.suggestMeetingTranscription"
+
+    static func registerDefaults() {
+        UserDefaults.standard.register(defaults: [
+            automaticallySummarizeKey: true,
+            includeSystemAudioKey: true,
+            suggestMeetingTranscriptionKey: true,
+        ])
+    }
+
+    static var automaticallySummarize: Bool {
+        UserDefaults.standard.bool(forKey: automaticallySummarizeKey)
+    }
+
+    static var includeSystemAudio: Bool {
+        UserDefaults.standard.bool(forKey: includeSystemAudioKey)
+    }
+
+    static var suggestMeetingTranscription: Bool {
+        UserDefaults.standard.bool(forKey: suggestMeetingTranscriptionKey)
+    }
+}
 
 enum AudioCapturePhase: Equatable {
     case idle
@@ -79,6 +107,8 @@ final class AudioCaptureLibrary: ObservableObject {
     private let voiceRecorder = VoiceAudioRecorder()
     private let meetingRecorder = SystemAudioMeetingRecorder()
     private let recordingOverlay = VoiceCaptureOverlayController()
+    private let meetingJoinMonitor = MeetingJoinMonitor()
+    private let meetingSuggestion = MeetingTranscriptionSuggestionController()
     private let analytics: AudioAnalyticsStore
     private var elapsedTimer: Timer?
     private var captureStartedAt: Date?
@@ -88,7 +118,26 @@ final class AudioCaptureLibrary: ObservableObject {
     private var lastMeterPublishAt = Date.distantPast
 
     init(analytics: AudioAnalyticsStore? = nil) {
+        AudioCapturePreferences.registerDefaults()
         self.analytics = analytics ?? .shared
+        meetingJoinMonitor.onMeetingJoined = { [weak self] application in
+            self?.offerMeetingTranscription(for: application) ?? false
+        }
+        meetingSuggestion.onStart = { [weak self] in
+            guard let self else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    return
+                }
+                await self.start(
+                    .meeting,
+                    automaticallySummarize: AudioCapturePreferences.automaticallySummarize,
+                    includeSystemAudio: AudioCapturePreferences.includeSystemAudio
+                )
+            }
+        }
         recordingOverlay.setAudioCaptureActions(
             complete: { [weak self] in
                 Task { @MainActor [weak self] in
@@ -118,6 +167,10 @@ final class AudioCaptureLibrary: ObservableObject {
             }
             self.publishMeter(level: level, elapsed: self.elapsed)
         }
+    }
+
+    func start() {
+        meetingJoinMonitor.start()
     }
 
     static var recordingsDirectory: URL {
@@ -464,6 +517,8 @@ final class AudioCaptureLibrary: ObservableObject {
     }
 
     func shutdown() {
+        meetingJoinMonitor.stop()
+        meetingSuggestion.dismiss()
         activeTask?.cancel()
         activeTask = nil
         stopElapsedTimer()
@@ -474,6 +529,16 @@ final class AudioCaptureLibrary: ObservableObject {
             await meetingRecorder.cancel()
         }
         resetCaptureState()
+    }
+
+    private func offerMeetingTranscription(for application: MeetingApplication) -> Bool {
+        guard AudioCapturePreferences.suggestMeetingTranscription,
+              phase == .idle
+        else {
+            return false
+        }
+        meetingSuggestion.show(for: application.displayName)
+        return true
     }
 
     private func processRecording(
@@ -789,5 +854,272 @@ final class AudioCaptureLibrary: ObservableObject {
             start = end
         }
         return chunks
+    }
+}
+
+struct MeetingApplication: Equatable {
+    let processIdentifier: pid_t
+    let displayName: String
+}
+
+@MainActor
+final class MeetingJoinMonitor {
+    var onMeetingJoined: ((MeetingApplication) -> Bool)?
+
+    private var timer: Timer?
+    private var workspaceObservers: [NSObjectProtocol] = []
+    private var promptedProcessIdentifiers = Set<pid_t>()
+    private var inputActivitySamples: [pid_t: Int] = [:]
+
+    private static let pollingInterval: TimeInterval = 0.5
+    private static let requiredInputActivitySamples = 2
+
+    func start() {
+        guard timer == nil else {
+            return
+        }
+
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        for notificationName in [
+            NSWorkspace.didActivateApplicationNotification,
+            NSWorkspace.didLaunchApplicationNotification,
+        ] {
+            workspaceObservers.append(
+                workspaceCenter.addObserver(
+                    forName: notificationName,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    Task { @MainActor [weak self] in
+                        self?.evaluate()
+                    }
+                }
+            )
+        }
+        workspaceObservers.append(
+            workspaceCenter.addObserver(
+                forName: NSWorkspace.didTerminateApplicationNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let application = notification.userInfo?[
+                    NSWorkspace.applicationUserInfoKey
+                ] as? NSRunningApplication else {
+                    return
+                }
+                Task { @MainActor [weak self] in
+                    self?.resetState(for: application.processIdentifier)
+                }
+            }
+        )
+
+        let timer = Timer(timeInterval: Self.pollingInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.evaluate()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+        evaluate()
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        workspaceObservers.forEach { workspaceCenter.removeObserver($0) }
+        workspaceObservers.removeAll()
+        promptedProcessIdentifiers.removeAll()
+        inputActivitySamples.removeAll()
+    }
+
+    private func evaluate() {
+        guard AudioCapturePreferences.suggestMeetingTranscription else {
+            promptedProcessIdentifiers.removeAll()
+            inputActivitySamples.removeAll()
+            return
+        }
+
+        clearInactiveMeetingStates()
+
+        guard let application = NSWorkspace.shared.frontmostApplication,
+              let bundleIdentifier = application.bundleIdentifier,
+              Self.meetingApplicationNames[bundleIdentifier] != nil,
+              application.activationPolicy == .regular
+        else {
+            return
+        }
+
+        let processIdentifier = application.processIdentifier
+        guard Self.isInputRunning(forProcessIdentifier: processIdentifier) else {
+            inputActivitySamples[processIdentifier] = 0
+            promptedProcessIdentifiers.remove(processIdentifier)
+            return
+        }
+
+        let sampleCount = min(
+            Self.requiredInputActivitySamples,
+            (inputActivitySamples[processIdentifier] ?? 0) + 1
+        )
+        inputActivitySamples[processIdentifier] = sampleCount
+        guard sampleCount >= Self.requiredInputActivitySamples,
+              !promptedProcessIdentifiers.contains(processIdentifier)
+        else {
+            return
+        }
+
+        let displayName = Self.meetingApplicationNames[bundleIdentifier]
+            ?? application.localizedName
+            ?? "the meeting app"
+        let shouldRememberPrompt = onMeetingJoined?(
+            MeetingApplication(
+                processIdentifier: processIdentifier,
+                displayName: displayName
+            )
+        ) ?? false
+        if shouldRememberPrompt {
+            promptedProcessIdentifiers.insert(processIdentifier)
+        }
+    }
+
+    private func clearInactiveMeetingStates() {
+        for processIdentifier in promptedProcessIdentifiers
+            where !Self.isInputRunning(forProcessIdentifier: processIdentifier)
+        {
+            resetState(for: processIdentifier)
+        }
+    }
+
+    private func resetState(for processIdentifier: pid_t) {
+        promptedProcessIdentifiers.remove(processIdentifier)
+        inputActivitySamples.removeValue(forKey: processIdentifier)
+    }
+
+    private static let meetingApplicationNames: [String: String] = [
+        "us.zoom.xos": "Zoom",
+        "com.microsoft.teams2": "Microsoft Teams",
+        "com.microsoft.teams": "Microsoft Teams",
+        "com.cisco.webexmeetingsapp": "Webex",
+        "com.tinyspeck.slackmacgap": "Slack",
+        "com.hnc.Discord": "Discord",
+        "com.apple.FaceTime": "FaceTime",
+        "com.google.Chrome": "Google Meet",
+        "com.apple.Safari": "Google Meet",
+        "org.mozilla.firefox": "Google Meet",
+        "com.microsoft.edgemac": "Google Meet",
+        "company.thebrowser.Browser": "Google Meet",
+        "com.brave.Browser": "Google Meet",
+    ]
+
+    private static func isInputRunning(forProcessIdentifier rootProcessIdentifier: pid_t) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyProcessObjectList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize
+        ) == noErr else {
+            return false
+        }
+
+        let processCount = Int(dataSize) / MemoryLayout<AudioObjectID>.stride
+        guard processCount > 0 else {
+            return false
+        }
+        var processObjects = [AudioObjectID](repeating: 0, count: processCount)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &processObjects
+        ) == noErr else {
+            return false
+        }
+
+        for processObject in processObjects {
+            guard let processIdentifier = processIdentifier(for: processObject),
+                  isDescendant(processIdentifier, of: rootProcessIdentifier),
+                  isProcessInputRunning(processObject)
+            else {
+                continue
+            }
+            return true
+        }
+        return false
+    }
+
+    private static func processIdentifier(for processObject: AudioObjectID) -> pid_t? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyPID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var processIdentifier: pid_t = 0
+        var dataSize = UInt32(MemoryLayout<pid_t>.size)
+        guard AudioObjectGetPropertyData(
+            processObject,
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &processIdentifier
+        ) == noErr else {
+            return nil
+        }
+        return processIdentifier
+    }
+
+    private static func isProcessInputRunning(_ processObject: AudioObjectID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioProcessPropertyIsRunningInput,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var isRunning: UInt32 = 0
+        var dataSize = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectGetPropertyData(
+            processObject,
+            &address,
+            0,
+            nil,
+            &dataSize,
+            &isRunning
+        ) == noErr && isRunning != 0
+    }
+
+    private static func isDescendant(_ processIdentifier: pid_t, of rootProcessIdentifier: pid_t) -> Bool {
+        var currentProcessIdentifier = processIdentifier
+        var visited = Set<pid_t>()
+        while currentProcessIdentifier > 1,
+              visited.insert(currentProcessIdentifier).inserted
+        {
+            if currentProcessIdentifier == rootProcessIdentifier {
+                return true
+            }
+
+            var processInfo = proc_bsdinfo()
+            let result = withUnsafeMutablePointer(to: &processInfo) { pointer in
+                proc_pidinfo(
+                    currentProcessIdentifier,
+                    PROC_PIDTBSDINFO,
+                    0,
+                    pointer,
+                    Int32(MemoryLayout<proc_bsdinfo>.size)
+                )
+            }
+            guard result == Int32(MemoryLayout<proc_bsdinfo>.size) else {
+                return false
+            }
+            currentProcessIdentifier = pid_t(processInfo.pbi_ppid)
+        }
+        return false
     }
 }

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -54,10 +54,12 @@ struct AudioView: View {
     @StateObject private var inputDevices = AudioInputDevicePreferences.shared
     @StateObject private var inputLevelMonitor = AudioInputLevelMonitor()
     @StateObject private var inputVolume = AudioInputVolumeController()
-    @AppStorage("audio.capture.automaticallySummarize")
+    @AppStorage(AudioCapturePreferences.automaticallySummarizeKey)
     private var automaticallySummarize = true
-    @AppStorage("audio.capture.includeSystemAudio")
+    @AppStorage(AudioCapturePreferences.includeSystemAudioKey)
     private var includeSystemAudio = true
+    @AppStorage(AudioCapturePreferences.suggestMeetingTranscriptionKey)
+    private var suggestMeetingTranscription = true
     @State private var searchText = ""
     @State private var editingShortcut: AudioShortcutKind?
     @State private var shortcutConflict: String?
@@ -288,6 +290,7 @@ struct AudioView: View {
                 maxContentWidth: 1_120
             ) {
                 audioInputPanel
+                meetingSuggestionPanel
                 captureControls
                 capturePrivacyPanel
             }
@@ -869,6 +872,27 @@ struct AudioView: View {
             Text("Private by default")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.green)
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private var meetingSuggestionPanel: some View {
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Suggest transcription when a meeting starts")
+                    .font(.caption.weight(.medium))
+                Text("Nativ watches supported meeting apps for microphone activity. It never records unless you choose Start transcription.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 12)
+            Toggle(
+                "Suggest transcription when a meeting starts",
+                isOn: $suggestMeetingTranscription
+            )
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .accessibilityLabel("Suggest transcription when a meeting starts")
         }
         .padding(.horizontal, 4)
     }

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -727,17 +727,6 @@ struct AudioView: View {
 
                 Spacer(minLength: 16)
 
-                HStack(spacing: 9) {
-                    Image(systemName: "sparkles")
-                        .foregroundStyle(Color.white)
-                    Text("Auto-summary")
-                        .font(.callout.weight(.medium))
-                    Toggle("Create summarized notes automatically", isOn: $automaticallySummarize)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
-                }
-                .disabled(captureLibrary.isBusy)
-
                 Button {
                     inputLevelMonitor.stop()
                     Task {
@@ -749,7 +738,8 @@ struct AudioView: View {
                     }
                 } label: {
                     Label("Start recording", systemImage: "record.circle")
-                        .padding(.horizontal, 8)
+                        .font(.callout.weight(.semibold))
+                        .frame(minWidth: 164)
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(tint)
@@ -759,7 +749,28 @@ struct AudioView: View {
             Divider()
                 .padding(.vertical, 16)
 
-            meetingSuggestionRow(tint: tint)
+            HStack(alignment: .center, spacing: 20) {
+                capturePreferenceRow(
+                    title: "Auto-summary",
+                    detail: "Create summarized notes automatically after each recording.",
+                    systemImage: "sparkles",
+                    tint: .purple,
+                    isOn: $automaticallySummarize,
+                    accessibilityLabel: "Create summarized notes automatically"
+                )
+
+                Divider()
+                    .frame(height: 52)
+
+                capturePreferenceRow(
+                    title: "Transcription suggestions",
+                    detail: "Prompt me when a supported meeting app begins using the microphone.",
+                    systemImage: "person.2.wave.2.fill",
+                    tint: tint,
+                    isOn: $suggestMeetingTranscription,
+                    accessibilityLabel: "Suggest transcription when a meeting starts"
+                )
+            }
         }
         .padding(18)
         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -945,33 +956,43 @@ struct AudioView: View {
         .padding(.horizontal, 4)
     }
 
-    private func meetingSuggestionRow(tint: Color) -> some View {
+    private func capturePreferenceRow(
+        title: String,
+        detail: String,
+        systemImage: String,
+        tint: Color,
+        isOn: Binding<Bool>,
+        accessibilityLabel: String
+    ) -> some View {
         HStack(alignment: .center, spacing: 14) {
-            Image(systemName: "person.2.wave.2.fill")
-                .font(.system(size: 19, weight: .semibold))
+            Image(systemName: systemImage)
+                .font(.system(size: 17, weight: .semibold))
                 .foregroundStyle(tint)
-                .frame(width: 42, height: 42)
+                .frame(width: 38, height: 38)
                 .background(
                     tint.opacity(0.12),
-                    in: RoundedRectangle(cornerRadius: 11, style: .continuous)
+                    in: RoundedRectangle(cornerRadius: 10, style: .continuous)
                 )
 
             VStack(alignment: .leading, spacing: 3) {
-                Text("Transcription suggestions")
-                    .font(.headline)
-                Text("Prompt me to start transcription when a supported meeting app begins using the microphone.")
+                Text(title)
+                    .font(.callout.weight(.semibold))
+                Text(detail)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
             }
+            .layoutPriority(1)
+
             Spacer(minLength: 12)
-            Toggle(
-                "Suggest transcription when a meeting starts",
-                isOn: $suggestMeetingTranscription
-            )
-            .labelsHidden()
-            .toggleStyle(.switch)
-            .accessibilityLabel("Suggest transcription when a meeting starts")
+
+            Toggle(accessibilityLabel, isOn: isOn)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .disabled(captureLibrary.isBusy)
+                .accessibilityLabel(accessibilityLabel)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var modelConfigurationPanel: some View {

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -2527,7 +2527,7 @@ private struct AudioCaptureRecordRow: View {
 
         var tint: Color {
             switch self {
-            case .summary: .white
+            case .summary: .primary
             case .transcript: .primary
             }
         }
@@ -2741,7 +2741,7 @@ private struct AudioCaptureRecordRow: View {
             .background(
                 isSelected
                     ? Color.accentColor
-                    : (isHovered ? Color.white.opacity(0.08) : Color.clear),
+                    : (isHovered ? Color.primary.opacity(0.06) : Color.clear),
                 in: RoundedRectangle(cornerRadius: 7, style: .continuous)
             )
             .contentShape(Rectangle())

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -191,6 +191,24 @@ struct AudioView: View {
             Text("The transcript and any retained audio will be permanently deleted.")
         }
         .alert(
+            "Delete recording?",
+            isPresented: Binding(
+                get: { pendingDeleteRecording != nil },
+                set: { if !$0 { pendingDeleteRecording = nil } }
+            ),
+            presenting: pendingDeleteRecording
+        ) { record in
+            Button("Delete", role: .destructive) {
+                captureLibrary.delete(record)
+                pendingDeleteRecording = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDeleteRecording = nil
+            }
+        } message: { record in
+            Text("\u{201c}\(record.displayTitle)\u{201d} and its audio, transcript, and summary will be permanently deleted.")
+        }
+        .alert(
             "Clear all recent dictations?",
             isPresented: $isConfirmingClearAllDictations
         ) {

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -59,7 +59,7 @@ struct AudioView: View {
     @AppStorage(AudioCapturePreferences.includeSystemAudioKey)
     private var includeSystemAudio = true
     @AppStorage(AudioCapturePreferences.suggestMeetingTranscriptionKey)
-    private var suggestMeetingTranscription = true
+    private var suggestMeetingTranscription = false
     @State private var searchText = ""
     @State private var editingShortcut: AudioShortcutKind?
     @State private var shortcutConflict: String?

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -290,7 +290,6 @@ struct AudioView: View {
                 maxContentWidth: 1_120
             ) {
                 audioInputPanel
-                meetingSuggestionPanel
                 captureControls
                 capturePrivacyPanel
             }
@@ -644,53 +643,60 @@ struct AudioView: View {
     private var unifiedCaptureCard: some View {
         let tint = Color.blue
 
-        return HStack(alignment: .center, spacing: 14) {
-            Image(systemName: "waveform.badge.mic")
-                .font(.system(size: 19, weight: .semibold))
-                .foregroundStyle(tint)
-                .frame(width: 42, height: 42)
-                .background(
-                    tint.opacity(0.12),
-                    in: RoundedRectangle(cornerRadius: 11, style: .continuous)
-                )
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text("New recording")
-                    .font(.headline)
-                Text("Capture audio, then transcribe it locally when you finish.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer(minLength: 16)
-
-            HStack(spacing: 9) {
-                Image(systemName: "sparkles")
-                    .foregroundStyle(Color.white)
-                Text("Auto-summary")
-                    .font(.callout.weight(.medium))
-                Toggle("Create summarized notes automatically", isOn: $automaticallySummarize)
-                    .labelsHidden()
-                    .toggleStyle(.switch)
-            }
-            .disabled(captureLibrary.isBusy)
-
-            Button {
-                inputLevelMonitor.stop()
-                Task {
-                    await captureLibrary.start(
-                        .meeting,
-                        automaticallySummarize: automaticallySummarize,
-                        includeSystemAudio: includeSystemAudio
+        return VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .center, spacing: 14) {
+                Image(systemName: "waveform.badge.mic")
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 42, height: 42)
+                    .background(
+                        tint.opacity(0.12),
+                        in: RoundedRectangle(cornerRadius: 11, style: .continuous)
                     )
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("New recording")
+                        .font(.headline)
+                    Text("Capture audio, then transcribe it locally when you finish.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-            } label: {
-                Label("Start recording", systemImage: "record.circle")
-                    .padding(.horizontal, 8)
+
+                Spacer(minLength: 16)
+
+                HStack(spacing: 9) {
+                    Image(systemName: "sparkles")
+                        .foregroundStyle(Color.white)
+                    Text("Auto-summary")
+                        .font(.callout.weight(.medium))
+                    Toggle("Create summarized notes automatically", isOn: $automaticallySummarize)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+                .disabled(captureLibrary.isBusy)
+
+                Button {
+                    inputLevelMonitor.stop()
+                    Task {
+                        await captureLibrary.start(
+                            .meeting,
+                            automaticallySummarize: automaticallySummarize,
+                            includeSystemAudio: includeSystemAudio
+                        )
+                    }
+                } label: {
+                    Label("Start recording", systemImage: "record.circle")
+                        .padding(.horizontal, 8)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(tint)
+                .controlSize(.large)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(tint)
-            .controlSize(.large)
+
+            Divider()
+                .padding(.vertical, 16)
+
+            meetingSuggestionRow(tint: tint)
         }
         .padding(18)
         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -876,13 +882,22 @@ struct AudioView: View {
         .padding(.horizontal, 4)
     }
 
-    private var meetingSuggestionPanel: some View {
-        HStack(alignment: .center, spacing: 10) {
+    private func meetingSuggestionRow(tint: Color) -> some View {
+        HStack(alignment: .center, spacing: 14) {
+            Image(systemName: "person.2.wave.2.fill")
+                .font(.system(size: 19, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 42, height: 42)
+                .background(
+                    tint.opacity(0.12),
+                    in: RoundedRectangle(cornerRadius: 11, style: .continuous)
+                )
+
             VStack(alignment: .leading, spacing: 3) {
-                Text("Suggest transcription when a meeting starts")
-                    .font(.caption.weight(.medium))
-                Text("Nativ watches supported meeting apps for microphone activity. It never records unless you choose Start transcription.")
-                    .font(.caption2)
+                Text("Transcription suggestions")
+                    .font(.headline)
+                Text("Prompt me to start transcription when a supported meeting app begins using the microphone.")
+                    .font(.caption)
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 12)
@@ -894,7 +909,6 @@ struct AudioView: View {
             .toggleStyle(.switch)
             .accessibilityLabel("Suggest transcription when a meeting starts")
         }
-        .padding(.horizontal, 4)
     }
 
     private var modelConfigurationPanel: some View {

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -192,24 +192,6 @@ struct AudioView: View {
             Text("The transcript and any retained audio will be permanently deleted.")
         }
         .alert(
-            "Delete recording?",
-            isPresented: Binding(
-                get: { pendingDeleteRecording != nil },
-                set: { if !$0 { pendingDeleteRecording = nil } }
-            ),
-            presenting: pendingDeleteRecording
-        ) { record in
-            Button("Delete", role: .destructive) {
-                captureLibrary.delete(record)
-                pendingDeleteRecording = nil
-            }
-            Button("Cancel", role: .cancel) {
-                pendingDeleteRecording = nil
-            }
-        } message: { record in
-            Text("\u{201c}\(record.displayTitle)\u{201d} and its audio, transcript, and summary will be permanently deleted.")
-        }
-        .alert(
             "Clear all recent dictations?",
             isPresented: $isConfirmingClearAllDictations
         ) {

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -66,6 +66,7 @@ struct AudioView: View {
     @State private var destination: AudioDestination = .record
     @State private var pendingDeleteDictation: AudioTranscriptionRecord?
     @State private var pendingDeleteRecording: AudioTranscriptionRecord?
+    @State private var hoveredActivity: AudioDailyUsage?
     @State private var isConfirmingClearAllDictations = false
 
     let titleLeadingInset: CGFloat
@@ -423,19 +424,44 @@ struct AudioView: View {
                 }
                 .frame(maxWidth: .infinity, minHeight: 220)
             } else {
-                Chart(dailyUsage) { item in
-                    BarMark(
-                        x: .value("Day", item.date, unit: .day),
-                        y: .value("Words", item.words)
-                    )
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: [.accentColor, .accentColor.opacity(0.5)],
-                            startPoint: .top,
-                            endPoint: .bottom
+                Chart {
+                    ForEach(dailyUsage) { item in
+                        BarMark(
+                            x: .value("Day", item.date, unit: .day),
+                            y: .value("Words", item.words)
                         )
-                    )
-                    .cornerRadius(4)
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [.accentColor, .accentColor.opacity(0.5)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .cornerRadius(4)
+                        .opacity(
+                            hoveredActivity == nil || hoveredActivity?.id == item.id
+                                ? 1
+                                : 0.42
+                        )
+                    }
+
+                    if let hoveredActivity {
+                        RuleMark(
+                            x: .value("Hovered day", hoveredActivity.date, unit: .day)
+                        )
+                        .foregroundStyle(Color.secondary.opacity(0.28))
+                        .lineStyle(.init(lineWidth: 1, dash: [3, 3]))
+                        .annotation(
+                            position: .top,
+                            spacing: 8,
+                            overflowResolution: .init(
+                                x: .fit(to: .chart),
+                                y: .disabled
+                            )
+                        ) {
+                            AudioActivityTooltip(item: hoveredActivity)
+                        }
+                    }
                 }
                 .chartXAxis {
                     AxisMarks(values: .stride(by: .day, count: 2)) { value in
@@ -445,6 +471,25 @@ struct AudioView: View {
                 }
                 .chartYAxis {
                     AxisMarks(position: .leading)
+                }
+                .chartOverlay { proxy in
+                    GeometryReader { geometry in
+                        Rectangle()
+                            .fill(Color.clear)
+                            .contentShape(Rectangle())
+                            .onContinuousHover { phase in
+                                switch phase {
+                                case let .active(location):
+                                    updateHoveredActivity(
+                                        at: location,
+                                        proxy: proxy,
+                                        geometry: geometry
+                                    )
+                                case .ended:
+                                    hoveredActivity = nil
+                                }
+                            }
+                    }
                 }
                 .frame(height: 230)
             }
@@ -1988,6 +2033,35 @@ struct AudioView: View {
         dailyUsage.reduce(0) { $0 + $1.words }
     }
 
+    private func updateHoveredActivity(
+        at location: CGPoint,
+        proxy: ChartProxy,
+        geometry: GeometryProxy
+    ) {
+        guard let plotFrameAnchor = proxy.plotFrame else {
+            hoveredActivity = nil
+            return
+        }
+
+        let plotFrame = geometry[plotFrameAnchor]
+        guard plotFrame.contains(location) else {
+            hoveredActivity = nil
+            return
+        }
+
+        let plotX = location.x - plotFrame.minX
+        guard let date: Date = proxy.value(atX: plotX) else {
+            hoveredActivity = nil
+            return
+        }
+
+        let nextActivity = dailyUsage.min {
+            abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
+        }
+        guard hoveredActivity != nextActivity else { return }
+        hoveredActivity = nextActivity
+    }
+
     private var filteredRecords: [AudioTranscriptionRecord] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {
@@ -2302,6 +2376,38 @@ private struct AudioMetricCard: View {
         }
         .padding(16)
         .audioPanelStyle()
+    }
+}
+
+private struct AudioActivityTooltip: View {
+    let item: AudioDailyUsage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(item.date.formatted(.dateTime.weekday(.wide).month(.abbreviated).day()))
+                .font(.caption.weight(.semibold))
+
+            HStack(spacing: 6) {
+                Text("\(item.words.formatted()) words")
+                Text("·")
+                    .foregroundStyle(.tertiary)
+                Text("\(item.sessions) \(item.sessions == 1 ? "dictation" : "dictations")")
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 8)
+        .background(
+            .regularMaterial,
+            in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.1), lineWidth: 0.5)
+        }
+        .shadow(color: .black.opacity(0.14), radius: 8, y: 3)
+        .fixedSize()
     }
 }
 

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureOverlay.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureOverlay.swift
@@ -10,6 +10,7 @@ private enum VoiceIslandLayoutMetrics {
 
 private let voiceCaptureDismissalDuration: TimeInterval = 0.38
 private let voiceCaptureMinimumLoadingDuration: TimeInterval = 0.65
+private let meetingTranscriptionSuggestionDuration: TimeInterval = 10
 
 private func voiceCaptureFinishProgress(
     state: VoiceCaptureOverlayModel.State,
@@ -2571,5 +2572,231 @@ struct VoiceVerticalLiveWaveform: View {
             maximumWidth,
             max(7, maximumWidth * CGFloat(normalizedWidth))
         )
+    }
+}
+
+@MainActor
+final class MeetingTranscriptionSuggestionController {
+    var onStart: (() -> Void)?
+
+    private let model: MeetingTranscriptionSuggestionModel
+    private let panel: MeetingTranscriptionSuggestionPanel
+    private var dismissalTask: Task<Void, Never>?
+
+    init() {
+        let model = MeetingTranscriptionSuggestionModel()
+        self.model = model
+        panel = MeetingTranscriptionSuggestionPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 72),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentView = NSHostingView(
+            rootView: MeetingTranscriptionSuggestionView(model: model)
+        )
+        model.onStart = { [weak self] in
+            guard let self else {
+                return
+            }
+            self.dismiss()
+            self.onStart?()
+        }
+        model.onDismiss = { [weak self] in
+            self?.dismiss()
+        }
+
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = false
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = false
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.level = .floating
+        panel.collectionBehavior = [
+            .canJoinAllSpaces,
+            .fullScreenAuxiliary,
+            .ignoresCycle,
+        ]
+    }
+
+    func show(for applicationName: String) {
+        dismissalTask?.cancel()
+        model.applicationName = applicationName
+        model.secondsRemaining = Int(meetingTranscriptionSuggestionDuration)
+        model.progress = 1
+        positionPanel()
+        panel.makeKeyAndOrderFront(nil)
+
+        dismissalTask = Task { [weak self] in
+            let deadline = Date().addingTimeInterval(meetingTranscriptionSuggestionDuration)
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .milliseconds(50))
+                } catch {
+                    return
+                }
+                guard let self, !Task.isCancelled else {
+                    return
+                }
+
+                let remaining = max(0, deadline.timeIntervalSinceNow)
+                self.model.secondsRemaining = Int(ceil(remaining))
+                self.model.progress = CGFloat(
+                    min(
+                        1,
+                        max(0, remaining / meetingTranscriptionSuggestionDuration)
+                    )
+                )
+
+                if remaining <= 0 {
+                    self.dismiss()
+                    return
+                }
+            }
+        }
+    }
+
+    func dismiss() {
+        dismissalTask?.cancel()
+        dismissalTask = nil
+        panel.orderOut(nil)
+    }
+
+    private func positionPanel() {
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first {
+            NSMouseInRect(mouseLocation, $0.frame, false)
+        } ?? NSScreen.main ?? NSScreen.screens[0]
+        let visibleFrame = screen.visibleFrame
+        let topInset: CGFloat = 8
+        panel.setFrameOrigin(
+            NSPoint(
+                x: visibleFrame.midX - (panel.frame.width / 2),
+                y: visibleFrame.maxY - panel.frame.height - topInset
+            )
+        )
+    }
+}
+
+@MainActor
+private final class MeetingTranscriptionSuggestionModel: ObservableObject {
+    @Published var applicationName = "the meeting app"
+    @Published var secondsRemaining = Int(meetingTranscriptionSuggestionDuration)
+    @Published var progress: CGFloat = 1
+    var onStart: (() -> Void)?
+    var onDismiss: (() -> Void)?
+}
+
+private final class MeetingTranscriptionSuggestionPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+@MainActor
+private struct MeetingTranscriptionSuggestionView: View {
+    @ObservedObject var model: MeetingTranscriptionSuggestionModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 11) {
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 30, height: 30)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Start AI Meeting Notes")
+                        .font(.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                    Text("\(model.applicationName) detected")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.76))
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 6)
+
+                Divider()
+                    .overlay(.white.opacity(0.22))
+                    .frame(height: 30)
+
+                HStack(spacing: 7) {
+                    Button(action: { model.onStart?() }) {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(Color(red: 0.10, green: 0.44, blue: 0.80))
+                            .frame(width: 31, height: 31)
+                            .background(.white, in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Start AI meeting notes")
+                    .accessibilityHint("Starts local meeting transcription")
+                    .help("Start transcription")
+
+                    Button(action: { model.onDismiss?() }) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(.white.opacity(0.92))
+                            .frame(width: 31, height: 31)
+                            .background(.white.opacity(0.16), in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Decline meeting transcription")
+                    .accessibilityHint("Dismisses this suggestion")
+                    .help("Not now")
+                }
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .frame(height: 60)
+
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(.white.opacity(0.18))
+                    Capsule()
+                        .fill(.white.opacity(0.92))
+                        .frame(width: geometry.size.width * model.progress)
+                        .animation(.linear(duration: 0.05), value: model.progress)
+                }
+            }
+            .frame(width: 380, height: 4)
+            .padding(.bottom, 8)
+        }
+        .frame(width: 440, height: 72)
+        .background {
+            ZStack(alignment: .leading) {
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.04, green: 0.07, blue: 0.12),
+                        Color(red: 0.07, green: 0.18, blue: 0.31),
+                        Color(red: 0.05, green: 0.11, blue: 0.20),
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                LinearGradient(
+                    colors: [.white.opacity(0.10), .white.opacity(0.035), .clear],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: 220)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 21, style: .continuous))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 21, style: .continuous)
+                .stroke(
+                    LinearGradient(
+                        colors: [.white.opacity(0.22), .blue.opacity(0.28)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1
+                )
+        }
+        .padding(1)
     }
 }


### PR DESCRIPTION
## Summary

- Suggest starting transcription when a supported meeting app begins using its microphone.
- Add a top-of-screen 10-second prompt with a smooth progress bar and accept/decline controls.
- Improve meeting detection by checking per-process audio input activity, requiring confirmation, and resetting stale prompts.
- Move the Audio setting above “New recording” for better discoverability.

<img width="449" height="80" alt="Screenshot 2026-08-09 at 11 59 43" src="https://github.com/user-attachments/assets/defea06f-a685-481d-9811-bfb2de6e5d3d" />



## Safety

The detector only offers a suggestion; recording starts only after the user accepts it. The existing preference can disable suggestions.

## Validation

- Debug build succeeded.
- All 216 tests passed.