### PR TITLE
Surface server error events from chat completion streams

### DIFF
--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -5,6 +5,7 @@ public enum NativChatError: Error, LocalizedError, CustomStringConvertible {
     case httpStatus(Int, String)
     case missingAssistantContent
     case malformedStreamEvent(String)
+    case serverError(String)
 
     public var description: String {
         switch self {
@@ -20,6 +21,9 @@ public enum NativChatError: Error, LocalizedError, CustomStringConvertible {
             return "Chat response did not include assistant content"
         case .malformedStreamEvent(let event):
             return "Malformed chat stream event: \(event)"
+        case .serverError(let message):
+            let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? "The server reported an error." : trimmed
         }
     }
 
@@ -643,6 +647,10 @@ public final class NativChatClient {
                 throw NativChatError.malformedStreamEvent(dataString)
             }
 
+            if let errorEvent = try? decoder.decode(ChatStreamErrorEvent.self, from: data) {
+                throw NativChatError.serverError(errorEvent.error.message)
+            }
+
             let chunk = try decoder.decode(ChatStreamChunk.self, from: data)
             responseModel = chunk.model ?? responseModel
             usage = chunk.usage ?? usage
@@ -810,6 +818,27 @@ private struct ChatCompletionResponse: Decodable {
 
         enum CodingKeys: String, CodingKey {
             case finishReason = "finish_reason"
+            case message
+        }
+    }
+}
+
+private struct ChatStreamErrorEvent: Decodable {
+    let error: Payload
+
+    struct Payload: Decodable {
+        let message: String
+
+        init(from decoder: Decoder) throws {
+            if let text = try? decoder.singleValueContainer().decode(String.self) {
+                message = text
+                return
+            }
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            message = try container.decode(String.self, forKey: .message)
+        }
+
+        enum CodingKeys: String, CodingKey {
             case message
         }
     }


### PR DESCRIPTION
Part of #194 (item 2).

## Problem

When streaming generation fails after the response has started, the server reports the failure as an SSE event inside the already-committed HTTP 200 stream:

```
data: {"error": "thinking_budget is not supported with speculative decoding in the server."}
```

The chat client only checks the HTTP status before reading the stream, then decodes every `data:` payload as a completion chunk. The error event has no `choices` key, so decoding fails and the chat shows an opaque message about a missing key instead of the server's actual error.

## Fix

- Each `data:` payload is first checked against an error envelope before chunk decoding. Both the plain-string form the server emits (`{"error": "..."}`) and the object form (`{"error": {"message": "..."}}`) are handled.
- A new `NativChatError.serverError` case carries the server's message, so the chat error row now shows e.g. `thinking_budget is not supported with speculative decoding in the server.` verbatim.

## Validation

- `swiftc -parse` on the touched file.
- Standalone decode checks: plain-string error envelope, object error envelope, a regular content chunk, and a usage-only chunk (the latter two must not match the error envelope) all behave as expected.