### PR TITLE
Draft model browsing, drafter compatibility hints, and a stable decode rate

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -157,6 +157,9 @@ private final class ModelMenuRowView: NSView {
             case .tools:
                 symbolName = "hammer.fill"
                 description = capability.displayName
+            case .drafter:
+                symbolName = "hare.fill"
+                description = capability.displayName
             }
             let configuration = NSImage.SymbolConfiguration(pointSize: 10, weight: .semibold)
             capabilityImage.image = NSImage(

--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -82,6 +82,7 @@ struct ModelConfigurationView: View {
     @State private var modelConfiguration: LocalModelConfigurationMetadata?
     @State private var isLoadingModelConfiguration = false
     @State private var modelConfigurationRevision = 0
+    @StateObject private var draftModelLibrary = LocalModelLibrary()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -110,9 +111,32 @@ struct ModelConfigurationView: View {
         .task(id: modelConfigurationLookupID) {
             await loadModelConfiguration(for: modelConfigurationLookupID)
         }
+        .task(id: draftModelScanKey) {
+            scanDraftModelLibraryIfNeeded()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
             modelConfigurationRevision += 1
+            scanDraftModelLibraryIfNeeded()
         }
+    }
+
+    private var draftModelScanKey: String {
+        let normalizedSettings = settings.normalized()
+        return ([
+            String(normalizedSettings.speculativeDecodingEnabled),
+            normalizedSettings.modelSearchPath
+        ] + normalizedSettings.additionalModelSearchPaths)
+            .joined(separator: "\u{0}")
+    }
+
+    private func scanDraftModelLibraryIfNeeded() {
+        guard settings.speculativeDecodingEnabled else {
+            return
+        }
+        draftModelLibrary.scan(
+            path: settings.modelSearchPath,
+            additionalPaths: settings.normalized().additionalModelSearchPaths
+        )
     }
 
     private var header: some View {
@@ -358,7 +382,10 @@ struct ModelConfigurationView: View {
                 .configurationToggleStyle()
 
             if settings.speculativeDecodingEnabled {
-                ConfigurationTextField(title: "Draft model", text: $settings.draftModelID)
+                HStack(alignment: .bottom, spacing: 8) {
+                    ConfigurationTextField(title: "Draft model", text: $settings.draftModelID)
+                    draftModelMenu
+                }
 
                 HStack(spacing: 8) {
                     Text("Family")
@@ -381,14 +408,106 @@ struct ModelConfigurationView: View {
                     range: 0...1024
                 )
 
-                Text(settings.draftModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ? "Enter a drafter model to activate speculative decoding."
-                    : "The drafter is loaded after the next server restart.")
-                    .configurationHintStyle(
-                        isError: settings.draftModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    )
+                Text(draftModelHint.text)
+                    .configurationHintStyle(isError: draftModelHint.isError)
             }
         }
+    }
+
+    private var draftModelMenu: some View {
+        Menu {
+            if !installedDrafters.isEmpty {
+                Section("Installed drafters") {
+                    ForEach(installedDrafters) { model in
+                        Button(draftMenuTitle(for: model)) {
+                            settings.draftModelID = model.repoID
+                        }
+                    }
+                }
+            }
+            if !otherDraftCandidates.isEmpty {
+                Section("Other installed models") {
+                    ForEach(otherDraftCandidates) { model in
+                        Button(model.displayName) {
+                            settings.draftModelID = model.repoID
+                        }
+                    }
+                }
+            }
+            if installedDrafters.isEmpty && otherDraftCandidates.isEmpty {
+                Button(draftModelLibrary.isScanning ? "Scanning models…" : "No installed models found") {}
+                    .disabled(true)
+            }
+            Divider()
+            Button("Refresh") {
+                scanDraftModelLibraryIfNeeded()
+            }
+        } label: {
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.footnote.weight(.semibold))
+        }
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Choose an installed model as the drafter")
+    }
+
+    private var installedDrafters: [LocalModel] {
+        draftModelLibrary.models.filter { $0.drafterKind != nil }
+    }
+
+    private var otherDraftCandidates: [LocalModel] {
+        draftModelLibrary.models.filter {
+            $0.drafterKind == nil
+                && $0.isEligibleForLanguageModelPicker
+                && $0.repoID != settings.normalized().languageModelID
+        }
+    }
+
+    private func draftMenuTitle(for model: LocalModel) -> String {
+        var title = model.displayName
+        if let kindLabel = model.drafterKindLabel {
+            title += " (\(kindLabel))"
+        }
+        if isDrafterIncompatible(model) {
+            title += " — different target"
+        }
+        return title
+    }
+
+    private func isDrafterIncompatible(_ model: LocalModel) -> Bool {
+        guard let drafterHiddenSize = model.hiddenSize,
+              let targetHiddenSize = modelConfiguration?.hiddenSize
+        else {
+            return false
+        }
+        return drafterHiddenSize != targetHiddenSize
+    }
+
+    private var draftModelHint: (text: String, isError: Bool) {
+        let trimmedID = settings.draftModelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedID.isEmpty {
+            return ("Enter or choose a drafter model to activate speculative decoding.", true)
+        }
+        guard let selected = draftModelLibrary.models.first(where: {
+            $0.repoID == trimmedID
+        }) else {
+            return ("The drafter is loaded after the next server restart.", false)
+        }
+        if isDrafterIncompatible(selected),
+           let drafterHiddenSize = selected.hiddenSize,
+           let targetHiddenSize = modelConfiguration?.hiddenSize {
+            return (
+                "This drafter was built for a different target model (hidden size \(drafterHiddenSize) vs \(targetHiddenSize)). The server will reject it.",
+                true
+            )
+        }
+        if let kindLabel = selected.drafterKindLabel {
+            return ("Detected \(kindLabel) drafter. Loaded after the next server restart.", false)
+        }
+        return (
+            "No drafter metadata found in this model. Speculative decoding may fall back to DFlash or fail to load.",
+            false
+        )
     }
 
     private var structuredOutputSection: some View {

--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -327,24 +327,28 @@ struct ChatResponseMetrics: Equatable, Codable {
     let generatedTokens: Int?
     let decodeTokensPerSecond: Double?
     let peakMemoryGB: Double?
+    let specAcceptanceRate: Double?
 
     var hasVisibleValues: Bool {
         totalTokens != nil
             || generatedTokens != nil
             || decodeTokensPerSecond != nil
             || peakMemoryGB != nil
+            || specAcceptanceRate != nil
     }
 
     init(
         totalTokens: Int? = nil,
         generatedTokens: Int? = nil,
         decodeTokensPerSecond: Double? = nil,
-        peakMemoryGB: Double? = nil
+        peakMemoryGB: Double? = nil,
+        specAcceptanceRate: Double? = nil
     ) {
         self.totalTokens = totalTokens
         self.generatedTokens = generatedTokens
         self.decodeTokensPerSecond = decodeTokensPerSecond
         self.peakMemoryGB = peakMemoryGB
+        self.specAcceptanceRate = specAcceptanceRate
     }
 
     init(completion: MLXChatCompletion) {
@@ -352,7 +356,8 @@ struct ChatResponseMetrics: Equatable, Codable {
             totalTokens: completion.usage?.resolvedTotalTokens,
             generatedTokens: completion.usage?.completionTokens,
             decodeTokensPerSecond: completion.resolvedDecodeTokensPerSecond,
-            peakMemoryGB: completion.usage?.peakMemoryGB
+            peakMemoryGB: completion.usage?.peakMemoryGB,
+            specAcceptanceRate: completion.usage?.specAcceptanceRate
         )
     }
 }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1426,7 +1426,8 @@ final class ChatViewModel: ObservableObject {
                         ?? message.responseMetrics?.generatedTokens,
                     decodeTokensPerSecond: metrics.decodeTokensPerSecond
                         ?? message.responseMetrics?.decodeTokensPerSecond,
-                    peakMemoryGB: message.responseMetrics?.peakMemoryGB
+                    peakMemoryGB: message.responseMetrics?.peakMemoryGB,
+                    specAcceptanceRate: message.responseMetrics?.specAcceptanceRate
                 )
             }
         }
@@ -2425,6 +2426,12 @@ private struct ChatResponseMetricsRow: View {
             label: "Decode tok/s",
             value: NativFormatting.rate(metrics.decodeTokensPerSecond)
         )
+        if let acceptanceRate = metrics.specAcceptanceRate {
+            ChatResponseMetricPill(
+                label: "Draft acceptance",
+                value: acceptanceRate.formatted(.percent.precision(.fractionLength(0)))
+            )
+        }
         ChatResponseMetricPill(
             label: "Peak memory",
             value: metrics.peakMemoryGB.map(NativFormatting.gigabytes) ?? "--"

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -16,6 +16,7 @@ enum LocalModelCapability: String, CaseIterable, Hashable, Sendable {
     case embeddings
     case reasoning
     case tools
+    case drafter
 
     var displayName: String {
         switch self {
@@ -41,6 +42,8 @@ enum LocalModelCapability: String, CaseIterable, Hashable, Sendable {
             "Reasoning"
         case .tools:
             "Tool Calling"
+        case .drafter:
+            "Drafter"
         }
     }
 }
@@ -70,6 +73,8 @@ struct LocalModel: Identifiable, Equatable, Sendable {
     let contextSize: Int?
     let provider: LocalModelProvider?
     let capabilities: Set<LocalModelCapability>
+    let drafterKind: String?
+    let hiddenSize: Int?
     var source: LocalModelSource = .huggingFaceCache
 
     var displayName: String {
@@ -87,8 +92,24 @@ struct LocalModel: Identifiable, Equatable, Sendable {
     var isEligibleForLanguageModelPicker: Bool {
         // Any text-generative model qualifies (chat + omni), even if it also carries an
         // image-generation tag. A vision model qualifies only when it isn't image-gen/editing.
-        capabilities.contains(.text)
+        guard !capabilities.contains(.drafter) else {
+            return false
+        }
+        return capabilities.contains(.text)
             || (capabilities.contains(.vision) && !capabilities.contains(.imageGeneration))
+    }
+
+    var drafterKindLabel: String? {
+        switch drafterKind {
+        case "mtp":
+            "MTP"
+        case "eagle3":
+            "EAGLE3"
+        case "dflash":
+            "DFlash"
+        default:
+            nil
+        }
     }
 
     var parameterSizeLabel: String? {
@@ -228,6 +249,7 @@ struct LocalModelMemoryEstimate: Equatable, Sendable {
 struct LocalModelConfigurationMetadata: Equatable, Sendable {
     let contextSize: Int?
     let defaultSystemPrompt: String?
+    let hiddenSize: Int?
 }
 
 enum LocalModelDiscovery {
@@ -384,6 +406,10 @@ enum LocalModelDiscovery {
                 snapshotURL: snapshotURL,
                 fileManager: fileManager
             )
+            let speculativeMetadata = speculativeMetadata(
+                at: snapshotURL,
+                fileManager: fileManager
+            )
             return LocalModel(
                 repoID: repoID,
                 snapshotURL: snapshotURL,
@@ -402,7 +428,9 @@ enum LocalModelDiscovery {
                     model: repoID,
                     at: snapshotURL,
                     fileManager: fileManager
-                )
+                ),
+                drafterKind: speculativeMetadata.drafterKind,
+                hiddenSize: speculativeMetadata.hiddenSize
             )
         }
 
@@ -487,6 +515,10 @@ enum LocalModelDiscovery {
             snapshotURL: modelURL,
             fileManager: fileManager
         )
+        let speculativeMetadata = speculativeMetadata(
+            at: modelURL,
+            fileManager: fileManager
+        )
         return LocalModel(
             repoID: standardizedPath,
             snapshotURL: modelURL,
@@ -506,6 +538,8 @@ enum LocalModelDiscovery {
                 at: modelURL,
                 fileManager: fileManager
             ),
+            drafterKind: speculativeMetadata.drafterKind,
+            hiddenSize: speculativeMetadata.hiddenSize,
             source: .external
         )
     }
@@ -523,7 +557,8 @@ enum LocalModelDiscovery {
             }
             return LocalModelConfigurationMetadata(
                 contextSize: contextSizeFromConfig(at: directURL, fileManager: fileManager),
-                defaultSystemPrompt: defaultSystemPrompt(at: directURL, fileManager: fileManager)
+                defaultSystemPrompt: defaultSystemPrompt(at: directURL, fileManager: fileManager),
+                hiddenSize: speculativeMetadata(at: directURL, fileManager: fileManager).hiddenSize
             )
         }
 
@@ -546,7 +581,11 @@ enum LocalModelDiscovery {
             defaultSystemPrompt: defaultSystemPrompt(
                 at: snapshotURL,
                 fileManager: fileManager
-            )
+            ),
+            hiddenSize: speculativeMetadata(
+                at: snapshotURL,
+                fileManager: fileManager
+            ).hiddenSize
         )
     }
 
@@ -1007,6 +1046,10 @@ enum LocalModelDiscovery {
         )
         var capabilities = Set<LocalModelCapability>()
 
+        if drafterKind(fromModelType: drafterModelType(in: config)) != nil {
+            capabilities.insert(.drafter)
+        }
+
         let textDescriptors = [
             "causallm", "conditionalgeneration", "language", "llm", "gpt",
             "gemma", "qwen", "mistral", "llama", "deepseek", "cohere"
@@ -1246,6 +1289,74 @@ enum LocalModelDiscovery {
     private static func containsToolCallingMarkers(_ template: String) -> Bool {
         let normalized = template.lowercased()
         return normalized.contains("tool_calls") || normalized.contains("tool_call")
+    }
+
+    static func drafterKind(fromModelType modelType: String?) -> String? {
+        guard let modelType = modelType?.lowercased(), !modelType.isEmpty else {
+            return nil
+        }
+        let exactKinds: [String: String] = [
+            "deepseek_v4_mtp": "mtp",
+            "eagle3": "eagle3",
+            "gemma4_assistant": "mtp",
+            "gemma4_unified_assistant": "mtp",
+            "glm4_moe_lite_mtp": "mtp",
+            "inkling_mtp": "mtp",
+            "qwen3_5_mtp": "mtp"
+        ]
+        if let kind = exactKinds[modelType] {
+            return kind
+        }
+        if modelType.contains("mtp") {
+            return "mtp"
+        }
+        if modelType.contains("dflash") {
+            return "dflash"
+        }
+        if modelType.contains("eagle") {
+            return "eagle3"
+        }
+        return nil
+    }
+
+    private static func drafterModelType(in config: [String: Any]) -> String? {
+        (config["model_type"] as? String) ?? (config["speculators_model_type"] as? String)
+    }
+
+    private static func hiddenSize(in config: [String: Any]) -> Int? {
+        for key in ["backbone_hidden_size", "target_hidden_size"] {
+            if let number = config[key] as? NSNumber, number.intValue > 0 {
+                return number.intValue
+            }
+        }
+        for nestedKey in ["text_config", "llm_config", "language_config"] {
+            if let nested = config[nestedKey] as? [String: Any],
+               let number = nested["hidden_size"] as? NSNumber,
+               number.intValue > 0 {
+                return number.intValue
+            }
+        }
+        if let number = config["hidden_size"] as? NSNumber, number.intValue > 0 {
+            return number.intValue
+        }
+        return nil
+    }
+
+    private static func speculativeMetadata(
+        at snapshotURL: URL,
+        fileManager: FileManager
+    ) -> (drafterKind: String?, hiddenSize: Int?) {
+        let configURL = snapshotURL.appendingPathComponent("config.json")
+        guard fileManager.fileExists(atPath: configURL.path),
+              let data = try? Data(contentsOf: configURL),
+              let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return (nil, nil)
+        }
+        return (
+            drafterKind(fromModelType: drafterModelType(in: config)),
+            hiddenSize(in: config)
+        )
     }
 
     private static func modelProvider(

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1665,6 +1665,8 @@ extension LocalModelCapability {
             URLQueryItem(name: "other", value: "reasoning")
         case .tools:
             URLQueryItem(name: "other", value: "tool-calling")
+        case .drafter:
+            URLQueryItem(name: "other", value: "speculative-decoding")
         }
     }
 
@@ -1681,6 +1683,7 @@ extension LocalModelCapability {
         case .embeddings: "circle.grid.3x3"
         case .reasoning: "brain.fill"
         case .tools: "hammer"
+        case .drafter: "hare"
         }
     }
 }

--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -247,6 +247,8 @@ public struct MLXChatUsage: Decodable, Equatable, Sendable {
     public let promptTokensPerSecond: Double?
     public let decodeTokensPerSecond: Double?
     public let peakMemoryGB: Double?
+    public let specDraftKind: String?
+    public let specAcceptanceRate: Double?
 
     init(
         promptTokens: Int?,
@@ -254,7 +256,9 @@ public struct MLXChatUsage: Decodable, Equatable, Sendable {
         totalTokens: Int?,
         promptTokensPerSecond: Double?,
         decodeTokensPerSecond: Double?,
-        peakMemoryGB: Double?
+        peakMemoryGB: Double?,
+        specDraftKind: String? = nil,
+        specAcceptanceRate: Double? = nil
     ) {
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
@@ -262,6 +266,8 @@ public struct MLXChatUsage: Decodable, Equatable, Sendable {
         self.promptTokensPerSecond = promptTokensPerSecond
         self.decodeTokensPerSecond = decodeTokensPerSecond
         self.peakMemoryGB = peakMemoryGB
+        self.specDraftKind = specDraftKind
+        self.specAcceptanceRate = specAcceptanceRate
     }
 
     public var resolvedTotalTokens: Int? {
@@ -302,6 +308,8 @@ public struct MLXChatUsage: Decodable, Equatable, Sendable {
         case promptTokensPerSecond = "prompt_tps"
         case decodeTokensPerSecond = "generation_tps"
         case peakMemoryGB = "peak_memory"
+        case specDraftKind = "draft_kind"
+        case specAcceptanceRate = "spec_acceptance_rate"
     }
 
     fileprivate func resolvingTimings(from timings: MLXChatTimings?) -> MLXChatUsage {
@@ -312,7 +320,9 @@ public struct MLXChatUsage: Decodable, Equatable, Sendable {
             promptTokensPerSecond: promptTokensPerSecond,
             decodeTokensPerSecond: timings?.resolvedDecodeTokensPerSecond
                 ?? decodeTokensPerSecond,
-            peakMemoryGB: timings?.peakMemoryGB ?? peakMemoryGB
+            peakMemoryGB: timings?.peakMemoryGB ?? peakMemoryGB,
+            specDraftKind: timings?.specDraftKind ?? specDraftKind,
+            specAcceptanceRate: timings?.resolvedSpecAcceptanceRate ?? specAcceptanceRate
         )
     }
 }
@@ -622,7 +632,23 @@ public final class NativChatClient {
         var timings: MLXChatTimings?
         var responseModel: String?
         var streamedGeneratedTokens = 0
+        var firstGeneratedTokenAt: Date?
+        var lastGeneratedTokenAt: Date?
         var toolCallAccumulator = MLXChatToolCallAccumulator()
+
+        func cumulativeDecodeTokensPerSecond() -> Double? {
+            guard streamedGeneratedTokens > 1,
+                  let firstGeneratedTokenAt,
+                  let lastGeneratedTokenAt
+            else {
+                return nil
+            }
+            let elapsed = lastGeneratedTokenAt.timeIntervalSince(firstGeneratedTokenAt)
+            guard elapsed > 0 else {
+                return nil
+            }
+            return Double(streamedGeneratedTokens - 1) / elapsed
+        }
 
         for try await line in bytes.lines {
             try Task.checkCancellation()
@@ -664,20 +690,26 @@ public final class NativChatClient {
                     || reasoningDelta?.isEmpty == false
                 if hasGeneratedToken {
                     streamedGeneratedTokens += 1
+                    let now = Date()
+                    if firstGeneratedTokenAt == nil {
+                        firstGeneratedTokenAt = now
+                    }
+                    lastGeneratedTokenAt = now
                 }
                 if let toolCallDeltas, !toolCallDeltas.isEmpty {
                     toolCallAccumulator.merge(toolCallDeltas)
                 }
+                let liveDecodeTokensPerSecond = cumulativeDecodeTokensPerSecond()
                 if contentDelta?.isEmpty == false
                     || reasoningDelta?.isEmpty == false
                     || toolCallDeltas?.isEmpty == false
-                    || decodeTokensPerSecond != nil {
+                    || liveDecodeTokensPerSecond != nil {
                     await onEvent(
                         MLXChatStreamDelta(
                             content: contentDelta,
                             reasoningContent: reasoningDelta,
                             toolCalls: toolCallDeltas,
-                            decodeTokensPerSecond: decodeTokensPerSecond,
+                            decodeTokensPerSecond: liveDecodeTokensPerSecond,
                             generatedTokens: chunk.usage?.completionTokens
                                 ?? streamedGeneratedTokens
                         )
@@ -883,6 +915,10 @@ struct MLXChatToolCallAccumulator {
 private struct MLXChatTimings: Decodable {
     let predictedTokensPerSecond: Double?
     let peakMemoryGB: Double?
+    let specDraftKind: String?
+    let specAcceptedTokens: Int?
+    let specDraftedTokens: Int?
+    let specAcceptanceRate: Double?
 
     var resolvedDecodeTokensPerSecond: Double? {
         guard let predictedTokensPerSecond,
@@ -894,8 +930,25 @@ private struct MLXChatTimings: Decodable {
         return predictedTokensPerSecond
     }
 
+    var resolvedSpecAcceptanceRate: Double? {
+        if let specAcceptanceRate, specAcceptanceRate >= 0, specAcceptanceRate.isFinite {
+            return specAcceptanceRate
+        }
+        guard let specAcceptedTokens,
+              let specDraftedTokens,
+              specDraftedTokens > 0
+        else {
+            return nil
+        }
+        return Double(specAcceptedTokens) / Double(specDraftedTokens)
+    }
+
     enum CodingKeys: String, CodingKey {
         case predictedTokensPerSecond = "predicted_per_second"
         case peakMemoryGB = "peak_memory"
+        case specDraftKind = "draft_kind"
+        case specAcceptedTokens = "spec_accepted_tokens"
+        case specDraftedTokens = "spec_drafted_tokens"
+        case specAcceptanceRate = "spec_acceptance_rate"
     }
 }

--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -916,9 +916,8 @@ private struct MLXChatTimings: Decodable {
     let predictedTokensPerSecond: Double?
     let peakMemoryGB: Double?
     let specDraftKind: String?
-    let specAcceptedTokens: Int?
     let specDraftedTokens: Int?
-    let specAcceptanceRate: Double?
+    let specAcceptedTokens: Int?
 
     var resolvedDecodeTokensPerSecond: Double? {
         guard let predictedTokensPerSecond,
@@ -931,9 +930,6 @@ private struct MLXChatTimings: Decodable {
     }
 
     var resolvedSpecAcceptanceRate: Double? {
-        if let specAcceptanceRate, specAcceptanceRate >= 0, specAcceptanceRate.isFinite {
-            return specAcceptanceRate
-        }
         guard let specAcceptedTokens,
               let specDraftedTokens,
               specDraftedTokens > 0
@@ -947,8 +943,7 @@ private struct MLXChatTimings: Decodable {
         case predictedTokensPerSecond = "predicted_per_second"
         case peakMemoryGB = "peak_memory"
         case specDraftKind = "draft_kind"
-        case specAcceptedTokens = "spec_accepted_tokens"
-        case specDraftedTokens = "spec_drafted_tokens"
-        case specAcceptanceRate = "spec_acceptance_rate"
+        case specDraftedTokens = "draft_n"
+        case specAcceptedTokens = "draft_n_accepted"
     }
 }

--- a/Tests/NativTests/LocalModelDiscoveryTests.swift
+++ b/Tests/NativTests/LocalModelDiscoveryTests.swift
@@ -238,6 +238,30 @@ final class LocalModelDiscoveryTests: XCTestCase {
         try data.write(to: url)
     }
 
+    func testDrafterKindDetection() {
+        XCTAssertEqual(LocalModelDiscovery.drafterKind(fromModelType: "qwen3_5_mtp"), "mtp")
+        XCTAssertEqual(LocalModelDiscovery.drafterKind(fromModelType: "gemma4_assistant"), "mtp")
+        XCTAssertEqual(LocalModelDiscovery.drafterKind(fromModelType: "eagle3"), "eagle3")
+        XCTAssertEqual(LocalModelDiscovery.drafterKind(fromModelType: "qwen3_dflash"), "dflash")
+        XCTAssertEqual(LocalModelDiscovery.drafterKind(fromModelType: "llama_eagle"), "eagle3")
+        XCTAssertNil(LocalModelDiscovery.drafterKind(fromModelType: "qwen3_5"))
+        XCTAssertNil(LocalModelDiscovery.drafterKind(fromModelType: nil))
+        XCTAssertNil(LocalModelDiscovery.drafterKind(fromModelType: ""))
+    }
+
+    func testDrafterExcludedFromLanguageModelPicker() {
+        let drafter = makeModel(
+            repoID: "mlx-community/Qwen3.5-4B-MTP-4bit",
+            capabilities: [.text, .drafter]
+        )
+        let chatModel = makeModel(
+            repoID: "mlx-community/Qwen3.5-4B-MLX-4bit",
+            capabilities: [.text]
+        )
+        XCTAssertFalse(drafter.isEligibleForLanguageModelPicker)
+        XCTAssertTrue(chatModel.isEligibleForLanguageModelPicker)
+    }
+
     private func write(_ string: String, to url: URL) throws {
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),
@@ -260,7 +284,9 @@ final class LocalModelDiscoveryTests: XCTestCase {
             quantizationGroupSize: nil,
             contextSize: nil,
             provider: nil,
-            capabilities: capabilities
+            capabilities: capabilities,
+            drafterKind: nil,
+            hiddenSize: nil
         )
     }
 }


### PR DESCRIPTION
Part of #194 (items 3 and 4).

**Draft model browsing (item 4).** The "Draft model" field in the model configuration panel now has a menu that lists installed models, with detected drafters first. Drafters are recognized from `config.json` `model_type` (matching the server's registry: `*_mtp`, `eagle3`, `*dflash*`, `gemma4_assistant`, …) and labeled with their family (MTP, EAGLE3, DFlash). Detected drafters also gain a "Drafter" capability badge in the model library and are excluded from the chat model picker, since they can't run standalone.

**Compatibility hints.** The scanner now reads the drafter's target hidden size (`backbone_hidden_size`/`target_hidden_size`/`hidden_size`) and compares it against the selected chat model, mirroring the server's own drafter validation. Incompatible pairs are flagged in the menu and in a red hint before the user burns a server restart on a drafter the server will reject. A note on limits: config compatibility guarantees the pair loads, not that it is fast — acceptance rate is runtime information.

**Stable decode rate (item 3).** With speculative decoding, accepted tokens arrive in bursts, and the streamed per-chunk `predicted_per_second` is an instantaneous rate, so the live badge could show tens of thousands of tok/s. The client now computes a cumulative decode rate (tokens since the first content token over elapsed time) and uses it for live updates. The final metrics keep the server-reported rate.

**Draft acceptance metric.** The client opportunistically decodes speculative-decoding stats (`draft_kind`, `spec_accepted_tokens`, `spec_drafted_tokens`, `spec_acceptance_rate`) from response timings and shows a "Draft acceptance" pill when the server provides them. These fields are optional, so this works with any server version; the server-side change to emit them is in mlx-vlm.