### PR TITLE
Fix dictation shortcut clashing with macOS navigation

### DIFF
--- a/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
+++ b/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
@@ -123,7 +123,7 @@ final class VoiceDictationExtension: NativHostExtension {
                 .init(
                     id: "com.nativ.voice-dictation.transcribe",
                     title: "Transcribe",
-                    defaultShortcut: "Fn+Control"
+                    defaultShortcut: "Control+Option+Command"
                 ),
                 .init(
                     id: "com.nativ.voice-dictation.retranscribe",

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -1669,6 +1669,15 @@ struct AudioView: View {
         }
     }
 
+    private var handsFreeDescription: String {
+        guard shortcuts.isHandsFreeEnabled else {
+            return "Hold while speaking; release to transcribe."
+        }
+        return shortcuts.recordShortcut.keyCode == nil
+            ? "Double-tap to start; double-tap again to transcribe."
+            : "Press once to start; press again to transcribe."
+    }
+
     private var shortcutConfigurationPanel: some View {
         VStack(alignment: .leading, spacing: 18) {
             VStack(alignment: .leading, spacing: 3) {
@@ -1684,13 +1693,9 @@ struct AudioView: View {
                     VStack(alignment: .leading, spacing: 3) {
                         Text("Hands-free")
                             .font(.callout.weight(.medium))
-                        Text(
-                            shortcuts.isHandsFreeEnabled
-                                ? "Press once to start; press again to transcribe."
-                                : "Hold while speaking; release to transcribe."
-                        )
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        Text(handsFreeDescription)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
 
                     Spacer(minLength: 16)
@@ -1710,6 +1715,7 @@ struct AudioView: View {
                     shortcut: shortcuts.recordShortcut,
                     kind: .record
                 )
+
                 shortcutRow(
                     title: "Retry recent audio",
                     shortcut: shortcuts.retryShortcut,

--- a/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
@@ -27,12 +27,16 @@ struct FnRetryShortcutState {
 }
 
 struct VoiceModifierToggleShortcutState {
+    static let doubleTapWindow: TimeInterval = 0.4
+
     private(set) var isHeld = false
     private(set) var wasUsedAsChord = false
+    private var lastCleanTapTime: Date?
 
     mutating func update(
         activeModifiers: VoiceShortcutModifiers,
-        shortcutModifiers: VoiceShortcutModifiers
+        shortcutModifiers: VoiceShortcutModifiers,
+        now: Date = Date()
     ) -> Bool {
         guard !shortcutModifiers.isEmpty else {
             reset()
@@ -43,9 +47,20 @@ struct VoiceModifierToggleShortcutState {
             activeModifiers.intersection(shortcutModifiers) == shortcutModifiers
         if isHeld {
             guard containsShortcut else {
-                let shouldToggle = !wasUsedAsChord
-                reset()
-                return shouldToggle
+                let wasCleanTap = !wasUsedAsChord
+                isHeld = false
+                wasUsedAsChord = false
+                guard wasCleanTap else {
+                    lastCleanTapTime = nil
+                    return false
+                }
+                if let previous = lastCleanTapTime,
+                   now.timeIntervalSince(previous) <= Self.doubleTapWindow {
+                    lastCleanTapTime = nil
+                    return true
+                }
+                lastCleanTapTime = now
+                return false
             }
             if activeModifiers != shortcutModifiers {
                 wasUsedAsChord = true
@@ -69,6 +84,7 @@ struct VoiceModifierToggleShortcutState {
     mutating func reset() {
         isHeld = false
         wasUsedAsChord = false
+        lastCleanTapTime = nil
     }
 }
 
@@ -320,10 +336,13 @@ final class FnControlShortcutMonitor {
             return
         }
 
-        let keyedShortcuts = [
-            (recordHotKeyID, preferences.recordShortcut),
-            (retryHotKeyID, preferences.retryShortcut),
-        ].filter { $0.1.keyCode != nil }
+        var keyedShortcuts: [(UInt32, VoiceShortcut)] = []
+        if preferences.recordShortcut.keyCode != nil {
+            keyedShortcuts.append((recordHotKeyID, preferences.recordShortcut))
+        }
+        if preferences.retryShortcut.keyCode != nil {
+            keyedShortcuts.append((retryHotKeyID, preferences.retryShortcut))
+        }
         guard !keyedShortcuts.isEmpty else {
             return
         }

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -421,11 +421,13 @@ final class VoiceCaptureCoordinator {
     }
 
     private func showRecentRecordingUnavailable() {
+        let preferences = VoiceShortcutPreferences.shared
         showTranscriptionError(
             title: "No Recent Recording",
             message: """
-            Audio is available for five minutes after recording. Hold Fn + Control \
-            to record again, then press Fn + R before the audio expires.
+            Audio is available for five minutes after recording. Use \
+            \(preferences.recordShortcut.displayName) to record again, then use \
+            \(preferences.retryShortcut.displayName) before the audio expires.
             """
         )
     }

--- a/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
@@ -77,7 +77,7 @@ struct VoiceShortcut: Codable, Equatable, Sendable {
     static let recordDefault = VoiceShortcut(
         keyCode: nil,
         keyDisplay: nil,
-        modifiers: [.function, .control]
+        modifiers: [.control, .option, .command]
     )
     static let retryDefault = VoiceShortcut(
         keyCode: UInt16(kVK_ANSI_R),

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -274,55 +274,71 @@ final class FnRetryShortcutStateTests: XCTestCase {
 }
 
 final class VoiceModifierToggleShortcutStateTests: XCTestCase {
-    func testTogglesAfterModifierIsPressedAndReleasedAlone() {
-        var state = VoiceModifierToggleShortcutState()
+    private let origin = Date(timeIntervalSinceReferenceDate: 0)
 
-        XCTAssertFalse(
-            state.update(
-                activeModifiers: [.option],
-                shortcutModifiers: [.option]
-            )
-        )
-        XCTAssertTrue(state.isHeld)
-        XCTAssertTrue(
-            state.update(
-                activeModifiers: [],
-                shortcutModifiers: [.option]
-            )
-        )
+    @discardableResult
+    private func tap(
+        _ state: inout VoiceModifierToggleShortcutState,
+        shortcut: VoiceShortcutModifiers = [.option],
+        at time: Date
+    ) -> Bool {
+        _ = state.update(activeModifiers: shortcut, shortcutModifiers: shortcut, now: time)
+        return state.update(activeModifiers: [], shortcutModifiers: shortcut, now: time)
+    }
+
+    func testSingleTapDoesNotToggle() {
+        var state = VoiceModifierToggleShortcutState()
+        XCTAssertFalse(tap(&state, at: origin))
         XCTAssertFalse(state.isHeld)
     }
 
-    func testDoesNotToggleWhenModifierBecomesPartOfChord() {
+    func testDoubleTapWithinWindowToggles() {
+        var state = VoiceModifierToggleShortcutState()
+        XCTAssertFalse(tap(&state, at: origin))
+        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(0.2)))
+    }
+
+    func testSecondTapAfterWindowDoesNotToggle() {
+        var state = VoiceModifierToggleShortcutState()
+        XCTAssertFalse(tap(&state, at: origin))
+        XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(1.0)))
+    }
+
+    func testChordTapDoesNotArmDoubleTap() {
         var state = VoiceModifierToggleShortcutState()
 
         XCTAssertFalse(
             state.update(
                 activeModifiers: [.option],
-                shortcutModifiers: [.option]
+                shortcutModifiers: [.option],
+                now: origin
             )
         )
         XCTAssertFalse(
             state.update(
                 activeModifiers: [.option, .shift],
-                shortcutModifiers: [.option]
+                shortcutModifiers: [.option],
+                now: origin
             )
         )
         XCTAssertFalse(
             state.update(
                 activeModifiers: [],
-                shortcutModifiers: [.option]
+                shortcutModifiers: [.option],
+                now: origin
             )
         )
+        XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(0.1)))
     }
 
-    func testDoesNotToggleWhenARegularKeyIsPressed() {
+    func testKeyPressDoesNotArmDoubleTap() {
         var state = VoiceModifierToggleShortcutState()
 
         XCTAssertFalse(
             state.update(
                 activeModifiers: [.option],
-                shortcutModifiers: [.option]
+                shortcutModifiers: [.option],
+                now: origin
             )
         )
         state.noteKeyDown()
@@ -330,38 +346,20 @@ final class VoiceModifierToggleShortcutStateTests: XCTestCase {
         XCTAssertFalse(
             state.update(
                 activeModifiers: [],
-                shortcutModifiers: [.option]
+                shortcutModifiers: [.option],
+                now: origin
             )
         )
+        XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(0.1)))
     }
 
-    func testCanToggleAgainAfterCompletingGesture() {
+    func testCanToggleAgainAfterCompletingDoubleTap() {
         var state = VoiceModifierToggleShortcutState()
+        XCTAssertFalse(tap(&state, at: origin))
+        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(0.2)))
 
-        XCTAssertFalse(
-            state.update(
-                activeModifiers: [.option],
-                shortcutModifiers: [.option]
-            )
-        )
-        XCTAssertTrue(
-            state.update(
-                activeModifiers: [],
-                shortcutModifiers: [.option]
-            )
-        )
-        XCTAssertFalse(
-            state.update(
-                activeModifiers: [.option],
-                shortcutModifiers: [.option]
-            )
-        )
-        XCTAssertTrue(
-            state.update(
-                activeModifiers: [],
-                shortcutModifiers: [.option]
-            )
-        )
+        XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(2)))
+        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(2.2)))
     }
 }
 


### PR DESCRIPTION
Closes Blaizzy/nativ#210.

The default global dictation shortcut was `Fn + Control`, a modifier-only chord matched on an exact modifier comparison. Because those modifiers are held during Spaces / Mission Control navigation, dictation fired every time the user switched spaces.

## Changes

* **Non-clashing default:** the default dictation shortcut is now **Control + Option + Command** instead of `Fn + Control` — a chord macOS binds to nothing and that isn't held during navigation.
* **Double-tap to start (hands-free):** a modifier-only shortcut now requires a **double-tap within 0.4s** to start hands-free dictation, so an accidental single chord press no longer triggers it. Push-to-talk (hands-free off) still holds-to-talk; keyed shortcuts are unchanged.
* Updated the now-stale "No Recent Recording" hint to use the live shortcut names, and the dictation extension's `defaultShortcut` label.

## Notes

* Per review feedback, the standalone "Enable dictation shortcut" toggle was dropped: the extension's own enable/disable state is the single switch, since the shortcut is currently the only way to trigger dictation. A dictation button in the chat composer (which would justify an independent toggle) is a good follow-up.
* Existing preferences are preserved; the new default only applies to fresh installs / restored defaults.
* `VoiceModifierToggleShortcutState` tests were rewritten for the double-tap behavior with an injectable clock.