### PR TITLE
Fix NativTests target: add missing NativSkill.swift

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -151,6 +151,7 @@ targets:
     sources:
       - path: Tests/NativTests
       - path: Sources/Nativ/NativSettings.swift
+      - path: Sources/Nativ/Features/Extensions/NativSkill.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioInputDevicePreferences.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
       - path: Sources/Nativ/Features/Models/LocalModelDiscovery.swift


### PR DESCRIPTION
Test target wasn't compiling — NativSettings.swift references NativSkill but the file was never added to the target, so the whole suite was being silently skipped instead of run. One line.