### PR TITLE
Require consent before running an MCP tool

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatToolConsentPolicy.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolConsentPolicy.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Which tool calls stop and ask before they run.
+///
+/// MCP tools are matched on their name prefix rather than on whether the host
+/// can currently route them. Connections reload asynchronously and debounced,
+/// so a name the host cannot route when the gate runs may well be routable by
+/// the time the call is dispatched — matching on the name alone closes that
+/// window, and keeps an unrecognized or misconfigured server gated rather than
+/// letting it through ungated.
+enum ChatToolConsentRequirement: Equatable {
+    case notRequired
+    case switchModel
+    case mcpTool(qualifiedName: String)
+
+    static func resolve(toolName: String?) -> ChatToolConsentRequirement {
+        guard let toolName else { return .notRequired }
+        if toolName == ChatSwitchModelToolRegistry.toolName {
+            return .switchModel
+        }
+        if toolName.hasPrefix(MCPHostManager.toolNamePrefix) {
+            return .mcpTool(qualifiedName: toolName)
+        }
+        return .notRequired
+    }
+
+    var isRequired: Bool {
+        self != .notRequired
+    }
+
+    /// What the model is told when the user declines.
+    func declinedPayload() -> String {
+        switch self {
+        case .switchModel:
+            return ChatSwitchModelToolExecutor().declinedPayload()
+        case .mcpTool, .notRequired:
+            return "The user declined to run this tool."
+        }
+    }
+}
+
+/// Splits a qualified MCP tool name for display.
+enum MCPToolDisplayName {
+    /// Best-effort split of `mcp__<server>__<tool>` for the consent prompt.
+    ///
+    /// Splits on the *last* separator: a server slug can contain one, since
+    /// every non-alphanumeric character becomes an underscore and two adjacent
+    /// ones produce `__`, while MCP tool names conventionally do not. Returns
+    /// `nil` rather than guessing when the name is not shaped as expected, so
+    /// callers can fall back to showing it verbatim.
+    static func split(_ qualifiedName: String) -> (server: String, tool: String)? {
+        guard qualifiedName.hasPrefix(MCPHostManager.toolNamePrefix) else { return nil }
+        let body = String(qualifiedName.dropFirst(MCPHostManager.toolNamePrefix.count))
+        guard let separator = body.range(of: MCPHostManager.toolNameSeparator, options: .backwards) else {
+            return nil
+        }
+        let server = String(body[body.startIndex..<separator.lowerBound])
+        let tool = String(body[separator.upperBound...])
+        guard !server.isEmpty, !tool.isEmpty else { return nil }
+        return (server: server, tool: tool)
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1158,7 +1158,8 @@ final class ChatViewModel: ObservableObject {
                 }
                 insertionAnchor = toolMessageID
 
-                if toolCall.function?.name == ChatSwitchModelToolRegistry.toolName {
+                let consentRequirement = ChatToolConsentRequirement.resolve(toolName: toolCall.function?.name)
+                if consentRequirement.isRequired {
                     updateToolMessage(
                         toolMessageID,
                         in: queuedRequest.sessionID,
@@ -1182,7 +1183,7 @@ final class ChatViewModel: ObservableObject {
                             toolMessageID,
                             in: queuedRequest.sessionID,
                             status: .declined,
-                            content: ChatSwitchModelToolExecutor().declinedPayload(),
+                            content: consentRequirement.declinedPayload(),
                             attachments: []
                         )
                         continue
@@ -1195,43 +1196,48 @@ final class ChatViewModel: ObservableObject {
                             attachments: []
                         )
                     }
-                    guard let appModel else {
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .failed,
-                            content: ChatSwitchModelToolExecutor().failurePayload(
-                                operation: ChatSwitchModelToolRegistry.toolName,
-                                error: ChatSwitchModelToolError.appModelUnavailable
-                            ),
-                            attachments: []
-                        )
+
+                    if case .switchModel = consentRequirement {
+                        guard let appModel else {
+                            updateToolMessage(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .failed,
+                                content: ChatSwitchModelToolExecutor().failurePayload(
+                                    operation: ChatSwitchModelToolRegistry.toolName,
+                                    error: ChatSwitchModelToolError.appModelUnavailable
+                                ),
+                                attachments: []
+                            )
+                            continue
+                        }
+                        do {
+                            let content = try await ChatSwitchModelToolExecutor().execute(call: toolCall, appModel: appModel)
+                            activeSettings.languageModelID = appModel.settings.normalized().languageModelID
+                            updateToolMessage(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .succeeded,
+                                content: content,
+                                attachments: []
+                            )
+                            appModel.refreshMetricsIfRunning(force: true)
+                        } catch {
+                            updateToolMessage(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .failed,
+                                content: ChatSwitchModelToolExecutor().failurePayload(
+                                    operation: ChatSwitchModelToolRegistry.toolName,
+                                    error: error
+                                ),
+                                attachments: []
+                            )
+                        }
                         continue
                     }
-                    do {
-                        let content = try await ChatSwitchModelToolExecutor().execute(call: toolCall, appModel: appModel)
-                        activeSettings.languageModelID = appModel.settings.normalized().languageModelID
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .succeeded,
-                            content: content,
-                            attachments: []
-                        )
-                        appModel.refreshMetricsIfRunning(force: true)
-                    } catch {
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .failed,
-                            content: ChatSwitchModelToolExecutor().failurePayload(
-                                operation: ChatSwitchModelToolRegistry.toolName,
-                                error: error
-                            ),
-                            attachments: []
-                        )
-                    }
-                    continue
+                    // An approved MCP call falls through to the shared
+                    // execution path below, which already routes it to the host.
                 }
 
                 do {
@@ -2442,9 +2448,7 @@ private struct ChatAgentStepCell: View {
 
     private var consentPrompt: some View {
         VStack(alignment: .leading, spacing: 8) {
-            (Text("The model wants to switch to ")
-                + Text(verbatim: requestedModelID).bold()
-                + Text(". The server restarts briefly; your session is kept."))
+            consentPromptText
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -2521,6 +2525,28 @@ private struct ChatAgentStepCell: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top, 7)
         }
+    }
+
+    private var consentPromptText: Text {
+        if message.toolName == ChatSwitchModelToolRegistry.toolName {
+            return Text("The model wants to switch to ")
+                + Text(verbatim: requestedModelID).bold()
+                + Text(". The server restarts briefly; your session is kept.")
+        }
+        if let toolName = message.toolName,
+           toolName.hasPrefix(MCPHostManager.toolNamePrefix) {
+            guard let split = MCPToolDisplayName.split(toolName) else {
+                return Text("The model wants to run ")
+                    + Text(verbatim: toolName).bold()
+                    + Text(". This runs outside Nativ and may change data.")
+            }
+            return Text("The model wants to run ")
+                + Text(verbatim: split.tool).bold()
+                + Text(" on ")
+                + Text(verbatim: split.server).bold()
+                + Text(". This runs outside Nativ and may change data.")
+        }
+        return Text("The model wants to run this tool. It needs your approval first.")
     }
 
     private var requestedModelID: String {

--- a/Sources/Nativ/Features/MCP/MCPHostManager.swift
+++ b/Sources/Nativ/Features/MCP/MCPHostManager.swift
@@ -11,6 +11,9 @@ enum MCPServerConnectionState: Equatable {
 
 @MainActor
 final class MCPHostManager: ObservableObject {
+    nonisolated static let toolNamePrefix = "mcp__"
+    nonisolated static let toolNameSeparator = "__"
+
     @Published private(set) var states: [UUID: MCPServerConnectionState] = [:]
 
     private struct Connection {
@@ -188,7 +191,7 @@ final class MCPHostManager: ObservableObject {
 
     private func route(for name: String) -> (client: MCPClient, toolName: String)? {
         for connection in connections.values {
-            let prefix = "mcp__\(connection.slug)__"
+            let prefix = "\(Self.toolNamePrefix)\(connection.slug)\(Self.toolNameSeparator)"
             guard name.hasPrefix(prefix) else { continue }
             let toolName = String(name.dropFirst(prefix.count))
             if connection.tools.contains(where: { $0.name == toolName }) {
@@ -204,7 +207,7 @@ final class MCPHostManager: ObservableObject {
     }
 
     private static func toolName(slug: String, tool: String) -> String {
-        "mcp__\(slug)__\(tool)"
+        "\(toolNamePrefix)\(slug)\(toolNameSeparator)\(tool)"
     }
 
     private static func launchEquivalent(_ lhs: MCPServerConfig, _ rhs: MCPServerConfig) -> Bool {

--- a/Tests/NativTests/ChatToolConsentPolicyTests.swift
+++ b/Tests/NativTests/ChatToolConsentPolicyTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import NativServerKit
+
+final class ChatToolConsentRequirementTests: XCTestCase {
+    func testNativeToolsRunWithoutAsking() {
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "get_system_stats"), .notRequired)
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "list_models"), .notRequired)
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "generate_image"), .notRequired)
+    }
+
+    func testMissingToolNameRequiresNothing() {
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: nil), .notRequired)
+    }
+
+    func testSwitchModelStillAsks() {
+        XCTAssertEqual(
+            ChatToolConsentRequirement.resolve(toolName: ChatSwitchModelToolRegistry.toolName),
+            .switchModel
+        )
+    }
+
+    func testEveryMCPToolAsks() {
+        XCTAssertEqual(
+            ChatToolConsentRequirement.resolve(toolName: "mcp__filesystem__read_file"),
+            .mcpTool(qualifiedName: "mcp__filesystem__read_file")
+        )
+    }
+
+    func testAnUnroutableServerStillAsks() {
+        // Fail-closed: the gate must not depend on whether the host can
+        // currently route the name. Connections reload asynchronously, so a
+        // name that looks unroutable here can be routable by dispatch time.
+        XCTAssertTrue(
+            ChatToolConsentRequirement.resolve(toolName: "mcp__never_connected__wipe_disk").isRequired
+        )
+    }
+
+    func testAMalformedMCPNameStillAsks() {
+        // No server, no tool, nothing to identify — still gated rather than
+        // waved through for being unrecognizable.
+        XCTAssertTrue(ChatToolConsentRequirement.resolve(toolName: "mcp__").isRequired)
+        XCTAssertTrue(ChatToolConsentRequirement.resolve(toolName: "mcp__filesystem").isRequired)
+    }
+
+    func testTheMCPPrefixMustLeadTheName() {
+        // A native tool that merely contains the prefix is not an MCP call,
+        // and must not be mistaken for one.
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "my_mcp__helper"), .notRequired)
+        XCTAssertEqual(ChatToolConsentRequirement.resolve(toolName: "run_mcp__tool"), .notRequired)
+    }
+
+    func testDeclinedPayloadsAreNeverEmpty() {
+        // The model is told something in every declined case; an empty tool
+        // result reads as a successful no-op.
+        for requirement: ChatToolConsentRequirement in [
+            .switchModel,
+            .mcpTool(qualifiedName: "mcp__filesystem__read_file"),
+        ] {
+            XCTAssertFalse(requirement.declinedPayload().isEmpty, "\(requirement)")
+        }
+    }
+}
+
+final class MCPToolDisplayNameTests: XCTestCase {
+    func testSplitsServerAndTool() {
+        let split = MCPToolDisplayName.split("mcp__filesystem__read_file")
+        XCTAssertEqual(split?.server, "filesystem")
+        XCTAssertEqual(split?.tool, "read_file")
+    }
+
+    func testASlugContainingTheSeparatorKeepsItsFullName() {
+        // Slugs are built by replacing each non-alphanumeric with "_", so two
+        // adjacent ones produce "__" inside the server name. Splitting on the
+        // last separator keeps that intact.
+        let split = MCPToolDisplayName.split("mcp__my__server__read_file")
+        XCTAssertEqual(split?.server, "my__server")
+        XCTAssertEqual(split?.tool, "read_file")
+    }
+
+    func testUnexpectedShapesReturnNilRatherThanGuessing() {
+        XCTAssertNil(MCPToolDisplayName.split("mcp__filesystem"))
+        XCTAssertNil(MCPToolDisplayName.split("mcp__filesystem__"))
+        XCTAssertNil(MCPToolDisplayName.split("mcp____read_file"))
+        XCTAssertNil(MCPToolDisplayName.split("get_system_stats"))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -169,6 +169,8 @@ targets:
       - path: Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+      - path: Sources/Nativ/Features/Chat/ChatToolConsentPolicy.swift
+      - path: Sources/Nativ/Features/MCP/MCPHostManager.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatSystemStatsTool.swift


### PR DESCRIPTION
Stacked on #207 (includes its commit too — GitHub can't base a fork PR on another fork-only branch, so this shows combined until #207 merges). The new commit here is bbb0770: routes MCP calls through the same consent gate switch_model already uses, fail-closed even when a server can't be identified. Tested.