### PR TITLE
Feature/routines chat first

### DIFF
--- a/PythonDistribution/Overlay/nativ_server.py
+++ b/PythonDistribution/Overlay/nativ_server.py
@@ -1327,6 +1327,27 @@ def install_metrics_overlay() -> None:
             "loaded_models": snapshot.get("loaded_models", {}),
         }
 
+    @base.app.post("/routines/{routine_id}/run", include_in_schema=False)
+    @base.app.post("/v1/routines/{routine_id}/run")
+    def run_routine_endpoint(routine_id: str, request: Request):
+        """Queue a routine for the Nativ app to run."""
+        require_api_key = getattr(base, "_require_management_api_key", None)
+        if require_api_key is not None:
+            require_api_key(request)
+
+        if not routine_id.strip():
+            raise HTTPException(status_code=400, detail="A routine id is required.")
+
+        directory = os.path.expanduser(
+            "~/Library/Application Support/Nativ/Routines/triggers"
+        )
+        os.makedirs(directory, exist_ok=True)
+        path = os.path.join(directory, f"{uuid.uuid4().hex}.json")
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump({"routineID": routine_id, "requestedAt": time.time()}, handle)
+
+        return {"status": "queued", "routine_id": routine_id}
+
 
 def main() -> None:
     install_metrics_overlay()

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import NativServerKit
 import SwiftUI
+import UserNotifications
 
 @MainActor
 private final class ModelMenuIconView: NSView {
@@ -339,7 +340,7 @@ private final class ModelMenuSectionHeaderView: NSView {
 }
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotificationCenterDelegate {
     private let model = NativModel()
     let softwareUpdater = SoftwareUpdater()
     private let voiceDictationExtension = VoiceDictationExtension()
@@ -348,6 +349,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     )
     private let controlPanelNavigation = ControlPanelNavigation()
     private let runtime = SystemRuntimeMonitor()
+    private let routineStore = RoutineStore.shared
+    private lazy var routineRunner = RoutineRunner(
+        model: model,
+        store: routineStore,
+        sessionStore: ChatSessionStore()
+    )
+    private lazy var routineScheduler = RoutineScheduler(
+        store: routineStore,
+        onFire: { [weak self] routine, source in
+            self?.routineRunner.run(routine, source: source)
+        }
+    )
     private let systemMenuBarPreferences = SystemMenuBarPreferences.shared
     private var mainWindowOpener: (() -> Void)?
     private var statusItem: NSStatusItem?
@@ -368,6 +381,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             self?.updateStatusItemButton()
         }
         runtime.start()
+        setUpRoutines()
         model.onMenuStateChanged = { [weak self] in
             guard let self else {
                 return
@@ -564,6 +578,63 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     func toggleSidebar() {
         controlPanelNavigation.toggleSidebar()
         showMainWindow()
+    }
+
+    private func setUpRoutines() {
+        RoutineRunCoordinator.shared.configure(runner: routineRunner)
+        routineRunner.onRunCompleted = { [weak self] routine, run in
+            self?.postRoutineNotification(routine: routine, run: run)
+        }
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: [.alert, .sound]
+        ) { _, _ in }
+        routineStore.onRoutinesChanged = { [weak self] in
+            self?.refreshRoutineAgents()
+        }
+        refreshRoutineAgents()
+        routineScheduler.start()
+    }
+
+    private func refreshRoutineAgents() {
+        RoutineLaunchAgent.refresh(routines: routineStore.routines)
+    }
+
+    private func postRoutineNotification(routine: Routine, run: RoutineRun) {
+        guard routine.notifyOnFinish else {
+            return
+        }
+        let content = UNMutableNotificationContent()
+        content.title = routine.name.isEmpty ? "Routine" : routine.name
+        content.body = run.status == .failed
+            ? "Run failed. \(run.resultSummary)"
+            : (run.resultSummary.isEmpty ? "Run finished." : run.resultSummary)
+        if let sessionID = run.sessionID {
+            content.userInfo = ["sessionID": sessionID.uuidString]
+        }
+        UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: run.id, content: content, trigger: nil)
+        )
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        DispatchQueue.main.async { [weak self] in
+            self?.controlPanelNavigation.open(.chat)
+            self?.showMainWindow()
+        }
+        completionHandler()
     }
 
     func toggleAllSidebarSections() {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -281,6 +281,9 @@ struct ControlPanelView: View {
     @State private var detailTransitionOffset: CGFloat = 0
     @State private var isSidebarTransitioning = false
     @State private var sidebarTransitionGeneration = 0
+    @ObservedObject private var routineStore = RoutineStore.shared
+    @StateObject private var routineModelLibrary = LocalModelLibrary()
+    @State private var schedulingRoutineDraft: RoutineDraft?
     @State private var isModelConfigurationVisible = false
     @State private var isFullScreen = false
     @State private var windowControlsRefreshTrigger = 0
@@ -514,7 +517,12 @@ struct ControlPanelView: View {
                 pendingDeleteRecent = nil
             }
         } message: { recent in
-            Text("“\(recent.title)” will be permanently deleted.")
+            if case .chat(let sessionID) = recent.selection,
+               let routine = routineStore.routine(forSession: sessionID) {
+                Text("“\(recent.title)” has a routine (\(RoutineFormatting.summary(routine))). Deleting the chat cancels the routine.")
+            } else {
+                Text("“\(recent.title)” will be permanently deleted.")
+            }
         }
         .alert(
             "Delete folder?",
@@ -544,6 +552,31 @@ struct ControlPanelView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("The selected chats are permanently deleted. Selected folders are removed but their chats are kept.")
+        }
+        .sheet(item: $schedulingRoutineDraft) { draft in
+            let textModelIDs = routineModelLibrary.models
+                .filter { $0.capabilities.contains(.text) }
+                .map(\.repoID)
+            let snapshotModelID = draft.routine.modelID
+            let availableModelIDs = (
+                snapshotModelID.isEmpty || textModelIDs.contains(snapshotModelID)
+                    ? textModelIDs
+                    : textModelIDs + [snapshotModelID]
+            ).sorted()
+            let isExistingRoutine = RoutineStore.shared.routine(id: draft.routine.id) != nil
+            RoutineEditor(
+                draft: draft,
+                availableModelIDs: availableModelIDs,
+                onSave: { routine in
+                    saveScheduledRoutine(routine)
+                    schedulingRoutineDraft = nil
+                },
+                onCancel: { schedulingRoutineDraft = nil },
+                onDelete: isExistingRoutine ? {
+                    RoutineStore.shared.delete(id: draft.routine.id)
+                    schedulingRoutineDraft = nil
+                } : nil
+            )
         }
     }
 
@@ -1039,17 +1072,28 @@ struct ControlPanelView: View {
             .disabled(recentSessions.isEmpty && chat.folders.isEmpty)
             .help("Select multiple")
 
-            Button {
-                withAnimation(.snappy(duration: 0.2)) {
-                    createRecentSession()
+            Menu {
+                Button {
+                    withAnimation(.snappy(duration: 0.2)) {
+                        createRecentSession()
+                    }
+                } label: {
+                    Label("New chat", systemImage: "square.and.pencil")
+                }
+                Button {
+                    presentNewRoutine()
+                } label: {
+                    Label("New routine", systemImage: "bolt")
                 }
             } label: {
-                Image(systemName: "square.and.pencil")
+                Image(systemName: "plus")
                     .font(.system(size: 15, weight: .medium))
                     .frame(width: 28, height: 28)
                     .foregroundStyle(isNewChatHovering ? Color.primary : Color.secondary.opacity(0.7))
             }
-            .buttonStyle(.plain)
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
             .disabled(selectedTab == .imageGeneration && imageGeneration.isGenerating)
             .help(newRecentHelp)
             .onHover { isNewChatHovering = $0 }
@@ -1416,6 +1460,7 @@ struct ControlPanelView: View {
     private func recentSessionRow(_ recent: ControlPanelRecentSession) -> some View {
         ControlPanelRecentSessionRow(
             recent: recent,
+            routineStatus: routineStatus(for: recent),
             isSelected: sidebarSelection == recent.selection,
             isCurrent: isCurrentRecent(recent),
             isSelectionDisabled: isRecentSelectionDisabled(recent),
@@ -1450,6 +1495,9 @@ struct ControlPanelView: View {
             onTogglePin: {
                 togglePinRecent(recent)
             },
+            onScheduleRoutine: {
+                scheduleRoutine(from: recent)
+            },
             folders: chat.folders,
             onMoveToFolder: { folderID in
                 moveRecentToFolder(recent, folderID: folderID)
@@ -1465,6 +1513,80 @@ struct ControlPanelView: View {
             return
         }
         chat.setPinned(sessionID, pinned: !recent.pinned)
+    }
+
+    private func routineStatus(for recent: ControlPanelRecentSession) -> RoutineRowStatus {
+        guard case .chat(let sessionID) = recent.selection,
+              let routine = routineStore.routine(forSession: sessionID)
+        else {
+            return .none
+        }
+        if routineStore.isRoutineRunning(forSession: sessionID) {
+            return .running
+        }
+        return routine.isEnabled ? .scheduled : .disabled
+    }
+
+    private func scheduleRoutine(from recent: ControlPanelRecentSession) {
+        guard case .chat(let sessionID) = recent.selection else {
+            return
+        }
+        let settings = model.settings.normalized()
+        routineModelLibrary.scan(
+            path: settings.modelSearchPath,
+            additionalPaths: settings.additionalModelSearchPaths
+        )
+        if let existing = RoutineStore.shared.routine(forSession: sessionID) {
+            schedulingRoutineDraft = RoutineDraft(routine: existing)
+            return
+        }
+        guard let session = ChatSessionStore().loadSession(id: sessionID) else {
+            return
+        }
+        let instructions = session.messages.last { $0.role == .user }?.content ?? ""
+        let modelID = session.messages
+            .last { $0.role == .assistant && !($0.modelID ?? "").isEmpty }?
+            .modelID
+            ?? settings.languageModelID
+            ?? ""
+        schedulingRoutineDraft = RoutineDraft(
+            routine: Routine(
+                name: recent.title,
+                instructions: instructions,
+                modelID: modelID,
+                triggerKind: .schedule,
+                sourceSessionID: sessionID
+            )
+        )
+    }
+
+    private func presentNewRoutine() {
+        let settings = model.settings.normalized()
+        routineModelLibrary.scan(
+            path: settings.modelSearchPath,
+            additionalPaths: settings.additionalModelSearchPaths
+        )
+        schedulingRoutineDraft = RoutineDraft(
+            routine: Routine(modelID: settings.languageModelID ?? "")
+        )
+    }
+
+    private func saveScheduledRoutine(_ routine: Routine) {
+        var routine = routine
+        if routine.sourceSessionID == nil {
+            let now = Date()
+            let session = ChatSession(
+                id: UUID(),
+                title: routine.name.isEmpty ? "Routine" : routine.name,
+                createdAt: now,
+                updatedAt: now,
+                messages: []
+            )
+            ChatSessionStore().saveSession(session)
+            routine.sourceSessionID = session.id
+        }
+        RoutineStore.shared.upsert(routine)
+        NotificationCenter.default.post(name: .routineDidSaveChatSession, object: nil)
     }
 
     private func moveRecentToFolder(_ recent: ControlPanelRecentSession, folderID: UUID?) {
@@ -2037,6 +2159,7 @@ struct ControlPanelView: View {
 
         switch recent.selection {
         case .chat(let sessionID):
+            routineStore.deleteRoutine(forSession: sessionID)
             chat.deleteSession(sessionID)
         case .imageGeneration(let sessionID):
             imageGeneration.deleteSession(sessionID)
@@ -3535,8 +3658,16 @@ private struct ControlPanelRecentSession: Identifiable, Equatable {
     }
 }
 
+private enum RoutineRowStatus {
+    case none
+    case disabled
+    case scheduled
+    case running
+}
+
 private struct ControlPanelRecentSessionRow: View {
     let recent: ControlPanelRecentSession
+    let routineStatus: RoutineRowStatus
     let isSelected: Bool
     let isCurrent: Bool
     let isSelectionDisabled: Bool
@@ -3553,6 +3684,7 @@ private struct ControlPanelRecentSessionRow: View {
     let onRename: (String) -> Void
     let onNewChat: () -> Void
     let onTogglePin: () -> Void
+    let onScheduleRoutine: () -> Void
     let folders: [ChatFolder]
     let onMoveToFolder: (UUID?) -> Void
     let onCreateFolderForSession: () -> Void
@@ -3561,6 +3693,29 @@ private struct ControlPanelRecentSessionRow: View {
     @State private var isRenaming = false
     @State private var renameDraft = ""
     @FocusState private var renameFieldFocused: Bool
+
+    @ViewBuilder
+    private var routineBolt: some View {
+        switch routineStatus {
+        case .none:
+            EmptyView()
+        case .disabled:
+            Image(systemName: "bolt.slash")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .help("Routine paused")
+        case .scheduled:
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .help("Routine scheduled")
+        case .running:
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.green)
+                .help("Routine running now")
+        }
+    }
 
     var body: some View {
         HStack(spacing: 2) {
@@ -3621,6 +3776,8 @@ private struct ControlPanelRecentSessionRow: View {
                         Text(recent.title)
                             .lineLimit(1)
                             .truncationMode(.tail)
+
+                        routineBolt
 
                         Spacer(minLength: 0)
                     }
@@ -3698,6 +3855,12 @@ private struct ControlPanelRecentSessionRow: View {
                     recent.pinned ? "Unpin" : "Pin",
                     systemImage: recent.pinned ? "pin.slash" : "pin"
                 )
+            }
+
+            Button {
+                onScheduleRoutine()
+            } label: {
+                Label(routineStatus == .none ? "Make recurring" : "Edit routine", systemImage: "bolt")
             }
 
             Menu {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -53,6 +53,9 @@ struct ChatView: View {
         }
         .background(Color.nativMainContentBackground)
         .onAppear { chat.mcpHost = mcpHost }
+        .onReceive(NotificationCenter.default.publisher(for: .routineDidSaveChatSession)) { _ in
+            chat.reloadPersistedSessions()
+        }
         .environment(\.chatFontScale, model.settings.chatFontScale)
     }
 
@@ -1968,6 +1971,24 @@ final class ChatViewModel: ObservableObject {
         refreshSessionList()
     }
 
+    func reloadPersistedSessions() {
+        guard !isLoadingSessions else {
+            return
+        }
+        storedSessions = sessionStore.loadSessions()
+        if let currentSession,
+           !storedSessions.contains(where: { $0.id == currentSession.id }) {
+            upsertStoredSession(currentSession)
+        }
+        if let id = currentSessionID,
+           activeRequestSessionID != id,
+           let fresh = storedSessions.first(where: { $0.id == id }),
+           fresh.messages.count != messages.count {
+            applyCurrentSession(fresh)
+        }
+        refreshSessionList()
+    }
+
     private func upsertStoredSession(_ session: ChatSession) {
         if let index = storedSessions.firstIndex(where: { $0.id == session.id }) {
             storedSessions[index] = session
@@ -2006,6 +2027,10 @@ final class ChatViewModel: ObservableObject {
             }
 
             if session.messages.isEmpty {
+                if RoutineStore.shared.routine(forSession: session.id) != nil {
+                    keptSessions.append(session)
+                    continue
+                }
                 if keptEmptySession {
                     removedSessionIDs.append(session.id)
                     continue

--- a/Sources/Nativ/Features/Routines/Routine.swift
+++ b/Sources/Nativ/Features/Routines/Routine.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+enum RoutineTriggerKind: String, Codable, Equatable, Sendable {
+    case schedule
+    case api
+}
+
+struct RoutineSchedule: Codable, Equatable, Sendable {
+    var weekdays: Set<Int>
+    var hour: Int
+    var minute: Int
+
+    init(weekdays: Set<Int> = [], hour: Int = 9, minute: Int = 0) {
+        self.weekdays = weekdays.filter { (1...7).contains($0) }
+        self.hour = min(max(hour, 0), 23)
+        self.minute = min(max(minute, 0), 59)
+    }
+
+    var runsEveryDay: Bool { weekdays.isEmpty }
+
+    func nextFireDate(after date: Date, calendar: Calendar = .current) -> Date? {
+        var components = DateComponents()
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+
+        if runsEveryDay {
+            return calendar.nextDate(
+                after: date,
+                matching: components,
+                matchingPolicy: .nextTime
+            )
+        }
+
+        return weekdays.compactMap { weekday -> Date? in
+            var dayComponents = components
+            dayComponents.weekday = weekday
+            return calendar.nextDate(
+                after: date,
+                matching: dayComponents,
+                matchingPolicy: .nextTime
+            )
+        }.min()
+    }
+}
+
+struct Routine: Codable, Identifiable, Equatable, Sendable {
+    var id: String
+    var name: String
+    var instructions: String
+    var modelID: String
+    var triggerKind: RoutineTriggerKind
+    var schedule: RoutineSchedule
+    var kitID: String?
+    var isEnabled: Bool
+    var notifyOnFinish: Bool
+    var createdAt: Date
+    var sourceSessionID: UUID?
+
+    init(
+        id: String = UUID().uuidString,
+        name: String = "",
+        instructions: String = "",
+        modelID: String = "",
+        triggerKind: RoutineTriggerKind = .schedule,
+        schedule: RoutineSchedule = RoutineSchedule(),
+        kitID: String? = nil,
+        isEnabled: Bool = true,
+        notifyOnFinish: Bool = true,
+        createdAt: Date = Date(),
+        sourceSessionID: UUID? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.instructions = instructions
+        self.modelID = modelID
+        self.triggerKind = triggerKind
+        self.schedule = schedule
+        self.kitID = kitID
+        self.isEnabled = isEnabled
+        self.notifyOnFinish = notifyOnFinish
+        self.createdAt = createdAt
+        self.sourceSessionID = sourceSessionID
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, instructions, modelID, triggerKind, schedule, kitID
+        case isEnabled, notifyOnFinish, createdAt, sourceSessionID
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(String.self, forKey: .id) ?? UUID().uuidString
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        instructions = try container.decodeIfPresent(String.self, forKey: .instructions) ?? ""
+        modelID = try container.decodeIfPresent(String.self, forKey: .modelID) ?? ""
+        triggerKind = try container.decodeIfPresent(RoutineTriggerKind.self, forKey: .triggerKind) ?? .schedule
+        schedule = try container.decodeIfPresent(RoutineSchedule.self, forKey: .schedule) ?? RoutineSchedule()
+        kitID = try container.decodeIfPresent(String.self, forKey: .kitID)
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+        notifyOnFinish = try container.decodeIfPresent(Bool.self, forKey: .notifyOnFinish) ?? true
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        sourceSessionID = try container.decodeIfPresent(UUID.self, forKey: .sourceSessionID)
+    }
+
+    var runsOnSchedule: Bool { triggerKind == .schedule }
+
+    func nextFireDate(after date: Date = Date()) -> Date? {
+        guard isEnabled, runsOnSchedule else { return nil }
+        return schedule.nextFireDate(after: date)
+    }
+}
+
+enum RoutineRunSource: String, Codable, Equatable, Sendable {
+    case scheduled
+    case manual
+    case api
+}
+
+enum RoutineRunStatus: String, Codable, Equatable, Sendable {
+    case running
+    case succeeded
+    case failed
+}
+
+struct RoutineRun: Codable, Identifiable, Equatable, Sendable {
+    var id: String
+    var routineID: String
+    var startedAt: Date
+    var finishedAt: Date?
+    var source: RoutineRunSource
+    var sessionID: UUID?
+    var status: RoutineRunStatus
+    var resultSummary: String
+
+    init(
+        id: String = UUID().uuidString,
+        routineID: String,
+        startedAt: Date = Date(),
+        finishedAt: Date? = nil,
+        source: RoutineRunSource,
+        sessionID: UUID? = nil,
+        status: RoutineRunStatus = .running,
+        resultSummary: String = ""
+    ) {
+        self.id = id
+        self.routineID = routineID
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.source = source
+        self.sessionID = sessionID
+        self.status = status
+        self.resultSummary = resultSummary
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineEditorView.swift
+++ b/Sources/Nativ/Features/Routines/RoutineEditorView.swift
@@ -1,0 +1,221 @@
+import SwiftUI
+
+struct RoutineEditor: View {
+    let draft: RoutineDraft
+    let availableModelIDs: [String]
+    let onSave: (Routine) -> Void
+    let onCancel: () -> Void
+    var onDelete: (() -> Void)?
+
+    @State private var name: String
+    @State private var instructions: String
+    @State private var modelID: String
+    @State private var triggerKind: RoutineTriggerKind
+    @State private var weekdays: Set<Int>
+    @State private var time: Date
+    @State private var kitID: String?
+    @State private var notifyOnFinish: Bool
+
+    init(
+        draft: RoutineDraft,
+        availableModelIDs: [String],
+        onSave: @escaping (Routine) -> Void,
+        onCancel: @escaping () -> Void,
+        onDelete: (() -> Void)? = nil
+    ) {
+        self.draft = draft
+        self.availableModelIDs = availableModelIDs
+        self.onSave = onSave
+        self.onCancel = onCancel
+        self.onDelete = onDelete
+
+        let routine = draft.routine
+        _name = State(initialValue: routine.name)
+        _instructions = State(initialValue: routine.instructions)
+        _modelID = State(initialValue: routine.modelID)
+        _triggerKind = State(initialValue: routine.triggerKind)
+        _weekdays = State(initialValue: routine.schedule.weekdays)
+        var components = DateComponents()
+        components.hour = routine.schedule.hour
+        components.minute = routine.schedule.minute
+        _time = State(initialValue: Calendar.current.date(from: components) ?? Date())
+        _kitID = State(initialValue: routine.kitID)
+        _notifyOnFinish = State(initialValue: routine.notifyOnFinish)
+    }
+
+    private var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+            && !modelID.isEmpty
+            && !instructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Text(name.trimmingCharacters(in: .whitespaces).isEmpty ? "New routine" : name)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let onDelete {
+                    Button("Delete", role: .destructive, action: onDelete)
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.red)
+                }
+            }
+            .padding(16)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    field("Name") {
+                        TextField("Routine name", text: $name)
+                            .textFieldStyle(.plain)
+                    }
+                    field("Instructions") {
+                        TextEditor(text: $instructions)
+                            .scrollContentBackground(.hidden)
+                            .frame(minHeight: 130)
+                            .font(.body)
+                    }
+                    field("Model") {
+                        Picker("Model", selection: $modelID) {
+                            Text("Select a model").tag("")
+                            ForEach(availableModelIDs, id: \.self) { id in
+                                Text(NativFormatting.truncateModelName(id, maxLength: 42)).tag(id)
+                            }
+                        }
+                        .labelsHidden()
+                    }
+                    field("Trigger") { triggerContent }
+                    field("Capabilities") {
+                        VStack(alignment: .leading, spacing: 10) {
+                            Picker("Kit", selection: $kitID) {
+                                Text("None").tag(String?.none)
+                                ForEach(NativKit.all) { kit in
+                                    Text(kit.name).tag(String?.some(kit.id))
+                                }
+                            }
+                            .labelsHidden()
+                            if let kitID, let kit = NativKit.all.first(where: { $0.id == kitID }) {
+                                Text(kit.inventory)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    box {
+                        Toggle("Notify me when this routine finishes", isOn: $notifyOnFinish)
+                    }
+                }
+                .padding(20)
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Save") {
+                    onSave(makeRoutine())
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!canSave)
+            }
+            .padding(16)
+        }
+        .frame(minWidth: 540, minHeight: 620)
+    }
+
+    @ViewBuilder
+    private var triggerContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Picker("Trigger", selection: $triggerKind) {
+                Text("Schedule").tag(RoutineTriggerKind.schedule)
+                Text("API request").tag(RoutineTriggerKind.api)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            if triggerKind == .schedule {
+                Divider()
+                HStack {
+                    Text("Time")
+                    Spacer()
+                    DatePicker("Time", selection: $time, displayedComponents: .hourAndMinute)
+                        .labelsHidden()
+                }
+                weekdayPicker
+            } else {
+                Divider()
+                Text("Runs when this routine's endpoint receives a POST request.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func field<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+            box { content() }
+        }
+    }
+
+    @ViewBuilder
+    private func box<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                Color(nsColor: .controlBackgroundColor),
+                in: RoundedRectangle(cornerRadius: 10)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+            )
+    }
+
+    private var weekdayPicker: some View {
+        HStack(spacing: 6) {
+            ForEach(1...7, id: \.self) { weekday in
+                let symbol = Calendar.current.veryShortWeekdaySymbols[weekday - 1]
+                let isOn = weekdays.contains(weekday)
+                Button(symbol) {
+                    if isOn { weekdays.remove(weekday) } else { weekdays.insert(weekday) }
+                }
+                .buttonStyle(.bordered)
+                .tint(isOn ? Color.accentColor : Color.secondary)
+            }
+            Spacer()
+            Text(weekdays.isEmpty ? "Every day" : "")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func makeRoutine() -> Routine {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: time)
+        let schedule = RoutineSchedule(
+            weekdays: weekdays,
+            hour: components.hour ?? 9,
+            minute: components.minute ?? 0
+        )
+        var routine = draft.routine
+        routine.name = name.trimmingCharacters(in: .whitespaces)
+        routine.instructions = instructions
+        routine.modelID = modelID
+        routine.triggerKind = triggerKind
+        routine.schedule = schedule
+        routine.kitID = kitID
+        routine.notifyOnFinish = notifyOnFinish
+        return routine
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
+++ b/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
@@ -1,0 +1,146 @@
+import AppKit
+import Foundation
+
+enum RoutineLaunchAgent {
+    private static let labelPrefix = "dev.local.Nativ.routine."
+
+    static func refresh(routines: [Routine]) {
+        guard let directory = launchAgentsDirectory,
+              let executablePath = Bundle.main.executablePath
+        else {
+            return
+        }
+
+        let scheduled = routines.filter { $0.isEnabled && $0.runsOnSchedule }
+        let desiredLabels = Set(scheduled.map { labelPrefix + $0.id })
+
+        if let existing = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) {
+            for url in existing where url.lastPathComponent.hasPrefix(labelPrefix) {
+                let label = url.deletingPathExtension().lastPathComponent
+                if !desiredLabels.contains(label) {
+                    unload(url)
+                    try? FileManager.default.removeItem(at: url)
+                }
+            }
+        }
+
+        for routine in scheduled {
+            let label = labelPrefix + routine.id
+            let url = directory.appendingPathComponent(label + ".plist")
+            let plist = makePlist(
+                label: label,
+                executablePath: executablePath,
+                routineID: routine.id,
+                schedule: routine.schedule
+            )
+            guard let data = try? PropertyListSerialization.data(
+                fromPropertyList: plist,
+                format: .xml,
+                options: 0
+            ) else {
+                continue
+            }
+            unload(url)
+            try? data.write(to: url, options: .atomic)
+            load(url)
+        }
+    }
+
+    private static func makePlist(
+        label: String,
+        executablePath: String,
+        routineID: String,
+        schedule: RoutineSchedule
+    ) -> [String: Any] {
+        let intervals: [[String: Int]]
+        if schedule.runsEveryDay {
+            intervals = [["Hour": schedule.hour, "Minute": schedule.minute]]
+        } else {
+            intervals = schedule.weekdays.sorted().map { weekday in
+                ["Weekday": weekday - 1, "Hour": schedule.hour, "Minute": schedule.minute]
+            }
+        }
+        return [
+            "Label": label,
+            "ProgramArguments": [executablePath, "--run-routine", routineID],
+            "StartCalendarInterval": intervals,
+            "RunAtLoad": false,
+            "ProcessType": "Background",
+        ]
+    }
+
+    private static var launchAgentsDirectory: URL? {
+        let directory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+
+    private static func load(_ url: URL) {
+        runLaunchctl(["load", "-w", url.path])
+    }
+
+    private static func unload(_ url: URL) {
+        runLaunchctl(["unload", url.path])
+    }
+
+    private static func runLaunchctl(_ arguments: [String]) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try? process.run()
+        process.waitUntilExit()
+    }
+}
+
+enum RoutineHeadlessRun {
+    private static var retainedRunner: RoutineRunner?
+    private static var retainedModel: NativModel?
+
+    static func execute(routineID: String) {
+        MainActor.assumeIsolated {
+            if anotherInstanceRunning() {
+                exit(EXIT_SUCCESS)
+            }
+            guard RoutineScheduler.hasSufficientBattery(),
+                  let routine = RoutineStore.shared.routine(id: routineID)
+            else {
+                exit(EXIT_SUCCESS)
+            }
+            let model = NativModel()
+            let runner = RoutineRunner(
+                model: model,
+                store: RoutineStore.shared,
+                sessionStore: ChatSessionStore()
+            )
+            retainedModel = model
+            retainedRunner = runner
+            runner.onRunCompleted = { _, _ in
+                model.stopServer()
+                exit(EXIT_SUCCESS)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 600) {
+                MainActor.assumeIsolated { retainedModel?.stopServer() }
+                exit(EXIT_SUCCESS)
+            }
+            runner.run(routine, source: .scheduled)
+        }
+        RunLoop.main.run()
+    }
+
+    private static func anotherInstanceRunning() -> Bool {
+        guard let bundleID = Bundle.main.bundleIdentifier else {
+            return false
+        }
+        return NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+            .contains { $0.processIdentifier != ProcessInfo.processInfo.processIdentifier }
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineRunCoordinator.swift
+++ b/Sources/Nativ/Features/Routines/RoutineRunCoordinator.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@MainActor
+final class RoutineRunCoordinator {
+    static let shared = RoutineRunCoordinator()
+
+    private var runner: RoutineRunner?
+
+    func configure(runner: RoutineRunner) {
+        self.runner = runner
+    }
+
+    func run(_ routine: Routine, source: RoutineRunSource) {
+        runner?.run(routine, source: source)
+    }
+
+    func runRoutine(id: String, source: RoutineRunSource) {
+        guard let routine = RoutineStore.shared.routine(id: id) else {
+            return
+        }
+        run(routine, source: source)
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineRunner.swift
+++ b/Sources/Nativ/Features/Routines/RoutineRunner.swift
@@ -1,0 +1,197 @@
+import Foundation
+import NativServerKit
+
+@MainActor
+final class RoutineRunner {
+    private let model: NativModel
+    private let store: RoutineStore
+    private let sessionStore: ChatSessionStore
+
+    var onRunCompleted: ((Routine, RoutineRun) -> Void)?
+
+    private var queue: [(Routine, RoutineRunSource)] = []
+    private var isExecuting = false
+
+    init(model: NativModel, store: RoutineStore, sessionStore: ChatSessionStore) {
+        self.model = model
+        self.store = store
+        self.sessionStore = sessionStore
+    }
+
+    func run(_ routine: Routine, source: RoutineRunSource) {
+        queue.append((routine, source))
+        drain()
+    }
+
+    private func drain() {
+        guard !isExecuting, !queue.isEmpty else {
+            return
+        }
+        isExecuting = true
+        let (routine, source) = queue.removeFirst()
+        Task { @MainActor in
+            await execute(routine, source: source)
+            isExecuting = false
+            drain()
+        }
+    }
+
+    private func execute(_ routine: Routine, source: RoutineRunSource) async {
+        var run = RoutineRun(routineID: routine.id, source: source, status: .running)
+        store.recordRun(run)
+
+        if !model.isRunning {
+            model.startServer()
+        }
+        await waitForServer()
+
+        guard let baseURL = model.activeServerBaseURL else {
+            finish(&run, routine: routine, status: .failed, summary: "The Nativ server isn’t running.")
+            return
+        }
+
+        let settings = model.settings.normalized()
+        var messages: [MLXChatMessage] = []
+        if let systemPrompt = systemPrompt(for: routine) {
+            messages.append(MLXChatMessage(role: "system", content: systemPrompt))
+        }
+        messages.append(MLXChatMessage(role: "user", content: routine.instructions))
+
+        let client = NativChatClient(baseURL: baseURL, apiKey: settings.serverAPIKey)
+        let request = MLXChatCompletionRequest(
+            model: routine.modelID,
+            messages: messages,
+            maxTokens: settings.maxTokens,
+            temperature: settings.temperature,
+            topK: settings.topK,
+            topP: settings.topP,
+            minP: settings.minP
+        )
+
+        do {
+            let completion = try await client.completeChat(request)
+            let sessionID = appendRun(routine: routine, completion: completion)
+            NotificationCenter.default.post(name: .routineDidSaveChatSession, object: nil)
+            run.sessionID = sessionID
+            finish(&run, routine: routine, status: .succeeded, summary: Self.summarize(completion.content))
+        } catch {
+            finish(&run, routine: routine, status: .failed, summary: error.localizedDescription)
+        }
+    }
+
+    private func appendRun(routine: Routine, completion: MLXChatCompletion) -> UUID {
+        let userMessage = ChatTranscriptMessage(
+            role: .user,
+            content: routine.instructions
+        )
+        let assistantMessage = ChatTranscriptMessage(
+            role: .assistant,
+            content: completion.content,
+            reasoningContent: completion.reasoningContent ?? "",
+            modelID: routine.modelID
+        )
+        if let sessionID = routine.sourceSessionID,
+           var session = sessionStore.loadSession(id: sessionID) {
+            session.messages.append(userMessage)
+            session.messages.append(assistantMessage)
+            session.updatedAt = Date()
+            sessionStore.saveSession(session)
+            return sessionID
+        }
+        let session = makeSession(routine: routine, completion: completion)
+        sessionStore.saveSession(session)
+        return session.id
+    }
+
+    private func finish(
+        _ run: inout RoutineRun,
+        routine: Routine,
+        status: RoutineRunStatus,
+        summary: String
+    ) {
+        run.status = status
+        run.finishedAt = Date()
+        run.resultSummary = summary
+        store.recordRun(run)
+        onRunCompleted?(routine, run)
+    }
+
+    private func waitForServer(timeout: TimeInterval = 120) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while model.activeServerBaseURL == nil, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+        guard let baseURL = model.activeServerBaseURL else {
+            return
+        }
+        let healthURL = baseURL.appendingPathComponent("v1/models")
+        while Date() < deadline {
+            if await Self.isReachable(healthURL) {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+        }
+    }
+
+    private static func isReachable(_ url: URL) async -> Bool {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 3
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return response is HTTPURLResponse
+        } catch {
+            return false
+        }
+    }
+
+    private func systemPrompt(for routine: Routine) -> String? {
+        guard let kitID = routine.kitID,
+              let kit = NativKit.all.first(where: { $0.id == kitID })
+        else {
+            return nil
+        }
+        let instructions = kit.skills
+            .filter(\.isEnabled)
+            .map(\.instructions)
+            .filter { !$0.isEmpty }
+        return instructions.isEmpty ? nil : instructions.joined(separator: "\n\n")
+    }
+
+    private func makeSession(routine: Routine, completion: MLXChatCompletion) -> ChatSession {
+        let userMessage = ChatTranscriptMessage(
+            role: .user,
+            content: routine.instructions
+        )
+        let assistantMessage = ChatTranscriptMessage(
+            role: .assistant,
+            content: completion.content,
+            reasoningContent: completion.reasoningContent ?? "",
+            modelID: routine.modelID
+        )
+        let now = Date()
+        return ChatSession(
+            id: UUID(),
+            title: routine.name.isEmpty ? "Routine" : routine.name,
+            customTitle: nil,
+            createdAt: now,
+            updatedAt: now,
+            messages: [userMessage, assistantMessage],
+            pinned: nil,
+            pinnedOrder: nil,
+            sessionOrder: nil,
+            folderID: nil
+        )
+    }
+
+    private static func summarize(_ content: String) -> String {
+        let firstLine = content
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { !$0.isEmpty } ?? ""
+        return firstLine.count > 140 ? String(firstLine.prefix(139)) + "…" : firstLine
+    }
+}
+
+extension Notification.Name {
+    static let routineDidSaveChatSession = Notification.Name("RoutineDidSaveChatSession")
+}

--- a/Sources/Nativ/Features/Routines/RoutineScheduler.swift
+++ b/Sources/Nativ/Features/Routines/RoutineScheduler.swift
@@ -1,0 +1,125 @@
+import Foundation
+import IOKit.ps
+
+@MainActor
+final class RoutineScheduler {
+    private let store: RoutineStore
+    private let onFire: (Routine, RoutineRunSource) -> Void
+    private var timer: Timer?
+    private var lastFiredScheduledDate: [String: Date] = [:]
+
+    private static let tickInterval: TimeInterval = 30
+    private static let lookbackWindow: TimeInterval = 90
+
+    init(store: RoutineStore, onFire: @escaping (Routine, RoutineRunSource) -> Void) {
+        self.store = store
+        self.onFire = onFire
+    }
+
+    func start() {
+        stop()
+        let timer = Timer(timeInterval: Self.tickInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+        tick()
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func tick() {
+        let now = Date()
+        for routine in store.scheduledRoutines {
+            guard let due = dueScheduledDate(for: routine, now: now) else {
+                continue
+            }
+            if lastFiredScheduledDate[routine.id] == due {
+                continue
+            }
+            lastFiredScheduledDate[routine.id] = due
+            guard Self.hasSufficientBattery() else {
+                continue
+            }
+            onFire(routine, .scheduled)
+        }
+        processAPITriggers()
+    }
+
+    private func processAPITriggers() {
+        guard let directory = Self.triggersDirectory,
+              let files = try? FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil
+              )
+        else {
+            return
+        }
+        for file in files where file.pathExtension == "json" {
+            defer { try? FileManager.default.removeItem(at: file) }
+            guard let data = try? Data(contentsOf: file),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let routineID = object["routineID"] as? String,
+                  let routine = store.routine(id: routineID),
+                  routine.isEnabled
+            else {
+                continue
+            }
+            onFire(routine, .api)
+        }
+    }
+
+    static var triggersDirectory: URL? {
+        let base = (try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? FileManager.default.homeDirectoryForCurrentUser
+        let directory = base
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("Routines", isDirectory: true)
+            .appendingPathComponent("triggers", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+
+    private func dueScheduledDate(for routine: Routine, now: Date) -> Date? {
+        guard let candidate = routine.schedule.nextFireDate(
+            after: now.addingTimeInterval(-Self.lookbackWindow)
+        ) else {
+            return nil
+        }
+        return candidate <= now ? candidate : nil
+    }
+
+    static func hasSufficientBattery() -> Bool {
+        guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+              let sources = IOPSCopyPowerSourcesList(snapshot)?.takeRetainedValue()
+                as? [CFTypeRef],
+              let source = sources.first,
+              let description = IOPSGetPowerSourceDescription(snapshot, source)?
+                .takeUnretainedValue() as? [String: Any]
+        else {
+            return true
+        }
+
+        if description[kIOPSPowerSourceStateKey] as? String == kIOPSACPowerValue {
+            return true
+        }
+
+        if let capacity = description[kIOPSCurrentCapacityKey] as? Int,
+           let maximum = description[kIOPSMaxCapacityKey] as? Int,
+           maximum > 0 {
+            return Double(capacity) / Double(maximum) >= 0.10
+        }
+
+        return true
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineStore.swift
+++ b/Sources/Nativ/Features/Routines/RoutineStore.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+@MainActor
+final class RoutineStore: ObservableObject {
+    static let shared = RoutineStore()
+
+    @Published private(set) var routines: [Routine] = []
+    @Published private(set) var runs: [RoutineRun] = []
+
+    var onRoutinesChanged: (() -> Void)?
+
+    private static let maxRunsPerRoutine = 50
+
+    init() {
+        routines = Self.loadRoutines()
+        runs = Self.loadRuns()
+    }
+
+    func routine(id: String) -> Routine? {
+        routines.first { $0.id == id }
+    }
+
+    func routine(forSession sessionID: UUID) -> Routine? {
+        routines.first { $0.sourceSessionID == sessionID }
+    }
+
+    func deleteRoutine(forSession sessionID: UUID) {
+        guard let routine = routine(forSession: sessionID) else {
+            return
+        }
+        delete(id: routine.id)
+    }
+
+    func isRoutineRunning(forSession sessionID: UUID) -> Bool {
+        guard let routine = routine(forSession: sessionID) else {
+            return false
+        }
+        return runs.contains { $0.routineID == routine.id && $0.status == .running }
+    }
+
+    func upsert(_ routine: Routine) {
+        if let index = routines.firstIndex(where: { $0.id == routine.id }) {
+            routines[index] = routine
+        } else {
+            routines.append(routine)
+        }
+        persistRoutines()
+        onRoutinesChanged?()
+    }
+
+    func delete(id: String) {
+        routines.removeAll { $0.id == id }
+        runs.removeAll { $0.routineID == id }
+        persistRoutines()
+        persistRuns()
+        onRoutinesChanged?()
+    }
+
+    func setEnabled(_ enabled: Bool, id: String) {
+        guard let index = routines.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        routines[index].isEnabled = enabled
+        persistRoutines()
+        onRoutinesChanged?()
+    }
+
+    var scheduledRoutines: [Routine] {
+        routines.filter { $0.isEnabled && $0.runsOnSchedule }
+    }
+
+    func runs(forRoutine id: String) -> [RoutineRun] {
+        runs.filter { $0.routineID == id }.sorted { $0.startedAt > $1.startedAt }
+    }
+
+    func recordRun(_ run: RoutineRun) {
+        if let index = runs.firstIndex(where: { $0.id == run.id }) {
+            runs[index] = run
+        } else {
+            runs.append(run)
+        }
+        pruneRuns(forRoutine: run.routineID)
+        persistRuns()
+    }
+
+    func reload() {
+        routines = Self.loadRoutines()
+        runs = Self.loadRuns()
+    }
+
+    private func pruneRuns(forRoutine id: String) {
+        let ordered = runs
+            .filter { $0.routineID == id }
+            .sorted { $0.startedAt > $1.startedAt }
+        guard ordered.count > Self.maxRunsPerRoutine else {
+            return
+        }
+        let stale = Set(ordered.dropFirst(Self.maxRunsPerRoutine).map(\.id))
+        runs.removeAll { stale.contains($0.id) }
+    }
+
+    private func persistRoutines() {
+        Self.write(routines, to: Self.routinesURL)
+    }
+
+    private func persistRuns() {
+        Self.write(runs, to: Self.runsURL)
+    }
+
+    static func loadRoutines() -> [Routine] {
+        guard let data = try? Data(contentsOf: routinesURL) else {
+            return []
+        }
+        return (try? JSONDecoder().decode([Routine].self, from: data)) ?? []
+    }
+
+    static func loadRuns() -> [RoutineRun] {
+        guard let data = try? Data(contentsOf: runsURL) else {
+            return []
+        }
+        return (try? JSONDecoder().decode([RoutineRun].self, from: data)) ?? []
+    }
+
+    static func appendRun(_ run: RoutineRun) {
+        var current = loadRuns()
+        if let index = current.firstIndex(where: { $0.id == run.id }) {
+            current[index] = run
+        } else {
+            current.append(run)
+        }
+        write(current, to: runsURL)
+    }
+
+    private static func write<T: Encodable>(_ value: T, to url: URL) {
+        guard let data = try? JSONEncoder().encode(value) else {
+            return
+        }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    private static var directory: URL {
+        let base = (try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? FileManager.default.homeDirectoryForCurrentUser
+        let directory = base
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("Routines", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+
+    private static var routinesURL: URL {
+        directory.appendingPathComponent("routines.json")
+    }
+
+    private static var runsURL: URL {
+        directory.appendingPathComponent("runs.json")
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineSupport.swift
+++ b/Sources/Nativ/Features/Routines/RoutineSupport.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum RoutineFormatting {
+    static func timeString(_ schedule: RoutineSchedule) -> String {
+        var components = DateComponents()
+        components.hour = schedule.hour
+        components.minute = schedule.minute
+        guard let date = Calendar.current.date(from: components) else {
+            return ""
+        }
+        return date.formatted(date: .omitted, time: .shortened)
+    }
+
+    static func summary(_ routine: Routine) -> String {
+        guard routine.runsOnSchedule else {
+            return "Runs on API request"
+        }
+        let time = timeString(routine.schedule)
+        if routine.schedule.runsEveryDay {
+            return "Every day at \(time)"
+        }
+        let symbols = Calendar.current.shortWeekdaySymbols
+        let days = routine.schedule.weekdays.sorted()
+            .compactMap { symbols.indices.contains($0 - 1) ? symbols[$0 - 1] : nil }
+            .joined(separator: ", ")
+        return days.isEmpty ? "Not scheduled" : "\(days) at \(time)"
+    }
+}
+
+final class RoutineDraft: Identifiable {
+    let id: String
+    var routine: Routine
+
+    init(routine: Routine) {
+        self.id = routine.id
+        self.routine = routine
+    }
+}

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -51,6 +51,11 @@ enum Main {
             }
         }
 
+        if let index = CommandLine.arguments.firstIndex(of: "--run-routine"),
+           index + 1 < CommandLine.arguments.count {
+            RoutineHeadlessRun.execute(routineID: CommandLine.arguments[index + 1])
+        }
+
         NativApplication.main()
     }
 


### PR DESCRIPTION
supersedes #203, where "Routines" page is removed and the UI follows a much simpler approach.

Users create recurrent routines from exiting or same button used by chat creation, and this marks chats with a sign to symbolize recurrent routine.



https://github.com/user-attachments/assets/f288acb7-f040-437b-8d81-465ba9df8225

Users can't delete a chat without approving it's a recurrent job as well:

<img width="310" height="268" alt="Screenshot 2026-08-07 at 8 08 30 AM" src="https://github.com/user-attachments/assets/fc942131-627d-4b63-b392-10c185c86bf8" />
