### PR TITLE
Add consent gating + process lifecycle to mcp-hub

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -344,6 +344,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         builtInExtensions: [voiceDictationExtension]
     )
     private let controlPanelNavigation = ControlPanelNavigation()
+    private let mcpHost = MCPHostManager()
     private let runtime = SystemRuntimeMonitor()
     private let systemMenuBarPreferences = SystemMenuBarPreferences.shared
     private var mainWindowOpener: (() -> Void)?
@@ -433,6 +434,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         modelScanTask?.cancel()
         extensionManager.shutdown()
+        mcpHost.shutdown()
         runtime.onUpdate = nil
         systemMenuBarPreferences.onChange = nil
         runtime.stop()
@@ -537,6 +539,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             navigation: controlPanelNavigation,
             runtime: runtime,
             extensionManager: extensionManager,
+            mcpHost: mcpHost,
             softwareUpdater: softwareUpdater,
             onComplete: { [weak self] modelID, serverAPIKey in
                 self?.completeWelcome(modelID: modelID, serverAPIKey: serverAPIKey)

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -260,9 +260,9 @@ struct ControlPanelView: View {
     @ObservedObject var navigation: ControlPanelNavigation
     @ObservedObject var runtime: SystemRuntimeMonitor
     @ObservedObject var extensionManager: NativExtensionManager
+    @ObservedObject var mcpHost: MCPHostManager
     let softwareUpdater: SoftwareUpdater
     @StateObject private var chat = ChatViewModel()
-    @StateObject private var mcpHost = MCPHostManager()
     @StateObject private var imageGeneration = ImageGenerationViewModel()
     @StateObject private var artifacts = ArtifactStore()
     @StateObject private var dashboard = DashboardViewModel()
@@ -3923,6 +3923,7 @@ private extension View {
         navigation: .init(),
         runtime: .init(),
         extensionManager: .init(builtInExtensions: []),
+        mcpHost: .init(),
         softwareUpdater: .init()
     )
 }

--- a/Sources/Nativ/Features/Chat/ChatToolConsentPolicy.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolConsentPolicy.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Which tool calls stop and ask before they run.
+///
+/// MCP tools are matched on their name prefix rather than on whether the host
+/// can currently route them. Connections reload asynchronously and debounced,
+/// so a name the host cannot route when the gate runs may well be routable by
+/// the time the call is dispatched — matching on the name alone closes that
+/// window, and keeps an unrecognized or misconfigured server gated rather than
+/// letting it through ungated.
+enum ChatToolConsentRequirement: Equatable {
+    case notRequired
+    case switchModel
+    case mcpTool(qualifiedName: String)
+
+    static func resolve(toolName: String?) -> ChatToolConsentRequirement {
+        guard let toolName else { return .notRequired }
+        if toolName == ChatSwitchModelToolRegistry.toolName {
+            return .switchModel
+        }
+        if toolName.hasPrefix(MCPHostManager.toolNamePrefix) {
+            return .mcpTool(qualifiedName: toolName)
+        }
+        return .notRequired
+    }
+
+    var isRequired: Bool {
+        self != .notRequired
+    }
+
+    /// What the model is told when the user declines.
+    func declinedPayload() -> String {
+        switch self {
+        case .switchModel:
+            return ChatSwitchModelToolExecutor().declinedPayload()
+        case .mcpTool, .notRequired:
+            return "The user declined to run this tool."
+        }
+    }
+}
+
+/// Splits a qualified MCP tool name for display.
+enum MCPToolDisplayName {
+    /// Best-effort split of `mcp__<server>__<tool>` for the consent prompt.
+    ///
+    /// Splits on the *last* separator: a server slug can contain one, since
+    /// every non-alphanumeric character becomes an underscore and two adjacent
+    /// ones produce `__`, while MCP tool names conventionally do not. Returns
+    /// `nil` rather than guessing when the name is not shaped as expected, so
+    /// callers can fall back to showing it verbatim.
+    static func split(_ qualifiedName: String) -> (server: String, tool: String)? {
+        guard qualifiedName.hasPrefix(MCPHostManager.toolNamePrefix) else { return nil }
+        let body = String(qualifiedName.dropFirst(MCPHostManager.toolNamePrefix.count))
+        guard let separator = body.range(of: MCPHostManager.toolNameSeparator, options: .backwards) else {
+            return nil
+        }
+        let server = String(body[body.startIndex..<separator.lowerBound])
+        let tool = String(body[separator.upperBound...])
+        guard !server.isEmpty, !tool.isEmpty else { return nil }
+        return (server: server, tool: tool)
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -951,7 +951,8 @@ final class ChatViewModel: ObservableObject {
                 }
                 insertionAnchor = toolMessageID
 
-                if toolCall.function?.name == ChatSwitchModelToolRegistry.toolName {
+                let consentRequirement = ChatToolConsentRequirement.resolve(toolName: toolCall.function?.name)
+                if consentRequirement.isRequired {
                     updateToolMessage(
                         toolMessageID,
                         in: queuedRequest.sessionID,
@@ -975,7 +976,7 @@ final class ChatViewModel: ObservableObject {
                             toolMessageID,
                             in: queuedRequest.sessionID,
                             status: .declined,
-                            content: ChatSwitchModelToolExecutor().declinedPayload(),
+                            content: consentRequirement.declinedPayload(),
                             attachments: []
                         )
                         continue
@@ -988,43 +989,48 @@ final class ChatViewModel: ObservableObject {
                             attachments: []
                         )
                     }
-                    guard let appModel else {
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .failed,
-                            content: ChatSwitchModelToolExecutor().failurePayload(
-                                operation: ChatSwitchModelToolRegistry.toolName,
-                                error: ChatSwitchModelToolError.appModelUnavailable
-                            ),
-                            attachments: []
-                        )
+
+                    if case .switchModel = consentRequirement {
+                        guard let appModel else {
+                            updateToolMessage(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .failed,
+                                content: ChatSwitchModelToolExecutor().failurePayload(
+                                    operation: ChatSwitchModelToolRegistry.toolName,
+                                    error: ChatSwitchModelToolError.appModelUnavailable
+                                ),
+                                attachments: []
+                            )
+                            continue
+                        }
+                        do {
+                            let content = try await ChatSwitchModelToolExecutor().execute(call: toolCall, appModel: appModel)
+                            activeSettings.languageModelID = appModel.settings.normalized().languageModelID
+                            updateToolMessage(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .succeeded,
+                                content: content,
+                                attachments: []
+                            )
+                            appModel.refreshMetricsIfRunning(force: true)
+                        } catch {
+                            updateToolMessage(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .failed,
+                                content: ChatSwitchModelToolExecutor().failurePayload(
+                                    operation: ChatSwitchModelToolRegistry.toolName,
+                                    error: error
+                                ),
+                                attachments: []
+                            )
+                        }
                         continue
                     }
-                    do {
-                        let content = try await ChatSwitchModelToolExecutor().execute(call: toolCall, appModel: appModel)
-                        activeSettings.languageModelID = appModel.settings.normalized().languageModelID
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .succeeded,
-                            content: content,
-                            attachments: []
-                        )
-                        appModel.refreshMetricsIfRunning(force: true)
-                    } catch {
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .failed,
-                            content: ChatSwitchModelToolExecutor().failurePayload(
-                                operation: ChatSwitchModelToolRegistry.toolName,
-                                error: error
-                            ),
-                            attachments: []
-                        )
-                    }
-                    continue
+                    // An approved MCP call falls through to the shared
+                    // execution path below, which already routes it to the host.
                 }
 
                 do {
@@ -2088,9 +2094,7 @@ private struct ChatAgentStepCell: View {
 
     private var consentPrompt: some View {
         VStack(alignment: .leading, spacing: 8) {
-            (Text("The model wants to switch to ")
-                + Text(verbatim: requestedModelID).bold()
-                + Text(". The server restarts briefly; your session is kept."))
+            consentPromptText
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -2108,6 +2112,28 @@ private struct ChatAgentStepCell: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.top, 7)
+    }
+
+    private var consentPromptText: Text {
+        if message.toolName == ChatSwitchModelToolRegistry.toolName {
+            return Text("The model wants to switch to ")
+                + Text(verbatim: requestedModelID).bold()
+                + Text(". The server restarts briefly; your session is kept.")
+        }
+        if let toolName = message.toolName,
+           toolName.hasPrefix(MCPHostManager.toolNamePrefix) {
+            guard let split = MCPToolDisplayName.split(toolName) else {
+                return Text("The model wants to run ")
+                    + Text(verbatim: toolName).bold()
+                    + Text(". This runs outside Nativ and may change data.")
+            }
+            return Text("The model wants to run ")
+                + Text(verbatim: split.tool).bold()
+                + Text(" on ")
+                + Text(verbatim: split.server).bold()
+                + Text(". This runs outside Nativ and may change data.")
+        }
+        return Text("The model wants to run this tool. It needs your approval first.")
     }
 
     private var requestedModelID: String {

--- a/Sources/Nativ/Features/MCP/MCPHostManager.swift
+++ b/Sources/Nativ/Features/MCP/MCPHostManager.swift
@@ -75,15 +75,18 @@ final class MCPHostManager: ObservableObject {
         scheduleReload(servers: appliedServers, debounce: false)
     }
 
+    /// Stops every server process.
+    ///
+    /// Terminates synchronously rather than awaiting `disconnect()`: this runs
+    /// on app termination, and the app exits before a detached task gets to
+    /// run, which would leave every MCP server still running after quit.
     func shutdown() {
         reloadTask?.cancel()
         let previous = connections
         connections = [:]
         states = [:]
-        Task {
-            for connection in previous.values {
-                await connection.client.disconnect()
-            }
+        for connection in previous.values {
+            connection.client.terminateImmediately()
         }
     }
 

--- a/Sources/Nativ/Features/MCP/MCPHostManager.swift
+++ b/Sources/Nativ/Features/MCP/MCPHostManager.swift
@@ -11,6 +11,9 @@ enum MCPServerConnectionState: Equatable {
 
 @MainActor
 final class MCPHostManager: ObservableObject {
+    nonisolated static let toolNamePrefix = "mcp__"
+    nonisolated static let toolNameSeparator = "__"
+
     @Published private(set) var states: [UUID: MCPServerConnectionState] = [:]
 
     private struct Connection {
@@ -163,7 +166,7 @@ final class MCPHostManager: ObservableObject {
 
     private func route(for name: String) -> (client: MCPClient, toolName: String)? {
         for connection in connections.values {
-            let prefix = "mcp__\(connection.slug)__"
+            let prefix = "\(Self.toolNamePrefix)\(connection.slug)\(Self.toolNameSeparator)"
             guard name.hasPrefix(prefix) else { continue }
             let toolName = String(name.dropFirst(prefix.count))
             if connection.tools.contains(where: { $0.name == toolName }) {
@@ -179,7 +182,7 @@ final class MCPHostManager: ObservableObject {
     }
 
     private static func toolName(slug: String, tool: String) -> String {
-        "mcp__\(slug)__\(tool)"
+        "\(toolNamePrefix)\(slug)\(toolNameSeparator)\(tool)"
     }
 
     private static func launchEquivalent(_ lhs: MCPServerConfig, _ rhs: MCPServerConfig) -> Bool {

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -21,6 +21,7 @@ struct WelcomeGateView: View {
     @ObservedObject var navigation: ControlPanelNavigation
     @ObservedObject var runtime: SystemRuntimeMonitor
     @ObservedObject var extensionManager: NativExtensionManager
+    @ObservedObject var mcpHost: MCPHostManager
     let softwareUpdater: SoftwareUpdater
     let onComplete: (_ modelID: String?, _ serverAPIKey: String?) -> Void
 
@@ -32,6 +33,7 @@ struct WelcomeGateView: View {
                     navigation: navigation,
                     runtime: runtime,
                     extensionManager: extensionManager,
+                    mcpHost: mcpHost,
                     softwareUpdater: softwareUpdater
                 )
             } else {

--- a/Sources/NativServerKit/MCPClient.swift
+++ b/Sources/NativServerKit/MCPClient.swift
@@ -36,6 +36,31 @@ public enum MCPClientError: LocalizedError {
     }
 }
 
+/// Holds the spawned process somewhere a nonisolated caller can reach it.
+///
+/// `MCPClient.disconnect()` is async, so it cannot run during app
+/// termination — the app exits before the task is ever scheduled. Terminating
+/// the child needs a handle usable synchronously from outside the actor.
+private final class MCPProcessBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+
+    func store(_ process: Process?) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.process = process
+    }
+
+    func terminate() {
+        lock.lock()
+        defer { lock.unlock() }
+        if let process, process.isRunning {
+            process.terminate()
+        }
+        process = nil
+    }
+}
+
 public actor MCPClient {
     private let executableURL: URL
     private let arguments: [String]
@@ -48,6 +73,7 @@ public actor MCPClient {
     private var outputPipe: Pipe?
     private var transport: StdioTransport?
     private var client: Client?
+    private let liveProcess = MCPProcessBox()
 
     public init(
         executableURL: URL,
@@ -101,6 +127,15 @@ public actor MCPClient {
         self.process = process
         self.transport = transport
         self.client = client
+        liveProcess.store(process)
+    }
+
+    /// Terminates the server process without waiting on the actor.
+    ///
+    /// The only option that works during app termination: `disconnect()` is
+    /// async, so the app exits before it runs and the child is left behind.
+    public nonisolated func terminateImmediately() {
+        liveProcess.terminate()
     }
 
     public func listTools() async throws -> [MCPToolInfo] {
@@ -155,6 +190,7 @@ public actor MCPClient {
         process = nil
         inputPipe = nil
         outputPipe = nil
+        liveProcess.store(nil)
     }
 
     private static func withTimeout<T: Sendable>(

--- a/Tests/NativTests/ChatToolConsentPolicyTests.swift
+++ b/Tests/NativTests/ChatToolConsentPolicyTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import NativServerKit
+
+final class ChatToolConsentRequirementTests: XCTestCase {
+    func testNativeToolsRunWithoutAsking() {
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "get_system_stats"), .notRequired)
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "list_models"), .notRequired)
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "generate_image"), .notRequired)
+    }
+
+    func testMissingToolNameRequiresNothing() {
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: nil), .notRequired)
+    }
+
+    func testSwitchModelStillAsks() {
+        XCTAssertEqual(
+            ChatToolConsentRequirement.resolve(toolName: ChatSwitchModelToolRegistry.toolName),
+            .switchModel
+        )
+    }
+
+    func testEveryMCPToolAsks() {
+        XCTAssertEqual(
+            ChatToolConsentRequirement.resolve(toolName: "mcp__filesystem__read_file"),
+            .mcpTool(qualifiedName: "mcp__filesystem__read_file")
+        )
+    }
+
+    func testAnUnroutableServerStillAsks() {
+        // Fail-closed: the gate must not depend on whether the host can
+        // currently route the name. Connections reload asynchronously, so a
+        // name that looks unroutable here can be routable by dispatch time.
+        XCTAssertTrue(
+            ChatToolConsentRequirement.resolve(toolName: "mcp__never_connected__wipe_disk").isRequired
+        )
+    }
+
+    func testAMalformedMCPNameStillAsks() {
+        // No server, no tool, nothing to identify — still gated rather than
+        // waved through for being unrecognizable.
+        XCTAssertTrue(ChatToolConsentRequirement.resolve(toolName: "mcp__").isRequired)
+        XCTAssertTrue(ChatToolConsentRequirement.resolve(toolName: "mcp__filesystem").isRequired)
+    }
+
+    func testTheMCPPrefixMustLeadTheName() {
+        // A native tool that merely contains the prefix is not an MCP call,
+        // and must not be mistaken for one.
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "my_mcp__helper"), .notRequired)
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "run_mcp__tool"), .notRequired)
+    }
+
+    func testDeclinedPayloadsAreNeverEmpty() {
+        // The model is told something in every declined case; an empty tool
+        // result reads as a successful no-op.
+        for requirement: ChatToolConsentRequirement in [
+            .switchModel,
+            .mcpTool(qualifiedName: "mcp__filesystem__read_file"),
+        ] {
+            XCTAssertFalse(requirement.declinedPayload().isEmpty, "\(requirement)")
+        }
+    }
+}
+
+final class MCPToolDisplayNameTests: XCTestCase {
+    func testSplitsServerAndTool() {
+        let split = MCPToolDisplayName.split("mcp__filesystem__read_file")
+        XCTAssertEqual(split?.server, "filesystem")
+        XCTAssertEqual(split?.tool, "read_file")
+    }
+
+    func testASlugContainingTheSeparatorKeepsItsFullName() {
+        // Slugs are built by replacing each non-alphanumeric with "_", so two
+        // adjacent ones produce "__" inside the server name. Splitting on the
+        // last separator keeps that intact.
+        let split = MCPToolDisplayName.split("mcp__my__server__read_file")
+        XCTAssertEqual(split?.server, "my__server")
+        XCTAssertEqual(split?.tool, "read_file")
+    }
+
+    func testUnexpectedShapesReturnNilRatherThanGuessing() {
+        XCTAssertNil(MCPToolDisplayName.split("mcp__filesystem"))
+        XCTAssertNil(MCPToolDisplayName.split("mcp__filesystem__"))
+        XCTAssertNil(MCPToolDisplayName.split("mcp____read_file"))
+        XCTAssertNil(MCPToolDisplayName.split("get_system_stats"))
+    }
+}

--- a/Tests/NativTests/Fixtures/idle_mcp_server.py
+++ b/Tests/NativTests/Fixtures/idle_mcp_server.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""A minimal MCP server that completes the handshake and then just sits there.
+
+Exists so a test can connect a real MCPClient to a real child process and
+then kill it. It answers `initialize` and `tools/list` and nothing else --
+enough for the handshake to succeed, and no reason to grow further.
+
+Writes its own pid to the path given as the first argument, so the test can
+watch the actual OS process rather than trusting the client's own bookkeeping
+about whether it terminated something.
+"""
+import json
+import os
+import sys
+
+if len(sys.argv) > 1:
+    with open(sys.argv[1], "w") as handle:
+        handle.write(str(os.getpid()))
+
+
+def write(message):
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+# Blocking on stdin is what keeps this alive: nothing else is sent after the
+# handshake, so the process stays up until it is signalled.
+for raw_line in sys.stdin:
+    line = raw_line.strip()
+    if not line:
+        continue
+    try:
+        request = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+
+    method = request.get("method")
+    request_id = request.get("id")
+    if request_id is None:
+        # A notification (`notifications/initialized`); nothing to answer.
+        continue
+
+    if method == "initialize":
+        # Echo the client's own protocol version back rather than pinning one,
+        # so this fixture keeps working across SDK upgrades.
+        requested = request.get("params", {}).get("protocolVersion", "2024-11-05")
+        write({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": requested,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "idle-mcp-server", "version": "1.0"},
+            },
+        })
+    elif method == "tools/list":
+        write({"jsonrpc": "2.0", "id": request_id, "result": {"tools": []}})
+    else:
+        write({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "Method not found"},
+        })

--- a/Tests/NativTests/MCPClientTerminationTests.swift
+++ b/Tests/NativTests/MCPClientTerminationTests.swift
@@ -1,0 +1,197 @@
+import XCTest
+@testable import NativServerKit
+
+/// Covers the one thing that makes quitting Nativ actually stop its MCP
+/// servers: terminating the child process without waiting on the actor.
+///
+/// These run real subprocesses rather than mocking the transport, because the
+/// bug being guarded against is precisely that the process outlives the app —
+/// a mocked client cannot fail that way.
+final class MCPClientTerminationTests: XCTestCase {
+    private var fixturePath: String {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/idle_mcp_server.py")
+            .path
+    }
+
+    /// Starts a fixture server and returns its client plus the pid of the real
+    /// process behind it.
+    private func startFixtureServer() async throws -> (client: MCPClient, pid: pid_t) {
+        let pidFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mcp-fixture-\(UUID().uuidString).pid")
+        let client = MCPClient(
+            executableURL: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["python3", fixturePath, pidFile.path],
+            environment: ProcessInfo.processInfo.environment
+        )
+        try await client.connect()
+        addTeardownBlock {
+            await client.disconnect()
+            try? FileManager.default.removeItem(at: pidFile)
+        }
+
+        let raw = try XCTUnwrap(
+            try? String(contentsOf: pidFile, encoding: .utf8),
+            "fixture never wrote its pid, so it never started"
+        )
+        let pid = try XCTUnwrap(pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)))
+        XCTAssertTrue(isRunning(pid), "fixture should be alive right after connecting")
+        return (client, pid)
+    }
+
+    /// Whether the OS still has a live process under this pid.
+    ///
+    /// Foundation reaps its own children, so a terminated fixture stops
+    /// answering `kill(_:0)` shortly after it dies; polling absorbs that gap
+    /// without making the test depend on exact timing.
+    private func isRunning(_ pid: pid_t) -> Bool {
+        kill(pid, 0) == 0
+    }
+
+    private func waitUntilNotRunning(_ pid: pid_t, timeout: TimeInterval = 5) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !isRunning(pid) { return true }
+            usleep(20_000)
+        }
+        return !isRunning(pid)
+    }
+
+    func testTerminateImmediatelyStopsTheServerProcess() async throws {
+        let (client, pid) = try await startFixtureServer()
+
+        // Deliberately synchronous, with nothing awaited afterwards — this is
+        // the call app termination makes, and it has to be enough on its own.
+        // Awaiting disconnect() here would prove nothing about the quit path.
+        client.terminateImmediately()
+
+        XCTAssertTrue(
+            waitUntilNotRunning(pid),
+            "the server process outlived terminateImmediately(), which is the exact bug this guards"
+        )
+    }
+
+    func testDisconnectAlsoStopsTheServerProcess() async throws {
+        let (client, pid) = try await startFixtureServer()
+
+        await client.disconnect()
+
+        XCTAssertTrue(
+            waitUntilNotRunning(pid),
+            "the graceful path should stop the process too"
+        )
+    }
+
+    func testTerminateImmediatelyIsSafeToCallTwice() async throws {
+        let (client, pid) = try await startFixtureServer()
+
+        client.terminateImmediately()
+        client.terminateImmediately()
+
+        XCTAssertTrue(waitUntilNotRunning(pid))
+    }
+
+    func testTerminateImmediatelyOnAClientThatNeverConnectedDoesNothing() {
+        let client = MCPClient(
+            executableURL: URL(fileURLWithPath: "/usr/bin/true"),
+            arguments: [],
+            environment: [:]
+        )
+
+        // No process was ever started; this must not trap.
+        client.terminateImmediately()
+    }
+}
+
+/// The manager-level path: what `applicationWillTerminate` actually calls.
+@MainActor
+final class MCPHostManagerShutdownTests: XCTestCase {
+    private var fixturePath: String {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/idle_mcp_server.py")
+            .path
+    }
+
+    private func fixtureConfig(named name: String, pidFile: URL) -> MCPServerConfig {
+        MCPServerConfig(
+            name: name,
+            command: "/usr/bin/env",
+            arguments: ["python3", fixturePath, pidFile.path],
+            environment: [:]
+        )
+    }
+
+    private func pid(from pidFile: URL) throws -> pid_t {
+        let raw = try XCTUnwrap(try? String(contentsOf: pidFile, encoding: .utf8))
+        return try XCTUnwrap(pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)))
+    }
+
+    private func isRunning(_ pid: pid_t) -> Bool {
+        kill(pid, 0) == 0
+    }
+
+    func testShutdownStopsEveryConnectedServer() async throws {
+        let pidFiles = (0..<2).map { index in
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent("mcp-host-\(index)-\(UUID().uuidString).pid")
+        }
+        addTeardownBlock {
+            pidFiles.forEach { try? FileManager.default.removeItem(at: $0) }
+        }
+
+        let manager = MCPHostManager()
+        let servers = [
+            fixtureConfig(named: "first", pidFile: pidFiles[0]),
+            fixtureConfig(named: "second", pidFile: pidFiles[1]),
+        ]
+        manager.reload(servers: servers)
+
+        // reload() debounces and connects asynchronously, so wait for the
+        // states it publishes rather than guessing at a sleep duration.
+        let deadline = Date().addingTimeInterval(20)
+        while Date() < deadline {
+            let connected = servers.allSatisfy { server in
+                if case .connected = manager.states[server.id] { return true }
+                return false
+            }
+            if connected { break }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        for server in servers {
+            guard case .connected = manager.states[server.id] else {
+                return XCTFail("\(server.name) never connected: \(String(describing: manager.states[server.id]))")
+            }
+        }
+
+        let pids = try pidFiles.map(pid(from:))
+        for pid in pids {
+            XCTAssertTrue(isRunning(pid), "fixture \(pid) should be up before shutdown")
+        }
+
+        manager.shutdown()
+
+        for pid in pids {
+            let stopped = waitUntilNotRunning(pid)
+            XCTAssertTrue(stopped, "server \(pid) survived shutdown() — it would outlive the app")
+        }
+    }
+
+    /// Polls synchronously on purpose, and that is load-bearing.
+    ///
+    /// The version of `shutdown()` this guards against handed its work to a
+    /// `Task` created in a main-actor context. Blocking the main actor here is
+    /// what makes this a faithful stand-in for app termination, where the main
+    /// actor stops servicing work and the process exits. Awaiting instead would
+    /// hand that task a chance to run and the test would pass against the very
+    /// bug it exists to catch.
+    private func waitUntilNotRunning(_ pid: pid_t, timeout: TimeInterval = 5) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !isRunning(pid) { return true }
+            usleep(20_000)
+        }
+        return !isRunning(pid)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -151,6 +151,7 @@ targets:
     sources:
       - path: Tests/NativTests
       - path: Sources/Nativ/NativSettings.swift
+      - path: Sources/Nativ/Features/Extensions/NativSkill.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioInputDevicePreferences.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
       - path: Sources/Nativ/Features/Models/LocalModelDiscovery.swift

--- a/project.yml
+++ b/project.yml
@@ -169,6 +169,8 @@ targets:
       - path: Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+      - path: Sources/Nativ/Features/Chat/ChatToolConsentPolicy.swift
+      - path: Sources/Nativ/Features/MCP/MCPHostManager.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatSystemStatsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift


### PR DESCRIPTION
Adds the two things flagged on #200: a consent gate for MCP tool calls (fail-closed, including when a server can't be identified) and wiring `MCPHostManager.shutdown()` into app termination, since it existed but nothing called it — both covered with tests against real subprocesses. Also fixes the test target, which wasn't compiling (missing NativSkill.swift), so the existing suite was being silently skipped. Nothing else touched.
