### PR TITLE
Disable thinking budget while speculative decoding is active

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -330,7 +330,9 @@ struct ChatComposer: View {
         guard model.settings.thinkingEnabled else {
             return .off
         }
-        guard model.settings.thinkingBudgetEnabled else {
+        guard model.settings.thinkingBudgetEnabled,
+              !model.settings.speculativeDecodingActive
+        else {
             return .max
         }
 
@@ -359,7 +361,7 @@ struct ChatComposer: View {
             title: "Reasoning",
             selectedID: reasoningLevel.rawValue,
             selectedLabel: reasoningLevel.rawValue,
-            options: ChatReasoningLevel.allCases.map {
+            options: availableReasoningLevels.map {
                 ComposerModelPickerSecondaryOption(
                     id: $0.rawValue,
                     title: $0.rawValue,
@@ -398,6 +400,13 @@ struct ChatComposer: View {
         ) {}
     }
 
+    private var availableReasoningLevels: [ChatReasoningLevel] {
+        guard model.settings.speculativeDecodingActive else {
+            return ChatReasoningLevel.allCases
+        }
+        return ChatReasoningLevel.allCases.filter { $0.tokenBudget == nil }
+    }
+
     private func applyReasoningLevel(_ level: ChatReasoningLevel) {
         switch level {
         case .off:
@@ -407,8 +416,12 @@ struct ChatComposer: View {
             model.settings.thinkingBudgetEnabled = false
         case .low, .medium, .high:
             model.settings.thinkingEnabled = true
-            model.settings.thinkingBudgetEnabled = true
-            model.settings.thinkingBudget = level.tokenBudget ?? model.settings.thinkingBudget
+            if model.settings.speculativeDecodingActive {
+                model.settings.thinkingBudgetEnabled = false
+            } else {
+                model.settings.thinkingBudgetEnabled = true
+                model.settings.thinkingBudget = level.tokenBudget ?? model.settings.thinkingBudget
+            }
         }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -300,10 +300,14 @@ struct ModelConfigurationView: View {
                 .configurationToggleStyle()
 
             if settings.thinkingEnabled {
-                Toggle("Limit thinking", isOn: $settings.thinkingBudgetEnabled)
+                Toggle("Limit thinking", isOn: thinkingBudgetBinding)
                     .configurationToggleStyle()
+                    .disabled(settings.speculativeDecodingActive)
 
-                if settings.thinkingBudgetEnabled {
+                if settings.speculativeDecodingActive {
+                    Text("Thinking limits are unavailable while speculative decoding is active.")
+                        .configurationHintStyle()
+                } else if settings.thinkingBudgetEnabled {
                     ConfigurationIntegerField(
                         title: "Budget",
                         value: $settings.thinkingBudget,
@@ -482,8 +486,16 @@ struct ModelConfigurationView: View {
                 settings.speculativeDecodingEnabled = enabled
                 if enabled {
                     settings.structuredOutputEnabled = false
+                    settings.thinkingBudgetEnabled = false
                 }
             }
+        )
+    }
+
+    private var thinkingBudgetBinding: Binding<Bool> {
+        Binding(
+            get: { settings.thinkingBudgetEnabled && !settings.speculativeDecodingActive },
+            set: { settings.thinkingBudgetEnabled = $0 }
         )
     }
 

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1138,7 +1138,9 @@ final class ChatViewModel: ObservableObject {
             minP: settings.minP,
             repetitionPenalty: settings.repetitionPenaltyEnabled ? settings.repetitionPenalty : nil,
             enableThinking: settings.thinkingEnabled,
-            thinkingBudget: settings.thinkingEnabled && settings.thinkingBudgetEnabled
+            thinkingBudget: settings.thinkingEnabled
+                && settings.thinkingBudgetEnabled
+                && !settings.speculativeDecodingActive
                 ? settings.thinkingBudget
                 : nil,
             thinkingStartToken: settings.thinkingEnabled ? settings.thinkingStartToken : nil,

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -775,11 +775,16 @@ struct NativSettings: Codable, Equatable {
         sidebarSessionsCollapsed = collapsed
     }
 
+    var speculativeDecodingActive: Bool {
+        speculativeDecodingEnabled
+            && !draftModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     func hasSameLaunchConfiguration(as other: Self) -> Bool {
         let lhs = normalized()
         let rhs = other.normalized()
-        let lhsSpeculativeDecodingActive = lhs.speculativeDecodingEnabled && !lhs.draftModelID.isEmpty
-        let rhsSpeculativeDecodingActive = rhs.speculativeDecodingEnabled && !rhs.draftModelID.isEmpty
+        let lhsSpeculativeDecodingActive = lhs.speculativeDecodingActive
+        let rhsSpeculativeDecodingActive = rhs.speculativeDecodingActive
         return lhs.modelSearchPath == rhs.modelSearchPath
             && lhs.languageModelID == rhs.languageModelID
             && lhs.imageGenerationModelID == rhs.imageGenerationModelID
@@ -890,7 +895,7 @@ struct NativSettings: Codable, Equatable {
             ])
         }
 
-        if settings.speculativeDecodingEnabled, !settings.draftModelID.isEmpty {
+        if settings.speculativeDecodingActive {
             arguments.append(contentsOf: ["--draft-model", settings.draftModelID])
             if settings.draftKind != "auto" {
                 arguments.append(contentsOf: ["--draft-kind", settings.draftKind])


### PR DESCRIPTION
Part of #194 (item 1).

The server rejects any request that carries `thinking_budget` while it was launched with `--draft-model`, failing mid-stream with `thinking_budget is not supported with speculative decoding in the server.` The app previously allowed this combination.

Changes:
- New `NativSettings.speculativeDecodingActive` helper (drafter enabled + non-empty draft model), reused by `hasSameLaunchConfiguration` and `launchArguments`.
- Enabling the drafter turns the thinking budget off, mirroring the existing structured-output exclusion. While the drafter is active, the "Limit thinking" toggle is disabled with a hint explaining why.
- The composer's Reasoning picker hides the budgeted levels (Low/Medium/High) while the drafter is active, and `applyReasoningLevel` never enables the budget in that state.
- `makeCompletionRequest` drops `thinking_budget` whenever the drafter is active, so a stale persisted budget can never reach the server.