### PR TITLE
Make user prompts editable and copyable

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		8B4DF732A8A6AA5FFBE11982 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BBF79010B8120057237B52 /* StatsView.swift */; };
 		8B86659B490F58DEC1363135 /* NativServerKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; };
 		8E16504AFD5457AC965426F2 /* FnControlShortcutMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D63523BA62CC95FDD8D51E /* FnControlShortcutMonitor.swift */; };
+		902CD676AA3002459DF7ACAE /* ChatPromptRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */; };
 		90EE7AA87400E84D947CBBF3 /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
 		96AE764D2F938395E9B76C9E /* ChatServerStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */; };
 		97EEA29CCD874048A8CE9D54 /* VoiceShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */; };
@@ -337,6 +338,7 @@
 		EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscovery.swift; sourceTree = "<group>"; };
 		EF7AE3F3DB48E640950CCDB4 /* SystemAudioMeetingRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioMeetingRecorder.swift; sourceTree = "<group>"; };
 		F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProvider.swift; sourceTree = "<group>"; };
+		F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPromptRevision.swift; sourceTree = "<group>"; };
 		F553434CA19B929108FF740F /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -686,6 +688,7 @@
 				D97F637262DB138A253DEA6F /* ChatComposer.swift */,
 				2CF9F903E2609C4A522C19CF /* ChatConfigurationView.swift */,
 				7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */,
+				F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */,
 				8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */,
 				530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */,
 				31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */,
@@ -863,11 +866,11 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				ED4CB78AB93E015D0BE21F7B /* NativExtensionSDK */,
 				1622B274F4DF5A85C2FDB081 /* NativServerKit */,
-				51AD42FA29E71F2450386688 /* NativTests */,
+				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				7082E254E8272A5E8D13E6F0 /* VoiceDictationExtensionRuntime */,
+				51AD42FA29E71F2450386688 /* NativTests */,
 			);
 		};
 /* End PBXProject section */
@@ -951,6 +954,7 @@
 				E1A4AA0C4AA32599FF2D54E7 /* ChatFontScale.swift in Sources */,
 				B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */,
 				04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */,
+				902CD676AA3002459DF7ACAE /* ChatPromptRevision.swift in Sources */,
 				C904E51D66BFED1808E18FE5 /* ChatScreenCapture.swift in Sources */,
 				96AE764D2F938395E9B76C9E /* ChatServerStatsTool.swift in Sources */,
 				D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -96,6 +96,14 @@ struct ChatComposer: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
+            if let promptEditContext = viewModel.promptEditContext {
+                ChatPromptEditBanner(
+                    discardedMessageCount: promptEditContext.discardedMessageCount,
+                    onCancel: viewModel.cancelPromptEditing
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
             if viewModel.isCurrentSessionSending, let sendingStartedAt = viewModel.sendingStartedAt {
                 TimelineView(.periodic(from: .now, by: 1)) { context in
                     let elapsed = context.date.timeIntervalSince(sendingStartedAt)
@@ -127,15 +135,17 @@ struct ChatComposer: View {
                         text: $viewModel.draft,
                         isEnabled: canCompose,
                         onSubmit: send,
+                        onCancel: cancelPromptEditingAction,
                         onPasteImage: { viewModel.attachImages(from: $0) },
                         onContentHeightChange: { height in
                             editorContentHeight = height
                         },
-                        fontScale: model.settings.chatFontScale
+                        fontScale: model.settings.chatFontScale,
+                        focusToken: viewModel.composerFocusToken
                     )
 
                     if viewModel.draft.isEmpty {
-                        Text("Message")
+                        Text(viewModel.promptEditContext == nil ? "Message" : "Edit message")
                             .font(ChatFontMetrics.bodyFont(scale: model.settings.chatFontScale))
                             .foregroundStyle(.tertiary)
                             .padding(textInset)
@@ -205,7 +215,7 @@ struct ChatComposer: View {
                     }
                     .buttonStyle(.plain)
                     .disabled(!showsStopButton && !canSend)
-                    .help(showsStopButton ? "Stop response" : "Send (Return)")
+                    .help(actionButtonHelp)
                 }
                 .padding(.leading, 10)
                 .padding(.trailing, 12)
@@ -502,6 +512,23 @@ struct ChatComposer: View {
         return Color(nsColor: .tertiaryLabelColor)
     }
 
+    private var cancelPromptEditingAction: (() -> Void)? {
+        guard viewModel.promptEditContext != nil else {
+            return nil
+        }
+        return viewModel.cancelPromptEditing
+    }
+
+    private var actionButtonHelp: String {
+        if showsStopButton {
+            return "Stop response"
+        }
+        if viewModel.promptEditContext != nil {
+            return "Save prompt and regenerate (Return)"
+        }
+        return "Send (Return)"
+    }
+
     private var showsStopButton: Bool {
         viewModel.isCurrentSessionSending && !canSend
     }
@@ -516,6 +543,65 @@ struct ChatComposer: View {
 
     private var editorHeight: CGFloat {
         min(max(editorContentHeight, editorMinimumHeight), editorMaximumHeight)
+    }
+}
+
+private struct ChatPromptEditBanner: View {
+    let discardedMessageCount: Int
+    let onCancel: () -> Void
+    @State private var isCancelHovered = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: "pencil")
+                .foregroundStyle(Color.accentColor)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Editing prompt")
+                    .fontWeight(.medium)
+                Text(replacementDescription)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 12)
+
+            Button(action: onCancel) {
+                Text("Cancel")
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(
+                        isCancelHovered ? Color.accentColor.opacity(0.12) : .clear,
+                        in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    )
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.accentColor)
+            .keyboardShortcut(.cancelAction)
+            .onHover { isCancelHovered = $0 }
+            .animation(.easeOut(duration: 0.12), value: isCancelHovered)
+            .help("Cancel editing")
+        }
+        .font(.caption)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.accentColor.opacity(0.22), lineWidth: 0.5)
+        }
+    }
+
+    private var replacementDescription: String {
+        switch discardedMessageCount {
+        case 0:
+            "Sending will generate a new response."
+        case 1:
+            "Sending will replace the following response."
+        default:
+            "Sending will replace \(discardedMessageCount) later conversation items."
+        }
     }
 }
 
@@ -1294,16 +1380,20 @@ struct ChatComposerTextEditor: NSViewRepresentable {
     @Binding var text: String
     let isEnabled: Bool
     let onSubmit: () -> Void
+    var onCancel: (() -> Void)?
     let onPasteImage: (NSPasteboard) -> Bool
     let onContentHeightChange: (CGFloat) -> Void
     var fontScale: Double = 1.0
+    var focusToken: Int = 0
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
             text: $text,
             onSubmit: onSubmit,
+            onCancel: onCancel,
             onPasteImage: onPasteImage,
-            onContentHeightChange: onContentHeightChange
+            onContentHeightChange: onContentHeightChange,
+            focusToken: focusToken
         )
     }
 
@@ -1311,6 +1401,7 @@ struct ChatComposerTextEditor: NSViewRepresentable {
         let textView = ChatComposerNSTextView()
         textView.delegate = context.coordinator
         textView.onSubmit = context.coordinator.handleSubmit
+        textView.onCancel = context.coordinator.handleCancel
         textView.onPasteImage = context.coordinator.handlePasteImage
         textView.isEditable = isEnabled
         textView.isSelectable = isEnabled
@@ -1344,6 +1435,7 @@ struct ChatComposerTextEditor: NSViewRepresentable {
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         context.coordinator.onSubmit = onSubmit
+        context.coordinator.onCancel = onCancel
         context.coordinator.onPasteImage = onPasteImage
         context.coordinator.onContentHeightChange = onContentHeightChange
 
@@ -1355,33 +1447,37 @@ struct ChatComposerTextEditor: NSViewRepresentable {
         textView.isSelectable = isEnabled
         textView.font = ChatFontMetrics.bodyNSFont(scale: fontScale)
 
-        guard textView.string != text else {
-            context.coordinator.reportContentHeight()
-            return
+        if textView.string != text {
+            textView.string = text
         }
-
-        textView.string = text
         context.coordinator.reportContentHeight()
+        context.coordinator.requestFocus(ifNeeded: focusToken)
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         @Binding private var text: String
         var onSubmit: () -> Void
+        var onCancel: (() -> Void)?
         var onPasteImage: (NSPasteboard) -> Bool
         var onContentHeightChange: (CGFloat) -> Void
         weak var textView: NSTextView?
         private var lastReportedHeight: CGFloat?
+        private var lastFocusToken: Int
 
         init(
             text: Binding<String>,
             onSubmit: @escaping () -> Void,
+            onCancel: (() -> Void)?,
             onPasteImage: @escaping (NSPasteboard) -> Bool,
-            onContentHeightChange: @escaping (CGFloat) -> Void
+            onContentHeightChange: @escaping (CGFloat) -> Void,
+            focusToken: Int
         ) {
             _text = text
             self.onSubmit = onSubmit
+            self.onCancel = onCancel
             self.onPasteImage = onPasteImage
             self.onContentHeightChange = onContentHeightChange
+            lastFocusToken = focusToken
         }
 
         func handlePasteImage(_ pasteboard: NSPasteboard) -> Bool {
@@ -1399,6 +1495,24 @@ struct ChatComposerTextEditor: NSViewRepresentable {
 
         func handleSubmit() {
             onSubmit()
+        }
+
+        func handleCancel() {
+            onCancel?()
+        }
+
+        func requestFocus(ifNeeded focusToken: Int) {
+            guard focusToken != lastFocusToken, let textView else {
+                return
+            }
+            lastFocusToken = focusToken
+            DispatchQueue.main.async { [weak textView] in
+                guard let textView else { return }
+                textView.window?.makeFirstResponder(textView)
+                let end = (textView.string as NSString).length
+                textView.setSelectedRange(NSRange(location: end, length: 0))
+                textView.scrollRangeToVisible(NSRange(location: end, length: 0))
+            }
         }
 
         func reportContentHeight() {
@@ -1440,6 +1554,7 @@ private final class ChatComposerNSScrollView: NSScrollView {
 
 private final class ChatComposerNSTextView: NSTextView {
     var onSubmit: (() -> Void)?
+    var onCancel: (() -> Void)?
     var onPasteImage: ((NSPasteboard) -> Bool)?
 
     override func keyDown(with event: NSEvent) {
@@ -1448,6 +1563,11 @@ private final class ChatComposerNSTextView: NSTextView {
         // before applying the composer send/newline behavior.
         if hasMarkedText() {
             super.keyDown(with: event)
+            return
+        }
+
+        if event.keyCode == 53, onCancel != nil {
+            onCancel?()
             return
         }
 

--- a/Sources/Nativ/Features/Chat/ChatPromptRevision.swift
+++ b/Sources/Nativ/Features/Chat/ChatPromptRevision.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+struct ChatPromptRevision: Equatable {
+    let messages: [ChatTranscriptMessage]
+    let discardedMessageCount: Int
+
+    static func make(
+        messageID: UUID,
+        content: String,
+        attachments: [ChatImageAttachment],
+        modelID: String,
+        createdAt: Date = Date(),
+        in messages: [ChatTranscriptMessage]
+    ) -> ChatPromptRevision? {
+        guard let messageIndex = messages.firstIndex(where: { $0.id == messageID }),
+              messages[messageIndex].role == .user
+        else {
+            return nil
+        }
+
+        let content = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !content.isEmpty || !attachments.isEmpty else {
+            return nil
+        }
+
+        var revisedMessage = messages[messageIndex]
+        revisedMessage.content = content
+        revisedMessage.modelID = modelID
+        revisedMessage.createdAt = createdAt
+        revisedMessage.imageAttachments = attachments
+
+        var revisedMessages = Array(messages[..<messageIndex])
+        revisedMessages.append(revisedMessage)
+
+        return ChatPromptRevision(
+            messages: revisedMessages,
+            discardedMessageCount: messages.count - messageIndex - 1
+        )
+    }
+
+    static func discardedMessageCount(
+        after messageID: UUID,
+        in messages: [ChatTranscriptMessage]
+    ) -> Int? {
+        guard let messageIndex = messages.firstIndex(where: { $0.id == messageID }),
+              messages[messageIndex].role == .user
+        else {
+            return nil
+        }
+        return messages.count - messageIndex - 1
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -12,6 +12,11 @@ struct ChatQueuedPrompt: Identifiable, Equatable {
     let position: Int
 }
 
+struct ChatPromptEditContext: Equatable {
+    let messageID: UUID
+    let discardedMessageCount: Int
+}
+
 private struct ChatSessionBootstrap {
     let sessions: [ChatSession]
 }
@@ -106,8 +111,13 @@ private struct ChatTranscriptView: View {
                     }
                 } else {
                     ForEach(chat.visibleMessages) { message in
+                        let editUnavailableReason = userPromptEditingUnavailableReason(for: message)
                         ChatMessageRow(
                             message: message,
+                            canEditUserMessage: editUnavailableReason == nil,
+                            editUserMessageUnavailableReason: editUnavailableReason,
+                            isEditingUserMessage: chat.promptEditContext?.messageID == message.id,
+                            onEditUserMessage: chat.beginEditingUserMessage,
                             onConfirmToolConsent: chat.confirmToolConsent,
                             onDenyToolConsent: chat.denyToolConsent
                         )
@@ -183,6 +193,30 @@ private struct ChatTranscriptView: View {
     private func isAtTranscriptBottom(_ geometry: ScrollGeometry) -> Bool {
         geometry.visibleRect.maxY >= geometry.contentSize.height - 8
     }
+
+    private func userPromptEditingUnavailableReason(
+        for message: ChatTranscriptMessage
+    ) -> String? {
+        guard message.role == .user else {
+            return "Only user prompts can be edited"
+        }
+        guard chat.canEditUserMessage(message.id) else {
+            return "Stop the response and remove queued prompts before editing"
+        }
+        guard model.isRunning else {
+            return "Start the server before editing a prompt"
+        }
+        guard !model.isModelLoading else {
+            return "Wait for the model to finish loading"
+        }
+        guard selectedModelID?.isEmpty == false else {
+            return "Select a language model before editing a prompt"
+        }
+        if let validationError = model.settings.structuredOutputValidationError {
+            return validationError
+        }
+        return nil
+    }
 }
 
 private struct ChatComposerContainer: View {
@@ -241,12 +275,19 @@ final class ChatViewModel: ObservableObject {
         let languageModelSupportsTools: Bool
     }
 
+    private struct ComposerSnapshot {
+        let draft: String
+        let attachments: [ChatImageAttachment]
+    }
+
     @Published private(set) var sessions: [ChatSessionSummary] = []
     @Published private(set) var folders: [ChatFolder] = []
     @Published private(set) var currentSessionID: UUID?
     @Published private(set) var messages: [ChatTranscriptMessage] = []
     @Published private(set) var pendingImageAttachments: [ChatImageAttachment] = []
     @Published var draft = ""
+    @Published private(set) var promptEditContext: ChatPromptEditContext?
+    @Published private(set) var composerFocusToken = 0
     @Published private(set) var activeRequestSessionID: UUID?
     @Published private(set) var sendingStartedAt: Date?
     @Published private(set) var scrollToken = 0
@@ -269,6 +310,7 @@ final class ChatViewModel: ObservableObject {
     private var streamFlushTasks: [UUID: Task<Void, Never>] = [:]
     private weak var appModel: NativModel?
     private let toolConsentGate = ChatToolConsentGate()
+    private var composerSnapshot: ComposerSnapshot?
 
     init() {
         folders = sessionStore.loadFolders()
@@ -352,6 +394,58 @@ final class ChatViewModel: ObservableObject {
                 || !pendingImageAttachments.isEmpty)
     }
 
+    func canEditUserMessage(_ messageID: UUID) -> Bool {
+        guard let currentSessionID,
+              !isSessionBusy(currentSessionID),
+              let message = messages.first(where: { $0.id == messageID })
+        else {
+            return false
+        }
+        return message.role == .user
+    }
+
+    func beginEditingUserMessage(_ messageID: UUID) {
+        guard canEditUserMessage(messageID),
+              let message = messages.first(where: { $0.id == messageID }),
+              let discardedMessageCount = ChatPromptRevision.discardedMessageCount(
+                after: messageID,
+                in: messages
+              )
+        else {
+            return
+        }
+
+        if promptEditContext?.messageID == messageID {
+            composerFocusToken += 1
+            return
+        }
+
+        cancelPromptEditing()
+        composerSnapshot = ComposerSnapshot(
+            draft: draft,
+            attachments: pendingImageAttachments
+        )
+        promptEditContext = ChatPromptEditContext(
+            messageID: messageID,
+            discardedMessageCount: discardedMessageCount
+        )
+        draft = message.content
+        pendingImageAttachments = message.imageAttachments
+        composerFocusToken += 1
+    }
+
+    func cancelPromptEditing() {
+        guard promptEditContext != nil else {
+            return
+        }
+        if let composerSnapshot {
+            draft = composerSnapshot.draft
+            pendingImageAttachments = composerSnapshot.attachments
+        }
+        promptEditContext = nil
+        composerSnapshot = nil
+    }
+
     func unavailableReason(isRunning: Bool, selectedModelID: String?) -> String? {
         if !isRunning {
             return "Server is stopped."
@@ -386,6 +480,7 @@ final class ChatViewModel: ObservableObject {
         storedSessions.append(session)
         pruneRedundantEmptySessions()
         sessionStore.saveSession(session)
+        discardPromptEditing()
         draft = ""
         pendingImageAttachments.removeAll()
         applyCurrentSession(session)
@@ -424,6 +519,7 @@ final class ChatViewModel: ObservableObject {
 
         if let session = storedSessions.first(where: { $0.id == sessionID }) {
             persistCurrentSession(updateTimestamp: false)
+            discardPromptEditing()
             draft = ""
             pendingImageAttachments.removeAll()
             applyCurrentSession(session)
@@ -433,6 +529,7 @@ final class ChatViewModel: ObservableObject {
         if let session = sessionStore.loadSession(id: sessionID) {
             persistCurrentSession(updateTimestamp: false)
             upsertStoredSession(session)
+            discardPromptEditing()
             draft = ""
             pendingImageAttachments.removeAll()
             applyCurrentSession(session)
@@ -605,6 +702,7 @@ final class ChatViewModel: ObservableObject {
             return
         }
 
+        discardPromptEditing()
         draft = ""
         pendingImageAttachments.removeAll()
 
@@ -671,10 +769,36 @@ final class ChatViewModel: ObservableObject {
         else {
             return
         }
-        appModel.clearModelLoadFailure(for: modelID)
 
         let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         let imageAttachments = pendingImageAttachments
+
+        if let promptEditContext {
+            guard canEditUserMessage(promptEditContext.messageID),
+                  let revision = ChatPromptRevision.make(
+                    messageID: promptEditContext.messageID,
+                    content: prompt,
+                    attachments: imageAttachments,
+                    modelID: modelID,
+                    in: messages
+                  )
+            else {
+                return
+            }
+
+            messages = revision.messages
+            restoreComposerAfterPromptEditing()
+            persistCurrentSession(updateTimestamp: true)
+            enqueueGeneration(
+                for: promptEditContext.messageID,
+                in: currentSession.id,
+                settings: settings,
+                languageModelSupportsTools: languageModelSupportsTools,
+                appModel: appModel
+            )
+            return
+        }
+
         draft = ""
         pendingImageAttachments.removeAll()
 
@@ -686,11 +810,30 @@ final class ChatViewModel: ObservableObject {
         )
         messages.append(userMessage)
         persistCurrentSession(updateTimestamp: true)
+        enqueueGeneration(
+            for: userMessage.id,
+            in: currentSession.id,
+            settings: settings,
+            languageModelSupportsTools: languageModelSupportsTools,
+            appModel: appModel
+        )
+    }
+
+    private func enqueueGeneration(
+        for userMessageID: UUID,
+        in sessionID: UUID,
+        settings: NativSettings,
+        languageModelSupportsTools: Bool,
+        appModel: NativModel
+    ) {
+        if let modelID = settings.languageModelID {
+            appModel.clearModelLoadFailure(for: modelID)
+        }
         self.appModel = appModel
         requestQueue.append(QueuedChatRequest(
             id: UUID(),
-            sessionID: currentSession.id,
-            userMessageID: userMessage.id,
+            sessionID: sessionID,
+            userMessageID: userMessageID,
             assistantMessageID: UUID(),
             settings: settings,
             languageModelSupportsTools: languageModelSupportsTools
@@ -818,11 +961,29 @@ final class ChatViewModel: ObservableObject {
         activeRequestSessionID = nil
         requestQueue.removeAll()
         sendingStartedAt = nil
+        discardPromptEditing()
         draft = ""
         pendingImageAttachments.removeAll()
         messages.removeAll()
         persistCurrentSession(updateTimestamp: true)
         bumpScroll()
+    }
+
+    private func restoreComposerAfterPromptEditing() {
+        if let composerSnapshot {
+            draft = composerSnapshot.draft
+            pendingImageAttachments = composerSnapshot.attachments
+        } else {
+            draft = ""
+            pendingImageAttachments.removeAll()
+        }
+        promptEditContext = nil
+        composerSnapshot = nil
+    }
+
+    private func discardPromptEditing() {
+        promptEditContext = nil
+        composerSnapshot = nil
     }
 
     private func startNextRequestIfNeeded() {
@@ -1708,13 +1869,20 @@ private struct ChatMessageRow: View, Equatable {
     private static let maximumUserBubbleWidth: CGFloat = 560
 
     let message: ChatTranscriptMessage
+    let canEditUserMessage: Bool
+    let editUserMessageUnavailableReason: String?
+    let isEditingUserMessage: Bool
+    let onEditUserMessage: (UUID) -> Void
     let onConfirmToolConsent: (UUID) -> Void
     let onDenyToolConsent: (UUID) -> Void
-    @State private var didCopyResponse = false
+    @State private var didCopyMessage = false
     @State private var isHoveringMessage = false
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.message == rhs.message
+            && lhs.canEditUserMessage == rhs.canEditUserMessage
+            && lhs.editUserMessageUnavailableReason == rhs.editUserMessageUnavailableReason
+            && lhs.isEditingUserMessage == rhs.isEditingUserMessage
     }
 
     var body: some View {
@@ -1762,20 +1930,36 @@ private struct ChatMessageRow: View, Equatable {
                 ChatResponseMetricsRow(metrics: responseMetrics)
             }
 
-            if showsCopyAction {
+            if showsMessageActions {
                 HStack(spacing: 8) {
-                    ChatCopyResponseButton(
-                        didCopy: didCopyResponse,
-                        onCopy: copyResponse
-                    )
+                    HStack(spacing: 0) {
+                        if canCopyMessage {
+                            ChatCopyMessageButton(
+                                didCopy: didCopyMessage,
+                                messageKind: message.role == .user ? "prompt" : "response",
+                                onCopy: copyMessage
+                            )
+                        }
+
+                        if message.role == .user {
+                            ChatMessageActionButton(
+                                systemImage: "square.and.pencil",
+                                title: editActionTitle,
+                                isActive: isEditingUserMessage,
+                                isEnabled: canEditUserMessage
+                            ) {
+                                onEditUserMessage(message.id)
+                            }
+                        }
+                    }
 
                     Text(message.createdAt, format: .dateTime.hour().minute())
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .monospacedDigit()
                 }
-                .opacity(isHoveringMessage || didCopyResponse ? 1 : 0)
-                .accessibilityHidden(!isHoveringMessage && !didCopyResponse)
+                .opacity(isHoveringMessage || didCopyMessage || isEditingUserMessage ? 1 : 0)
+                .accessibilityHidden(!isHoveringMessage && !didCopyMessage && !isEditingUserMessage)
             }
         }
         .frame(maxWidth: .infinity, alignment: rowAlignment)
@@ -1791,7 +1975,8 @@ private struct ChatMessageRow: View, Equatable {
                 ChatMessageText(
                     content: displayContent,
                     rendersMarkdown: rendersMarkdown,
-                    isStreaming: message.isStreaming
+                    isStreaming: message.isStreaming,
+                    isUserPrompt: message.role == .user
                 )
                 .lineSpacing(2)
                 .fixedSize(horizontal: true, vertical: false)
@@ -1799,7 +1984,8 @@ private struct ChatMessageRow: View, Equatable {
                 ChatMessageText(
                     content: displayContent,
                     rendersMarkdown: rendersMarkdown,
-                    isStreaming: message.isStreaming
+                    isStreaming: message.isStreaming,
+                    isUserPrompt: message.role == .user
                 )
                 .lineSpacing(2)
                 .multilineTextAlignment(textAlignment)
@@ -1941,25 +2127,39 @@ private struct ChatMessageRow: View, Equatable {
         return responseMetrics
     }
 
-    private var showsCopyAction: Bool {
-        message.role == .assistant
+    private var canCopyMessage: Bool {
+        (message.role == .user || message.role == .assistant)
             && !message.isStreaming
             && !message.content.isEmpty
     }
 
-    private func copyResponse() {
+    private var showsMessageActions: Bool {
+        message.role == .user || canCopyMessage
+    }
+
+    private var editActionTitle: String {
+        if isEditingUserMessage {
+            return "Editing prompt"
+        }
+        if canEditUserMessage {
+            return "Edit prompt"
+        }
+        return editUserMessageUnavailableReason ?? "Prompt editing is temporarily unavailable"
+    }
+
+    private func copyMessage() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(message.content, forType: .string)
 
         withAnimation(.easeInOut(duration: 0.15)) {
-            didCopyResponse = true
+            didCopyMessage = true
         }
 
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(1.5))
             withAnimation(.easeInOut(duration: 0.15)) {
-                didCopyResponse = false
+                didCopyMessage = false
             }
         }
     }
@@ -2226,8 +2426,9 @@ private struct ChatLiveDecodeMetricsBadge: View, Equatable {
     }
 }
 
-private struct ChatCopyResponseButton: View {
+private struct ChatCopyMessageButton: View {
     let didCopy: Bool
+    let messageKind: String
     let onCopy: () -> Void
     @State private var isHovering = false
 
@@ -2244,11 +2445,37 @@ private struct ChatCopyResponseButton: View {
                 .contentShape(.rect)
         }
         .buttonStyle(.plain)
-        .help(didCopy ? "Copied" : "Copy response")
-        .accessibilityLabel(didCopy ? "Response copied" : "Copy response")
+        .help(didCopy ? "Copied" : "Copy \(messageKind)")
+        .accessibilityLabel(didCopy ? "\(messageKind.capitalized) copied" : "Copy \(messageKind)")
         .onHover { isHovering = $0 }
         .animation(.easeInOut(duration: 0.12), value: isHovering)
         .animation(.easeInOut(duration: 0.15), value: didCopy)
+    }
+}
+
+private struct ChatMessageActionButton: View {
+    let systemImage: String
+    let title: String
+    let isActive: Bool
+    let isEnabled: Bool
+    let action: () -> Void
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(isActive ? Color.accentColor : (isHovering ? Color.primary : Color.secondary))
+                .frame(width: 30, height: 28)
+                .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .help(title)
+        .accessibilityLabel(title)
+        .onHover { isHovering = $0 }
+        .animation(.easeInOut(duration: 0.12), value: isHovering)
+        .animation(.easeInOut(duration: 0.15), value: isActive)
     }
 }
 
@@ -2610,11 +2837,17 @@ private struct ChatMessageText: View {
     let content: String
     let rendersMarkdown: Bool
     let isStreaming: Bool
+    var isUserPrompt = false
     @Environment(\.chatFontScale) private var chatFontScale
 
     @ViewBuilder
     var body: some View {
-        if rendersMarkdown && !isStreaming {
+        if isUserPrompt {
+            ChatSelectablePromptText(
+                content: content,
+                fontScale: chatFontScale
+            )
+        } else if rendersMarkdown && !isStreaming {
             StructuredText(
                 markdown: NativMarkdownFormatting.normalizedMathDelimiters(in: content),
                 syntaxExtensions: [.math]
@@ -2640,6 +2873,71 @@ private struct ChatMessageText: View {
         }
 
         return Text(attributed)
+    }
+}
+
+private struct ChatSelectablePromptText: NSViewRepresentable {
+    let content: String
+    let fontScale: Double
+
+    func makeNSView(context: Context) -> NSTextField {
+        let textField = NSTextField(wrappingLabelWithString: content)
+        textField.isSelectable = true
+        textField.isEditable = false
+        textField.isBezeled = false
+        textField.drawsBackground = false
+        textField.focusRingType = .none
+        textField.maximumNumberOfLines = 0
+        textField.lineBreakMode = .byWordWrapping
+        textField.cell?.wraps = true
+        textField.cell?.isScrollable = false
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textField.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        update(textField)
+        return textField
+    }
+
+    func updateNSView(_ textField: NSTextField, context: Context) {
+        update(textField)
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        nsView textField: NSTextField,
+        context: Context
+    ) -> CGSize? {
+        let font = ChatFontMetrics.bodyNSFont(scale: fontScale)
+        let availableWidth = proposal.width ?? .greatestFiniteMagnitude
+        let bounds = (content as NSString).boundingRect(
+            with: CGSize(width: availableWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: textAttributes(font: font)
+        )
+        let measuredWidth = max(1, ceil(bounds.width))
+        let width = proposal.width.map { min($0, measuredWidth) } ?? measuredWidth
+        return CGSize(width: width, height: max(1, ceil(bounds.height)))
+    }
+
+    private func update(_ textField: NSTextField) {
+        let font = ChatFontMetrics.bodyNSFont(scale: fontScale)
+        if textField.stringValue != content || textField.font != font {
+            textField.attributedStringValue = NSAttributedString(
+                string: content,
+                attributes: textAttributes(font: font)
+            )
+        }
+        textField.setAccessibilityLabel(content)
+    }
+
+    private func textAttributes(font: NSFont) -> [NSAttributedString.Key: Any] {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.lineSpacing = 2
+        return [
+            .font: font,
+            .foregroundColor: NSColor.white,
+            .paragraphStyle: paragraphStyle
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary

- make user prompts reliably selectable and add a copy action consistent with assistant responses
- allow earlier user prompts to be edited in the existing composer and regenerated
- preserve any unsent draft and attachments while editing, restoring them after save or cancellation
- disable editing while the session is busy or the current model configuration is unavailable

Resending an edited prompt updates that prompt in place, removes all later conversation items, persists the revised transcript, and generates a fresh assistant response using the current model settings.