### PR TITLE
Skip pre-loading a speech model that cannot load

### DIFF
--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -544,6 +544,57 @@ enum LocalModelDiscovery {
         )
     }
 
+    static let speechToTextModelTypesRequiringPreprocessor: Set<String> = [
+        "mms",
+        "moss_transcribe_diarize",
+        "qwen2_audio",
+        "qwen3_asr",
+        "voxtral"
+    ]
+
+    static func speechToTextPreloadIssue(repoID: String, path: String) -> String? {
+        let fileManager = FileManager.default
+        guard let snapshotURL = modelSnapshotURL(
+            repoID: repoID,
+            path: expandedPath(path),
+            fileManager: fileManager
+        ) else {
+            return nil
+        }
+
+        let configURL = snapshotURL.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let modelType = (config["model_type"] as? String)?.lowercased(),
+              speechToTextModelTypesRequiringPreprocessor.contains(modelType)
+        else {
+            return nil
+        }
+
+        let preprocessorURL = snapshotURL.appendingPathComponent("preprocessor_config.json")
+        guard !fileManager.fileExists(atPath: preprocessorURL.path) else {
+            return nil
+        }
+
+        return "\(repoID) is missing preprocessor_config.json, which \(modelType) speech models need in order to load."
+    }
+
+    private static func modelSnapshotURL(
+        repoID: String,
+        path: String,
+        fileManager: FileManager
+    ) -> URL? {
+        if repoID.hasPrefix("/") {
+            let directURL = URL(fileURLWithPath: repoID, isDirectory: true)
+            return isDirectoryURL(directURL, fileManager: fileManager) ? directURL : nil
+        }
+
+        let repositoryName = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+        let repositoryURL = URL(fileURLWithPath: path, isDirectory: true)
+            .appendingPathComponent(repositoryName, isDirectory: true)
+        return preferredSnapshotURL(for: repositoryURL, fileManager: fileManager)
+    }
+
     private static func configurationMetadataSynchronously(
         repoID: String,
         path: String

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -330,6 +330,16 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
             modelLoadingProgress = nil
             appendLog("\n\(languageModelID) is not a text-generation model — starting the server without pre-loading it. Pick a chat model to load one.\n")
         }
+        if let speechToTextModelID = settings.normalized().speechToTextModelID,
+           let speechIssue = LocalModelDiscovery.speechToTextPreloadIssue(
+               repoID: speechToTextModelID,
+               path: settings.modelSearchPath
+           ),
+           let speechFlagIndex = launchArguments.firstIndex(of: "--stt-model"),
+           speechFlagIndex + 1 < launchArguments.count {
+            launchArguments.removeSubrange(speechFlagIndex...(speechFlagIndex + 1))
+            appendLog("\n\(speechIssue) Starting the server without it — dictation stays unavailable until that model is replaced or repaired.\n")
+        }
         do {
             var launchEnvironment = settings.launchEnvironment
             launchEnvironment["MLX_PLATFORM_ANALYTICS_DB_PATH"] = currentAnalyticsDatabaseURL().path

--- a/Tests/NativTests/LocalModelDiscoveryTests.swift
+++ b/Tests/NativTests/LocalModelDiscoveryTests.swift
@@ -142,6 +142,93 @@ final class LocalModelDiscoveryTests: XCTestCase {
         )
     }
 
+    func testSpeechToTextPreloadIssueFlagsMissingPreprocessorConfig() throws {
+        let repoID = "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
+        try makeSpeechSnapshot(
+            repoID: repoID,
+            modelType: "qwen3_asr",
+            includesPreprocessorConfig: false
+        )
+
+        let issue = LocalModelDiscovery.speechToTextPreloadIssue(
+            repoID: repoID,
+            path: temporaryCache.path
+        )
+
+        let message = try XCTUnwrap(issue)
+        XCTAssertTrue(message.contains("preprocessor_config.json"))
+        XCTAssertTrue(message.contains(repoID))
+    }
+
+    func testSpeechToTextPreloadIssueAcceptsCompleteSnapshot() throws {
+        let repoID = "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
+        try makeSpeechSnapshot(
+            repoID: repoID,
+            modelType: "qwen3_asr",
+            includesPreprocessorConfig: true
+        )
+
+        XCTAssertNil(
+            LocalModelDiscovery.speechToTextPreloadIssue(
+                repoID: repoID,
+                path: temporaryCache.path
+            )
+        )
+    }
+
+    func testSpeechToTextPreloadIssueIgnoresModelTypesWithoutPreprocessor() throws {
+        let repoID = "mlx-community/whisper-tiny"
+        try makeSpeechSnapshot(
+            repoID: repoID,
+            modelType: "whisper",
+            includesPreprocessorConfig: false
+        )
+
+        XCTAssertNil(
+            LocalModelDiscovery.speechToTextPreloadIssue(
+                repoID: repoID,
+                path: temporaryCache.path
+            )
+        )
+    }
+
+    func testSpeechToTextPreloadIssueIgnoresUnknownModel() {
+        XCTAssertNil(
+            LocalModelDiscovery.speechToTextPreloadIssue(
+                repoID: "nobody/not-installed",
+                path: temporaryCache.path
+            )
+        )
+    }
+
+    private func makeSpeechSnapshot(
+        repoID: String,
+        modelType: String,
+        includesPreprocessorConfig: Bool
+    ) throws {
+        let repository = temporaryCache.appendingPathComponent(
+            "models--" + repoID.replacingOccurrences(of: "/", with: "--"),
+            isDirectory: true
+        )
+        let revision = "speech-test-revision"
+        let snapshot =
+            repository
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(revision, isDirectory: true)
+
+        try write(revision, to: repository.appendingPathComponent("refs/main"))
+        try writeJSON(
+            ["model_type": modelType, "architectures": ["Qwen3ASRForConditionalGeneration"]],
+            to: snapshot.appendingPathComponent("config.json")
+        )
+        if includesPreprocessorConfig {
+            try writeJSON(
+                ["feature_extractor_type": "WhisperFeatureExtractor"],
+                to: snapshot.appendingPathComponent("preprocessor_config.json")
+            )
+        }
+    }
+
     private func makeMageFlowSnapshot(repoID: String) throws {
         let repository = temporaryCache.appendingPathComponent(
             "models--" + repoID.replacingOccurrences(of: "/", with: "--"),


### PR DESCRIPTION
When a selected speech-to-text model can't load, pre-loading it aborts server startup and takes chat down with it (#226); this detects that case before launch and starts the server without --stt-model, logging which model was skipped and why, so a broken dictation model can no longer brick the app, complementing the upstream fix in https://github.com/Blaizzy/mlx-vlm/pull/1814, which this does not depend on.
