### PR TITLE
Fix hub discover pagination: filter at the API + paginate over visibl…

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -367,6 +367,7 @@ private struct HuggingFaceHubClient: Sendable {
     func search(
         query: String,
         sort: HuggingFaceModelSort,
+        capabilities: Set<LocalModelCapability>,
         token: String?
     ) async throws -> HuggingFaceModelPage {
         var components = URLComponents()
@@ -380,6 +381,9 @@ private struct HuggingFaceHubClient: Sendable {
             URLQueryItem(name: "direction", value: "-1"),
             URLQueryItem(name: "limit", value: "50")
         ]
+        if let pipelineTag = Self.pipelineTag(for: capabilities) {
+            queryItems.append(URLQueryItem(name: "pipeline_tag", value: pipelineTag))
+        }
         queryItems.append(contentsOf: [
             "downloads", "likes", "pipeline_tag", "library_name", "tags",
             "private", "gated", "safetensors"
@@ -395,6 +399,26 @@ private struct HuggingFaceHubClient: Sendable {
         }
 
         return try await page(at: url, token: token)
+    }
+
+    private static func pipelineTag(for capabilities: Set<LocalModelCapability>) -> String? {
+        guard capabilities.count == 1, let capability = capabilities.first else {
+            return nil
+        }
+        switch capability {
+        case .imageGeneration:
+            return "text-to-image"
+        case .imageEditing:
+            return "image-to-image"
+        case .speechToText:
+            return "automatic-speech-recognition"
+        case .textToSpeech:
+            return "text-to-speech"
+        case .vision:
+            return "image-text-to-text"
+        case .text, .audio, .video, .embeddings, .reasoning, .tools, .drafter:
+            return nil
+        }
     }
 
     func model(id: String, token: String?) async throws -> HuggingFaceModel {
@@ -485,15 +509,23 @@ final class HuggingFaceModelLibrary: ObservableObject {
     private var searchTask: Task<Void, Never>?
     private var buffer: [HuggingFaceModel] = []
     private var activeSort: HuggingFaceModelSort = .downloads
+    private var visibilityPredicate: (HuggingFaceModel) -> Bool = { _ in true }
     private var nextPageURL: URL?
     private let pageSize = 24
     private let maximumPageCount = 5
+    private let maximumFillFetches = 8
 
     deinit {
         searchTask?.cancel()
     }
 
-    func search(query: String, sort: HuggingFaceModelSort, token: String?) {
+    func search(
+        query: String,
+        sort: HuggingFaceModelSort,
+        capabilities: Set<LocalModelCapability>,
+        predicate: @escaping (HuggingFaceModel) -> Bool,
+        token: String?
+    ) {
         searchTask?.cancel()
         isSearching = true
         error = nil
@@ -502,11 +534,17 @@ final class HuggingFaceModelLibrary: ObservableObject {
         nextPageURL = nil
         pageNumber = 1
         activeSort = sort
+        visibilityPredicate = predicate
 
         searchTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let page = try await client.search(query: query, sort: sort, token: token)
+                let page = try await client.search(
+                    query: query,
+                    sort: sort,
+                    capabilities: capabilities,
+                    token: token
+                )
                 try Task.checkCancellation()
                 self.buffer = page.models
                 self.nextPageURL = page.nextPageURL
@@ -536,6 +574,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
         nextPageURL = nil
         pageNumber = 1
         activeSort = .downloads
+        visibilityPredicate = { _ in true }
 
         searchTask = Task { [weak self] in
             guard let self else { return }
@@ -572,7 +611,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
 
     var canGoToNextPage: Bool {
         guard !isSearching, pageNumber < maximumPageCount else { return false }
-        return buffer.count > pageNumber * pageSize || nextPageURL != nil
+        return orderedVisible.count > pageNumber * pageSize || nextPageURL != nil
     }
 
     func goToPreviousPage() {
@@ -586,13 +625,12 @@ final class HuggingFaceModelLibrary: ObservableObject {
         guard canGoToNextPage else { return }
         let target = pageNumber + 1
 
-        if buffer.count >= target * pageSize || nextPageURL == nil {
+        if orderedVisible.count >= target * pageSize || nextPageURL == nil {
             pageNumber = target
             models = slice(forPage: target)
             error = nil
             return
         }
-        guard let nextPageURL else { return }
 
         searchTask?.cancel()
         isSearching = true
@@ -601,10 +639,8 @@ final class HuggingFaceModelLibrary: ObservableObject {
         searchTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let page = try await client.page(at: nextPageURL, token: token)
+                try await self.fillBuffer(upTo: target * self.pageSize, token: token)
                 try Task.checkCancellation()
-                self.buffer.append(contentsOf: page.models)
-                self.nextPageURL = page.nextPageURL
                 let nextModels = self.slice(forPage: target)
                 if !nextModels.isEmpty {
                     self.pageNumber = target
@@ -624,7 +660,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
 
     private func fillBuffer(upTo count: Int, token: String?) async throws {
         var fetches = 0
-        while buffer.count < count, let url = nextPageURL, fetches < 8 {
+        while orderedVisible.count < count, let url = nextPageURL, fetches < maximumFillFetches {
             let nextPage = try await client.page(at: url, token: token)
             try Task.checkCancellation()
             buffer.append(contentsOf: nextPage.models)
@@ -634,7 +670,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
     }
 
     private func slice(forPage number: Int) -> [HuggingFaceModel] {
-        let ordered = orderedBuffer
+        let ordered = orderedVisible
         let start = (number - 1) * pageSize
         guard start < ordered.count else { return [] }
         return Array(ordered[start..<min(start + pageSize, ordered.count)])
@@ -650,6 +686,10 @@ final class HuggingFaceModelLibrary: ObservableObject {
             case (_, nil): return true
             }
         }
+    }
+
+    private var orderedVisible: [HuggingFaceModel] {
+        orderedBuffer.filter(visibilityPredicate)
     }
 
     func cancel() {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -46,6 +46,8 @@ private struct HubSearchTaskID: Hashable {
     let section: ModelsPageSection
     let query: String
     let sort: HuggingFaceModelSort
+    let capabilities: Set<LocalModelCapability>
+    let access: HubAccessFilter
     let authenticationToken: String?
 }
 
@@ -108,6 +110,8 @@ struct ModelsView: View {
             hubLibrary.search(
                 query: hubQuery,
                 sort: hubSort,
+                capabilities: hubCapabilityFilters,
+                predicate: hubVisibilityPredicate,
                 token: model.effectiveHuggingFaceToken
             )
         }
@@ -334,17 +338,15 @@ struct ModelsView: View {
                             title: hubQuery.isEmpty
                                 ? "Finding popular Safetensors models…" : "Searching Hugging Face…")
                     } else if hubLibrary.models.isEmpty {
-                        ModelsEmptyState(
-                            systemImage: "magnifyingglass",
-                            title: "No Safetensors models found",
-                            message: "Try a model family, provider, or repository name.",
-                            actionTitle: nil,
-                            action: {}
-                        )
-                    } else {
-                        discoverResultsHeader
-
-                        if filteredHubModels.isEmpty {
+                        if hubCapabilityFilters.isEmpty && hubAccessFilter == .all {
+                            ModelsEmptyState(
+                                systemImage: "magnifyingglass",
+                                title: "No Safetensors models found",
+                                message: "Try a model family, provider, or repository name.",
+                                actionTitle: nil,
+                                action: {}
+                            )
+                        } else {
                             ModelsEmptyState(
                                 systemImage: "line.3.horizontal.decrease.circle",
                                 title: "No models match these filters",
@@ -353,33 +355,35 @@ struct ModelsView: View {
                                 actionTitle: nil,
                                 action: {}
                             )
-                        } else {
-                            ForEach(filteredHubModels) { hubModel in
-                                HubModelRowContainer(
-                                    model: hubModel,
-                                    isInstalled: installedModelIDs.contains(hubModel.id),
-                                    cachePath: model.settings.modelSearchPath,
-                                    onDownload: {
-                                        downloadManager.download(
-                                            repoID: hubModel.id,
-                                            sizeBytes: HubModelSizeResolver.shared
-                                                .resolvedSize(for: hubModel.id) ?? hubModel.estimatedDownloadBytes,
-                                            cachePath: model.settings.modelSearchPath,
-                                            token: model.effectiveHuggingFaceToken
-                                        ) {}
-                                    },
-                                    onPauseResume: {
-                                        if downloadManager.isPaused(for: hubModel.id) {
-                                            downloadManager.resumeDownload(hubModel.id)
-                                        } else {
-                                            downloadManager.pauseDownload(hubModel.id)
-                                        }
-                                    },
-                                    onRemoveDownload: {
-                                        downloadManager.removeDownload(hubModel.id)
+                        }
+                    } else {
+                        discoverResultsHeader
+
+                        ForEach(filteredHubModels) { hubModel in
+                            HubModelRowContainer(
+                                model: hubModel,
+                                isInstalled: installedModelIDs.contains(hubModel.id),
+                                cachePath: model.settings.modelSearchPath,
+                                onDownload: {
+                                    downloadManager.download(
+                                        repoID: hubModel.id,
+                                        sizeBytes: HubModelSizeResolver.shared
+                                            .resolvedSize(for: hubModel.id) ?? hubModel.estimatedDownloadBytes,
+                                        cachePath: model.settings.modelSearchPath,
+                                        token: model.effectiveHuggingFaceToken
+                                    ) {}
+                                },
+                                onPauseResume: {
+                                    if downloadManager.isPaused(for: hubModel.id) {
+                                        downloadManager.resumeDownload(hubModel.id)
+                                    } else {
+                                        downloadManager.pauseDownload(hubModel.id)
                                     }
-                                )
-                            }
+                                },
+                                onRemoveDownload: {
+                                    downloadManager.removeDownload(hubModel.id)
+                                }
+                            )
                         }
 
                         HStack(spacing: 12) {
@@ -734,13 +738,15 @@ struct ModelsView: View {
         .fixedSize()
     }
 
-    private var filteredHubModels: [HuggingFaceModel] {
-        hubLibrary.models.filter { hubModel in
-            let matchesCapability = hubCapabilityFilters.allSatisfy {
+    private var hubVisibilityPredicate: (HuggingFaceModel) -> Bool {
+        let capabilities = hubCapabilityFilters
+        let access = hubAccessFilter
+        return { hubModel in
+            let matchesCapability = capabilities.allSatisfy {
                 hubModel.capabilities.contains($0)
             }
             let matchesAccess: Bool
-            switch hubAccessFilter {
+            switch access {
             case .all:
                 matchesAccess = true
             case .open:
@@ -750,6 +756,10 @@ struct ModelsView: View {
             }
             return matchesCapability && matchesAccess
         }
+    }
+
+    private var filteredHubModels: [HuggingFaceModel] {
+        hubLibrary.models
     }
 
     private var installedFilterIsActive: Bool {
@@ -825,6 +835,8 @@ struct ModelsView: View {
             section: section,
             query: hubQuery,
             sort: hubSort,
+            capabilities: hubCapabilityFilters,
+            access: hubAccessFilter,
             authenticationToken: model.effectiveHuggingFaceToken
         )
     }


### PR DESCRIPTION
The discover search fetched top-sorted safetensors models capability-agnostic and only filtered by capability/access client-side after slicing a raw page, so pages showed a varying count and Trending/Downloads for image models could come back empty. Map a single selected capability to a HuggingFace pipeline_tag so the API returns matching models, re-fetch when the capability/access filters change, and paginate over the filtered (visible) results so every page holds a consistent count.

Discovered while doing #216, and below is what it used to look like: 


https://github.com/user-attachments/assets/be0721a3-e142-4474-9ba8-41daec08f74f

