### PR TITLE
fetch model size using async calls, cached

### DIFF
--- a/Sources/Nativ/Features/Models/HubModelSizeResolver.swift
+++ b/Sources/Nativ/Features/Models/HubModelSizeResolver.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@MainActor
+final class HubModelSizeResolver: ObservableObject {
+    static let shared = HubModelSizeResolver()
+
+    @Published private(set) var sizes: [String: Int64] = [:]
+    private var inFlight: Set<String> = []
+
+    func resolvedSize(for repoID: String) -> Int64? {
+        sizes[repoID]
+    }
+
+    func prefetch(_ repoID: String) async {
+        if sizes[repoID] != nil || inFlight.contains(repoID) {
+            return
+        }
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        if Task.isCancelled || sizes[repoID] != nil || inFlight.contains(repoID) {
+            return
+        }
+        inFlight.insert(repoID)
+        Task {
+            let bytes = await Self.fetchTotalBytes(repoID: repoID)
+            inFlight.remove(repoID)
+            if let bytes {
+                sizes[repoID] = bytes
+            }
+        }
+    }
+
+    private nonisolated static func fetchTotalBytes(repoID: String) async -> Int64? {
+        guard let encoded = repoID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let url = URL(string: "https://huggingface.co/api/models/\(encoded)?blobs=true")
+        else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 20
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200
+        else {
+            return nil
+        }
+        guard let payload = try? JSONDecoder().decode(SizePayload.self, from: data) else {
+            return nil
+        }
+        let total = payload.siblings?.reduce(Int64(0)) { partial, sibling in
+            partial + (sibling.lfs?.size ?? sibling.size ?? 0)
+        } ?? 0
+        return total > 0 ? total : nil
+    }
+
+    private struct SizePayload: Decodable {
+        struct Sibling: Decodable {
+            struct LFS: Decodable {
+                let size: Int64?
+            }
+            let size: Int64?
+            let lfs: LFS?
+        }
+        let siblings: [Sibling]?
+    }
+}

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -113,6 +113,27 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         )
     }
 
+    // Fallback download size shown until the real file sizes are fetched (and if
+    // that fetch fails). The safetensors parameter summary only covers the
+    // diffusion transformer, so for image models it lands well under the real
+    // download; scale it toward the components a modern image pipeline also ships
+    // (text encoder + VAE). This is a placeholder — the async fetch replaces it.
+    var estimatedDownloadBytes: Int64? {
+        guard let sizeBytes else {
+            return nil
+        }
+        let isImageModel = capabilities.contains(.imageGeneration)
+            || capabilities.contains(.imageEditing)
+        guard isImageModel else {
+            return sizeBytes
+        }
+        let scaled = Double(sizeBytes) * 2.5
+        guard scaled <= Double(Int64.max) else {
+            return sizeBytes
+        }
+        return Int64(scaled.rounded(.up))
+    }
+
     private static func resolveMemoryEstimate(
         repoID: String,
         safetensors: HuggingFaceSafetensors?,

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -362,7 +362,8 @@ struct ModelsView: View {
                                     onDownload: {
                                         downloadManager.download(
                                             repoID: hubModel.id,
-                                            sizeBytes: hubModel.sizeBytes,
+                                            sizeBytes: HubModelSizeResolver.shared
+                                                .resolvedSize(for: hubModel.id) ?? hubModel.sizeBytes,
                                             cachePath: model.settings.modelSearchPath,
                                             token: model.effectiveHuggingFaceToken
                                         ) {}
@@ -1159,6 +1160,7 @@ private struct ActiveDownloadBannerView: View {
 
 private struct HubModelRow: View, Equatable {
     let model: HuggingFaceModel
+    let downloadSizeBytes: Int64?
     let isInstalled: Bool
     let isDownloading: Bool
     let downloadProgress: Double
@@ -1173,6 +1175,7 @@ private struct HubModelRow: View, Equatable {
         // Actions are intentionally excluded: they do not affect rendering,
         // while closures are recreated whenever the parent view is rebuilt.
         lhs.model == rhs.model
+            && lhs.downloadSizeBytes == rhs.downloadSizeBytes
             && lhs.isInstalled == rhs.isInstalled
             && lhs.isDownloading == rhs.isDownloading
             && lhs.downloadProgress == rhs.downloadProgress
@@ -1225,7 +1228,7 @@ private struct HubModelRow: View, Equatable {
                         ModelPill(
                             title: compactCount(model.downloads), systemImage: "arrow.down.circle")
                         ModelPill(title: compactCount(model.likes), systemImage: "heart")
-                        if let sizeBytes = model.sizeBytes {
+                        if let sizeBytes = downloadSizeBytes {
                             ModelPill(
                                 title: ByteCountFormatter.string(
                                     fromByteCount: sizeBytes, countStyle: .file),
@@ -1313,6 +1316,7 @@ private struct HubModelRow: View, Equatable {
 /// Discover view remains stable while a download reports progress.
 private struct HubModelRowContainer: View {
     @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
+    @ObservedObject private var sizeResolver = HubModelSizeResolver.shared
 
     let model: HuggingFaceModel
     let isInstalled: Bool
@@ -1322,14 +1326,16 @@ private struct HubModelRowContainer: View {
     let onRemoveDownload: () -> Void
 
     var body: some View {
+        let downloadSizeBytes = sizeResolver.resolvedSize(for: model.id) ?? model.sizeBytes
         HubModelRow(
             model: model,
+            downloadSizeBytes: downloadSizeBytes,
             isInstalled: isInstalled,
             isDownloading: downloadManager.isDownloading(model.id),
             downloadProgress: downloadManager.progress(for: model.id),
             isDownloadPaused: downloadManager.isPaused(for: model.id),
             downloadBlockedReason: downloadManager.capacityBlocker(
-                sizeBytes: model.sizeBytes,
+                sizeBytes: downloadSizeBytes,
                 cachePath: cachePath
             ),
             downloadError: downloadManager.errorByModelID[model.id],
@@ -1338,6 +1344,9 @@ private struct HubModelRowContainer: View {
             onRemoveDownload: onRemoveDownload
         )
         .equatable()
+        .task(id: model.id) {
+            await sizeResolver.prefetch(model.id)
+        }
     }
 }
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -363,7 +363,7 @@ struct ModelsView: View {
                                         downloadManager.download(
                                             repoID: hubModel.id,
                                             sizeBytes: HubModelSizeResolver.shared
-                                                .resolvedSize(for: hubModel.id) ?? hubModel.sizeBytes,
+                                                .resolvedSize(for: hubModel.id) ?? hubModel.estimatedDownloadBytes,
                                             cachePath: model.settings.modelSearchPath,
                                             token: model.effectiveHuggingFaceToken
                                         ) {}
@@ -1326,7 +1326,7 @@ private struct HubModelRowContainer: View {
     let onRemoveDownload: () -> Void
 
     var body: some View {
-        let downloadSizeBytes = sizeResolver.resolvedSize(for: model.id) ?? model.sizeBytes
+        let downloadSizeBytes = sizeResolver.resolvedSize(for: model.id) ?? model.estimatedDownloadBytes
         HubModelRow(
             model: model,
             downloadSizeBytes: downloadSizeBytes,


### PR DESCRIPTION
instead of doing local calculations like in #214, we'd instead make async calls to hf for model size, addresses the issue of inaccurate model param report