### PR TITLE
LLM image generation tool calling feature request #131

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
 		2B89F9E09ABB37B82AC2FEB5 /* NativAudioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9B712CAFE08083D1679354E /* NativAudioClient.swift */; };
 		2B988CEEF0FD7FCCD3862AF6 /* NativExtensionStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */; };
+		2BF78B0A20ED752102326A38 /* ChatImageModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */; };
 		2BF94914481EEA1A493F5926 /* VoiceDictationExtensionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1573A2D88784C9D404156D25 /* VoiceDictationExtensionRuntime.swift */; };
 		2C9930764FCB1AF6B4C66363 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
 		2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
@@ -80,6 +81,7 @@
 		6CFBB2F5B3720F1334BF3D47 /* UISFXMinimalStop.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8B12071ED75397C8639954B7 /* UISFXMinimalStop.mp3 */; };
 		6E7B34D02D005C83C71A412F /* NativServerKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		71659335E55225ABCBB4E993 /* IssueReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46B388273DDFAD7C6C0F4E1 /* IssueReport.swift */; };
+		76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */; };
 		7748996AA574868ED694F974 /* AudioCaptureLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820A7EF6D7E1FA0F171A5A59 /* AudioCaptureLibrary.swift */; };
 		77B9284EE48D020C2B5A2DF3 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */; };
 		7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */; };
@@ -320,6 +322,7 @@
 		D0952EC469768D8775A2D188 /* VoiceAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioRecorder.swift; sourceTree = "<group>"; };
 		D1651E057CC5D05857CF1595 /* NativServerKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativServerKit.swift; sourceTree = "<group>"; };
 		D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputDevicePreferences.swift; sourceTree = "<group>"; };
+		D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatImageModelSelection.swift; sourceTree = "<group>"; };
 		D8EF4E95FDA6F6E337FC4C47 /* ExtensionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsView.swift; sourceTree = "<group>"; };
 		D941186B3A4BA46FB90201DE /* NativExtensionMessaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionMessaging.swift; sourceTree = "<group>"; };
 		D97F637262DB138A253DEA6F /* ChatComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposer.swift; sourceTree = "<group>"; };
@@ -559,6 +562,7 @@
 		967B3678137E2B152FAC9838 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */,
 				87EF3E0B4A9EEC293EFD5F8A /* ChatImageTool.swift */,
 				B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */,
 				068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */,
@@ -952,6 +956,7 @@
 				A2606518E424E92625661281 /* ChatComposer.swift in Sources */,
 				61598EC22589683F1A54B047 /* ChatConfigurationView.swift in Sources */,
 				E1A4AA0C4AA32599FF2D54E7 /* ChatFontScale.swift in Sources */,
+				2BF78B0A20ED752102326A38 /* ChatImageModelSelection.swift in Sources */,
 				B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */,
 				04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */,
 				902CD676AA3002459DF7ACAE /* ChatPromptRevision.swift in Sources */,
@@ -1022,6 +1027,7 @@
 				AB1C4B8494B46754E6E8BE24 /* AudioAnalyticsStore.swift in Sources */,
 				01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */,
 				4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */,
+				76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */,
 				D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */,
 				39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */,
 				A0D30C905A2788C3BD2149BF /* ChatScreenCapture.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -14,6 +14,7 @@ struct ChatSession: Identifiable, Equatable, Codable {
     var pinnedOrder: Int?
     var sessionOrder: Int?
     var folderID: UUID?
+    var imageGenerationModelID: String?
 
     var summary: ChatSessionSummary {
         ChatSessionSummary(
@@ -153,6 +154,8 @@ struct ChatTranscriptMessage: Identifiable, Equatable, Codable {
     }
 
     enum ToolStatus: String, Equatable, Codable {
+        case preparing
+        case awaitingImageModelSelection
         case running
         case succeeded
         case failed

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -1,6 +1,10 @@
 import Foundation
 import NativServerKit
 
+typealias ChatImageModelSelectionHandler = @MainActor @Sendable (
+    ChatImageModelSelectionRequest
+) async throws -> String
+
 struct ChatToolExecutionContext {
     let imageGenerationModelID: String?
     let baseURL: URL
@@ -9,6 +13,8 @@ struct ChatToolExecutionContext {
     let modelSearchPath: String
     let additionalModelSearchPaths: [String]
     var analyticsDatabaseURL: URL? = nil
+    var imageModelSelection: ChatImageModelSelectionHandler? = nil
+    var imageExecutionWillStart: (@MainActor @Sendable (String) -> Void)? = nil
 }
 
 struct ChatToolExecutionOutcome {
@@ -29,10 +35,7 @@ enum ChatToolRegistry {
         context: ChatToolExecutionContext,
         canEditImage: Bool
     ) -> [MLXChatToolDefinition] {
-        var tools: [MLXChatToolDefinition] = []
-        if context.imageGenerationModelID?.isEmpty == false {
-            tools.append(contentsOf: ChatImageToolRegistry.definitions(canEdit: canEditImage))
-        }
+        var tools = ChatImageToolRegistry.definitions(canEdit: canEditImage)
         tools.append(contentsOf: ChatSystemMonitorToolRegistry.definitions())
         tools.append(contentsOf: ChatModelLibraryToolRegistry.definitions())
         tools.append(contentsOf: ChatServerStatsToolRegistry.definitions())
@@ -91,17 +94,49 @@ enum ChatToolDispatcher {
         call: MLXChatToolCall,
         context: ChatToolExecutionContext
     ) async throws -> ChatToolExecutionOutcome {
-        guard let imageModelID = context.imageGenerationModelID else {
-            throw ChatImageToolError.unsupportedTool(call.function?.name ?? "image")
-        }
-        let result = try await ChatImageToolExecutor().execute(
+        let imageRequest = try ChatImageToolRequest(
             call: call,
+            hasImageReference: !context.imageReferences.isEmpty
+        )
+        let installedModels = try await ChatImageModelSelection.installedOptions(
+            modelSearchPath: context.modelSearchPath,
+            additionalModelSearchPaths: context.additionalModelSearchPaths
+        )
+        let imageModelID: String
+        switch ChatImageModelSelection.resolve(
+            operation: imageRequest.operation,
+            selectedModelID: context.imageGenerationModelID,
+            installedModels: installedModels
+        ) {
+        case .selected(let model):
+            imageModelID = model.modelID
+        case .selectionRequired(let selectionRequest):
+            guard let requestSelection = context.imageModelSelection else {
+                throw ChatImageToolError.modelSelectionUnavailable(imageRequest.operation)
+            }
+            let selectedModelID = try await requestSelection(selectionRequest)
+            guard let selectedModel = ChatImageModelSelection.selectedModel(
+                withID: selectedModelID,
+                from: selectionRequest
+            ) else {
+                throw ChatImageToolError.modelSelectionUnavailable(imageRequest.operation)
+            }
+            imageModelID = selectedModel.modelID
+        case .installationRequired:
+            throw ChatImageToolError.noCompatibleModels(imageRequest.operation)
+        }
+        await context.imageExecutionWillStart?(imageModelID)
+        let result = try await ChatImageToolExecutor().execute(
+            request: imageRequest,
             modelID: imageModelID,
             baseURL: context.baseURL,
             apiKey: context.apiKey,
             references: context.imageReferences
         )
-        return ChatToolExecutionOutcome(content: result.content, attachments: result.attachments)
+        return ChatToolExecutionOutcome(
+            content: result.content,
+            attachments: result.attachments
+        )
     }
 
     private static func executeSystemMonitorTool(
@@ -202,6 +237,10 @@ enum ChatToolPresentation {
 
     static func symbolName(toolName: String?, status: ChatTranscriptMessage.ToolStatus?) -> String {
         switch status {
+        case .preparing:
+            return "magnifyingglass"
+        case .awaitingImageModelSelection:
+            return "photo.badge.checkmark"
         case .failed:
             return "exclamationmark.triangle.fill"
         case .cancelled, .declined:
@@ -228,6 +267,10 @@ enum ChatToolPresentation {
 
     private static func imageTitle(isEdit: Bool, status: ChatTranscriptMessage.ToolStatus?) -> String {
         switch status {
+        case .preparing:
+            return "Checking image model…"
+        case .awaitingImageModelSelection:
+            return "Choose image model"
         case .running:
             return isEdit ? "Editing image…" : "Generating image…"
         case .succeeded:
@@ -241,11 +284,11 @@ enum ChatToolPresentation {
 
     private static func systemMonitorTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {
         switch status {
-        case .running:
+        case .preparing, .running:
             return "Checking system stats…"
         case .succeeded:
             return "Checked system stats"
-        case .failed, .cancelled, .awaitingConsent, .declined:
+        case .failed, .cancelled, .awaitingConsent, .awaitingImageModelSelection, .declined:
             return "System stats"
         case nil:
             return "System tool"
@@ -254,11 +297,11 @@ enum ChatToolPresentation {
 
     private static func modelLibraryTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {
         switch status {
-        case .running:
+        case .preparing, .running:
             return "Listing downloaded models…"
         case .succeeded:
             return "Listed downloaded models"
-        case .failed, .cancelled, .awaitingConsent, .declined:
+        case .failed, .cancelled, .awaitingConsent, .awaitingImageModelSelection, .declined:
             return "Model library"
         case nil:
             return "Model library tool"
@@ -267,11 +310,11 @@ enum ChatToolPresentation {
 
     private static func serverStatsTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {
         switch status {
-        case .running:
+        case .preparing, .running:
             return "Checking server stats…"
         case .succeeded:
             return "Checked server stats"
-        case .failed, .cancelled, .awaitingConsent, .declined:
+        case .failed, .cancelled, .awaitingConsent, .awaitingImageModelSelection, .declined:
             return "Server stats"
         case nil:
             return "Server stats tool"
@@ -282,7 +325,9 @@ enum ChatToolPresentation {
         switch status {
         case .awaitingConsent:
             return "Switch model?"
-        case .running:
+        case .awaitingImageModelSelection:
+            return "Model switch"
+        case .preparing, .running:
             return "Switching model…"
         case .succeeded:
             return "Switched model"
@@ -298,11 +343,11 @@ enum ChatToolPresentation {
     private static func genericTitle(toolName: String?, status: ChatTranscriptMessage.ToolStatus?) -> String {
         let name = toolName ?? "tool"
         switch status {
-        case .running:
+        case .preparing, .running:
             return "Running \(name)…"
         case .succeeded:
             return "Ran \(name)"
-        case .failed, .cancelled, .awaitingConsent, .declined, nil:
+        case .failed, .cancelled, .awaitingConsent, .awaitingImageModelSelection, .declined, nil:
             return name
         }
     }

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -13,6 +13,7 @@ struct ChatToolExecutionContext {
     let modelSearchPath: String
     let additionalModelSearchPaths: [String]
     var analyticsDatabaseURL: URL? = nil
+    var imageToolDependencies = ChatImageToolDependencies.live
     var imageModelSelection: ChatImageModelSelectionHandler? = nil
     var imageExecutionWillStart: (@MainActor @Sendable (String) -> Void)? = nil
 }
@@ -31,10 +32,7 @@ enum ChatToolRoundGate {
 }
 
 enum ChatToolRegistry {
-    static func definitions(
-        context: ChatToolExecutionContext,
-        canEditImage: Bool
-    ) -> [MLXChatToolDefinition] {
+    static func definitions(canEditImage: Bool) -> [MLXChatToolDefinition] {
         var tools = ChatImageToolRegistry.definitions(canEdit: canEditImage)
         tools.append(contentsOf: ChatSystemMonitorToolRegistry.definitions())
         tools.append(contentsOf: ChatModelLibraryToolRegistry.definitions())
@@ -49,16 +47,16 @@ enum ChatToolDispatcher {
     private typealias FailureHandler = (String, Error) -> String
 
     private static let handlers: [String: Handler] = [
-        "generate_image": executeImageTool,
-        "edit_image": executeImageTool,
+        ChatImageToolRegistry.generateToolName: executeImageTool,
+        ChatImageToolRegistry.editToolName: executeImageTool,
         ChatSystemMonitorToolRegistry.toolName: executeSystemMonitorTool,
         ChatModelLibraryToolRegistry.toolName: executeModelLibraryTool,
         ChatServerStatsToolRegistry.toolName: executeServerStatsTool,
     ]
 
     private static let failureHandlers: [String: FailureHandler] = [
-        "generate_image": failurePayloadForImageTool,
-        "edit_image": failurePayloadForImageTool,
+        ChatImageToolRegistry.generateToolName: failurePayloadForImageTool,
+        ChatImageToolRegistry.editToolName: failurePayloadForImageTool,
         ChatSystemMonitorToolRegistry.toolName: { name, error in
             ChatSystemMonitorToolExecutor().failurePayload(operation: name, error: error)
         },
@@ -98,9 +96,9 @@ enum ChatToolDispatcher {
             call: call,
             hasImageReference: !context.imageReferences.isEmpty
         )
-        let installedModels = try await ChatImageModelSelection.installedOptions(
-            modelSearchPath: context.modelSearchPath,
-            additionalModelSearchPaths: context.additionalModelSearchPaths
+        let installedModels = try await context.imageToolDependencies.discoverModels(
+            context.modelSearchPath,
+            context.additionalModelSearchPaths
         )
         let imageModelID: String
         switch ChatImageModelSelection.resolve(
@@ -126,12 +124,12 @@ enum ChatToolDispatcher {
             throw ChatImageToolError.noCompatibleModels(imageRequest.operation)
         }
         await context.imageExecutionWillStart?(imageModelID)
-        let result = try await ChatImageToolExecutor().execute(
-            request: imageRequest,
-            modelID: imageModelID,
-            baseURL: context.baseURL,
-            apiKey: context.apiKey,
-            references: context.imageReferences
+        let result = try await context.imageToolDependencies.execute(
+            imageRequest,
+            imageModelID,
+            context.baseURL,
+            context.apiKey,
+            context.imageReferences
         )
         return ChatToolExecutionOutcome(
             content: result.content,
@@ -218,9 +216,9 @@ enum ChatToolConsentRouter {
 enum ChatToolPresentation {
     static func title(toolName: String?, status: ChatTranscriptMessage.ToolStatus?) -> String {
         switch toolName {
-        case "generate_image":
+        case ChatImageToolRegistry.generateToolName:
             return imageTitle(isEdit: false, status: status)
-        case "edit_image":
+        case ChatImageToolRegistry.editToolName:
             return imageTitle(isEdit: true, status: status)
         case ChatSystemMonitorToolRegistry.toolName:
             return systemMonitorTitle(status: status)
@@ -249,7 +247,8 @@ enum ChatToolPresentation {
             return "questionmark.circle"
         case .succeeded, .running, nil:
             switch toolName {
-            case "generate_image", "edit_image":
+            case ChatImageToolRegistry.generateToolName,
+                 ChatImageToolRegistry.editToolName:
                 return "photo"
             case ChatSystemMonitorToolRegistry.toolName:
                 return "cpu"

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -750,7 +750,9 @@ final class ChatViewModel: ObservableObject {
             case .assistant:
                 speaker = message.modelID.map { NativFormatting.truncateModelName($0, maxLength: 60) } ?? "Assistant"
             case .tool:
-                speaker = message.toolName == "edit_image" ? "Image edit" : "Image generation"
+                speaker = message.toolName == ChatImageToolRegistry.editToolName
+                    ? "Image edit"
+                    : "Image generation"
             case .error:
                 speaker = "Error"
             }
@@ -1103,8 +1105,7 @@ final class ChatViewModel: ObservableObject {
                 for: queuedRequest,
                 before: assistantMessageID,
                 advertisesTools: advertisesTools,
-                settings: activeSettings,
-                imageGenerationModelID: activeImageModelID
+                settings: activeSettings
             ) else {
                 throw NativChatError.invalidResponse
             }
@@ -1138,7 +1139,8 @@ final class ChatViewModel: ObservableObject {
                 try Task.checkCancellation()
                 let toolMessageID = UUID()
                 let initialToolStatus: ChatTranscriptMessage.ToolStatus = switch toolCall.function?.name {
-                case "generate_image", "edit_image": .preparing
+                case ChatImageToolRegistry.generateToolName,
+                     ChatImageToolRegistry.editToolName: .preparing
                 default: .running
                 }
                 guard insertToolMessage(
@@ -1266,14 +1268,10 @@ final class ChatViewModel: ObservableObject {
                         },
                         imageExecutionWillStart: { [weak self] selectedModelID in
                             activeImageModelID = selectedModelID
-                            self?.setImageGenerationModelID(
-                                selectedModelID,
-                                for: queuedRequest.sessionID
-                            )
-                            self?.setToolMessageStatus(
+                            self?.beginImageExecution(
                                 toolMessageID,
-                                in: queuedRequest.sessionID,
-                                status: .running
+                                modelID: selectedModelID,
+                                in: queuedRequest.sessionID
                             )
                         }
                     )
@@ -1336,8 +1334,7 @@ final class ChatViewModel: ObservableObject {
         for queuedRequest: QueuedChatRequest,
         before assistantMessageID: UUID,
         advertisesTools: Bool,
-        settings: NativSettings,
-        imageGenerationModelID: String?
+        settings: NativSettings
     ) -> MLXChatCompletionRequest? {
         guard let modelID = settings.languageModelID,
               let sessionMessages = sessionMessages(for: queuedRequest.sessionID),
@@ -1358,14 +1355,6 @@ final class ChatViewModel: ObservableObject {
         let advertisesToolsForModel = advertisesTools && queuedRequest.languageModelSupportsTools
         let toolDefinitions = advertisesToolsForModel
             ? ChatToolRegistry.definitions(
-                context: ChatToolExecutionContext(
-                    imageGenerationModelID: imageGenerationModelID,
-                    baseURL: settings.serverBaseURL,
-                    apiKey: settings.serverAPIKey,
-                    imageReferences: [],
-                    modelSearchPath: settings.expandedModelSearchPath,
-                    additionalModelSearchPaths: settings.additionalModelSearchPaths
-                ),
                 canEditImage: precedingMessages.contains { !$0.imageAttachments.isEmpty }
             )
             : []
@@ -1608,21 +1597,30 @@ final class ChatViewModel: ObservableObject {
             .imageGenerationModelID
     }
 
-    private func setImageGenerationModelID(_ modelID: String, for sessionID: UUID) {
+    private func beginImageExecution(
+        _ toolMessageID: UUID,
+        modelID: String,
+        in sessionID: UUID
+    ) {
         if currentSessionID == sessionID {
             currentSession?.imageGenerationModelID = modelID
-            persistCurrentSession(updateTimestamp: false)
-            return
+        } else {
+            guard let sessionIndex = storedSessions.firstIndex(where: {
+                $0.id == sessionID
+            }) else {
+                return
+            }
+            storedSessions[sessionIndex].imageGenerationModelID = modelID
         }
 
-        guard let sessionIndex = storedSessions.firstIndex(where: {
-            $0.id == sessionID
-        }) else {
-            return
+        updateMessage(toolMessageID, in: sessionID) { message in
+            message.toolStatus = .running
         }
-        storedSessions[sessionIndex].imageGenerationModelID = modelID
-        sessionStore.saveSession(storedSessions[sessionIndex])
-        refreshSessionList()
+        imageModelSelectionRequests.removeValue(forKey: toolMessageID)
+        persistSession(sessionID, updateTimestamp: true)
+        if currentSessionID == sessionID {
+            bumpScroll()
+        }
     }
 
     private func message(_ messageID: UUID, in sessionID: UUID) -> ChatTranscriptMessage? {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -114,12 +114,17 @@ private struct ChatTranscriptView: View {
                         let editUnavailableReason = userPromptEditingUnavailableReason(for: message)
                         ChatMessageRow(
                             message: message,
+                            imageModelSelectionRequest: chat.imageModelSelectionRequest(
+                                for: message.id
+                            ),
                             canEditUserMessage: editUnavailableReason == nil,
                             editUserMessageUnavailableReason: editUnavailableReason,
                             isEditingUserMessage: chat.promptEditContext?.messageID == message.id,
                             onEditUserMessage: chat.beginEditingUserMessage,
                             onConfirmToolConsent: chat.confirmToolConsent,
-                            onDenyToolConsent: chat.denyToolConsent
+                            onDenyToolConsent: chat.denyToolConsent,
+                            onSelectImageModel: chat.selectImageModel,
+                            onCancelImageModelSelection: chat.cancelImageModelSelection
                         )
                         .equatable()
                         .id(message.id)
@@ -272,6 +277,7 @@ final class ChatViewModel: ObservableObject {
         let userMessageID: UUID
         let assistantMessageID: UUID
         let settings: NativSettings
+        let imageGenerationModelID: String?
         let languageModelSupportsTools: Bool
     }
 
@@ -293,6 +299,9 @@ final class ChatViewModel: ObservableObject {
     @Published private(set) var scrollToken = 0
     @Published var scrollTargetMessageID: UUID?
     @Published private(set) var isLoadingSessions = true
+    @Published private(set) var imageModelSelectionRequests: [
+        UUID: ChatImageModelSelectionRequest
+    ] = [:]
 
     private let sessionStore = ChatSessionStore()
     private var sessionLoadTask: Task<Void, Never>?
@@ -310,6 +319,7 @@ final class ChatViewModel: ObservableObject {
     private var streamFlushTasks: [UUID: Task<Void, Never>] = [:]
     private weak var appModel: NativModel?
     private let toolConsentGate = ChatToolConsentGate()
+    private let imageModelSelectionGate = ChatImageModelSelectionGate()
     private var composerSnapshot: ComposerSnapshot?
 
     init() {
@@ -836,6 +846,8 @@ final class ChatViewModel: ObservableObject {
             userMessageID: userMessageID,
             assistantMessageID: UUID(),
             settings: settings,
+            imageGenerationModelID: imageGenerationModelID(for: sessionID)
+                ?? settings.imageGenerationModelID,
             languageModelSupportsTools: languageModelSupportsTools
         ))
         bumpScroll()
@@ -848,6 +860,31 @@ final class ChatViewModel: ObservableObject {
 
     func denyToolConsent(_ toolMessageID: UUID) {
         toolConsentGate.deny(toolMessageID)
+    }
+
+    func imageModelSelectionRequest(
+        for toolMessageID: UUID
+    ) -> ChatImageModelSelectionRequest? {
+        imageModelSelectionRequests[toolMessageID]
+    }
+
+    func selectImageModel(_ toolMessageID: UUID, _ modelID: String) {
+        guard let request = imageModelSelectionRequests[toolMessageID],
+              ChatImageModelSelection.selectedModel(
+                  withID: modelID,
+                  from: request
+              ) != nil
+        else {
+            return
+        }
+        imageModelSelectionGate.select(modelID: modelID, for: toolMessageID)
+    }
+
+    func cancelImageModelSelection(_ toolMessageID: UUID) {
+        guard imageModelSelectionRequests[toolMessageID] != nil else {
+            return
+        }
+        imageModelSelectionGate.cancel(toolMessageID)
     }
 
     private func awaitToolConsent(for toolMessageID: UUID) async -> Bool {
@@ -1057,6 +1094,7 @@ final class ChatViewModel: ObservableObject {
         var assistantMessageID = queuedRequest.assistantMessageID
         var toolRounds = 0
         var activeSettings = queuedRequest.settings
+        var activeImageModelID = queuedRequest.imageGenerationModelID
 
         while true {
             try Task.checkCancellation()
@@ -1065,7 +1103,8 @@ final class ChatViewModel: ObservableObject {
                 for: queuedRequest,
                 before: assistantMessageID,
                 advertisesTools: advertisesTools,
-                settings: activeSettings
+                settings: activeSettings,
+                imageGenerationModelID: activeImageModelID
             ) else {
                 throw NativChatError.invalidResponse
             }
@@ -1098,11 +1137,16 @@ final class ChatViewModel: ObservableObject {
             for (index, toolCall) in toolCalls.enumerated() {
                 try Task.checkCancellation()
                 let toolMessageID = UUID()
+                let initialToolStatus: ChatTranscriptMessage.ToolStatus = switch toolCall.function?.name {
+                case "generate_image", "edit_image": .preparing
+                default: .running
+                }
                 guard insertToolMessage(
                     id: toolMessageID,
                     call: toolCall,
                     after: insertionAnchor,
-                    in: queuedRequest.sessionID
+                    in: queuedRequest.sessionID,
+                    status: initialToolStatus
                 ) else {
                     throw NativChatError.invalidResponse
                 }
@@ -1190,12 +1234,48 @@ final class ChatViewModel: ObservableObject {
                         in: queuedRequest.sessionID
                     )
                     let context = ChatToolExecutionContext(
-                        imageGenerationModelID: queuedRequest.settings.imageGenerationModelID,
+                        imageGenerationModelID: activeImageModelID,
                         baseURL: queuedRequest.settings.serverBaseURL,
                         apiKey: queuedRequest.settings.serverAPIKey,
                         imageReferences: references,
                         modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
-                        additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths
+                        additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
+                        imageModelSelection: { [weak self] request in
+                            guard let self else {
+                                throw CancellationError()
+                            }
+                            defer {
+                                self.imageModelSelectionRequests.removeValue(
+                                    forKey: toolMessageID
+                                )
+                            }
+
+                            let selectedModelID = await self.imageModelSelectionGate
+                                .awaitSelection(for: toolMessageID) {
+                                    self.imageModelSelectionRequests[toolMessageID] = request
+                                    self.setToolMessageStatus(
+                                        toolMessageID,
+                                        in: queuedRequest.sessionID,
+                                        status: .awaitingImageModelSelection
+                                    )
+                                }
+                            guard let selectedModelID else {
+                                throw CancellationError()
+                            }
+                            return selectedModelID
+                        },
+                        imageExecutionWillStart: { [weak self] selectedModelID in
+                            activeImageModelID = selectedModelID
+                            self?.setImageGenerationModelID(
+                                selectedModelID,
+                                for: queuedRequest.sessionID
+                            )
+                            self?.setToolMessageStatus(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .running
+                            )
+                        }
                     )
                     let outcome = try await ChatToolDispatcher.execute(call: toolCall, context: context)
                     updateToolMessage(
@@ -1256,7 +1336,8 @@ final class ChatViewModel: ObservableObject {
         for queuedRequest: QueuedChatRequest,
         before assistantMessageID: UUID,
         advertisesTools: Bool,
-        settings: NativSettings
+        settings: NativSettings,
+        imageGenerationModelID: String?
     ) -> MLXChatCompletionRequest? {
         guard let modelID = settings.languageModelID,
               let sessionMessages = sessionMessages(for: queuedRequest.sessionID),
@@ -1278,7 +1359,7 @@ final class ChatViewModel: ObservableObject {
         let toolDefinitions = advertisesToolsForModel
             ? ChatToolRegistry.definitions(
                 context: ChatToolExecutionContext(
-                    imageGenerationModelID: settings.imageGenerationModelID,
+                    imageGenerationModelID: imageGenerationModelID,
                     baseURL: settings.serverBaseURL,
                     apiKey: settings.serverAPIKey,
                     imageReferences: [],
@@ -1346,7 +1427,8 @@ final class ChatViewModel: ObservableObject {
         id: UUID,
         call: MLXChatToolCall,
         after messageID: UUID,
-        in sessionID: UUID
+        in sessionID: UUID,
+        status: ChatTranscriptMessage.ToolStatus = .running
     ) -> Bool {
         insertMessage(
             ChatTranscriptMessage(
@@ -1356,7 +1438,7 @@ final class ChatViewModel: ObservableObject {
                 isStreaming: true,
                 toolCallID: call.id,
                 toolName: call.function?.name,
-                toolStatus: .running,
+                toolStatus: status,
                 toolArguments: call.function?.arguments
             ),
             after: messageID,
@@ -1430,6 +1512,26 @@ final class ChatViewModel: ObservableObject {
             message.toolStatus = status
             message.isStreaming = false
         }
+        if status != .awaitingImageModelSelection {
+            imageModelSelectionRequests.removeValue(forKey: id)
+        }
+        persistSession(sessionID, updateTimestamp: true)
+        if currentSessionID == sessionID {
+            bumpScroll()
+        }
+    }
+
+    private func setToolMessageStatus(
+        _ id: UUID,
+        in sessionID: UUID,
+        status: ChatTranscriptMessage.ToolStatus
+    ) {
+        updateMessage(id, in: sessionID) { message in
+            message.toolStatus = status
+        }
+        if status != .awaitingImageModelSelection {
+            imageModelSelectionRequests.removeValue(forKey: id)
+        }
         persistSession(sessionID, updateTimestamp: true)
         if currentSessionID == sessionID {
             bumpScroll()
@@ -1496,6 +1598,31 @@ final class ChatViewModel: ObservableObject {
             return messages
         }
         return storedSessions.first(where: { $0.id == sessionID })?.messages
+    }
+
+    private func imageGenerationModelID(for sessionID: UUID) -> String? {
+        if currentSessionID == sessionID {
+            return currentSession?.imageGenerationModelID
+        }
+        return storedSessions.first(where: { $0.id == sessionID })?
+            .imageGenerationModelID
+    }
+
+    private func setImageGenerationModelID(_ modelID: String, for sessionID: UUID) {
+        if currentSessionID == sessionID {
+            currentSession?.imageGenerationModelID = modelID
+            persistCurrentSession(updateTimestamp: false)
+            return
+        }
+
+        guard let sessionIndex = storedSessions.firstIndex(where: {
+            $0.id == sessionID
+        }) else {
+            return
+        }
+        storedSessions[sessionIndex].imageGenerationModelID = modelID
+        sessionStore.saveSession(storedSessions[sessionIndex])
+        refreshSessionList()
     }
 
     private func message(_ messageID: UUID, in sessionID: UUID) -> ChatTranscriptMessage? {
@@ -1761,7 +1888,11 @@ final class ChatViewModel: ObservableObject {
     private func normalizedForLoad(_ messages: [ChatTranscriptMessage]) -> [ChatTranscriptMessage] {
         messages.map { message in
             var message = message
-            if message.toolStatus == .awaitingConsent || message.toolStatus == .running {
+            if message.toolStatus == .awaitingConsent
+                || message.toolStatus == .awaitingImageModelSelection
+                || message.toolStatus == .preparing
+                || message.toolStatus == .running
+            {
                 message.toolStatus = .cancelled
                 message.content = ChatToolDispatcher.failurePayload(
                     toolName: message.toolName,
@@ -1870,17 +2001,21 @@ private struct ChatMessageRow: View, Equatable {
     private static let maximumUserBubbleWidth: CGFloat = 560
 
     let message: ChatTranscriptMessage
+    let imageModelSelectionRequest: ChatImageModelSelectionRequest?
     let canEditUserMessage: Bool
     let editUserMessageUnavailableReason: String?
     let isEditingUserMessage: Bool
     let onEditUserMessage: (UUID) -> Void
     let onConfirmToolConsent: (UUID) -> Void
     let onDenyToolConsent: (UUID) -> Void
+    let onSelectImageModel: (UUID, String) -> Void
+    let onCancelImageModelSelection: (UUID) -> Void
     @State private var didCopyMessage = false
     @State private var isHoveringMessage = false
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.message == rhs.message
+            && lhs.imageModelSelectionRequest == rhs.imageModelSelectionRequest
             && lhs.canEditUserMessage == rhs.canEditUserMessage
             && lhs.editUserMessageUnavailableReason == rhs.editUserMessageUnavailableReason
             && lhs.isEditingUserMessage == rhs.isEditingUserMessage
@@ -1897,8 +2032,11 @@ private struct ChatMessageRow: View, Equatable {
             if message.role == .tool {
                 ChatAgentStepCell(
                     message: message,
+                    imageModelSelectionRequest: imageModelSelectionRequest,
                     onConfirm: onConfirmToolConsent,
-                    onDeny: onDenyToolConsent
+                    onDeny: onDenyToolConsent,
+                    onSelectImageModel: onSelectImageModel,
+                    onCancelImageModelSelection: onCancelImageModelSelection
                 )
             }
 
@@ -2168,12 +2306,20 @@ private struct ChatMessageRow: View, Equatable {
 
 private struct ChatAgentStepCell: View {
     let message: ChatTranscriptMessage
+    let imageModelSelectionRequest: ChatImageModelSelectionRequest?
     let onConfirm: (UUID) -> Void
     let onDeny: (UUID) -> Void
+    let onSelectImageModel: (UUID, String) -> Void
+    let onCancelImageModelSelection: (UUID) -> Void
     @State private var isExpanded = false
 
     private var isAwaitingConsent: Bool {
         message.toolStatus == .awaitingConsent
+    }
+
+    private var isAwaitingImageModelSelection: Bool {
+        message.toolStatus == .awaitingImageModelSelection
+            && imageModelSelectionRequest != nil
     }
 
     var body: some View {
@@ -2187,9 +2333,13 @@ private struct ChatAgentStepCell: View {
             }
             .buttonStyle(.plain)
             .help(isExpanded ? "Hide call details" : "Show call details")
-            .disabled(isAwaitingConsent)
+            .disabled(isAwaitingConsent || isAwaitingImageModelSelection)
 
-            if isAwaitingConsent {
+            if isAwaitingImageModelSelection {
+                Divider()
+                    .padding(.top, 7)
+                imageModelSelectionPrompt
+            } else if isAwaitingConsent {
                 Divider()
                     .padding(.top, 7)
                 consentPrompt
@@ -2231,7 +2381,7 @@ private struct ChatAgentStepCell: View {
 
                 Spacer(minLength: 12)
 
-                if !isAwaitingConsent {
+                if !isAwaitingConsent && !isAwaitingImageModelSelection {
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
@@ -2256,7 +2406,8 @@ private struct ChatAgentStepCell: View {
             "Failed"
         case .declined:
             "Declined"
-        case .running, .succeeded, .awaitingConsent, nil:
+        case .preparing, .running, .succeeded, .awaitingConsent,
+             .awaitingImageModelSelection, nil:
             nil
         }
     }
@@ -2283,6 +2434,65 @@ private struct ChatAgentStepCell: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.top, 7)
+    }
+
+    @ViewBuilder
+    private var imageModelSelectionPrompt: some View {
+        if let request = imageModelSelectionRequest {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Choose the model to use for \(request.operation.capabilityName).")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(request.models) { model in
+                        Button {
+                            onSelectImageModel(message.id, model.modelID)
+                        } label: {
+                            HStack(spacing: 10) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(model.displayName)
+                                        .font(.callout.weight(.medium))
+                                        .foregroundStyle(.primary)
+                                    Text(model.modelID)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                }
+                                Spacer(minLength: 12)
+                                Image(systemName: "chevron.right")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                            .contentShape(.rect)
+                            .background(
+                                Color(nsColor: .controlBackgroundColor),
+                                in: RoundedRectangle(cornerRadius: 7)
+                            )
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 7)
+                                    .stroke(
+                                        Color(nsColor: .separatorColor),
+                                        lineWidth: 0.5
+                                    )
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Use \(model.displayName)")
+                    }
+                }
+
+                Button("Cancel") {
+                    onCancelImageModelSelection(message.id)
+                }
+                .buttonStyle(.bordered)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 7)
+        }
     }
 
     private var requestedModelID: String {
@@ -2344,6 +2554,8 @@ private struct ChatAgentStepCell: View {
 
     private var accessibilityStatus: String {
         switch message.toolStatus {
+        case .preparing:
+            "preparing"
         case .running:
             "running"
         case .succeeded:
@@ -2354,6 +2566,8 @@ private struct ChatAgentStepCell: View {
             "cancelled"
         case .awaitingConsent:
             "awaiting your confirmation"
+        case .awaitingImageModelSelection:
+            "awaiting image model selection"
         case .declined:
             "declined"
         case nil:

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
@@ -6,9 +6,9 @@ enum ChatImageOperation: String, Equatable, Sendable {
 
     init(toolName: String?) throws {
         switch toolName {
-        case "generate_image":
+        case ChatImageToolRegistry.generateToolName:
             self = .generate
-        case "edit_image":
+        case ChatImageToolRegistry.editToolName:
             self = .edit
         default:
             throw ChatImageToolError.unsupportedTool(toolName ?? "unknown")

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+enum ChatImageOperation: String, Equatable, Sendable {
+    case generate
+    case edit
+
+    init(toolName: String?) throws {
+        switch toolName {
+        case "generate_image":
+            self = .generate
+        case "edit_image":
+            self = .edit
+        default:
+            throw ChatImageToolError.unsupportedTool(toolName ?? "unknown")
+        }
+    }
+
+    var requiredCapability: LocalModelCapability {
+        switch self {
+        case .generate: .imageGeneration
+        case .edit: .imageEditing
+        }
+    }
+
+    var capabilityName: String {
+        switch self {
+        case .generate: "image generation"
+        case .edit: "image editing"
+        }
+    }
+}
+
+struct ChatImageModelOption: Identifiable, Equatable, Sendable {
+    var id: String { modelID }
+
+    let displayName: String
+    let modelID: String
+    let capabilities: Set<LocalModelCapability>
+
+    init(model: LocalModel) {
+        let repositoryName = model.repoID.split(separator: "/").last.map(String.init)
+        displayName = repositoryName ?? model.displayName
+        modelID = model.repoID
+        capabilities = model.capabilities
+    }
+
+    init(
+        displayName: String,
+        modelID: String,
+        capabilities: Set<LocalModelCapability>
+    ) {
+        self.displayName = displayName
+        self.modelID = modelID
+        self.capabilities = capabilities
+    }
+
+    func supports(_ operation: ChatImageOperation) -> Bool {
+        capabilities.contains(operation.requiredCapability)
+    }
+}
+
+struct ChatImageModelSelectionRequest: Equatable, Sendable {
+    let operation: ChatImageOperation
+    let models: [ChatImageModelOption]
+}
+
+enum ChatImageModelResolution: Equatable, Sendable {
+    case selected(ChatImageModelOption)
+    case selectionRequired(ChatImageModelSelectionRequest)
+    case installationRequired(ChatImageOperation)
+}
+
+enum ChatImageModelSelection {
+    static func installedOptions(
+        modelSearchPath: String,
+        additionalModelSearchPaths: [String]
+    ) async throws -> [ChatImageModelOption] {
+        let models: [LocalModel]
+        do {
+            models = try await LocalModelDiscovery.scan(
+                path: modelSearchPath,
+                additionalPaths: additionalModelSearchPaths
+            )
+        } catch LocalModelDiscoveryError.pathNotFound {
+            // A fresh install may not have a model cache directory yet.
+            models = []
+        }
+
+        return models
+            .map(ChatImageModelOption.init(model:))
+            .sorted(by: modelOrder)
+    }
+
+    static func resolve(
+        operation: ChatImageOperation,
+        selectedModelID: String?,
+        installedModels: [ChatImageModelOption]
+    ) -> ChatImageModelResolution {
+        let compatibleModels = compatibleModels(for: operation, in: installedModels)
+        guard !compatibleModels.isEmpty else {
+            return .installationRequired(operation)
+        }
+
+        if let selectedModelID = normalized(selectedModelID),
+           let selectedModel = compatibleModels.first(where: {
+               $0.modelID == selectedModelID
+           }) {
+            return .selected(selectedModel)
+        }
+
+        return .selectionRequired(ChatImageModelSelectionRequest(
+            operation: operation,
+            models: compatibleModels
+        ))
+    }
+
+    static func compatibleModels(
+        for operation: ChatImageOperation,
+        in installedModels: [ChatImageModelOption]
+    ) -> [ChatImageModelOption] {
+        installedModels.filter { $0.supports(operation) }
+    }
+
+    static func selectedModel(
+        withID modelID: String,
+        from request: ChatImageModelSelectionRequest
+    ) -> ChatImageModelOption? {
+        request.models.first { $0.modelID == modelID }
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        return value
+    }
+
+    private static func modelOrder(
+        _ lhs: ChatImageModelOption,
+        _ rhs: ChatImageModelOption
+    ) -> Bool {
+        let displayOrder = lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+        if displayOrder == .orderedSame {
+            return lhs.modelID < rhs.modelID
+        }
+        return displayOrder == .orderedAscending
+    }
+}
+
+@MainActor
+final class ChatImageModelSelectionGate {
+    private var pending: [UUID: CheckedContinuation<String?, Never>] = [:]
+
+    var pendingCount: Int {
+        pending.count
+    }
+
+    func select(modelID: String, for requestID: UUID) {
+        pending.removeValue(forKey: requestID)?.resume(returning: modelID)
+    }
+
+    func cancel(_ requestID: UUID) {
+        pending.removeValue(forKey: requestID)?.resume(returning: nil)
+    }
+
+    func awaitSelection(
+        for requestID: UUID,
+        onReady: () -> Void
+    ) async -> String? {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                pending.removeValue(forKey: requestID)?.resume(returning: nil)
+                pending[requestID] = continuation
+                onReady()
+                if Task.isCancelled {
+                    pending.removeValue(forKey: requestID)?.resume(returning: nil)
+                }
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor in
+                self?.pending.removeValue(forKey: requestID)?.resume(returning: nil)
+            }
+        }
+    }
+}

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
@@ -3,14 +3,17 @@ import Foundation
 import NativServerKit
 
 enum ChatImageToolRegistry {
+    static let generateToolName = "generate_image"
+    static let editToolName = "edit_image"
+
     static func definitions(canEdit: Bool) -> [MLXChatToolDefinition] {
         var tools = [tool(
-            name: "generate_image",
+            name: generateToolName,
             description: "Create one or more new images from a detailed text prompt. Image-model selection is handled by the app; do not ask for or provide a model identifier."
         )]
         if canEdit {
             tools.append(tool(
-                name: "edit_image",
+                name: editToolName,
                 description: "Edit the most recently attached or generated image using a text instruction. Image-model selection is handled by the app; do not ask for or provide a model identifier."
             ))
         }
@@ -128,9 +131,44 @@ struct ChatImageToolResultPayload: Encodable {
     }
 }
 
-struct ChatImageToolExecution {
+struct ChatImageToolExecution: Sendable {
     let content: String
     let attachments: [ChatImageAttachment]
+}
+
+struct ChatImageToolDependencies: Sendable {
+    typealias ModelDiscovery = @Sendable (
+        String,
+        [String]
+    ) async throws -> [ChatImageModelOption]
+    typealias Execution = @Sendable (
+        ChatImageToolRequest,
+        String,
+        URL,
+        String?,
+        [ChatImageAttachment]
+    ) async throws -> ChatImageToolExecution
+
+    let discoverModels: ModelDiscovery
+    let execute: Execution
+
+    static let live = Self(
+        discoverModels: { path, additionalPaths in
+            try await ChatImageModelSelection.installedOptions(
+                modelSearchPath: path,
+                additionalModelSearchPaths: additionalPaths
+            )
+        },
+        execute: { request, modelID, baseURL, apiKey, references in
+            try await ChatImageToolExecutor().execute(
+                request: request,
+                modelID: modelID,
+                baseURL: baseURL,
+                apiKey: apiKey,
+                references: references
+            )
+        }
+    )
 }
 
 enum ChatImageToolError: LocalizedError {
@@ -216,7 +254,7 @@ struct ChatImageToolExecutor {
         }
         let payload = ChatImageToolResultPayload(
             ok: false,
-            operation: operation == "edit_image" ? "edit" : "generate",
+            operation: operation == ChatImageToolRegistry.editToolName ? "edit" : "generate",
             images: nil,
             installationRequired: installationRequired,
             error: error.localizedDescription

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
@@ -6,12 +6,12 @@ enum ChatImageToolRegistry {
     static func definitions(canEdit: Bool) -> [MLXChatToolDefinition] {
         var tools = [tool(
             name: "generate_image",
-            description: "Create one or more new images from a detailed text prompt."
+            description: "Create one or more new images from a detailed text prompt. Image-model selection is handled by the app; do not ask for or provide a model identifier."
         )]
         if canEdit {
             tools.append(tool(
                 name: "edit_image",
-                description: "Edit the most recently attached or generated image using a text instruction."
+                description: "Edit the most recently attached or generated image using a text instruction. Image-model selection is handled by the app; do not ask for or provide a model identifier."
             ))
         }
         return tools
@@ -60,6 +60,42 @@ struct ChatImageToolArguments: Decodable {
     let height: Int?
     let count: Int?
     let seed: Int?
+
+    static func decode(call: MLXChatToolCall) throws -> Self {
+        guard let arguments = call.function?.arguments?.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(Self.self, from: arguments)
+        else {
+            throw ChatImageToolError.invalidArguments
+        }
+        return decoded
+    }
+}
+
+struct ChatImageToolRequest: Equatable, Sendable {
+    let operation: ChatImageOperation
+    let prompt: String
+    let width: Int?
+    let height: Int?
+    let count: Int?
+    let seed: Int?
+
+    init(call: MLXChatToolCall, hasImageReference: Bool) throws {
+        operation = try ChatImageOperation(toolName: call.function?.name)
+        let arguments = try ChatImageToolArguments.decode(call: call)
+        let prompt = arguments.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw ChatImageToolError.emptyPrompt
+        }
+        guard operation != .edit || hasImageReference else {
+            throw ChatImageToolError.missingReference
+        }
+
+        self.prompt = prompt
+        width = arguments.width
+        height = arguments.height
+        count = arguments.count
+        seed = arguments.seed
+    }
 }
 
 struct ChatImageToolResultPayload: Encodable {
@@ -80,7 +116,16 @@ struct ChatImageToolResultPayload: Encodable {
     let ok: Bool
     let operation: String
     let images: [Image]?
+    let installationRequired: Bool?
     let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case operation
+        case images
+        case installationRequired = "installation_required"
+        case error
+    }
 }
 
 struct ChatImageToolExecution {
@@ -93,6 +138,8 @@ enum ChatImageToolError: LocalizedError {
     case invalidArguments
     case emptyPrompt
     case missingReference
+    case modelSelectionUnavailable(ChatImageOperation)
+    case noCompatibleModels(ChatImageOperation)
 
     var errorDescription: String? {
         switch self {
@@ -104,60 +151,46 @@ enum ChatImageToolError: LocalizedError {
             "The image prompt cannot be empty."
         case .missingReference:
             "No earlier image is available to edit."
+        case .modelSelectionUnavailable(let operation):
+            "The app could not present the \(operation.capabilityName) model picker."
+        case .noCompatibleModels(let operation):
+            "No compatible \(operation.capabilityName) model is installed. Download one from the Models tab, then try again."
         }
     }
 }
 
 struct ChatImageToolExecutor {
     func execute(
-        call: MLXChatToolCall,
+        request: ChatImageToolRequest,
         modelID: String,
         baseURL: URL,
         apiKey: String?,
         references: [ChatImageAttachment]
     ) async throws -> ChatImageToolExecution {
-        guard let name = call.function?.name else {
-            throw ChatImageToolError.unsupportedTool("unknown")
-        }
-        guard name == "generate_image" || name == "edit_image" else {
-            throw ChatImageToolError.unsupportedTool(name)
-        }
-        guard let arguments = call.function?.arguments?.data(using: .utf8),
-              let decoded = try? JSONDecoder().decode(ChatImageToolArguments.self, from: arguments)
-        else {
-            throw ChatImageToolError.invalidArguments
-        }
-
-        let prompt = decoded.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !prompt.isEmpty else {
-            throw ChatImageToolError.emptyPrompt
-        }
-        if name == "edit_image", references.isEmpty {
-            throw ChatImageToolError.missingReference
-        }
-
-        let sourceSize = name == "edit_image" ? imageSize(for: references.first) : nil
+        let sourceSize = request.operation == .edit
+            ? imageSize(for: references.first)
+            : nil
         let settings = ImageRequestSettings(
-            count: min(max(decoded.count ?? 1, 1), 4),
-            width: boundedDimension(decoded.width ?? sourceSize?.width ?? 512),
-            height: boundedDimension(decoded.height ?? sourceSize?.height ?? 512),
+            count: min(max(request.count ?? 1, 1), 4),
+            width: boundedDimension(request.width ?? sourceSize?.width ?? 512),
+            height: boundedDimension(request.height ?? sourceSize?.height ?? 512),
             steps: 4,
             guidance: 1,
-            seedText: decoded.seed.map(String.init) ?? ""
+            seedText: request.seed.map(String.init) ?? ""
         )
         let outputs = try await ImageGenerationExecutor().run(
             baseURL: baseURL,
             apiKey: apiKey,
             modelID: modelID,
-            prompt: prompt,
-            references: name == "edit_image" ? references : [],
+            prompt: request.prompt,
+            references: request.operation == .edit ? references : [],
             settings: settings,
-            seed: decoded.seed
+            seed: request.seed
         )
         let attachments = outputs.map(\.attachment)
         let payload = ChatImageToolResultPayload(
             ok: true,
-            operation: name == "edit_image" ? "edit" : "generate",
+            operation: request.operation.rawValue,
             images: outputs.map {
                 ChatImageToolResultPayload.Image(
                     attachmentID: $0.id.uuidString,
@@ -166,6 +199,7 @@ struct ChatImageToolExecutor {
                     seed: $0.seed
                 )
             },
+            installationRequired: nil,
             error: nil
         )
         return ChatImageToolExecution(
@@ -175,10 +209,16 @@ struct ChatImageToolExecutor {
     }
 
     func failurePayload(operation: String, error: Error) -> String {
+        let installationRequired: Bool? = if case ChatImageToolError.noCompatibleModels = error {
+            true
+        } else {
+            nil
+        }
         let payload = ChatImageToolResultPayload(
             ok: false,
-            operation: operation,
+            operation: operation == "edit_image" ? "edit" : "generate",
             images: nil,
+            installationRequired: installationRequired,
             error: error.localizedDescription
         )
         return (try? encodedPayload(payload))

--- a/Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
@@ -7,7 +7,7 @@ enum ChatModelLibraryToolRegistry {
     static func definitions() -> [MLXChatToolDefinition] {
         [MLXChatToolDefinition(function: MLXChatFunctionDefinition(
             name: toolName,
-            description: "List all MLX models already downloaded on this Mac, including display name, exact repository ID, size, quantization, and capabilities.",
+            description: "List the MLX models already downloaded on this Mac, with size and quantization.",
             parameters: .object([
                 "type": .string("object"),
                 "additionalProperties": .bool(false),
@@ -19,7 +19,6 @@ enum ChatModelLibraryToolRegistry {
 
 struct ChatModelLibraryToolResultPayload: Encodable {
     struct Model: Encodable {
-        let displayName: String
         let repoID: String
         let sizeGB: Double?
         let parameterCount: Int64?
@@ -27,7 +26,6 @@ struct ChatModelLibraryToolResultPayload: Encodable {
         let capabilities: [String]
 
         enum CodingKeys: String, CodingKey {
-            case displayName = "display_name"
             case repoID = "repo_id"
             case sizeGB = "size_gb"
             case parameterCount = "parameter_count"
@@ -47,21 +45,14 @@ struct ChatModelLibraryToolExecutor {
             throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
         }
 
-        let models: [LocalModel]
-        do {
-            models = try await LocalModelDiscovery.scan(
-                path: context.modelSearchPath,
-                additionalPaths: context.additionalModelSearchPaths
-            )
-        } catch LocalModelDiscoveryError.pathNotFound {
-            models = []
-        }
+        let models = try await LocalModelDiscovery.scan(
+            path: context.modelSearchPath,
+            additionalPaths: context.additionalModelSearchPaths
+        )
         let payload = ChatModelLibraryToolResultPayload(
             ok: true,
             models: models.map { model in
                 ChatModelLibraryToolResultPayload.Model(
-                    displayName: model.repoID.split(separator: "/").last.map(String.init)
-                        ?? model.displayName,
                     repoID: model.repoID,
                     sizeGB: model.sizeBytes.map(gigabytes),
                     parameterCount: model.parameterCount,

--- a/Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
@@ -7,7 +7,7 @@ enum ChatModelLibraryToolRegistry {
     static func definitions() -> [MLXChatToolDefinition] {
         [MLXChatToolDefinition(function: MLXChatFunctionDefinition(
             name: toolName,
-            description: "List the MLX models already downloaded on this Mac, with size and quantization.",
+            description: "List all MLX models already downloaded on this Mac, including display name, exact repository ID, size, quantization, and capabilities.",
             parameters: .object([
                 "type": .string("object"),
                 "additionalProperties": .bool(false),
@@ -19,6 +19,7 @@ enum ChatModelLibraryToolRegistry {
 
 struct ChatModelLibraryToolResultPayload: Encodable {
     struct Model: Encodable {
+        let displayName: String
         let repoID: String
         let sizeGB: Double?
         let parameterCount: Int64?
@@ -26,6 +27,7 @@ struct ChatModelLibraryToolResultPayload: Encodable {
         let capabilities: [String]
 
         enum CodingKeys: String, CodingKey {
+            case displayName = "display_name"
             case repoID = "repo_id"
             case sizeGB = "size_gb"
             case parameterCount = "parameter_count"
@@ -45,14 +47,21 @@ struct ChatModelLibraryToolExecutor {
             throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
         }
 
-        let models = try await LocalModelDiscovery.scan(
-            path: context.modelSearchPath,
-            additionalPaths: context.additionalModelSearchPaths
-        )
+        let models: [LocalModel]
+        do {
+            models = try await LocalModelDiscovery.scan(
+                path: context.modelSearchPath,
+                additionalPaths: context.additionalModelSearchPaths
+            )
+        } catch LocalModelDiscoveryError.pathNotFound {
+            models = []
+        }
         let payload = ChatModelLibraryToolResultPayload(
             ok: true,
             models: models.map { model in
                 ChatModelLibraryToolResultPayload.Model(
+                    displayName: model.repoID.split(separator: "/").last.map(String.init)
+                        ?? model.displayName,
                     repoID: model.repoID,
                     sizeGB: model.sizeBytes.map(gigabytes),
                     parameterCount: model.parameterCount,

--- a/Sources/Nativ/Features/Models/MLXImageModelResolver.swift
+++ b/Sources/Nativ/Features/Models/MLXImageModelResolver.swift
@@ -38,18 +38,27 @@ struct MLXImageModelResolver: Sendable {
         at root: URL,
         fileManager: FileManager
     ) -> Bool {
-        guard supportedModelType(
+        guard let modelType = supportedModelType(
             model: model,
             at: root,
             fileManager: fileManager
-        ) == "mage_flow" else {
+        ) else {
             return false
         }
-        return isMageFlowEditModel(
-            model: model,
-            at: root,
-            fileManager: fileManager
-        )
+        switch modelType {
+        case "flux2":
+            // Every FLUX.2 variant supported by the bundled backend can use
+            // reference images as well as generate from text.
+            return true
+        case "mage_flow":
+            return isMageFlowEditModel(
+                model: model,
+                at: root,
+                fileManager: fileManager
+            )
+        default:
+            return false
+        }
     }
 
     func isSupportedImageModel(

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -12,6 +12,18 @@ private struct FakeToolError: Error, LocalizedError {
     var errorDescription: String? { "fake failure" }
 }
 
+private actor ImageToolExecutionRecorder {
+    private var modelID: String?
+
+    func record(modelID: String) {
+        self.modelID = modelID
+    }
+
+    func recordedModelID() -> String? {
+        modelID
+    }
+}
+
 @MainActor
 private final class FakeModelSwitchingSurface: ChatModelSwitchingSurface {
     var settings: NativSettings
@@ -58,45 +70,32 @@ private func makeCall(name: String, arguments: String = "{}") -> MLXChatToolCall
 
 final class ChatToolRegistryTests: XCTestCase {
     func testDefinitionsAdvertiseGenerationAndGuidanceWithNoImageModelConfigured() {
-        let names = ChatToolRegistry.definitions(context: makeContext(), canEditImage: false)
+        let names = ChatToolRegistry.definitions(canEditImage: false)
             .map(\.function.name)
 
-        XCTAssertTrue(names.contains("generate_image"))
-        XCTAssertFalse(names.contains("edit_image"))
+        XCTAssertTrue(names.contains(ChatImageToolRegistry.generateToolName))
+        XCTAssertFalse(names.contains(ChatImageToolRegistry.editToolName))
         for toolName in nativeToolNames {
             XCTAssertTrue(names.contains(toolName), "\(toolName) should be advertised without an image model")
         }
     }
 
     func testDefinitionsOfferEditOnlyWhenAnImageIsAvailable() {
-        let withoutEdit = ChatToolRegistry.definitions(
-            context: makeContext(imageModelID: "org/image"),
-            canEditImage: false
-        ).map(\.function.name)
-        XCTAssertTrue(withoutEdit.contains("generate_image"))
-        XCTAssertFalse(withoutEdit.contains("edit_image"))
-
-        let withEdit = ChatToolRegistry.definitions(
-            context: makeContext(imageModelID: "org/image"),
-            canEditImage: true
-        ).map(\.function.name)
-        XCTAssertTrue(withEdit.contains("edit_image"))
-    }
-
-    func testDefinitionsTreatAnEmptyModelIDAsUnselectedButStillAdvertiseGuidance() {
-        let names = ChatToolRegistry.definitions(context: makeContext(imageModelID: ""), canEditImage: true)
+        let withoutEdit = ChatToolRegistry.definitions(canEditImage: false)
             .map(\.function.name)
+        XCTAssertTrue(withoutEdit.contains(ChatImageToolRegistry.generateToolName))
+        XCTAssertFalse(withoutEdit.contains(ChatImageToolRegistry.editToolName))
 
-        XCTAssertTrue(names.contains("generate_image"))
-        XCTAssertTrue(names.contains("edit_image"))
+        let withEdit = ChatToolRegistry.definitions(canEditImage: true)
+            .map(\.function.name)
+        XCTAssertTrue(withEdit.contains(ChatImageToolRegistry.editToolName))
     }
 
     func testDefinitionsNeverAdvertiseDuplicateToolNames() {
-        for imageModelID in [nil, "", "org/image"] {
-            let names = ChatToolRegistry.definitions(context: makeContext(imageModelID: imageModelID), canEditImage: true)
-                .map(\.function.name)
-            XCTAssertEqual(names.count, Set(names).count, "duplicate tool names advertised for imageModelID=\(String(describing: imageModelID))")
-        }
+        let names = ChatToolRegistry.definitions(canEditImage: true)
+            .map(\.function.name)
+
+        XCTAssertEqual(names.count, Set(names).count)
     }
 
     func testImageToolSchemasAreGoldenPinned() throws {
@@ -239,7 +238,7 @@ final class ChatToolRegistryTests: XCTestCase {
 
     func testInstallationFailurePayloadDoesNotExposeModelChoices() throws {
         let object = try decode(ChatImageToolExecutor().failurePayload(
-            operation: "generate_image",
+            operation: ChatImageToolRegistry.generateToolName,
             error: ChatImageToolError.noCompatibleModels(.generate)
         ))
 
@@ -250,19 +249,10 @@ final class ChatToolRegistryTests: XCTestCase {
     }
 
     @MainActor
-    func testMissingModelCacheReturnsEmptyLibraryWithoutStartingGeneration() async throws {
+    func testMissingModelCacheDoesNotStartImageGeneration() async throws {
         let missingPath = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .path
-        let libraryContext = makeContext(modelSearchPath: missingPath)
-        let libraryResult = try await ChatModelLibraryToolExecutor().execute(
-            call: makeCall(name: ChatModelLibraryToolRegistry.toolName),
-            context: libraryContext
-        )
-        let libraryPayload = try decode(libraryResult)
-        XCTAssertEqual(libraryPayload["ok"] as? Bool, true)
-        XCTAssertEqual((libraryPayload["models"] as? [[String: Any]])?.count, 0)
-
         var didStartExecution = false
         var imageContext = makeContext(modelSearchPath: missingPath)
         imageContext.imageExecutionWillStart = { _ in
@@ -271,7 +261,7 @@ final class ChatToolRegistryTests: XCTestCase {
         do {
             _ = try await ChatToolDispatcher.execute(
                 call: makeCall(
-                    name: "generate_image",
+                    name: ChatImageToolRegistry.generateToolName,
                     arguments: #"{"prompt":"A lake"}"#
                 ),
                 context: imageContext
@@ -285,6 +275,49 @@ final class ChatToolRegistryTests: XCTestCase {
             XCTFail("expected ChatImageToolError, got \(error)")
         }
         XCTAssertFalse(didStartExecution)
+    }
+
+    @MainActor
+    func testNativeSelectionPropagatesExactModelIDToExecutionAndSessionCallback() async throws {
+        let selectedModel = ChatImageModelOption(
+            displayName: "Image Model",
+            modelID: "org/image-model",
+            capabilities: [.imageGeneration]
+        )
+        let languageModel = ChatImageModelOption(
+            displayName: "Language Model",
+            modelID: "org/language-model",
+            capabilities: [.text, .tools]
+        )
+        let recorder = ImageToolExecutionRecorder()
+        var sessionModelID: String?
+        var context = makeContext()
+        context.imageToolDependencies = ChatImageToolDependencies(
+            discoverModels: { _, _ in [selectedModel, languageModel] },
+            execute: { _, modelID, _, _, _ in
+                await recorder.record(modelID: modelID)
+                return ChatImageToolExecution(content: #"{"ok":true}"#, attachments: [])
+            }
+        )
+        context.imageModelSelection = { request in
+            XCTAssertEqual(request.models, [selectedModel])
+            return selectedModel.modelID
+        }
+        context.imageExecutionWillStart = { modelID in
+            sessionModelID = modelID
+        }
+
+        _ = try await ChatToolDispatcher.execute(
+            call: makeCall(
+                name: ChatImageToolRegistry.generateToolName,
+                arguments: #"{"prompt":"A lake"}"#
+            ),
+            context: context
+        )
+
+        let executedModelID = await recorder.recordedModelID()
+        XCTAssertEqual(sessionModelID, selectedModel.modelID)
+        XCTAssertEqual(executedModelID, selectedModel.modelID)
     }
 
     func testDispatchRoutesToRegisteredHandler() async throws {
@@ -540,6 +573,19 @@ final class ChatImageModelSelectionGateTests: XCTestCase {
         }
         await waitUntilPending(gate)
 
+        task.cancel()
+
+        let selectedModelID = await task.value
+        XCTAssertNil(selectedModelID)
+        XCTAssertEqual(gate.pendingCount, 0)
+    }
+
+    func testAlreadyCancelledTaskCannotLeaveASelectionPending() async {
+        let gate = ChatImageModelSelectionGate()
+        let requestID = UUID()
+        let task = Task<String?, Never> {
+            await gate.awaitSelection(for: requestID) {}
+        }
         task.cancel()
 
         let selectedModelID = await task.value

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -35,13 +35,16 @@ private final class FakeModelSwitchingSurface: ChatModelSwitchingSurface {
     }
 }
 
-private func makeContext(imageModelID: String? = nil) -> ChatToolExecutionContext {
+private func makeContext(
+    imageModelID: String? = nil,
+    modelSearchPath: String = ""
+) -> ChatToolExecutionContext {
     ChatToolExecutionContext(
         imageGenerationModelID: imageModelID,
         baseURL: URL(string: "http://127.0.0.1:8080")!,
         apiKey: nil,
         imageReferences: [],
-        modelSearchPath: "",
+        modelSearchPath: modelSearchPath,
         additionalModelSearchPaths: [],
         analyticsDatabaseURL: FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
@@ -54,18 +57,18 @@ private func makeCall(name: String, arguments: String = "{}") -> MLXChatToolCall
 }
 
 final class ChatToolRegistryTests: XCTestCase {
-    func testDefinitionsOmitImageToolsWithNoImageModelConfigured() {
+    func testDefinitionsAdvertiseGenerationAndGuidanceWithNoImageModelConfigured() {
         let names = ChatToolRegistry.definitions(context: makeContext(), canEditImage: false)
             .map(\.function.name)
 
-        XCTAssertFalse(names.contains("generate_image"))
+        XCTAssertTrue(names.contains("generate_image"))
         XCTAssertFalse(names.contains("edit_image"))
         for toolName in nativeToolNames {
             XCTAssertTrue(names.contains(toolName), "\(toolName) should be advertised without an image model")
         }
     }
 
-    func testDefinitionsIncludeImageToolsOnlyWhenImageModelConfigured() {
+    func testDefinitionsOfferEditOnlyWhenAnImageIsAvailable() {
         let withoutEdit = ChatToolRegistry.definitions(
             context: makeContext(imageModelID: "org/image"),
             canEditImage: false
@@ -80,12 +83,12 @@ final class ChatToolRegistryTests: XCTestCase {
         XCTAssertTrue(withEdit.contains("edit_image"))
     }
 
-    func testDefinitionsOmitImageToolsWithAnEmptyStringImageModelID() {
+    func testDefinitionsTreatAnEmptyModelIDAsUnselectedButStillAdvertiseGuidance() {
         let names = ChatToolRegistry.definitions(context: makeContext(imageModelID: ""), canEditImage: true)
             .map(\.function.name)
 
-        XCTAssertFalse(names.contains("generate_image"), "an empty-string model id must be treated the same as no model configured")
-        XCTAssertFalse(names.contains("edit_image"))
+        XCTAssertTrue(names.contains("generate_image"))
+        XCTAssertTrue(names.contains("edit_image"))
     }
 
     func testDefinitionsNeverAdvertiseDuplicateToolNames() {
@@ -98,7 +101,7 @@ final class ChatToolRegistryTests: XCTestCase {
 
     func testImageToolSchemasAreGoldenPinned() throws {
         let golden = #"""
-            [{"function":{"description":"Create one or more new images from a detailed text prompt.","name":"generate_image","parameters":{"additionalProperties":false,"properties":{"count":{"maximum":4,"minimum":1,"type":"integer"},"height":{"maximum":2048,"minimum":256,"type":"integer"},"prompt":{"description":"A specific visual description or edit instruction.","type":"string"},"seed":{"type":["integer","null"]},"width":{"maximum":2048,"minimum":256,"type":"integer"}},"required":["prompt"],"type":"object"}},"type":"function"},{"function":{"description":"Edit the most recently attached or generated image using a text instruction.","name":"edit_image","parameters":{"additionalProperties":false,"properties":{"count":{"maximum":4,"minimum":1,"type":"integer"},"height":{"maximum":2048,"minimum":256,"type":"integer"},"prompt":{"description":"A specific visual description or edit instruction.","type":"string"},"seed":{"type":["integer","null"]},"width":{"maximum":2048,"minimum":256,"type":"integer"}},"required":["prompt"],"type":"object"}},"type":"function"}]
+            [{"function":{"description":"Create one or more new images from a detailed text prompt. Image-model selection is handled by the app; do not ask for or provide a model identifier.","name":"generate_image","parameters":{"additionalProperties":false,"properties":{"count":{"maximum":4,"minimum":1,"type":"integer"},"height":{"maximum":2048,"minimum":256,"type":"integer"},"prompt":{"description":"A specific visual description or edit instruction.","type":"string"},"seed":{"type":["integer","null"]},"width":{"maximum":2048,"minimum":256,"type":"integer"}},"required":["prompt"],"type":"object"}},"type":"function"},{"function":{"description":"Edit the most recently attached or generated image using a text instruction. Image-model selection is handled by the app; do not ask for or provide a model identifier.","name":"edit_image","parameters":{"additionalProperties":false,"properties":{"count":{"maximum":4,"minimum":1,"type":"integer"},"height":{"maximum":2048,"minimum":256,"type":"integer"},"prompt":{"description":"A specific visual description or edit instruction.","type":"string"},"seed":{"type":["integer","null"]},"width":{"maximum":2048,"minimum":256,"type":"integer"}},"required":["prompt"],"type":"object"}},"type":"function"}]
             """#
 
         let encoder = JSONEncoder()
@@ -107,6 +110,181 @@ final class ChatToolRegistryTests: XCTestCase {
         let actual = String(decoding: data, as: UTF8.self)
 
         XCTAssertEqual(actual, golden, "generate_image/edit_image's schema must match the intended schema exactly -- if this fails, either the schema drifted unintentionally or this pin needs updating alongside a deliberate schema change")
+    }
+
+    func testImageToolKeepsModelSelectionOutOfTheLLMProtocol() throws {
+        let definition = try XCTUnwrap(
+            ChatImageToolRegistry.definitions(canEdit: false).first
+        )
+        XCTAssertTrue(definition.function.description.contains("handled by the app"))
+        XCTAssertFalse(definition.function.description.contains("model_id"))
+        XCTAssertFalse(definition.function.description.contains("list_image_models"))
+    }
+
+    func testPreselectedCompatibleImageModelResolvesExactly() {
+        let resolution = ChatImageModelSelection.resolve(
+            operation: .generate,
+            selectedModelID: "org/generator",
+            installedModels: imageModelOptions
+        )
+
+        guard case .selected(let model) = resolution else {
+            return XCTFail("expected the app-owned selection to resolve")
+        }
+        XCTAssertEqual(model.modelID, "org/generator")
+    }
+
+    func testMissingSelectionReturnsOnlyGenerationModelsToTheApp() {
+        let resolution = ChatImageModelSelection.resolve(
+            operation: .generate,
+            selectedModelID: nil,
+            installedModels: imageModelOptions
+        )
+
+        guard case .selectionRequired(let request) = resolution else {
+            return XCTFail("expected native model selection")
+        }
+        XCTAssertEqual(request.operation, .generate)
+        XCTAssertEqual(request.models.map(\.modelID), ["org/generator", "org/both"])
+    }
+
+    func testSingleCompatibleModelStillRequiresExplicitSelection() {
+        let onlyModel = ChatImageModelOption(
+            displayName: "only-image-model",
+            modelID: "org/only-image-model",
+            capabilities: [.imageGeneration]
+        )
+
+        let resolution = ChatImageModelSelection.resolve(
+            operation: .generate,
+            selectedModelID: nil,
+            installedModels: [onlyModel]
+        )
+
+        guard case .selectionRequired(let request) = resolution else {
+            return XCTFail("the app must not auto-select the only compatible model")
+        }
+        XCTAssertEqual(request.models, [onlyModel])
+    }
+
+    func testLLMSuppliedModelIDHasNoPlaceInTheImageRequest() throws {
+        let request = try ChatImageToolRequest(
+            call: makeCall(
+                name: "generate_image",
+                arguments: #"{"prompt":"A lake","model_id":"org/untrusted"}"#
+            ),
+            hasImageReference: false
+        )
+
+        XCTAssertEqual(request.operation, .generate)
+        XCTAssertEqual(request.prompt, "A lake")
+    }
+
+    func testStaleSelectionFallsBackToNativePicker() {
+        let resolution = ChatImageModelSelection.resolve(
+            operation: .generate,
+            selectedModelID: "org/not-installed",
+            installedModels: imageModelOptions
+        )
+
+        guard case .selectionRequired(let request) = resolution else {
+            return XCTFail("a stale setting must recover through native selection")
+        }
+        XCTAssertEqual(request.models.map(\.modelID), ["org/generator", "org/both"])
+    }
+
+    func testImageEditSelectionReturnsOnlyEditingModelsToTheApp() {
+        let resolution = ChatImageModelSelection.resolve(
+            operation: .edit,
+            selectedModelID: "org/generator",
+            installedModels: imageModelOptions
+        )
+
+        guard case .selectionRequired(let request) = resolution else {
+            return XCTFail("an incompatible saved model must trigger native selection")
+        }
+        XCTAssertEqual(request.models.map(\.modelID), ["org/editor", "org/both"])
+    }
+
+    func testNoInstalledImageModelRequiresInstallation() {
+        let resolution = ChatImageModelSelection.resolve(
+            operation: .generate,
+            selectedModelID: nil,
+            installedModels: []
+        )
+
+        guard case .installationRequired(.generate) = resolution else {
+            return XCTFail("expected installationRequired(.generate)")
+        }
+    }
+
+    func testNativeSelectionRejectsAnIdentifierOutsideItsRequest() throws {
+        let request = ChatImageModelSelectionRequest(
+            operation: .generate,
+            models: imageModelOptions.filter { $0.supports(.generate) }
+        )
+
+        XCTAssertNil(ChatImageModelSelection.selectedModel(
+            withID: "org/language-model",
+            from: request
+        ))
+        XCTAssertEqual(
+            ChatImageModelSelection.selectedModel(
+                withID: "org/both",
+                from: request
+            )?.modelID,
+            "org/both"
+        )
+    }
+
+    func testInstallationFailurePayloadDoesNotExposeModelChoices() throws {
+        let object = try decode(ChatImageToolExecutor().failurePayload(
+            operation: "generate_image",
+            error: ChatImageToolError.noCompatibleModels(.generate)
+        ))
+
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["installation_required"] as? Bool, true)
+        XCTAssertNil(object["models"])
+        XCTAssertNil(object["model_id"])
+    }
+
+    @MainActor
+    func testMissingModelCacheReturnsEmptyLibraryWithoutStartingGeneration() async throws {
+        let missingPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .path
+        let libraryContext = makeContext(modelSearchPath: missingPath)
+        let libraryResult = try await ChatModelLibraryToolExecutor().execute(
+            call: makeCall(name: ChatModelLibraryToolRegistry.toolName),
+            context: libraryContext
+        )
+        let libraryPayload = try decode(libraryResult)
+        XCTAssertEqual(libraryPayload["ok"] as? Bool, true)
+        XCTAssertEqual((libraryPayload["models"] as? [[String: Any]])?.count, 0)
+
+        var didStartExecution = false
+        var imageContext = makeContext(modelSearchPath: missingPath)
+        imageContext.imageExecutionWillStart = { _ in
+            didStartExecution = true
+        }
+        do {
+            _ = try await ChatToolDispatcher.execute(
+                call: makeCall(
+                    name: "generate_image",
+                    arguments: #"{"prompt":"A lake"}"#
+                ),
+                context: imageContext
+            )
+            XCTFail("generation must not start when the model cache is missing")
+        } catch let error as ChatImageToolError {
+            guard case .noCompatibleModels(.generate) = error else {
+                return XCTFail("expected noCompatibleModels(.generate), got \(error)")
+            }
+        } catch {
+            XCTFail("expected ChatImageToolError, got \(error)")
+        }
+        XCTAssertFalse(didStartExecution)
     }
 
     func testDispatchRoutesToRegisteredHandler() async throws {
@@ -211,6 +389,31 @@ final class ChatToolRegistryTests: XCTestCase {
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
+
+    private var imageModelOptions: [ChatImageModelOption] {
+        [
+            ChatImageModelOption(
+                displayName: "generator",
+                modelID: "org/generator",
+                capabilities: [.imageGeneration]
+            ),
+            ChatImageModelOption(
+                displayName: "editor",
+                modelID: "org/editor",
+                capabilities: [.imageEditing]
+            ),
+            ChatImageModelOption(
+                displayName: "both",
+                modelID: "org/both",
+                capabilities: [.imageGeneration, .imageEditing]
+            ),
+            ChatImageModelOption(
+                displayName: "language-model",
+                modelID: "org/language-model",
+                capabilities: [.text, .tools]
+            ),
+        ]
+    }
 }
 
 @MainActor
@@ -301,6 +504,56 @@ final class ChatToolConsentGateTests: XCTestCase {
     }
 }
 
+@MainActor
+final class ChatImageModelSelectionGateTests: XCTestCase {
+    func testSelectionResumesWithTheAppOwnedModelID() async {
+        let gate = ChatImageModelSelectionGate()
+        let requestID = UUID()
+
+        async let result = gate.awaitSelection(for: requestID) {}
+        await waitUntilPending(gate)
+
+        gate.select(modelID: "org/image", for: requestID)
+        let selectedModelID = await result
+        XCTAssertEqual(selectedModelID, "org/image")
+        XCTAssertEqual(gate.pendingCount, 0)
+    }
+
+    func testCancellingSelectionResumesWithNil() async {
+        let gate = ChatImageModelSelectionGate()
+        let requestID = UUID()
+
+        async let result = gate.awaitSelection(for: requestID) {}
+        await waitUntilPending(gate)
+        gate.cancel(requestID)
+
+        let selectedModelID = await result
+        XCTAssertNil(selectedModelID)
+        XCTAssertEqual(gate.pendingCount, 0)
+    }
+
+    func testCancellingWaitingTaskCannotLeaveASelectionPending() async {
+        let gate = ChatImageModelSelectionGate()
+        let requestID = UUID()
+        let task = Task<String?, Never> {
+            await gate.awaitSelection(for: requestID) {}
+        }
+        await waitUntilPending(gate)
+
+        task.cancel()
+
+        let selectedModelID = await task.value
+        XCTAssertNil(selectedModelID)
+        XCTAssertEqual(gate.pendingCount, 0)
+    }
+
+    private func waitUntilPending(_ gate: ChatImageModelSelectionGate) async {
+        for _ in 0..<200 where gate.pendingCount == 0 {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+}
+
 final class ChatSessionLoadPolicyTests: XCTestCase {
     func testDoesNotNormalizeTheSessionWithTheActiveInFlightRequest() {
         let sessionID = UUID()
@@ -323,44 +576,59 @@ final class ChatSessionLoadPolicyTests: XCTestCase {
 
 final class ChatToolPresentationTests: XCTestCase {
     private static let allStatuses: [ChatTranscriptMessage.ToolStatus?] = [
-        nil, .running, .succeeded, .failed, .cancelled, .awaitingConsent, .declined,
+        nil, .preparing, .awaitingImageModelSelection, .running, .succeeded,
+        .failed, .cancelled, .awaitingConsent, .declined,
     ]
 
     func testTitlePinnedForEveryToolAndStatus() {
         let expected: [String: [ChatTranscriptMessage.ToolStatus?: String]] = [
             "generate_image": [
-                nil: "Image tool", .running: "Generating image…", .succeeded: "Generated image",
+                nil: "Image tool", .preparing: "Checking image model…",
+                .running: "Generating image…", .succeeded: "Generated image",
                 .failed: "Image generation", .cancelled: "Image generation",
+                .awaitingImageModelSelection: "Choose image model",
                 .awaitingConsent: "Image generation", .declined: "Image generation",
             ],
             "edit_image": [
-                nil: "Image tool", .running: "Editing image…", .succeeded: "Edited image",
+                nil: "Image tool", .preparing: "Checking image model…",
+                .running: "Editing image…", .succeeded: "Edited image",
                 .failed: "Image edit", .cancelled: "Image edit",
+                .awaitingImageModelSelection: "Choose image model",
                 .awaitingConsent: "Image edit", .declined: "Image edit",
             ],
             ChatSystemMonitorToolRegistry.toolName: [
-                nil: "System tool", .running: "Checking system stats…", .succeeded: "Checked system stats",
+                nil: "System tool", .preparing: "Checking system stats…",
+                .running: "Checking system stats…", .succeeded: "Checked system stats",
                 .failed: "System stats", .cancelled: "System stats",
+                .awaitingImageModelSelection: "System stats",
                 .awaitingConsent: "System stats", .declined: "System stats",
             ],
             ChatModelLibraryToolRegistry.toolName: [
-                nil: "Model library tool", .running: "Listing downloaded models…", .succeeded: "Listed downloaded models",
+                nil: "Model library tool", .preparing: "Listing downloaded models…",
+                .running: "Listing downloaded models…", .succeeded: "Listed downloaded models",
                 .failed: "Model library", .cancelled: "Model library",
+                .awaitingImageModelSelection: "Model library",
                 .awaitingConsent: "Model library", .declined: "Model library",
             ],
             ChatServerStatsToolRegistry.toolName: [
-                nil: "Server stats tool", .running: "Checking server stats…", .succeeded: "Checked server stats",
+                nil: "Server stats tool", .preparing: "Checking server stats…",
+                .running: "Checking server stats…", .succeeded: "Checked server stats",
                 .failed: "Server stats", .cancelled: "Server stats",
+                .awaitingImageModelSelection: "Server stats",
                 .awaitingConsent: "Server stats", .declined: "Server stats",
             ],
             ChatSwitchModelToolRegistry.toolName: [
-                nil: "Model switch tool", .running: "Switching model…", .succeeded: "Switched model",
+                nil: "Model switch tool", .preparing: "Switching model…",
+                .running: "Switching model…", .succeeded: "Switched model",
                 .failed: "Model switch", .cancelled: "Model switch",
+                .awaitingImageModelSelection: "Model switch",
                 .awaitingConsent: "Switch model?", .declined: "Model switch declined",
             ],
             "some_unknown_tool": [
-                nil: "some_unknown_tool", .running: "Running some_unknown_tool…", .succeeded: "Ran some_unknown_tool",
+                nil: "some_unknown_tool", .preparing: "Running some_unknown_tool…",
+                .running: "Running some_unknown_tool…", .succeeded: "Ran some_unknown_tool",
                 .failed: "some_unknown_tool", .cancelled: "some_unknown_tool",
+                .awaitingImageModelSelection: "some_unknown_tool",
                 .awaitingConsent: "some_unknown_tool", .declined: "some_unknown_tool",
             ],
         ]
@@ -404,6 +672,8 @@ final class ChatToolPresentationTests: XCTestCase {
             XCTAssertEqual(ChatToolPresentation.symbolName(toolName: toolName, status: .cancelled), "xmark.circle")
             XCTAssertEqual(ChatToolPresentation.symbolName(toolName: toolName, status: .declined), "xmark.circle")
             XCTAssertEqual(ChatToolPresentation.symbolName(toolName: toolName, status: .awaitingConsent), "questionmark.circle")
+            XCTAssertEqual(ChatToolPresentation.symbolName(toolName: toolName, status: .awaitingImageModelSelection), "photo.badge.checkmark")
+            XCTAssertEqual(ChatToolPresentation.symbolName(toolName: toolName, status: .preparing), "magnifyingglass")
 
             // Only succeeded/running/nil fall through to the per-tool icon.
             XCTAssertEqual(ChatToolPresentation.symbolName(toolName: toolName, status: .succeeded), successLikeSymbol[toolName])
@@ -577,6 +847,32 @@ final class ChatSystemMonitorToolExecutorTests: XCTestCase {
 }
 
 final class ChatTranscriptMessageCodableTests: XCTestCase {
+    func testChatSessionPersistsSelectedImageModelID() throws {
+        let session = ChatSession(
+            id: UUID(),
+            title: "Images",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            messages: [],
+            imageGenerationModelID: "org/image"
+        )
+
+        let data = try JSONEncoder().encode(session)
+        let decoded = try JSONDecoder().decode(ChatSession.self, from: data)
+
+        XCTAssertEqual(decoded.imageGenerationModelID, "org/image")
+    }
+
+    func testOldChatSessionWithoutImageModelSelectionStillDecodes() throws {
+        let oldJSON = #"{"id":"8A6D9E1B-2C1B-4A9E-9C1B-2C1B4A9E9C1B","title":"Old","createdAt":0,"updatedAt":0,"messages":[]}"#
+        let session = try JSONDecoder().decode(
+            ChatSession.self,
+            from: try XCTUnwrap(oldJSON.data(using: .utf8))
+        )
+
+        XCTAssertNil(session.imageGenerationModelID)
+    }
+
     func testOldJSONWithoutToolArgumentsStillDecodes() throws {
         // Predates toolArguments existing on disk at all -- must not fail to decode.
         let oldJSON = """
@@ -601,8 +897,12 @@ final class ChatTranscriptMessageCodableTests: XCTestCase {
         XCTAssertEqual(message.toolName, "get_system_stats")
     }
 
-    func testAwaitingConsentAndDeclinedStatusesRoundTrip() throws {
-        for status in [ChatTranscriptMessage.ToolStatus.awaitingConsent, .declined] {
+    func testInteractiveAndDeclinedStatusesRoundTrip() throws {
+        for status in [
+            ChatTranscriptMessage.ToolStatus.awaitingConsent,
+            .awaitingImageModelSelection,
+            .declined,
+        ] {
             let original = ChatTranscriptMessage(
                 role: .tool,
                 content: "",

--- a/Tests/NativTests/MLXImageModelResolverTests.swift
+++ b/Tests/NativTests/MLXImageModelResolverTests.swift
@@ -58,6 +58,14 @@ final class MLXImageModelResolverTests: XCTestCase {
                 fileManager: .default
             )
         )
+        XCTAssertTrue(
+            resolver().isImageEditingModel(
+                model: "black-forest-labs/FLUX.2-klein-9B-kv",
+                at: temporaryRoot,
+                fileManager: .default
+            ),
+            "the bundled FLUX.2 backend supports reference-image editing"
+        )
     }
 
     func testFlux2RequiresLoadableLocalLayout() throws {

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -292,6 +292,11 @@ final class NativSettingsTests: XCTestCase {
             request.value(forHTTPHeaderField: "Authorization"),
             "Bearer nativ_image_token"
         )
+        let body = try XCTUnwrap(request.httpBody)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        XCTAssertEqual(object["model"] as? String, "org/model")
     }
 
     func testEveryPreloadSelectionRequiresServerRestart() {

--- a/project.yml
+++ b/project.yml
@@ -163,6 +163,7 @@ targets:
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
+      - path: Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatSystemStatsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatServerStatsTool.swift


### PR DESCRIPTION
Summary
Adds image generation and editing tool calling to chat.
When the LLM requests an image operation, the app checks the models installed locally and filters them by the required capability. If there isn’t already a compatible model selected for the chat, the user sees a native model picker. The selected model is validated and remembered for future image requests in that chat.
Model selection is handled entirely by the app—the LLM never provides or controls model identifiers. This prevents invalid, escaped, or hallucinated model IDs from breaking image generation.
If no compatible image model is installed, the app explains that one needs to be downloaded from the Models page.