### PR TITLE
Calibrate the param size estimate for image models

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -99,18 +99,42 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         }
 
         provider = LocalModelProviderResolver.resolve(repoID: id, modelType: nil, architectures: [])
-        sizeBytes = safetensors?.sizeBytes
         capabilities = Self.resolveCapabilities(
             pipelineTag: pipelineTag,
             libraryName: libraryName,
             tags: tags
         )
+        let parameterBytes = safetensors?.sizeBytes
+        sizeBytes = Self.calibratedDownloadBytes(parameterBytes, capabilities: capabilities)
         memoryEstimate = Self.resolveMemoryEstimate(
             repoID: id,
             safetensors: safetensors,
-            sizeBytes: sizeBytes,
+            sizeBytes: parameterBytes,
             capabilities: capabilities
         )
+    }
+
+    // The safetensors parameter summary only covers the diffusion transformer.
+    // Image-generation repos also ship a text encoder, VAE, and other components
+    // that get downloaded, so the raw estimate lands well under the real download.
+    // Scale it up for those models until we can sum the repo's actual file sizes.
+    private static func calibratedDownloadBytes(
+        _ parameterBytes: Int64?,
+        capabilities: Set<LocalModelCapability>
+    ) -> Int64? {
+        guard let parameterBytes else {
+            return nil
+        }
+        let isImageModel = capabilities.contains(.imageGeneration)
+            || capabilities.contains(.imageEditing)
+        guard isImageModel else {
+            return parameterBytes
+        }
+        let scaled = Double(parameterBytes) * 2.0
+        guard scaled <= Double(Int64.max) else {
+            return parameterBytes
+        }
+        return Int64(scaled.rounded(.up))
     }
 
     private static func resolveMemoryEstimate(


### PR DESCRIPTION
Calibrating the param estimate for image models.

Prior, the advertised model size was taken straight from HuggingFace's `safetensors` parameter summary — `Σ params[dtype] × bits/8`. For image-generation (diffusion) repos that summary only counts the diffusion **transformer** and omits the text encoder(s), VAE, and other components that actually get downloaded, so the size shown sat well **below** the real download:

| Model | Shown (param estimate) | Real files |
|---|---|---|
| FLUX.1-dev | ~24 GB | ~58 GB |
| Stable Diffusion 3.5 Large | ~16 GB | ~72 GB |
| Qwen-Image | ~41 GB | ~58 GB |

(And repos with no `safetensors` summary showed no size at all, then downloaded ~24 GB.)

This scales the parameter estimate up for image-generation / image-editing models so the advertised size — and the disk-capacity check and download-progress denominator that reuse it — land closer to the real download. The memory estimate stays on the raw parameter figure (that reflects the transformer in memory).

Minimal by design: it's a calibration, not exact. The precise fix is to sum the repo's real file sizes via the HF `?blobs=true` API for the selected model, which also covers the no-summary case — left as a follow-up.