### PR TITLE
Add MCP (Model Context Protocol) client support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ DerivedData/
 __pycache__/
 .DS_Store
 AGENTS.md
+.playwright-mcp/
 /Configuration/Signing.local.xcconfig

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		E4D299AADEA8470C37256DDE /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
 		E4D6CCEFDC2BA5A68FAE230A /* NativMCPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5AE12A6EA1216750AFED5E /* NativMCPClient.swift */; };
 		E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */; };
+		E6C6A47E0949A0087BCE08D8 /* MCPServersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCD43578DBAFBEC2F0D651D /* MCPServersView.swift */; };
 		E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41417C210BF817681A8C6D87 /* IntegrationsView.swift */; };
 		ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
 		EF3678F684519D8ADC625B20 /* MLXImageModelResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */; };
@@ -243,6 +244,7 @@
 /* Begin PBXFileReference section */
 		068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatServerStatsTool.swift; sourceTree = "<group>"; };
 		07E0B18D848E96DBF258FD8F /* NativMCPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativMCPClientTests.swift; sourceTree = "<group>"; };
+		0DCD43578DBAFBEC2F0D651D /* MCPServersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServersView.swift; sourceTree = "<group>"; };
 		0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCLIProfile.swift; sourceTree = "<group>"; };
 		141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPrimaryTaskResolver.swift; sourceTree = "<group>"; };
 		1573A2D88784C9D404156D25 /* VoiceDictationExtensionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtensionRuntime.swift; sourceTree = "<group>"; };
@@ -530,6 +532,14 @@
 			path = SystemMonitor;
 			sourceTree = "<group>";
 		};
+		5CE0523415094EB82A398A6A /* MCP */ = {
+			isa = PBXGroup;
+			children = (
+				0DCD43578DBAFBEC2F0D651D /* MCPServersView.swift */,
+			);
+			path = MCP;
+			sourceTree = "<group>";
+		};
 		6FC4F77BDC88A365FD01B7C9 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -597,6 +607,7 @@
 				374FD298864C11262A44F37B /* ImageGeneration */,
 				28D631CB7BF8B65D28E11E43 /* Integrations */,
 				40D3B01A6A8BFAE6E98FDD3C /* IssueReport */,
+				5CE0523415094EB82A398A6A /* MCP */,
 				BAC9F35045D83344BC059CB2 /* Models */,
 				4D59C5326FE266C76E71C52A /* Settings */,
 				52ECEB1EB0B83451B1DE3C20 /* SystemMonitor */,
@@ -1012,6 +1023,7 @@
 				BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */,
 				1423FD497A75A14770FCA9E1 /* LocalModelDiscovery.swift in Sources */,
 				482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */,
+				E6C6A47E0949A0087BCE08D8 /* MCPServersView.swift in Sources */,
 				A1492AA9B1D71B4E57310EF6 /* MLXImageModelResolver.swift in Sources */,
 				DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */,
 				052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
 		256B07A9158557D2E3AD2A35 /* Manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AF8F6359E4523814FB0EFDA /* Manifest.json */; };
 		293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
+		2ABC05D54F01B4A2C6111C8E /* ChatMCPToolBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC318D1228E4B596FAAF22E /* ChatMCPToolBridgeTests.swift */; };
 		2B89F9E09ABB37B82AC2FEB5 /* NativAudioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9B712CAFE08083D1679354E /* NativAudioClient.swift */; };
 		2B988CEEF0FD7FCCD3862AF6 /* NativExtensionStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */; };
 		2BF94914481EEA1A493F5926 /* VoiceDictationExtensionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1573A2D88784C9D404156D25 /* VoiceDictationExtensionRuntime.swift */; };
@@ -51,6 +52,7 @@
 		3BEBB4EA0D9713BA240A2209 /* NativMCPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E0B18D848E96DBF258FD8F /* NativMCPClientTests.swift */; };
 		3D7F718E2E136C35CD3509B4 /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
 		3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */; };
+		40F51358AC49A49E82C34F04 /* ChatMCPToolBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7727F4DE10CD917B1C37DF68 /* ChatMCPToolBridge.swift */; };
 		41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */; };
@@ -126,6 +128,7 @@
 		C8B10834D4DF407907FCCF6C /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5919AB4E9488642C73886266 /* ShellEnvironment.swift */; };
 		C904E51D66BFED1808E18FE5 /* ChatScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */; };
 		CA20EE3DD93349A3DB96A783 /* ExtensionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EF4E95FDA6F6E337FC4C47 /* ExtensionsView.swift */; };
+		CDD148617A6B535658A193DD /* ChatMCPToolBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7727F4DE10CD917B1C37DF68 /* ChatMCPToolBridge.swift */; };
 		D4F073244DE11FD98AD708E2 /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */; };
 		D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EF3E0B4A9EEC293EFD5F8A /* ChatImageTool.swift */; };
 		D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */; };
@@ -281,6 +284,7 @@
 		6BB0CD839020E3F5FF4F8DED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6CDD9C3FE179B2E8D76FC769 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceShortcut.swift; sourceTree = "<group>"; };
+		7727F4DE10CD917B1C37DF68 /* ChatMCPToolBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMCPToolBridge.swift; sourceTree = "<group>"; };
 		7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontScale.swift; sourceTree = "<group>"; };
 		7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatting.swift; sourceTree = "<group>"; };
 		7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionPlatform.swift; sourceTree = "<group>"; };
@@ -317,6 +321,7 @@
 		B7C7712D68B2782589312766 /* ControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelView.swift; sourceTree = "<group>"; };
 		B7E0BD007DAD141D50E1BAA4 /* AudioAnalyticsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioAnalyticsStore.swift; sourceTree = "<group>"; };
 		BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormatting.swift; sourceTree = "<group>"; };
+		BEC318D1228E4B596FAAF22E /* ChatMCPToolBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMCPToolBridgeTests.swift; sourceTree = "<group>"; };
 		C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscoveryTests.swift; sourceTree = "<group>"; };
 		C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSwitchModelTool.swift; sourceTree = "<group>"; };
 		C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolRegistryTests.swift; sourceTree = "<group>"; };
@@ -701,6 +706,7 @@
 				D97F637262DB138A253DEA6F /* ChatComposer.swift */,
 				2CF9F903E2609C4A522C19CF /* ChatConfigurationView.swift */,
 				7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */,
+				7727F4DE10CD917B1C37DF68 /* ChatMCPToolBridge.swift */,
 				8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */,
 				530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */,
 				31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */,
@@ -714,6 +720,7 @@
 			isa = PBXGroup;
 			children = (
 				3B965B701714787B0A85AE6B /* AudioTests.swift */,
+				BEC318D1228E4B596FAAF22E /* ChatMCPToolBridgeTests.swift */,
 				C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */,
 				A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */,
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
@@ -978,6 +985,7 @@
 				E1A4AA0C4AA32599FF2D54E7 /* ChatFontScale.swift in Sources */,
 				B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */,
 				04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */,
+				CDD148617A6B535658A193DD /* ChatMCPToolBridge.swift in Sources */,
 				C904E51D66BFED1808E18FE5 /* ChatScreenCapture.swift in Sources */,
 				96AE764D2F938395E9B76C9E /* ChatServerStatsTool.swift in Sources */,
 				D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */,
@@ -1047,6 +1055,8 @@
 				4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */,
 				D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */,
 				39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */,
+				40F51358AC49A49E82C34F04 /* ChatMCPToolBridge.swift in Sources */,
+				2ABC05D54F01B4A2C6111C8E /* ChatMCPToolBridgeTests.swift in Sources */,
 				A0D30C905A2788C3BD2149BF /* ChatScreenCapture.swift in Sources */,
 				32E3DD03D61C201E783539AF /* ChatServerStatsTool.swift in Sources */,
 				1CD847CE1BC2696D9306656D /* ChatSessionStore.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		39DF704E9F1D23E2F8248F02 /* LocalModelDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */; };
 		39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		3A4D3E1F9313D9896173130D /* VoiceShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */; };
+		3BEBB4EA0D9713BA240A2209 /* NativMCPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E0B18D848E96DBF258FD8F /* NativMCPClientTests.swift */; };
 		3D7F718E2E136C35CD3509B4 /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
 		3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */; };
 		41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
@@ -95,6 +96,7 @@
 		9A1E1FD2D597C682F4A8D2A9 /* AudioInputLevelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DDA5274474AC8D54DFDF71 /* AudioInputLevelMonitor.swift */; };
 		9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */; };
 		9E6B93B1603C4E964422E09B /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9F48FDDED0FC0AB7501A1A97 /* fake_mcp_server.py in Resources */ = {isa = PBXBuildFile; fileRef = E32D3F2A27D1E1073A6E3E29 /* fake_mcp_server.py */; };
 		A0D30C905A2788C3BD2149BF /* ChatScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */; };
 		A1492AA9B1D71B4E57310EF6 /* MLXImageModelResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61126D4235AFF77D82F1F80B /* MLXImageModelResolver.swift */; };
 		A2606518E424E92625661281 /* ChatComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97F637262DB138A253DEA6F /* ChatComposer.swift */; };
@@ -139,6 +141,7 @@
 		E1A4AA0C4AA32599FF2D54E7 /* ChatFontScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */; };
 		E407C7F9CE883C978DE7D716 /* PersistentMenuActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */; };
 		E4D299AADEA8470C37256DDE /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
+		E4D6CCEFDC2BA5A68FAE230A /* NativMCPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5AE12A6EA1216750AFED5E /* NativMCPClient.swift */; };
 		E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */; };
 		E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41417C210BF817681A8C6D87 /* IntegrationsView.swift */; };
 		ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
@@ -236,6 +239,7 @@
 
 /* Begin PBXFileReference section */
 		068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatServerStatsTool.swift; sourceTree = "<group>"; };
+		07E0B18D848E96DBF258FD8F /* NativMCPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativMCPClientTests.swift; sourceTree = "<group>"; };
 		0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCLIProfile.swift; sourceTree = "<group>"; };
 		141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPrimaryTaskResolver.swift; sourceTree = "<group>"; };
 		1573A2D88784C9D404156D25 /* VoiceDictationExtensionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtensionRuntime.swift; sourceTree = "<group>"; };
@@ -295,6 +299,7 @@
 		8BB9D1D0FC24AC771442B628 /* Artifact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artifact.swift; sourceTree = "<group>"; };
 		8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureCoordinator.swift; sourceTree = "<group>"; };
 		8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProviderTests.swift; sourceTree = "<group>"; };
+		8F5AE12A6EA1216750AFED5E /* NativMCPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativMCPClient.swift; sourceTree = "<group>"; };
 		9AF7F0D894C4EB6521F21D4D /* SystemMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorView.swift; sourceTree = "<group>"; };
 		9FB275767AC2B912FA2FEDEE /* UISFXMinimalPlay.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = UISFXMinimalPlay.mp3; sourceTree = "<group>"; };
 		9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativImageClient.swift; sourceTree = "<group>"; };
@@ -328,6 +333,7 @@
 		DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionTests.swift; sourceTree = "<group>"; };
 		E2DDA5274474AC8D54DFDF71 /* AudioInputLevelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputLevelMonitor.swift; sourceTree = "<group>"; };
+		E32D3F2A27D1E1073A6E3E29 /* fake_mcp_server.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = fake_mcp_server.py; sourceTree = "<group>"; };
 		E46B388273DDFAD7C6C0F4E1 /* IssueReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueReport.swift; sourceTree = "<group>"; };
 		E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSettingsTests.swift; sourceTree = "<group>"; };
 		E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentMenuActionView.swift; sourceTree = "<group>"; };
@@ -432,6 +438,7 @@
 				D9B712CAFE08083D1679354E /* NativAudioClient.swift */,
 				38E6FD97A66F91B3B667B3FE /* NativChatClient.swift */,
 				9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */,
+				8F5AE12A6EA1216750AFED5E /* NativMCPClient.swift */,
 				D1651E057CC5D05857CF1595 /* NativServerKit.swift */,
 			);
 			path = NativServerKit;
@@ -564,6 +571,14 @@
 				A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */,
 			);
 			path = Tools;
+			sourceTree = "<group>";
+		};
+		989FD56964EF7EBFB340A55A /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				E32D3F2A27D1E1073A6E3E29 /* fake_mcp_server.py */,
+			);
+			path = Fixtures;
 			sourceTree = "<group>";
 		};
 		A42368BA82350C2FA4CC12DF /* Features */ = {
@@ -707,8 +722,10 @@
 				3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */,
 				2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */,
 				E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */,
+				07E0B18D848E96DBF258FD8F /* NativMCPClientTests.swift */,
 				E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */,
 				3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */,
+				989FD56964EF7EBFB340A55A /* Fixtures */,
 			);
 			path = NativTests;
 			sourceTree = "<group>";
@@ -765,6 +782,7 @@
 			buildConfigurationList = 8FA69753D127D0D7E830A862 /* Build configuration list for PBXNativeTarget "NativTests" */;
 			buildPhases = (
 				945BA7400D20635505997582 /* Sources */,
+				3C606585E35DCFD759B3B509 /* Resources */,
 				3DA0B1CAF783C6D917E68DA4 /* Frameworks */,
 				53E3EAE39BF1C72400065105 /* Embed Frameworks */,
 			);
@@ -881,6 +899,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3C606585E35DCFD759B3B509 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F48FDDED0FC0AB7501A1A97 /* fake_mcp_server.py in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4326294893A83DE89EE26630 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -927,6 +953,7 @@
 				2B89F9E09ABB37B82AC2FEB5 /* NativAudioClient.swift in Sources */,
 				1A6F5207528E44EA9FF8F831 /* NativChatClient.swift in Sources */,
 				DC1ED6C1A11081FB70F1F019 /* NativImageClient.swift in Sources */,
+				E4D6CCEFDC2BA5A68FAE230A /* NativMCPClient.swift in Sources */,
 				506A12DCE5B56E53208A8BA2 /* NativServerKit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1048,6 +1075,7 @@
 				252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */,
 				ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */,
 				0E326825AE5A1A5EEA33D928 /* NativExtensionTests.swift in Sources */,
+				3BEBB4EA0D9713BA240A2209 /* NativMCPClientTests.swift in Sources */,
 				025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */,
 				90EE7AA87400E84D947CBBF3 /* NativSettings.swift in Sources */,
 				DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */,

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -12,6 +12,7 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
     case models = "Models"
     case integrations = "Integrations"
     case extensions = "Extensions"
+    case mcpServers = "MCP Servers"
     case developer = "Developer"
     case settings = "Settings"
 
@@ -25,6 +26,7 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
             .models,
             .integrations,
             .extensions,
+            .mcpServers,
             .developer,
         ]
     }
@@ -49,6 +51,8 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
             "puzzlepiece.extension"
         case .extensions:
             "shippingbox"
+        case .mcpServers:
+            "server.rack"
         case .developer:
             "hammer"
         case .settings:
@@ -1231,7 +1235,7 @@ struct ControlPanelView: View {
         switch selectedTab {
         case .chat, .models, .developer:
             true
-        case .imageGeneration, .artifacts, .dashboard, .system, .integrations, .extensions, .settings:
+        case .imageGeneration, .artifacts, .dashboard, .system, .integrations, .extensions, .mcpServers, .settings:
             false
         }
     }
@@ -1792,6 +1796,11 @@ struct ControlPanelView: View {
                 manager: extensionManager,
                 titleLeadingInset: detailTitleLeadingInset
             )
+        case .mcpServers:
+            MCPServersView(
+                model: model,
+                titleLeadingInset: detailTitleLeadingInset
+            )
         case .developer:
             DeveloperView(
                 model: model,
@@ -1888,7 +1897,7 @@ struct ControlPanelView: View {
             return true
         }
         switch selectedTab {
-        case .dashboard, .system, .models, .integrations, .extensions, .developer:
+        case .dashboard, .system, .models, .integrations, .extensions, .mcpServers, .developer:
             return true
         case .chat, .imageGeneration, .artifacts, .settings:
             return false

--- a/Sources/Nativ/Features/Chat/ChatMCPToolBridge.swift
+++ b/Sources/Nativ/Features/Chat/ChatMCPToolBridge.swift
@@ -1,0 +1,72 @@
+import Foundation
+import NativServerKit
+
+struct ChatMCPToolBridge {
+    let manager: MCPServerManager
+
+    @MainActor
+    func definitions() -> [MLXChatToolDefinition] {
+        manager.connections.flatMap { connection in
+            connection.tools.map { tool in
+                MLXChatToolDefinition(function: MLXChatFunctionDefinition(
+                    name: MCPToolNameQualifier.qualify(server: connection.configuration.name, tool: tool.name),
+                    description: tool.description,
+                    parameters: tool.inputSchema
+                ))
+            }
+        }
+    }
+
+    func canHandle(_ name: String) -> Bool {
+        MCPToolNameQualifier.hasPrefix(name)
+    }
+
+    @MainActor
+    func requiresConsent(_ qualifiedName: String) -> Bool {
+        guard canHandle(qualifiedName) else {
+            return false
+        }
+        guard let (serverName, toolName) = MCPToolNameQualifier.unqualify(qualifiedName),
+              let connection = manager.connections.first(where: { $0.configuration.name == serverName })
+        else {
+            return true
+        }
+        return !connection.configuration.consentExemptTools.contains(toolName)
+    }
+
+    @MainActor
+    func execute(call: MLXChatToolCall) async throws -> ChatToolExecutionOutcome {
+        guard let qualifiedName = call.function?.name,
+              let (serverName, toolName) = MCPToolNameQualifier.unqualify(qualifiedName)
+        else {
+            throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
+        }
+        guard let connection = manager.connections.first(where: { $0.configuration.name == serverName }) else {
+            throw ChatImageToolError.unsupportedTool(qualifiedName)
+        }
+        let resultText = try await connection.callTool(name: toolName, argumentsJSON: call.function?.arguments)
+        return ChatToolExecutionOutcome(content: resultText, attachments: [])
+    }
+
+    static func declinedPayload(toolName: String) -> String {
+        let payload = ChatMCPToolResultPayload(ok: false, declined: true, error: "The user declined this action.")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return (try? String(decoding: encoder.encode(payload), as: UTF8.self))
+            ?? #"{"ok":false,"declined":true,"error":"The user declined this action."}"#
+    }
+
+    static func failurePayload(toolName: String, error: Error) -> String {
+        let payload = ChatMCPToolResultPayload(ok: false, declined: nil, error: error.localizedDescription)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return (try? String(decoding: encoder.encode(payload), as: UTF8.self))
+            ?? #"{"ok":false,"error":"MCP tool failed."}"#
+    }
+}
+
+private struct ChatMCPToolResultPayload: Encodable {
+    let ok: Bool
+    let declined: Bool?
+    let error: String?
+}

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -9,6 +9,7 @@ struct ChatToolExecutionContext {
     let modelSearchPath: String
     let additionalModelSearchPaths: [String]
     var analyticsDatabaseURL: URL? = nil
+    var mcpBridge: ChatMCPToolBridge? = nil
 }
 
 struct ChatToolExecutionOutcome {
@@ -25,6 +26,7 @@ enum ChatToolRoundGate {
 }
 
 enum ChatToolRegistry {
+    @MainActor
     static func definitions(
         context: ChatToolExecutionContext,
         canEditImage: Bool
@@ -37,6 +39,7 @@ enum ChatToolRegistry {
         tools.append(contentsOf: ChatModelLibraryToolRegistry.definitions())
         tools.append(contentsOf: ChatServerStatsToolRegistry.definitions())
         tools.append(contentsOf: ChatSwitchModelToolRegistry.definitions())
+        tools.append(contentsOf: context.mcpBridge?.definitions() ?? [])
         return tools
     }
 }
@@ -70,21 +73,34 @@ enum ChatToolDispatcher {
         },
     ]
 
+    @MainActor
     static func execute(
         call: MLXChatToolCall,
         context: ChatToolExecutionContext
     ) async throws -> ChatToolExecutionOutcome {
-        guard let name = call.function?.name, let handler = handlers[name] else {
-            throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
+        guard let name = call.function?.name else {
+            throw ChatImageToolError.unsupportedTool("unknown")
         }
-        return try await handler(call, context)
+        if let handler = handlers[name] {
+            return try await handler(call, context)
+        }
+        if context.mcpBridge?.canHandle(name) == true, let mcpBridge = context.mcpBridge {
+            return try await mcpBridge.execute(call: call)
+        }
+        throw ChatImageToolError.unsupportedTool(name)
     }
 
     static func failurePayload(toolName: String?, error: Error) -> String {
-        guard let toolName, let handler = failureHandlers[toolName] else {
-            return ChatImageToolExecutor().failurePayload(operation: toolName ?? "tool", error: error)
+        guard let toolName else {
+            return ChatImageToolExecutor().failurePayload(operation: "tool", error: error)
         }
-        return handler(toolName, error)
+        if let handler = failureHandlers[toolName] {
+            return handler(toolName, error)
+        }
+        if MCPToolNameQualifier.hasPrefix(toolName) {
+            return ChatMCPToolBridge.failurePayload(toolName: toolName, error: error)
+        }
+        return ChatImageToolExecutor().failurePayload(operation: toolName, error: error)
     }
 
     private static func executeImageTool(
@@ -180,6 +196,58 @@ enum ChatToolConsentRouter {
     }
 }
 
+enum ChatConsentGatedAction {
+    case switchModel(call: MLXChatToolCall)
+    case mcpTool(call: MLXChatToolCall, bridge: ChatMCPToolBridge)
+
+    @MainActor
+    static func detect(call: MLXChatToolCall, mcpBridge: ChatMCPToolBridge?) -> ChatConsentGatedAction? {
+        guard let name = call.function?.name else { return nil }
+        if name == ChatSwitchModelToolRegistry.toolName {
+            return .switchModel(call: call)
+        }
+        if let mcpBridge, mcpBridge.requiresConsent(name) {
+            return .mcpTool(call: call, bridge: mcpBridge)
+        }
+        return nil
+    }
+
+    @MainActor
+    func execute(appModel: NativModel?) async throws -> String {
+        switch self {
+        case .switchModel(let call):
+            guard let appModel else {
+                throw ChatSwitchModelToolError.appModelUnavailable
+            }
+            return try await ChatSwitchModelToolExecutor().execute(call: call, appModel: appModel)
+        case .mcpTool(let call, let bridge):
+            let outcome = try await bridge.execute(call: call)
+            return outcome.content
+        }
+    }
+
+    func declinedPayload() -> String {
+        switch self {
+        case .switchModel:
+            return ChatSwitchModelToolExecutor().declinedPayload()
+        case .mcpTool(let call, _):
+            return ChatMCPToolBridge.declinedPayload(toolName: call.function?.name ?? "tool")
+        }
+    }
+
+    func failurePayload(error: Error) -> String {
+        switch self {
+        case .switchModel(let call):
+            return ChatSwitchModelToolExecutor().failurePayload(
+                operation: call.function?.name ?? ChatSwitchModelToolRegistry.toolName,
+                error: error
+            )
+        case .mcpTool(let call, _):
+            return ChatMCPToolBridge.failurePayload(toolName: call.function?.name ?? "tool", error: error)
+        }
+    }
+}
+
 enum ChatToolPresentation {
     static func title(toolName: String?, status: ChatTranscriptMessage.ToolStatus?) -> String {
         switch toolName {
@@ -193,6 +261,8 @@ enum ChatToolPresentation {
             return modelLibraryTitle(status: status)
         case ChatServerStatsToolRegistry.toolName:
             return serverStatsTitle(status: status)
+        case let name? where MCPToolNameQualifier.hasPrefix(name):
+            return mcpTitle(toolName: name, status: status)
         case ChatSwitchModelToolRegistry.toolName:
             return switchModelTitle(status: status)
         default:
@@ -218,6 +288,8 @@ enum ChatToolPresentation {
                 return "shippingbox"
             case ChatServerStatsToolRegistry.toolName:
                 return "chart.line.uptrend.xyaxis"
+            case let name? where MCPToolNameQualifier.hasPrefix(name):
+                return "puzzlepiece.extension"
             case ChatSwitchModelToolRegistry.toolName:
                 return "arrow.triangle.2.circlepath"
             default:
@@ -276,6 +348,27 @@ enum ChatToolPresentation {
         case nil:
             return "Server stats tool"
         }
+    }
+
+    private static func mcpTitle(toolName: String, status: ChatTranscriptMessage.ToolStatus?) -> String {
+        let name = mcpDisplayName(for: toolName) ?? toolName
+        switch status {
+        case .awaitingConsent:
+            return "Run \(name)?"
+        case .running:
+            return "Running \(name)…"
+        case .succeeded:
+            return "Ran \(name)"
+        case .declined:
+            return "\(name) declined"
+        case .failed, .cancelled, nil:
+            return name
+        }
+    }
+
+    private static func mcpDisplayName(for qualifiedName: String) -> String? {
+        guard let (server, tool) = MCPToolNameQualifier.unqualify(qualifiedName) else { return nil }
+        return "\(tool) (\(server))"
     }
 
     private static func switchModelTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -934,6 +934,7 @@ final class ChatViewModel: ObservableObject {
             }
 
             var insertionAnchor = assistantMessageID
+            let mcpBridge = appModel.map { ChatMCPToolBridge(manager: $0.mcpServers) }
             for (index, toolCall) in toolCalls.enumerated() {
                 try Task.checkCancellation()
                 let toolMessageID = UUID()
@@ -947,7 +948,7 @@ final class ChatViewModel: ObservableObject {
                 }
                 insertionAnchor = toolMessageID
 
-                if toolCall.function?.name == ChatSwitchModelToolRegistry.toolName {
+                if let consentGatedAction = ChatConsentGatedAction.detect(call: toolCall, mcpBridge: mcpBridge) {
                     updateToolMessage(
                         toolMessageID,
                         in: queuedRequest.sessionID,
@@ -971,7 +972,7 @@ final class ChatViewModel: ObservableObject {
                             toolMessageID,
                             in: queuedRequest.sessionID,
                             status: .declined,
-                            content: ChatSwitchModelToolExecutor().declinedPayload(),
+                            content: consentGatedAction.declinedPayload(),
                             attachments: []
                         )
                         continue
@@ -984,7 +985,7 @@ final class ChatViewModel: ObservableObject {
                             attachments: []
                         )
                     }
-                    guard let appModel else {
+                    if case .switchModel = consentGatedAction, appModel == nil {
                         updateToolMessage(
                             toolMessageID,
                             in: queuedRequest.sessionID,
@@ -998,8 +999,10 @@ final class ChatViewModel: ObservableObject {
                         continue
                     }
                     do {
-                        let content = try await ChatSwitchModelToolExecutor().execute(call: toolCall, appModel: appModel)
-                        activeSettings.languageModelID = appModel.settings.normalized().languageModelID
+                        let content = try await consentGatedAction.execute(appModel: appModel)
+                        if case .switchModel = consentGatedAction, let appModel {
+                            activeSettings.languageModelID = appModel.settings.normalized().languageModelID
+                        }
                         updateToolMessage(
                             toolMessageID,
                             in: queuedRequest.sessionID,
@@ -1007,16 +1010,13 @@ final class ChatViewModel: ObservableObject {
                             content: content,
                             attachments: []
                         )
-                        appModel.refreshMetricsIfRunning(force: true)
+                        appModel?.refreshMetricsIfRunning(force: true)
                     } catch {
                         updateToolMessage(
                             toolMessageID,
                             in: queuedRequest.sessionID,
                             status: .failed,
-                            content: ChatSwitchModelToolExecutor().failurePayload(
-                                operation: ChatSwitchModelToolRegistry.toolName,
-                                error: error
-                            ),
+                            content: consentGatedAction.failurePayload(error: error),
                             attachments: []
                         )
                     }
@@ -1034,7 +1034,8 @@ final class ChatViewModel: ObservableObject {
                         apiKey: queuedRequest.settings.serverAPIKey,
                         imageReferences: references,
                         modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
-                        additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths
+                        additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
+                        mcpBridge: mcpBridge
                     )
                     let outcome = try await ChatToolDispatcher.execute(call: toolCall, context: context)
                     updateToolMessage(
@@ -1122,7 +1123,8 @@ final class ChatViewModel: ObservableObject {
                     apiKey: settings.serverAPIKey,
                     imageReferences: [],
                     modelSearchPath: settings.expandedModelSearchPath,
-                    additionalModelSearchPaths: settings.additionalModelSearchPaths
+                    additionalModelSearchPaths: settings.additionalModelSearchPaths,
+                    mcpBridge: appModel.map { ChatMCPToolBridge(manager: $0.mcpServers) }
                 ),
                 canEditImage: precedingMessages.contains { !$0.imageAttachments.isEmpty }
             )
@@ -2060,9 +2062,7 @@ private struct ChatAgentStepCell: View {
 
     private var consentPrompt: some View {
         VStack(alignment: .leading, spacing: 8) {
-            (Text("The model wants to switch to ")
-                + Text(verbatim: requestedModelID).bold()
-                + Text(". The server restarts briefly; your session is kept."))
+            Text(consentPromptText)
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -2080,6 +2080,21 @@ private struct ChatAgentStepCell: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.top, 7)
+    }
+
+    private var consentPromptText: String {
+        if message.toolName == ChatSwitchModelToolRegistry.toolName {
+            return "The model wants to switch to **\(requestedModelID)**. The server restarts briefly; your session is kept."
+        }
+        if let toolName = message.toolName, MCPToolNameQualifier.hasPrefix(toolName) {
+            return "The model wants to run **\(mcpConsentDisplayName(for: toolName))**. This will change data outside Nativ."
+        }
+        return "The model wants to perform an action that needs your approval."
+    }
+
+    private func mcpConsentDisplayName(for qualifiedName: String) -> String {
+        guard let (server, tool) = MCPToolNameQualifier.unqualify(qualifiedName) else { return qualifiedName }
+        return "\(tool) (\(server))"
     }
 
     private var requestedModelID: String {

--- a/Sources/Nativ/Features/MCP/MCPServersView.swift
+++ b/Sources/Nativ/Features/MCP/MCPServersView.swift
@@ -1,0 +1,231 @@
+import NativServerKit
+import SwiftUI
+
+struct MCPServersView: View {
+    @ObservedObject var model: NativModel
+    @ObservedObject private var manager: MCPServerManager
+    var titleLeadingInset: CGFloat = 0
+    @State private var isPresentingAddServer = false
+
+    init(model: NativModel, titleLeadingInset: CGFloat = 0) {
+        self.model = model
+        self.manager = model.mcpServers
+        self.titleLeadingInset = titleLeadingInset
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(Color.nativMainContentBackground)
+        .sheet(isPresented: $isPresentingAddServer) {
+            MCPAddServerSheet(model: model)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("MCP Servers")
+                    .font(.title2.weight(.semibold))
+                Text("Connect Nativ's chat to Model Context Protocol servers. Nothing runs until you add and start one.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button {
+                isPresentingAddServer = true
+            } label: {
+                Label("Add Server", systemImage: "plus")
+            }
+        }
+        .padding(.horizontal, 28)
+        .padding(.leading, titleLeadingInset)
+        .padding(.top, 24)
+        .padding(.bottom, 18)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if manager.connections.isEmpty {
+            VStack(spacing: 8) {
+                Image(systemName: "puzzlepiece.extension")
+                    .font(.largeTitle)
+                    .foregroundStyle(.secondary)
+                Text("No MCP servers configured")
+                    .font(.headline)
+                Text("Add a server to let chat use its tools.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List {
+                ForEach(manager.connections) { connection in
+                    MCPServerRow(connection: connection, model: model)
+                }
+            }
+            .listStyle(.inset)
+        }
+    }
+}
+
+private struct MCPServerRow: View {
+    @ObservedObject var connection: MCPServerConnection
+    let model: NativModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(connection.configuration.name)
+                    .font(.body.weight(.medium))
+                Text(statusText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            actionButton
+            Button {
+                model.removeMCPServer(connection.configuration.id)
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove this server")
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statusColor: Color {
+        switch connection.state {
+        case .stopped:
+            .secondary
+        case .starting:
+            .yellow
+        case .running:
+            .green
+        case .crashed:
+            .red
+        }
+    }
+
+    private var statusText: String {
+        switch connection.state {
+        case .stopped:
+            "Stopped"
+        case .starting:
+            "Starting…"
+        case .running(let toolCount):
+            "Running · \(toolCount) tool\(toolCount == 1 ? "" : "s")"
+        case .crashed:
+            connection.lastError.map { "Failed to start: \($0)" } ?? "Failed to start"
+        }
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        switch connection.state {
+        case .stopped, .crashed:
+            Button("Start") {
+                model.startMCPServer(connection.configuration.id)
+            }
+        case .starting:
+            ProgressView()
+                .controlSize(.small)
+        case .running:
+            Button("Stop") {
+                model.stopMCPServer(connection.configuration.id)
+            }
+        }
+    }
+}
+
+private struct MCPAddServerSheet: View {
+    let model: NativModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var command = ""
+    @State private var argumentsText = ""
+    @State private var environmentText = ""
+    @State private var consentExemptToolsText = ""
+
+    var body: some View {
+        Form {
+            Section("Server") {
+                TextField("Name", text: $name)
+                if !name.isEmpty, !MCPToolNameQualifier.isValidServerName(name) {
+                    Text("Name can't be empty or contain \"__\".")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+                TextField("Command", text: $command, prompt: Text("npx"))
+                TextField("Arguments (space-separated)", text: $argumentsText, prompt: Text("-y @modelcontextprotocol/server-filesystem /path/to/folder"))
+            }
+            Section("Environment (optional, one KEY=VALUE per line)") {
+                TextEditor(text: $environmentText)
+                    .frame(minHeight: 60)
+                    .font(.system(.body, design: .monospaced))
+            }
+            Section("Tools that don't need approval (optional, comma-separated)") {
+                TextField("read_file, list_directory", text: $consentExemptToolsText)
+                Text("Every other tool on this server will ask for confirmation before it runs.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .frame(minWidth: 420, minHeight: 360)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Add") {
+                    model.addMCPServer(makeConfiguration())
+                    dismiss()
+                }
+                .disabled(!canSubmit)
+            }
+        }
+    }
+
+    private var canSubmit: Bool {
+        MCPToolNameQualifier.isValidServerName(name)
+            && !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func makeConfiguration() -> MCPServerConfiguration {
+        let arguments = argumentsText
+            .split(separator: " ")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+        var environment: [String: String] = [:]
+        for line in environmentText.split(separator: "\n") {
+            guard let separatorIndex = line.firstIndex(of: "=") else { continue }
+            let key = String(line[line.startIndex..<separatorIndex]).trimmingCharacters(in: .whitespaces)
+            let value = String(line[line.index(after: separatorIndex)...]).trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else { continue }
+            environment[key] = value
+        }
+        let consentExemptTools = Set(
+            consentExemptToolsText
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+        )
+        return MCPServerConfiguration(
+            name: name.trimmingCharacters(in: .whitespaces),
+            command: command.trimmingCharacters(in: .whitespaces),
+            arguments: arguments,
+            environment: environment,
+            consentExemptTools: consentExemptTools
+        )
+    }
+}

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -60,6 +60,8 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     var onMenuStateChanged: (() -> Void)?
 
     private let server = NativProcessController()
+    let mcpServers = MCPServerManager()
+    private var resolvedMCPLaunchEnvironment: [String: String] = [:]
     private var metricsClient = NativMetricsClient()
     private var metricsFetchTask: Task<Void, Never>?
     private var metricsTimer: Timer?
@@ -85,7 +87,9 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
         allTimeStats = NativAllTimeStats.load(from: currentAnalyticsDatabaseURL())
         configureServerCallbacks()
         isRunning = server.isRunning
+        mcpServers.configure(settings.mcpServers)
         resolveHuggingFaceEnvironmentFromLoginShell()
+        resolveMCPLaunchEnvironmentFromLoginShell()
         migrateCustomHuggingFaceCredentialIfNeeded()
     }
 
@@ -134,6 +138,41 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
                     in: effectiveEnvironment
                 )
             }
+        }
+    }
+
+    /// launchd's PATH is missing /opt/homebrew/bin, so `npx`/`uvx` only
+    /// resolve from Xcode/a terminal, not a real Finder launch. Same probe
+    /// as resolveHuggingFaceEnvironmentFromLoginShell, a different variable.
+    private func resolveMCPLaunchEnvironmentFromLoginShell() {
+        Task { [weak self] in
+            let resolved = await Task.detached(priority: .utility) {
+                ShellEnvironment.resolveFromLoginShell(names: ["PATH"])
+            }.value
+            guard !resolved.isEmpty else { return }
+            self?.resolvedMCPLaunchEnvironment = resolved
+        }
+    }
+
+    func addMCPServer(_ configuration: MCPServerConfiguration) {
+        settings.mcpServers.append(configuration)
+        mcpServers.configure(settings.mcpServers)
+    }
+
+    func removeMCPServer(_ id: MCPServerConfiguration.ID) {
+        settings.mcpServers.removeAll { $0.id == id }
+        mcpServers.configure(settings.mcpServers)
+    }
+
+    func startMCPServer(_ id: MCPServerConfiguration.ID) {
+        Task { [mcpServers, resolvedMCPLaunchEnvironment] in
+            await mcpServers.start(id, additionalEnvironment: resolvedMCPLaunchEnvironment)
+        }
+    }
+
+    func stopMCPServer(_ id: MCPServerConfiguration.ID) {
+        Task { [mcpServers] in
+            await mcpServers.stop(id)
         }
     }
 
@@ -675,6 +714,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     }
 
     func applicationWillTerminate() {
+        mcpServers.stopAllSynchronously()
         stopMetricsPolling(clearSession: true)
         if server.isRunning {
             try? server.stop(timeout: 2)

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -324,6 +324,7 @@ struct NativSettings: Codable, Equatable {
 
     var modelSearchPath: String
     var additionalModelSearchPaths: [String]
+    var mcpServers: [MCPServerConfiguration]
     var languageModelID: String?
     var imageGenerationModelID: String?
     var textToSpeechModelID: String?
@@ -371,6 +372,7 @@ struct NativSettings: Codable, Equatable {
     init(
         modelSearchPath: String = Self.defaultModelSearchPath,
         additionalModelSearchPaths: [String] = [],
+        mcpServers: [MCPServerConfiguration] = [],
         languageModelID: String? = nil,
         imageGenerationModelID: String? = nil,
         textToSpeechModelID: String? = nil,
@@ -417,6 +419,7 @@ struct NativSettings: Codable, Equatable {
     ) {
         self.modelSearchPath = modelSearchPath
         self.additionalModelSearchPaths = additionalModelSearchPaths
+        self.mcpServers = mcpServers
         self.languageModelID = languageModelID
         self.imageGenerationModelID = imageGenerationModelID
         self.textToSpeechModelID = textToSpeechModelID
@@ -465,6 +468,7 @@ struct NativSettings: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case modelSearchPath
         case additionalModelSearchPaths
+        case mcpServers
         case languageModelID
         case imageGenerationModelID
         case textToSpeechModelID
@@ -518,6 +522,7 @@ struct NativSettings: Codable, Equatable {
         let storedModelSearchPath = try container.decodeIfPresent(String.self, forKey: .modelSearchPath)
         modelSearchPath = HuggingFaceCache.resolvedSearchPath(stored: storedModelSearchPath)
         additionalModelSearchPaths = try container.decodeIfPresent([String].self, forKey: .additionalModelSearchPaths) ?? defaults.additionalModelSearchPaths
+        mcpServers = try container.decodeIfPresent([MCPServerConfiguration].self, forKey: .mcpServers) ?? defaults.mcpServers
         languageModelID = try container.decodeIfPresent(String.self, forKey: .languageModelID) ?? legacySelectedModelID ?? defaults.languageModelID
         imageGenerationModelID = try container.decodeIfPresent(String.self, forKey: .imageGenerationModelID) ?? defaults.imageGenerationModelID
         textToSpeechModelID = try container.decodeIfPresent(String.self, forKey: .textToSpeechModelID) ?? defaults.textToSpeechModelID
@@ -567,6 +572,7 @@ struct NativSettings: Codable, Equatable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(modelSearchPath, forKey: .modelSearchPath)
         try container.encode(additionalModelSearchPaths, forKey: .additionalModelSearchPaths)
+        try container.encode(mcpServers, forKey: .mcpServers)
         try container.encodeIfPresent(languageModelID, forKey: .languageModelID)
         try container.encodeIfPresent(imageGenerationModelID, forKey: .imageGenerationModelID)
         try container.encodeIfPresent(textToSpeechModelID, forKey: .textToSpeechModelID)
@@ -709,6 +715,9 @@ struct NativSettings: Codable, Equatable {
         settings.additionalModelSearchPaths = settings.additionalModelSearchPaths
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty && seenAdditionalPaths.insert($0).inserted }
+        settings.mcpServers = settings.mcpServers.filter {
+            MCPToolNameQualifier.isValidServerName($0.name) && !$0.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
         settings.languageModelID = Self.normalizedModelID(settings.languageModelID)
         settings.imageGenerationModelID = Self.normalizedModelID(settings.imageGenerationModelID)
         if let imageModelID = settings.imageGenerationModelID,

--- a/Sources/NativServerKit/NativMCPClient.swift
+++ b/Sources/NativServerKit/NativMCPClient.swift
@@ -1,0 +1,473 @@
+import Foundation
+
+public struct MCPServerConfiguration: Identifiable, Codable, Equatable, Sendable {
+    public let id: UUID
+    public var name: String
+    public var command: String
+    public var arguments: [String]
+    public var environment: [String: String]
+    public var consentExemptTools: Set<String>
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        command: String,
+        arguments: [String],
+        environment: [String: String] = [:],
+        consentExemptTools: Set<String> = []
+    ) {
+        self.id = id
+        self.name = name
+        self.command = command
+        self.arguments = arguments
+        self.environment = environment
+        self.consentExemptTools = consentExemptTools
+    }
+}
+
+public struct MCPToolDescriptor: Equatable, Sendable {
+    public let name: String
+    public let description: String
+    public let inputSchema: MLXJSONValue
+
+    public init(name: String, description: String, inputSchema: MLXJSONValue) {
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+    }
+}
+
+public enum MCPServerState: Equatable, Sendable {
+    case stopped
+    case starting
+    case running(toolCount: Int)
+    case crashed(exitCode: Int32)
+}
+
+public enum MCPClientError: LocalizedError, Sendable {
+    case processUnavailable
+    case malformedResponse(String)
+    case serverError(code: Int, message: String)
+    case callTimedOut
+    case invalidToolResult
+
+    public var errorDescription: String? {
+        switch self {
+        case .processUnavailable:
+            "The MCP server is not running."
+        case .malformedResponse(let raw):
+            "Malformed MCP response: \(raw)"
+        case .serverError(let code, let message):
+            "MCP server error \(code): \(message)"
+        case .callTimedOut:
+            "The MCP tool call timed out."
+        case .invalidToolResult:
+            "The MCP tool result did not contain usable text content."
+        }
+    }
+}
+
+public enum MCPToolNameQualifier {
+    private static let prefix = "mcp__"
+    private static let separator = "__"
+
+    public static func isValidServerName(_ name: String) -> Bool {
+        !name.isEmpty && !name.contains(separator)
+    }
+
+    public static func qualify(server: String, tool: String) -> String {
+        "\(prefix)\(server)\(separator)\(tool)"
+    }
+
+    public static func unqualify(_ name: String) -> (server: String, tool: String)? {
+        guard name.hasPrefix(prefix) else { return nil }
+        let remainder = name.dropFirst(prefix.count)
+        guard let separatorRange = remainder.range(of: separator) else { return nil }
+        let server = String(remainder[..<separatorRange.lowerBound])
+        let tool = String(remainder[separatorRange.upperBound...])
+        guard !server.isEmpty, !tool.isEmpty else { return nil }
+        return (server, tool)
+    }
+
+    public static func hasPrefix(_ name: String) -> Bool {
+        name.hasPrefix(prefix)
+    }
+}
+
+public enum MCPLineFramer {
+    public static func extractLines(appending chunk: String, to buffer: inout String) -> [String] {
+        buffer += chunk
+        var lines: [String] = []
+        while let newlineRange = buffer.range(of: "\n") {
+            let line = String(buffer[..<newlineRange.lowerBound])
+            buffer.removeSubrange(..<newlineRange.upperBound)
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                lines.append(trimmed)
+            }
+        }
+        return lines
+    }
+}
+
+public enum MCPJSONRPCCodec {
+    public enum DecodedResponse: Equatable {
+        case result(id: Int, value: MLXJSONValue)
+        case error(id: Int, code: Int, message: String)
+        case malformedEnvelope(id: Int)
+        case unrecognized
+    }
+
+    public static func decodeResponse(_ line: String) -> DecodedResponse {
+        guard let data = line.data(using: .utf8),
+              let value = try? JSONDecoder().decode(MLXJSONValue.self, from: data),
+              case .object(let object) = value,
+              case .number(let rawID)? = object["id"]
+        else {
+            return .unrecognized
+        }
+        let id = Int(rawID)
+
+        if case .object(let errorObject)? = object["error"] {
+            return .error(
+                id: id,
+                code: numericValue(errorObject["code"]),
+                message: stringValue(errorObject["message"]) ?? "Unknown MCP error"
+            )
+        }
+        if let result = object["result"] {
+            return .result(id: id, value: result)
+        }
+        return .malformedEnvelope(id: id)
+    }
+
+    public static func encodeRequest(id: Int, method: String, params: MLXJSONValue) throws -> Data {
+        let payload: MLXJSONValue = .object([
+            "jsonrpc": .string("2.0"),
+            "id": .number(Double(id)),
+            "method": .string(method),
+            "params": params
+        ])
+        var data = try JSONEncoder().encode(payload)
+        data.append(0x0A)
+        return data
+    }
+
+    public static func encodeNotification(method: String) throws -> Data {
+        let payload: MLXJSONValue = .object([
+            "jsonrpc": .string("2.0"),
+            "method": .string(method),
+            "params": .object([:])
+        ])
+        var data = try JSONEncoder().encode(payload)
+        data.append(0x0A)
+        return data
+    }
+
+    public static func toolDescriptors(fromToolsListResult result: MLXJSONValue) throws -> [MCPToolDescriptor] {
+        guard case .object(let object) = result,
+              case .array(let toolValues)? = object["tools"]
+        else {
+            throw MCPClientError.malformedResponse("tools/list result missing a \"tools\" array")
+        }
+        return try toolValues.map(toolDescriptor)
+    }
+
+    public static func parseArguments(_ argumentsJSON: String?) throws -> MLXJSONValue {
+        guard let argumentsJSON, let data = argumentsJSON.data(using: .utf8), !argumentsJSON.isEmpty else {
+            return .object([:])
+        }
+        return try MLXJSONValue(jsonData: data)
+    }
+
+    public static func extractText(fromToolCallResult result: MLXJSONValue) throws -> String {
+        guard case .object(let object) = result,
+              case .array(let contentValues)? = object["content"]
+        else {
+            throw MCPClientError.invalidToolResult
+        }
+        let texts = contentValues.compactMap { value -> String? in
+            guard case .object(let part) = value,
+                  case .string("text")? = part["type"],
+                  case .string(let text)? = part["text"]
+            else {
+                return nil
+            }
+            return text
+        }
+        guard !texts.isEmpty else {
+            throw MCPClientError.invalidToolResult
+        }
+        let combined = texts.joined(separator: "\n")
+        if case .bool(true)? = object["isError"] {
+            throw MCPClientError.serverError(code: -32000, message: combined)
+        }
+        return combined
+    }
+
+    private static func toolDescriptor(_ value: MLXJSONValue) throws -> MCPToolDescriptor {
+        guard case .object(let object) = value,
+              case .string(let name)? = object["name"]
+        else {
+            throw MCPClientError.malformedResponse("tool descriptor missing a \"name\"")
+        }
+        let description = stringValue(object["description"]) ?? ""
+        let inputSchema = object["inputSchema"] ?? .object([
+            "type": .string("object"),
+            "properties": .object([:])
+        ])
+        return MCPToolDescriptor(name: name, description: description, inputSchema: inputSchema)
+    }
+
+    private static func numericValue(_ value: MLXJSONValue?) -> Int {
+        guard case .number(let value)? = value else { return -1 }
+        return Int(value)
+    }
+
+    private static func stringValue(_ value: MLXJSONValue?) -> String? {
+        guard case .string(let value)? = value else { return nil }
+        return value
+    }
+}
+
+actor MCPStdioTransport {
+    private let process: NativProcessController
+    private let requestTimeoutSeconds: Double
+    private var buffer = ""
+    private var pending: [Int: CheckedContinuation<MLXJSONValue, Error>] = [:]
+    private var timeoutTasks: [Int: Task<Void, Never>] = [:]
+    private var nextRequestID = 0
+    private let outputContinuation: AsyncStream<String>.Continuation
+
+    init(process: NativProcessController, requestTimeoutSeconds: Double = 30) {
+        self.process = process
+        self.requestTimeoutSeconds = requestTimeoutSeconds
+        let (stream, continuation) = AsyncStream<String>.makeStream()
+        self.outputContinuation = continuation
+        process.onOutput = { chunk in
+            continuation.yield(chunk)
+        }
+        Task { [weak self] in
+            for await chunk in stream {
+                await self?.consume(chunk)
+            }
+        }
+    }
+
+    func start(executableURL: URL, arguments: [String], environment: [String: String]) throws {
+        try process.start(executableURL: executableURL, arguments: arguments, environment: environment)
+    }
+
+    func stop() {
+        failAllPending(with: MCPClientError.processUnavailable)
+        outputContinuation.finish()
+        try? process.stop()
+    }
+
+    func initialize() async throws {
+        _ = try await request(method: "initialize", params: .object([
+            "protocolVersion": .string("2024-11-05"),
+            "capabilities": .object([:]),
+            "clientInfo": .object([
+                "name": .string("Nativ"),
+                "version": .string("1.0")
+            ])
+        ]))
+        try send(MCPJSONRPCCodec.encodeNotification(method: "notifications/initialized"))
+    }
+
+    func listTools() async throws -> [MCPToolDescriptor] {
+        let result = try await request(method: "tools/list", params: .object([:]))
+        return try MCPJSONRPCCodec.toolDescriptors(fromToolsListResult: result)
+    }
+
+    func callTool(name: String, argumentsJSON: String?) async throws -> String {
+        let arguments = try MCPJSONRPCCodec.parseArguments(argumentsJSON)
+        let result = try await request(
+            method: "tools/call",
+            params: .object(["name": .string(name), "arguments": arguments])
+        )
+        return try MCPJSONRPCCodec.extractText(fromToolCallResult: result)
+    }
+
+    private func request(method: String, params: MLXJSONValue) async throws -> MLXJSONValue {
+        let id = nextRequestID
+        nextRequestID += 1
+        try send(MCPJSONRPCCodec.encodeRequest(id: id, method: method, params: params))
+
+        let timeoutSeconds = requestTimeoutSeconds
+        return try await withCheckedThrowingContinuation { continuation in
+            pending[id] = continuation
+            timeoutTasks[id] = Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                await self.timeoutIfStillPending(id: id)
+            }
+        }
+    }
+
+    private func send(_ data: Data) throws {
+        try process.write(data)
+    }
+
+    private func resolvePending(id: Int, result: Result<MLXJSONValue, Error>) {
+        timeoutTasks.removeValue(forKey: id)?.cancel()
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        continuation.resume(with: result)
+    }
+
+    private func timeoutIfStillPending(id: Int) {
+        timeoutTasks.removeValue(forKey: id)
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        continuation.resume(throwing: MCPClientError.callTimedOut)
+    }
+
+    private func failAllPending(with error: Error) {
+        for task in timeoutTasks.values {
+            task.cancel()
+        }
+        timeoutTasks.removeAll()
+        for (_, continuation) in pending {
+            continuation.resume(throwing: error)
+        }
+        pending.removeAll()
+    }
+
+    private func consume(_ chunk: String) {
+        for line in MCPLineFramer.extractLines(appending: chunk, to: &buffer) {
+            handle(decoded: MCPJSONRPCCodec.decodeResponse(line), rawLine: line)
+        }
+    }
+
+    private func handle(decoded: MCPJSONRPCCodec.DecodedResponse, rawLine: String) {
+        switch decoded {
+        case .result(let id, let value):
+            resolvePending(id: id, result: .success(value))
+        case .error(let id, let code, let message):
+            resolvePending(id: id, result: .failure(MCPClientError.serverError(code: code, message: message)))
+        case .malformedEnvelope(let id):
+            resolvePending(id: id, result: .failure(MCPClientError.malformedResponse(rawLine)))
+        case .unrecognized:
+            break
+        }
+    }
+}
+
+@MainActor
+public final class MCPServerConnection: ObservableObject, Identifiable {
+    public var id: MCPServerConfiguration.ID { configuration.id }
+    public let configuration: MCPServerConfiguration
+    @Published public private(set) var state: MCPServerState = .stopped
+    @Published public private(set) var tools: [MCPToolDescriptor] = []
+    @Published public private(set) var lastError: String?
+
+    private let process = NativProcessController()
+    private let transport: MCPStdioTransport
+    private var isStopping = false
+
+    public init(configuration: MCPServerConfiguration, requestTimeoutSeconds: Double = 30) {
+        self.configuration = configuration
+        self.transport = MCPStdioTransport(process: process, requestTimeoutSeconds: requestTimeoutSeconds)
+        process.onTermination = { [weak self] exitCode in
+            Task { @MainActor in
+                self?.handleTermination(exitCode: exitCode)
+            }
+        }
+    }
+
+    public func start(additionalEnvironment: [String: String] = [:]) async {
+        isStopping = false
+        state = .starting
+        tools = []
+        lastError = nil
+        let launchEnvironment = additionalEnvironment.merging(configuration.environment) { _, override in override }
+        do {
+            try await transport.start(
+                executableURL: URL(fileURLWithPath: "/usr/bin/env"),
+                arguments: [configuration.command] + configuration.arguments,
+                environment: launchEnvironment
+            )
+            try await transport.initialize()
+            let descriptors = try await transport.listTools()
+            tools = descriptors
+            state = .running(toolCount: descriptors.count)
+        } catch {
+            await transport.stop()
+            lastError = error.localizedDescription
+            state = .crashed(exitCode: -1)
+        }
+    }
+
+    public func stop() async {
+        isStopping = true
+        await transport.stop()
+        tools = []
+        state = .stopped
+    }
+
+    public func stopSynchronously() {
+        isStopping = true
+        try? process.stop(timeout: 2)
+        tools = []
+        state = .stopped
+    }
+
+    public func callTool(name: String, argumentsJSON: String?) async throws -> String {
+        guard case .running = state else {
+            throw MCPClientError.processUnavailable
+        }
+        return try await transport.callTool(name: name, argumentsJSON: argumentsJSON)
+    }
+
+    private func handleTermination(exitCode: Int32) {
+        guard !isStopping else { return }
+        tools = []
+        lastError = nil
+        state = .crashed(exitCode: exitCode)
+        Task { await transport.stop() }
+    }
+}
+
+@MainActor
+public final class MCPServerManager: ObservableObject {
+    @Published public private(set) var connections: [MCPServerConnection] = []
+
+    public init() {}
+
+    public func configure(_ configurations: [MCPServerConfiguration]) {
+        let existingByID = Dictionary(uniqueKeysWithValues: connections.map { ($0.configuration.id, $0) })
+        var updated: [MCPServerConnection] = []
+        for configuration in configurations {
+            if let existing = existingByID[configuration.id], existing.configuration == configuration {
+                updated.append(existing)
+            } else {
+                existingByID[configuration.id]?.stopSynchronously()
+                updated.append(MCPServerConnection(configuration: configuration))
+            }
+        }
+        let keptIDs = Set(configurations.map(\.id))
+        for (id, connection) in existingByID where !keptIDs.contains(id) {
+            connection.stopSynchronously()
+        }
+        connections = updated
+    }
+
+    public func startAll(additionalEnvironment: [String: String] = [:]) async {
+        for connection in connections {
+            await connection.start(additionalEnvironment: additionalEnvironment)
+        }
+    }
+
+    public func start(_ configurationID: MCPServerConfiguration.ID, additionalEnvironment: [String: String] = [:]) async {
+        guard let connection = connections.first(where: { $0.configuration.id == configurationID }) else { return }
+        await connection.start(additionalEnvironment: additionalEnvironment)
+    }
+
+    public func stop(_ configurationID: MCPServerConfiguration.ID) async {
+        guard let connection = connections.first(where: { $0.configuration.id == configurationID }) else { return }
+        await connection.stop()
+    }
+
+    public func stopAllSynchronously() {
+        connections.forEach { $0.stopSynchronously() }
+    }
+}

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -653,6 +653,7 @@ public final class NativProcessController {
 
     private let lock = NSLock()
     private var process: Process?
+    private var inputPipe: Pipe?
     private var outputPipe: Pipe?
     private var errorPipe: Pipe?
 
@@ -672,17 +673,50 @@ public final class NativProcessController {
         arguments: [String] = [],
         environment: [String: String] = [:]
     ) throws -> Process {
+        try launch(try Nativ.makeProcess(arguments: arguments, environment: environment))
+    }
+
+    @discardableResult
+    public func start(
+        executableURL: URL,
+        arguments: [String] = [],
+        environment: [String: String] = [:]
+    ) throws -> Process {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        var processEnvironment = ProcessInfo.processInfo.environment
+        processEnvironment.merge(environment) { _, newValue in newValue }
+        process.environment = processEnvironment
+        return try launch(process, wiresStandardInput: true)
+    }
+
+    public func write(_ data: Data) throws {
+        let pipe = try lock.withLock { () -> Pipe in
+            guard let inputPipe, process?.isRunning == true else {
+                throw NativError.notRunning
+            }
+            return inputPipe
+        }
+        try pipe.fileHandleForWriting.write(contentsOf: data)
+    }
+
+    private func launch(_ process: Process, wiresStandardInput: Bool = false) throws -> Process {
         try lock.withLock {
-            if process?.isRunning == true {
+            if self.process?.isRunning == true {
                 throw NativError.alreadyRunning
             }
 
-            let process = try Nativ.makeProcess(arguments: arguments, environment: environment)
+            let inputPipe = wiresStandardInput ? Pipe() : nil
             let outputPipe = Pipe()
             let errorPipe = Pipe()
+            if let inputPipe {
+                process.standardInput = inputPipe
+            }
             process.standardOutput = outputPipe
             process.standardError = errorPipe
 
+            self.inputPipe = inputPipe
             self.outputPipe = outputPipe
             self.errorPipe = errorPipe
             self.process = process
@@ -702,6 +736,7 @@ public final class NativProcessController {
                 try process.run()
             } catch {
                 self.process = nil
+                self.inputPipe = nil
                 self.outputPipe = nil
                 self.errorPipe = nil
                 throw error
@@ -751,6 +786,7 @@ public final class NativProcessController {
                 return
             }
             self.process = nil
+            self.inputPipe = nil
             self.outputPipe = nil
             self.errorPipe = nil
         }

--- a/Tests/NativTests/ChatMCPToolBridgeTests.swift
+++ b/Tests/NativTests/ChatMCPToolBridgeTests.swift
@@ -1,0 +1,60 @@
+import NativServerKit
+import XCTest
+
+@MainActor
+final class ChatMCPToolBridgeTests: XCTestCase {
+    private func makeBridge(exemptTool: String? = nil) -> ChatMCPToolBridge {
+        let manager = MCPServerManager()
+        manager.configure([
+            MCPServerConfiguration(
+                name: "filesystem",
+                command: "true",
+                arguments: [],
+                consentExemptTools: exemptTool.map { Set([$0]) } ?? []
+            )
+        ])
+        return ChatMCPToolBridge(manager: manager)
+    }
+
+    func testRequiresConsentFalseForNonMCPShapedName() {
+        let bridge = makeBridge()
+        XCTAssertFalse(bridge.requiresConsent(ChatSystemMonitorToolRegistry.toolName))
+        XCTAssertFalse(bridge.requiresConsent("not_a_qualified_name"))
+    }
+
+    func testRequiresConsentFailsClosedOnMalformedMCPShapedName() {
+        let bridge = makeBridge()
+        XCTAssertTrue(bridge.requiresConsent("mcp__onlyoneseg"))
+    }
+
+    func testRequiresConsentFailsClosedWhenServerNotFound() {
+        let bridge = makeBridge()
+        XCTAssertTrue(bridge.requiresConsent(MCPToolNameQualifier.qualify(server: "nonexistent", tool: "read_file")))
+    }
+
+    // The consent policy is exempt-by-allowlist, not gated-by-allowlist: a
+    // tool on a known server requires consent by default unless explicitly
+    // marked exempt. This is the fail-open gap fable-reviewer flagged.
+    func testRequiresConsentTrueForToolNotInExemptListOnRealConnection() {
+        let bridge = makeBridge()
+        XCTAssertTrue(bridge.requiresConsent(MCPToolNameQualifier.qualify(server: "filesystem", tool: "write_file")))
+    }
+
+    func testRequiresConsentFalseForExemptToolOnRealConnection() {
+        let bridge = makeBridge(exemptTool: "read_file")
+        XCTAssertFalse(bridge.requiresConsent(MCPToolNameQualifier.qualify(server: "filesystem", tool: "read_file")))
+        XCTAssertTrue(bridge.requiresConsent(MCPToolNameQualifier.qualify(server: "filesystem", tool: "write_file")))
+    }
+
+    // Regression test for the real, reachable bug grind-reviewer found: with a
+    // non-nil but zero-config MCP bridge (the app's default state), a plain
+    // native tool call must never be routed into MCP consent gating.
+    func testDetectReturnsNilForNativeToolCallWithMCPBridgePresent() {
+        let bridge = ChatMCPToolBridge(manager: MCPServerManager())
+        let call = MLXChatToolCall(
+            id: "1",
+            function: MLXChatFunctionCall(name: ChatSystemMonitorToolRegistry.toolName, arguments: "{}")
+        )
+        XCTAssertNil(ChatConsentGatedAction.detect(call: call, mcpBridge: bridge))
+    }
+}

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -53,6 +53,7 @@ private func makeCall(name: String, arguments: String = "{}") -> MLXChatToolCall
     MLXChatToolCall(id: "1", function: MLXChatFunctionCall(name: name, arguments: arguments))
 }
 
+@MainActor
 final class ChatToolRegistryTests: XCTestCase {
     func testDefinitionsOmitImageToolsWithNoImageModelConfigured() {
         let names = ChatToolRegistry.definitions(context: makeContext(), canEditImage: false)

--- a/Tests/NativTests/Fixtures/fake_mcp_server.py
+++ b/Tests/NativTests/Fixtures/fake_mcp_server.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+import json
+import sys
+import time
+
+die_on_call = "--die-on-call" in sys.argv
+malformed_tools_list = "--malformed-tools-list" in sys.argv
+empty_tools = "--empty-tools" in sys.argv
+split_write_tools_call = "--split-write-tools-call" in sys.argv
+
+
+def write(message):
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+
+    if method == "initialize":
+        write({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "fake-mcp-server", "version": "1.0"}
+            }
+        })
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/list":
+        if malformed_tools_list:
+            write({"jsonrpc": "2.0", "id": request_id, "result": {"nope": True}})
+        elif empty_tools:
+            write({"jsonrpc": "2.0", "id": request_id, "result": {"tools": []}})
+        else:
+            write({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "tools": [{
+                        "name": "echo",
+                        "description": "Echoes back its input argument.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"text": {"type": "string"}}
+                        }
+                    }]
+                }
+            })
+    elif method == "tools/call":
+        if die_on_call:
+            sys.exit(0)
+        arguments = request.get("params", {}).get("arguments", {})
+        text = arguments.get("text", "")
+        payload = json.dumps({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "content": [{"type": "text", "text": f"echo:{text}"}],
+                "isError": False
+            }
+        })
+        if split_write_tools_call:
+            midpoint = len(payload) // 2
+            sys.stdout.write(payload[:midpoint])
+            sys.stdout.flush()
+            time.sleep(0.05)
+            sys.stdout.write(payload[midpoint:] + "\n")
+            sys.stdout.flush()
+        else:
+            sys.stdout.write(payload + "\n")
+            sys.stdout.flush()

--- a/Tests/NativTests/NativMCPClientTests.swift
+++ b/Tests/NativTests/NativMCPClientTests.swift
@@ -1,0 +1,325 @@
+import Foundation
+import NativServerKit
+import XCTest
+
+final class NativMCPClientTests: XCTestCase {
+    // MARK: - MCPLineFramer
+
+    func testLineFramerBuffersTruncatedChunkUntilNewlineArrives() {
+        var buffer = ""
+        let firstChunk = MCPLineFramer.extractLines(appending: #"{"jsonrpc":"2.0","#, to: &buffer)
+        XCTAssertEqual(firstChunk, [])
+        XCTAssertFalse(buffer.isEmpty)
+
+        let secondChunk = MCPLineFramer.extractLines(appending: "\"id\":1,\"result\":{}}\n", to: &buffer)
+        XCTAssertEqual(secondChunk, [#"{"jsonrpc":"2.0","id":1,"result":{}}"#])
+        XCTAssertEqual(buffer, "")
+    }
+
+    func testLineFramerHandlesMultipleLinesInOneChunk() {
+        var buffer = ""
+        let lines = MCPLineFramer.extractLines(appending: "one\ntwo\nthree", to: &buffer)
+        XCTAssertEqual(lines, ["one", "two"])
+        XCTAssertEqual(buffer, "three")
+    }
+
+    func testLineFramerSkipsBlankLines() {
+        var buffer = ""
+        let lines = MCPLineFramer.extractLines(appending: "\n\nreal\n\n", to: &buffer)
+        XCTAssertEqual(lines, ["real"])
+    }
+
+    // MARK: - MCPJSONRPCCodec.decodeResponse
+
+    func testDecodeResponseParsesWellFormedResult() {
+        let decoded = MCPJSONRPCCodec.decodeResponse(#"{"jsonrpc":"2.0","id":3,"result":{"ok":true}}"#)
+        guard case .result(let id, let value) = decoded else {
+            return XCTFail("expected .result, got \(decoded)")
+        }
+        XCTAssertEqual(id, 3)
+        XCTAssertEqual(value, .object(["ok": .bool(true)]))
+    }
+
+    func testDecodeResponseParsesWellFormedError() {
+        let decoded = MCPJSONRPCCodec.decodeResponse(
+            #"{"jsonrpc":"2.0","id":4,"error":{"code":-32601,"message":"Method not found"}}"#
+        )
+        XCTAssertEqual(decoded, .error(id: 4, code: -32601, message: "Method not found"))
+    }
+
+    func testDecodeResponseTreatsInvalidJSONAsUnrecognizedNotCrash() {
+        XCTAssertEqual(MCPJSONRPCCodec.decodeResponse("not json at all {{{"), .unrecognized)
+        XCTAssertEqual(MCPJSONRPCCodec.decodeResponse(""), .unrecognized)
+        XCTAssertEqual(MCPJSONRPCCodec.decodeResponse("null"), .unrecognized)
+    }
+
+    func testDecodeResponseTreatsMissingIDAsUnrecognized() {
+        let decoded = MCPJSONRPCCodec.decodeResponse(#"{"jsonrpc":"2.0","method":"notifications/progress"}"#)
+        XCTAssertEqual(decoded, .unrecognized)
+    }
+
+    func testDecodeResponseTreatsIDWithNoResultOrErrorAsMalformedEnvelope() {
+        let decoded = MCPJSONRPCCodec.decodeResponse(#"{"jsonrpc":"2.0","id":7}"#)
+        XCTAssertEqual(decoded, .malformedEnvelope(id: 7))
+    }
+
+    // MARK: - MCPJSONRPCCodec.toolDescriptors
+
+    func testToolDescriptorsParsesWellFormedList() throws {
+        let result: MLXJSONValue = .object([
+            "tools": .array([
+                .object([
+                    "name": .string("read_file"),
+                    "description": .string("Reads a file."),
+                    "inputSchema": .object(["type": .string("object")])
+                ])
+            ])
+        ])
+        let descriptors = try MCPJSONRPCCodec.toolDescriptors(fromToolsListResult: result)
+        XCTAssertEqual(descriptors, [
+            MCPToolDescriptor(
+                name: "read_file",
+                description: "Reads a file.",
+                inputSchema: .object(["type": .string("object")])
+            )
+        ])
+    }
+
+    func testToolDescriptorsThrowsWhenToolsKeyMissing() {
+        XCTAssertThrowsError(try MCPJSONRPCCodec.toolDescriptors(fromToolsListResult: .object(["nope": .bool(true)])))
+    }
+
+    func testToolDescriptorsThrowsWhenToolMissingName() {
+        let result: MLXJSONValue = .object(["tools": .array([.object(["description": .string("x")])])])
+        XCTAssertThrowsError(try MCPJSONRPCCodec.toolDescriptors(fromToolsListResult: result))
+    }
+
+    func testToolDescriptorsDefaultsMissingDescriptionAndSchema() throws {
+        let result: MLXJSONValue = .object(["tools": .array([.object(["name": .string("noop")])])])
+        let descriptors = try MCPJSONRPCCodec.toolDescriptors(fromToolsListResult: result)
+        XCTAssertEqual(descriptors.first?.description, "")
+        XCTAssertEqual(descriptors.first?.inputSchema, .object([
+            "type": .string("object"),
+            "properties": .object([:])
+        ]))
+    }
+
+    // MARK: - MCPJSONRPCCodec.extractText / parseArguments
+
+    func testExtractTextJoinsTextContentParts() throws {
+        let result: MLXJSONValue = .object([
+            "content": .array([
+                .object(["type": .string("text"), "text": .string("first")]),
+                .object(["type": .string("text"), "text": .string("second")])
+            ])
+        ])
+        XCTAssertEqual(try MCPJSONRPCCodec.extractText(fromToolCallResult: result), "first\nsecond")
+    }
+
+    func testExtractTextThrowsOnIsErrorTrue() {
+        let result: MLXJSONValue = .object([
+            "content": .array([.object(["type": .string("text"), "text": .string("boom")])]),
+            "isError": .bool(true)
+        ])
+        XCTAssertThrowsError(try MCPJSONRPCCodec.extractText(fromToolCallResult: result))
+    }
+
+    func testExtractTextThrowsWhenNoTextContent() {
+        XCTAssertThrowsError(try MCPJSONRPCCodec.extractText(fromToolCallResult: .object(["content": .array([])])))
+    }
+
+    func testParseArgumentsDefaultsToEmptyObjectForNilOrEmpty() throws {
+        XCTAssertEqual(try MCPJSONRPCCodec.parseArguments(nil), .object([:]))
+        XCTAssertEqual(try MCPJSONRPCCodec.parseArguments(""), .object([:]))
+    }
+
+    func testParseArgumentsDecodesValidJSON() throws {
+        XCTAssertEqual(
+            try MCPJSONRPCCodec.parseArguments(#"{"path":"notes.md"}"#),
+            .object(["path": .string("notes.md")])
+        )
+    }
+
+    // MARK: - MCPToolNameQualifier
+
+    func testQualifyUnqualifyRoundTrip() {
+        let qualified = MCPToolNameQualifier.qualify(server: "filesystem", tool: "read_file")
+        XCTAssertEqual(qualified, "mcp__filesystem__read_file")
+        let parsed = MCPToolNameQualifier.unqualify(qualified)
+        XCTAssertEqual(parsed?.server, "filesystem")
+        XCTAssertEqual(parsed?.tool, "read_file")
+    }
+
+    func testTwoServersWithSameLocalToolNameDoNotCollide() {
+        let first = MCPToolNameQualifier.qualify(server: "filesystem", tool: "search")
+        let second = MCPToolNameQualifier.qualify(server: "github", tool: "search")
+        XCTAssertNotEqual(first, second)
+        XCTAssertEqual(MCPToolNameQualifier.unqualify(first)?.server, "filesystem")
+        XCTAssertEqual(MCPToolNameQualifier.unqualify(second)?.server, "github")
+    }
+
+    func testUnqualifyRejectsMalformedNames() {
+        XCTAssertNil(MCPToolNameQualifier.unqualify("read_file"))
+        XCTAssertNil(MCPToolNameQualifier.unqualify("mcp__nosep"))
+        XCTAssertNil(MCPToolNameQualifier.unqualify("mcp____"))
+        XCTAssertNil(MCPToolNameQualifier.unqualify("mcp__server__"))
+    }
+
+    func testIsValidServerNameRejectsNamesContainingTheSeparator() {
+        XCTAssertTrue(MCPToolNameQualifier.isValidServerName("filesystem"))
+        XCTAssertFalse(MCPToolNameQualifier.isValidServerName(""))
+        XCTAssertFalse(MCPToolNameQualifier.isValidServerName("my__server"))
+    }
+
+    // unqualify splits forward, on the first "__" after the prefix. A server
+    // name is validated (isValidServerName) to never contain "__", so this
+    // is unambiguous for any server actually accepted by configuration --
+    // a tool name containing "__" still splits correctly, taking everything
+    // after the first "__" as the tool name.
+    func testUnqualifySplitsForwardSoToolNamesMayContainTheSeparator() {
+        let parsed = MCPToolNameQualifier.unqualify("mcp__filesystem__weird__tool__name")
+        XCTAssertEqual(parsed?.server, "filesystem")
+        XCTAssertEqual(parsed?.tool, "weird__tool__name")
+    }
+
+    // MARK: - Process lifecycle (real subprocesses, no network)
+
+    private var fixturePath: String {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/fake_mcp_server.py")
+            .path
+    }
+
+    private func fakeServerConfiguration(extraArguments: [String] = []) -> MCPServerConfiguration {
+        MCPServerConfiguration(name: "fake", command: "python3", arguments: [fixturePath] + extraArguments)
+    }
+
+    @MainActor
+    func testConnectionStartsHandshakesAndListsTools() async throws {
+        let connection = MCPServerConnection(configuration: fakeServerConfiguration())
+        await connection.start()
+        XCTAssertEqual(connection.state, .running(toolCount: 1))
+        XCTAssertEqual(connection.tools.first?.name, "echo")
+
+        let result = try await connection.callTool(name: "echo", argumentsJSON: #"{"text":"hi"}"#)
+        XCTAssertEqual(result, "echo:hi")
+
+        await connection.stop()
+    }
+
+    // Regression test for the chunk-ordering race: the fixture deliberately
+    // writes one response in two separate stdout writes with a delay between
+    // them, forcing two distinct pipe reads. Line reassembly must still
+    // produce the exact original response.
+    @MainActor
+    func testConnectionReassemblesAResponseSplitAcrossTwoStdoutWrites() async throws {
+        let connection = MCPServerConnection(
+            configuration: fakeServerConfiguration(extraArguments: ["--split-write-tools-call"])
+        )
+        await connection.start()
+        XCTAssertEqual(connection.state, .running(toolCount: 1))
+
+        let result = try await connection.callTool(name: "echo", argumentsJSON: #"{"text":"split-write"}"#)
+        XCTAssertEqual(result, "echo:split-write")
+
+        await connection.stop()
+    }
+
+    @MainActor
+    func testConnectionCrashesQuicklyWhenProcessExitsImmediately() async throws {
+        let configuration = MCPServerConfiguration(name: "dead-on-arrival", command: "/bin/sh", arguments: ["-c", "exit 1"])
+        let connection = MCPServerConnection(configuration: configuration, requestTimeoutSeconds: 5)
+        let start = Date()
+        await connection.start()
+        XCTAssertLessThan(Date().timeIntervalSince(start), 2, "should fail via the termination path, not the 5s request timeout")
+        guard case .crashed = connection.state else {
+            return XCTFail("expected .crashed, got \(connection.state)")
+        }
+        XCTAssertTrue(connection.tools.isEmpty)
+    }
+
+    @MainActor
+    func testConnectionCrashesWithinBoundedTimeWhenProcessNeverResponds() async throws {
+        let configuration = MCPServerConfiguration(name: "silent", command: "/bin/sh", arguments: ["-c", "sleep 30"])
+        let connection = MCPServerConnection(configuration: configuration, requestTimeoutSeconds: 0.3)
+        let start = Date()
+        await connection.start()
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+        guard case .crashed = connection.state else {
+            return XCTFail("expected .crashed, got \(connection.state)")
+        }
+        await connection.stop()
+    }
+
+    @MainActor
+    func testConnectionReportsEmptyToolListAsRunningNotCrashed() async throws {
+        let connection = MCPServerConnection(configuration: fakeServerConfiguration(extraArguments: ["--empty-tools"]))
+        await connection.start()
+        XCTAssertEqual(connection.state, .running(toolCount: 0))
+        XCTAssertTrue(connection.tools.isEmpty)
+        await connection.stop()
+        XCTAssertEqual(connection.state, .stopped)
+    }
+
+    @MainActor
+    func testConnectionCrashesOnMalformedToolsListInsteadOfHanging() async throws {
+        let connection = MCPServerConnection(
+            configuration: fakeServerConfiguration(extraArguments: ["--malformed-tools-list"]),
+            requestTimeoutSeconds: 5
+        )
+        let start = Date()
+        await connection.start()
+        XCTAssertLessThan(Date().timeIntervalSince(start), 2)
+        guard case .crashed = connection.state else {
+            return XCTFail("expected .crashed, got \(connection.state)")
+        }
+        await connection.stop()
+    }
+
+    // Regression test: a pending tool call used to hang until the full
+    // request timeout elapsed when the server process died mid-call.
+    @MainActor
+    func testCallFailsQuicklyWhenServerDiesMidCall() async throws {
+        let connection = MCPServerConnection(
+            configuration: fakeServerConfiguration(extraArguments: ["--die-on-call"]),
+            requestTimeoutSeconds: 10
+        )
+        await connection.start()
+        XCTAssertEqual(connection.state, .running(toolCount: 1))
+
+        let start = Date()
+        do {
+            _ = try await connection.callTool(name: "echo", argumentsJSON: #"{"text":"hi"}"#)
+            XCTFail("expected the call to fail")
+        } catch let error as MCPClientError {
+            guard case .processUnavailable = error else {
+                return XCTFail("expected .processUnavailable, got \(error)")
+            }
+        }
+        XCTAssertLessThan(
+            Date().timeIntervalSince(start),
+            3,
+            "a dead server should fail the pending call promptly, not after the full 10s request timeout"
+        )
+        guard case .crashed = connection.state else {
+            return XCTFail("expected .crashed after the process died, got \(connection.state)")
+        }
+    }
+
+    @MainActor
+    func testCallAgainstAlreadyStoppedServerFailsCleanly() async throws {
+        let connection = MCPServerConnection(configuration: fakeServerConfiguration())
+        await connection.start()
+        await connection.stop()
+
+        do {
+            _ = try await connection.callTool(name: "echo", argumentsJSON: nil)
+            XCTFail("expected the call to fail")
+        } catch let error as MCPClientError {
+            guard case .processUnavailable = error else {
+                return XCTFail("expected .processUnavailable, got \(error)")
+            }
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -162,6 +162,7 @@ targets:
       - path: Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+      - path: Sources/Nativ/Features/Chat/ChatMCPToolBridge.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatSystemStatsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift


### PR DESCRIPTION
This adds MCP client support to Nativ's chat — any MCP server can plug into the same tool registry PR #141 introduced, alongside the native tools.

**What changed**
- A stdio JSON-RPC MCP client (`NativMCPClient.swift`), with `NativProcessController` extended to wire a child process's stdin (it previously only ever wired stdout/stderr for the app's own bundled server).
- Tool names are namespaced `mcp__<server>__<tool>` so servers can't collide with each other or with native tools.
- Servers are configured through a new **MCP Servers** settings panel — add/start/stop/remove, per-server tool-exemption list. **Nothing is bundled or hardcoded** — no server auto-starts or ships pre-configured; every server is explicitly added and explicitly started.
- Consent gating is fail-closed: any MCP tool call needs an explicit in-chat approve/deny, same pattern as `switch_model` from #141 — extended so a tool whose server can't be identified still requires approval rather than running quietly.
- 252/252 tests, zero regressions to existing native tools. Covered against a real fixture server, not a mock transport.

**On #154** — two layers of the same stack, not competing. This answers "can Nativ talk to MCP servers at all, safely." #154's catalog/CI-verification idea answers "how do we vet many community servers at scale" — additive, not conflicting.

**Demo**

`filesystem`
![filesystem demo](https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/mcp-filesystem.gif?raw=true)
Full quality: https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/mcp-filesystem.mp4

`fetch`
![fetch demo](https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/mcp-fetch.gif?raw=true)
Full quality: https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/mcp-fetch.mp4

`memory`
![memory demo](https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/mcp-memory.gif?raw=true)
Full quality: https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/mcp-memory.mp4

Multiple servers together in one conversation:
![mcp ecosystem demo](https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/mcp-ecosystem.gif?raw=true)
Full quality: https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/mcp-ecosystem.mp4

*(Browser/Playwright demo to follow shortly — server works, clip's still in review.)*
