### PR TITLE
Remove universal label from the header

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -83,7 +83,7 @@
             Join the Discord <span aria-hidden="true">↗</span>
           </a>
         </div>
-        <p class="system-note reveal">Universal · Apple Silicon (M1+)</p>
+        <p class="system-note reveal">Apple Silicon (M1+)</p>
         <div class="open-source-stamp" aria-hidden="true">
           <svg viewBox="0 0 140 140">
             <defs><path id="stamp-path" d="M70,70 m-51,0 a51,51 0 1,1 102,0 a51,51 0 1,1 -102,0" /></defs>


### PR DESCRIPTION
"Universal" means Intel + Apple Silicon, which is not the case for Nativ, so we shouldn't include that terminology. Resolves https://github.com/Blaizzy/nativ/issues/35