### PR TITLE
Fix voice dictation shortcut reliability

### DIFF
--- a/Extensions/VoiceDictation/Manifest.json
+++ b/Extensions/VoiceDictation/Manifest.json
@@ -32,7 +32,7 @@
       {
         "id": "com.nativ.voice-dictation.transcribe",
         "title": "Transcribe",
-        "defaultShortcut": "Fn+Control"
+        "defaultShortcut": "Control+Option+Command"
       },
       {
         "id": "com.nativ.voice-dictation.retranscribe",

--- a/Extensions/VoiceDictation/Manifest.json
+++ b/Extensions/VoiceDictation/Manifest.json
@@ -32,7 +32,7 @@
       {
         "id": "com.nativ.voice-dictation.transcribe",
         "title": "Transcribe",
-        "defaultShortcut": "Control+Option+Command"
+        "defaultShortcut": "Fn+Control"
       },
       {
         "id": "com.nativ.voice-dictation.retranscribe",

--- a/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
+++ b/Sources/Nativ/Features/Extensions/VoiceDictationExtension.swift
@@ -123,7 +123,7 @@ final class VoiceDictationExtension: NativHostExtension {
                 .init(
                     id: "com.nativ.voice-dictation.transcribe",
                     title: "Transcribe",
-                    defaultShortcut: "Control+Option+Command"
+                    defaultShortcut: "Fn+Control"
                 ),
                 .init(
                     id: "com.nativ.voice-dictation.retranscribe",

--- a/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
@@ -27,7 +27,7 @@ struct FnRetryShortcutState {
 }
 
 struct VoiceModifierToggleShortcutState {
-    static let doubleTapWindow: TimeInterval = 0.4
+    static let doubleTapWindow: TimeInterval = 0.6
 
     private(set) var isHeld = false
     private(set) var wasUsedAsChord = false
@@ -62,13 +62,10 @@ struct VoiceModifierToggleShortcutState {
                 lastCleanTapTime = now
                 return false
             }
-            if activeModifiers != shortcutModifiers {
-                wasUsedAsChord = true
-            }
             return false
         }
 
-        if activeModifiers == shortcutModifiers {
+        if containsShortcut {
             isHeld = true
             wasUsedAsChord = false
         }
@@ -85,6 +82,43 @@ struct VoiceModifierToggleShortcutState {
         isHeld = false
         wasUsedAsChord = false
         lastCleanTapTime = nil
+    }
+}
+
+struct PushToTalkHoldState {
+    static let releaseGrace: TimeInterval = 0.12
+
+    private(set) var isHeld = false
+    private var releaseTime: Date?
+
+    mutating func update(rawHeld: Bool, now: Date = Date()) -> Bool? {
+        if rawHeld {
+            releaseTime = nil
+            guard !isHeld else {
+                return nil
+            }
+            isHeld = true
+            return true
+        }
+        guard isHeld else {
+            releaseTime = nil
+            return nil
+        }
+        guard let since = releaseTime else {
+            releaseTime = now
+            return nil
+        }
+        guard now.timeIntervalSince(since) >= Self.releaseGrace else {
+            return nil
+        }
+        releaseTime = nil
+        isHeld = false
+        return false
+    }
+
+    mutating func reset() {
+        isHeld = false
+        releaseTime = nil
     }
 }
 
@@ -129,6 +163,7 @@ final class FnControlShortcutMonitor {
     private var retryModifierIsHeld = false
     private var retryState = FnRetryShortcutState()
     private var recordModifierToggleState = VoiceModifierToggleShortcutState()
+    private var recordPushToTalkState = PushToTalkHoldState()
     private var recordKeyToggleState = FnRetryShortcutState()
     private var hotKeys: [UInt32: EventHotKeyRef] = [:]
     private var hotKeyEventHandler: EventHandlerRef?
@@ -197,6 +232,7 @@ final class FnControlShortcutMonitor {
         uninstallHotKeys()
         retryState = FnRetryShortcutState()
         recordModifierToggleState.reset()
+        recordPushToTalkState.reset()
         recordKeyToggleState = FnRetryShortcutState()
     }
 
@@ -206,6 +242,7 @@ final class FnControlShortcutMonitor {
         retryModifierIsHeld = false
         retryState = FnRetryShortcutState()
         recordModifierToggleState.reset()
+        recordPushToTalkState.reset()
         recordKeyToggleState = FnRetryShortcutState()
 
         if recordWasHeld {
@@ -263,17 +300,21 @@ final class FnControlShortcutMonitor {
                 }
             } else {
                 recordModifierToggleState.reset()
-                let isHeld =
-                    activeModifiers == preferences.recordShortcut.modifiers
-                    && !activeModifiers.isEmpty
-                updateRecordState(isHeld)
+                let shortcut = preferences.recordShortcut.modifiers
+                let rawHeld =
+                    !shortcut.isEmpty
+                    && activeModifiers.intersection(shortcut) == shortcut
+                if let change = recordPushToTalkState.update(rawHeld: rawHeld) {
+                    updateRecordState(change)
+                }
             }
         }
 
         if preferences.retryShortcut.keyCode == nil {
+            let shortcut = preferences.retryShortcut.modifiers
             let isHeld =
-                activeModifiers == preferences.retryShortcut.modifiers
-                && !activeModifiers.isEmpty
+                !shortcut.isEmpty
+                && activeModifiers.intersection(shortcut) == shortcut
             if isHeld && !retryModifierIsHeld {
                 onRetry?()
             }
@@ -325,6 +366,7 @@ final class FnControlShortcutMonitor {
         retryModifierIsHeld = false
         retryState = FnRetryShortcutState()
         recordModifierToggleState.reset()
+        recordPushToTalkState.reset()
         recordKeyToggleState = FnRetryShortcutState()
         uninstallHotKeys()
         installHotKeys()

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -121,12 +121,24 @@ final class VoiceCaptureCoordinator {
             guard let self else {
                 return
             }
-            let isAuthorized = Self.hasMicrophoneAccess()
+            let status = AVCaptureDevice.authorizationStatus(for: .audio)
+            let granted: Bool
+            switch status {
+            case .authorized:
+                granted = true
+            case .notDetermined:
+                granted = await AVCaptureDevice.requestAccess(for: .audio)
+            default:
+                granted = false
+            }
             guard !Task.isCancelled, self.isShortcutHeld else {
                 return
             }
-            guard isAuthorized else {
+            guard granted else {
                 self.overlay.showFailure()
+                if status == .denied || status == .restricted {
+                    self.presentMicrophonePermissionAlert()
+                }
                 return
             }
 
@@ -598,7 +610,28 @@ final class VoiceCaptureCoordinator {
         }
     }
 
-    private static func hasMicrophoneAccess() -> Bool {
-        AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+    private func presentMicrophonePermissionAlert() {
+        guard !isPresentingAlert else {
+            return
+        }
+        isPresentingAlert = true
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Microphone Access Needed"
+        alert.informativeText = """
+        Nativ needs microphone access to record dictation. Enable Nativ under \
+        Microphone in System Settings, then try the shortcut again.
+        """
+        alert.addButton(withTitle: "Open System Settings")
+        alert.addButton(withTitle: "Not Now")
+        let response = alert.runModal()
+        isPresentingAlert = false
+        shortcutMonitor.resynchronizeAfterModalInteraction()
+
+        if response == .alertFirstButtonReturn {
+            NativSystemPermissionController.openMicrophoneSettings()
+        }
     }
 }

--- a/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
@@ -77,11 +77,6 @@ struct VoiceShortcut: Codable, Equatable, Sendable {
     static let recordDefault = VoiceShortcut(
         keyCode: nil,
         keyDisplay: nil,
-        modifiers: [.control, .option, .command]
-    )
-    static let legacyRecordDefault = VoiceShortcut(
-        keyCode: nil,
-        keyDisplay: nil,
         modifiers: [.function, .control]
     )
     static let retryDefault = VoiceShortcut(
@@ -157,13 +152,10 @@ final class VoiceShortcutPreferences: ObservableObject {
     }
 
     private struct Payload: Codable {
-        let version: Int?
         let recordShortcut: VoiceShortcut
         let retryShortcut: VoiceShortcut
         let isHandsFreeEnabled: Bool?
     }
-
-    private static let currentVersion = 2
 
     private let defaults: UserDefaults
     private let storageKey: String
@@ -179,17 +171,9 @@ final class VoiceShortcutPreferences: ObservableObject {
            payload.recordShortcut.isValid,
            payload.retryShortcut.isValid
         {
-            let needsMigration = (payload.version ?? 1) < Self.currentVersion
-            if needsMigration, payload.recordShortcut == .legacyRecordDefault {
-                recordShortcut = .recordDefault
-            } else {
-                recordShortcut = payload.recordShortcut
-            }
+            recordShortcut = payload.recordShortcut
             retryShortcut = payload.retryShortcut
             isHandsFreeEnabled = payload.isHandsFreeEnabled ?? true
-            if needsMigration {
-                persistCurrent()
-            }
         } else {
             recordShortcut = .recordDefault
             retryShortcut = .retryDefault
@@ -207,7 +191,6 @@ final class VoiceShortcutPreferences: ObservableObject {
 
     private func persistCurrent() {
         let payload = Payload(
-            version: Self.currentVersion,
             recordShortcut: recordShortcut,
             retryShortcut: retryShortcut,
             isHandsFreeEnabled: isHandsFreeEnabled

--- a/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
@@ -79,6 +79,11 @@ struct VoiceShortcut: Codable, Equatable, Sendable {
         keyDisplay: nil,
         modifiers: [.control, .option, .command]
     )
+    static let legacyRecordDefault = VoiceShortcut(
+        keyCode: nil,
+        keyDisplay: nil,
+        modifiers: [.function, .control]
+    )
     static let retryDefault = VoiceShortcut(
         keyCode: UInt16(kVK_ANSI_R),
         keyDisplay: "R",
@@ -152,10 +157,13 @@ final class VoiceShortcutPreferences: ObservableObject {
     }
 
     private struct Payload: Codable {
+        let version: Int?
         let recordShortcut: VoiceShortcut
         let retryShortcut: VoiceShortcut
         let isHandsFreeEnabled: Bool?
     }
+
+    private static let currentVersion = 2
 
     private let defaults: UserDefaults
     private let storageKey: String
@@ -171,9 +179,17 @@ final class VoiceShortcutPreferences: ObservableObject {
            payload.recordShortcut.isValid,
            payload.retryShortcut.isValid
         {
-            recordShortcut = payload.recordShortcut
+            let needsMigration = (payload.version ?? 1) < Self.currentVersion
+            if needsMigration, payload.recordShortcut == .legacyRecordDefault {
+                recordShortcut = .recordDefault
+            } else {
+                recordShortcut = payload.recordShortcut
+            }
             retryShortcut = payload.retryShortcut
             isHandsFreeEnabled = payload.isHandsFreeEnabled ?? true
+            if needsMigration {
+                persistCurrent()
+            }
         } else {
             recordShortcut = .recordDefault
             retryShortcut = .retryDefault
@@ -189,8 +205,9 @@ final class VoiceShortcutPreferences: ObservableObject {
         retryShortcut = .retryDefault
     }
 
-    private func preferencesDidChange() {
+    private func persistCurrent() {
         let payload = Payload(
+            version: Self.currentVersion,
             recordShortcut: recordShortcut,
             retryShortcut: retryShortcut,
             isHandsFreeEnabled: isHandsFreeEnabled
@@ -198,6 +215,10 @@ final class VoiceShortcutPreferences: ObservableObject {
         if let data = try? JSONEncoder().encode(payload) {
             defaults.set(data, forKey: storageKey)
         }
+    }
+
+    private func preferencesDidChange() {
+        persistCurrent()
         NotificationCenter.default.post(
             name: .voiceShortcutPreferencesDidChange,
             object: self

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -709,7 +709,6 @@ final class VoiceAudioRetentionTests: XCTestCase {
 }
 
 private struct VoiceStoredPreferencesPayload: Codable {
-    let version: Int?
     let recordShortcut: VoiceShortcut
     let retryShortcut: VoiceShortcut
     let isHandsFreeEnabled: Bool?
@@ -718,7 +717,7 @@ private struct VoiceStoredPreferencesPayload: Codable {
 @MainActor
 final class VoiceShortcutPreferencesTests: XCTestCase {
     func testDefaultsMatchExistingVoiceCommands() {
-        XCTAssertEqual(VoiceShortcut.recordDefault.displayName, "Control + Option + Command")
+        XCTAssertEqual(VoiceShortcut.recordDefault.displayName, "Fn + Control")
         XCTAssertEqual(VoiceShortcut.retryDefault.displayName, "Fn + R")
 
         let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
@@ -792,75 +791,8 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
         XCTAssertTrue(restored.isHandsFreeEnabled)
     }
 
-    func testMigratesLegacyDefaultRecordShortcut() throws {
-        let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let payload = VoiceStoredPreferencesPayload(
-            version: nil,
-            recordShortcut: .legacyRecordDefault,
-            retryShortcut: .retryDefault,
-            isHandsFreeEnabled: true
-        )
-        defaults.set(
-            try JSONEncoder().encode(payload),
-            forKey: "voiceShortcutPreferences.v1"
-        )
 
-        let restored = VoiceShortcutPreferences(defaults: defaults)
-        XCTAssertEqual(restored.recordShortcut, .recordDefault)
 
-        let persisted = try XCTUnwrap(defaults.data(forKey: "voiceShortcutPreferences.v1"))
-        let decoded = try JSONDecoder().decode(
-            VoiceStoredPreferencesPayload.self,
-            from: persisted
-        )
-        XCTAssertEqual(decoded.version, 2)
-        XCTAssertEqual(decoded.recordShortcut, .recordDefault)
-    }
-
-    func testPreservesCustomShortcutDuringMigration() throws {
-        let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let custom = VoiceShortcut(
-            keyCode: nil,
-            keyDisplay: nil,
-            modifiers: [.control, .shift]
-        )
-        let payload = VoiceStoredPreferencesPayload(
-            version: nil,
-            recordShortcut: custom,
-            retryShortcut: .retryDefault,
-            isHandsFreeEnabled: true
-        )
-        defaults.set(
-            try JSONEncoder().encode(payload),
-            forKey: "voiceShortcutPreferences.v1"
-        )
-
-        let restored = VoiceShortcutPreferences(defaults: defaults)
-        XCTAssertEqual(restored.recordShortcut, custom)
-    }
-
-    func testDoesNotRemigrateVersionedLegacyShortcut() throws {
-        let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let payload = VoiceStoredPreferencesPayload(
-            version: 2,
-            recordShortcut: .legacyRecordDefault,
-            retryShortcut: .retryDefault,
-            isHandsFreeEnabled: true
-        )
-        defaults.set(
-            try JSONEncoder().encode(payload),
-            forKey: "voiceShortcutPreferences.v1"
-        )
-
-        let restored = VoiceShortcutPreferences(defaults: defaults)
-        XCTAssertEqual(restored.recordShortcut, .legacyRecordDefault)
-    }
 
     func testAddsHandsFreeModeDefaultToLegacyPreferences() throws {
         struct LegacyPayload: Codable {

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -304,7 +304,7 @@ final class VoiceModifierToggleShortcutStateTests: XCTestCase {
         XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(1.0)))
     }
 
-    func testChordTapDoesNotArmDoubleTap() {
+    func testExtraModifierDoesNotInvalidateDoubleTap() {
         var state = VoiceModifierToggleShortcutState()
 
         XCTAssertFalse(
@@ -328,7 +328,7 @@ final class VoiceModifierToggleShortcutStateTests: XCTestCase {
                 now: origin
             )
         )
-        XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(0.1)))
+        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(0.1)))
     }
 
     func testKeyPressDoesNotArmDoubleTap() {
@@ -360,6 +360,60 @@ final class VoiceModifierToggleShortcutStateTests: XCTestCase {
 
         XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(2)))
         XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(2.2)))
+    }
+
+    func testDoubleTapWithinWidenedWindowToggles() {
+        var state = VoiceModifierToggleShortcutState()
+        XCTAssertFalse(tap(&state, at: origin))
+        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(0.5)))
+    }
+
+    func testEntersHeldWithExtraModifier() {
+        var state = VoiceModifierToggleShortcutState()
+        let shortcut: VoiceShortcutModifiers = [.control, .option, .command]
+        XCTAssertFalse(
+            state.update(
+                activeModifiers: [.control, .option, .command, .shift],
+                shortcutModifiers: shortcut,
+                now: origin
+            )
+        )
+        XCTAssertTrue(state.isHeld)
+        XCTAssertFalse(
+            state.update(activeModifiers: [], shortcutModifiers: shortcut, now: origin)
+        )
+        XCTAssertTrue(tap(&state, shortcut: shortcut, at: origin.addingTimeInterval(0.2)))
+    }
+}
+
+final class PushToTalkHoldStateTests: XCTestCase {
+    private let origin = Date(timeIntervalSinceReferenceDate: 0)
+
+    func testRisingEdgeStartsAndSustainedIsNoChange() {
+        var state = PushToTalkHoldState()
+        XCTAssertEqual(state.update(rawHeld: true, now: origin), true)
+        XCTAssertNil(state.update(rawHeld: true, now: origin.addingTimeInterval(0.05)))
+        XCTAssertTrue(state.isHeld)
+    }
+
+    func testTransientDropWithinGraceKeepsHeld() {
+        var state = PushToTalkHoldState()
+        XCTAssertEqual(state.update(rawHeld: true, now: origin), true)
+        XCTAssertNil(state.update(rawHeld: false, now: origin.addingTimeInterval(0.05)))
+        XCTAssertTrue(state.isHeld)
+        XCTAssertNil(state.update(rawHeld: true, now: origin.addingTimeInterval(0.08)))
+        XCTAssertTrue(state.isHeld)
+    }
+
+    func testSustainedReleaseAfterGraceStops() {
+        var state = PushToTalkHoldState()
+        XCTAssertEqual(state.update(rawHeld: true, now: origin), true)
+        XCTAssertNil(state.update(rawHeld: false, now: origin.addingTimeInterval(0.05)))
+        XCTAssertEqual(
+            state.update(rawHeld: false, now: origin.addingTimeInterval(0.2)),
+            false
+        )
+        XCTAssertFalse(state.isHeld)
     }
 }
 

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -654,6 +654,13 @@ final class VoiceAudioRetentionTests: XCTestCase {
     }
 }
 
+private struct VoiceStoredPreferencesPayload: Codable {
+    let version: Int?
+    let recordShortcut: VoiceShortcut
+    let retryShortcut: VoiceShortcut
+    let isHandsFreeEnabled: Bool?
+}
+
 @MainActor
 final class VoiceShortcutPreferencesTests: XCTestCase {
     func testDefaultsMatchExistingVoiceCommands() {
@@ -729,6 +736,76 @@ final class VoiceShortcutPreferencesTests: XCTestCase {
         XCTAssertEqual(restored.recordShortcut, .recordDefault)
         XCTAssertEqual(restored.retryShortcut, .retryDefault)
         XCTAssertTrue(restored.isHandsFreeEnabled)
+    }
+
+    func testMigratesLegacyDefaultRecordShortcut() throws {
+        let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let payload = VoiceStoredPreferencesPayload(
+            version: nil,
+            recordShortcut: .legacyRecordDefault,
+            retryShortcut: .retryDefault,
+            isHandsFreeEnabled: true
+        )
+        defaults.set(
+            try JSONEncoder().encode(payload),
+            forKey: "voiceShortcutPreferences.v1"
+        )
+
+        let restored = VoiceShortcutPreferences(defaults: defaults)
+        XCTAssertEqual(restored.recordShortcut, .recordDefault)
+
+        let persisted = try XCTUnwrap(defaults.data(forKey: "voiceShortcutPreferences.v1"))
+        let decoded = try JSONDecoder().decode(
+            VoiceStoredPreferencesPayload.self,
+            from: persisted
+        )
+        XCTAssertEqual(decoded.version, 2)
+        XCTAssertEqual(decoded.recordShortcut, .recordDefault)
+    }
+
+    func testPreservesCustomShortcutDuringMigration() throws {
+        let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let custom = VoiceShortcut(
+            keyCode: nil,
+            keyDisplay: nil,
+            modifiers: [.control, .shift]
+        )
+        let payload = VoiceStoredPreferencesPayload(
+            version: nil,
+            recordShortcut: custom,
+            retryShortcut: .retryDefault,
+            isHandsFreeEnabled: true
+        )
+        defaults.set(
+            try JSONEncoder().encode(payload),
+            forKey: "voiceShortcutPreferences.v1"
+        )
+
+        let restored = VoiceShortcutPreferences(defaults: defaults)
+        XCTAssertEqual(restored.recordShortcut, custom)
+    }
+
+    func testDoesNotRemigrateVersionedLegacyShortcut() throws {
+        let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let payload = VoiceStoredPreferencesPayload(
+            version: 2,
+            recordShortcut: .legacyRecordDefault,
+            retryShortcut: .retryDefault,
+            isHandsFreeEnabled: true
+        )
+        defaults.set(
+            try JSONEncoder().encode(payload),
+            forKey: "voiceShortcutPreferences.v1"
+        )
+
+        let restored = VoiceShortcutPreferences(defaults: defaults)
+        XCTAssertEqual(restored.recordShortcut, .legacyRecordDefault)
     }
 
     func testAddsHandsFreeModeDefaultToLegacyPreferences() throws {

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -657,7 +657,7 @@ final class VoiceAudioRetentionTests: XCTestCase {
 @MainActor
 final class VoiceShortcutPreferencesTests: XCTestCase {
     func testDefaultsMatchExistingVoiceCommands() {
-        XCTAssertEqual(VoiceShortcut.recordDefault.displayName, "Fn + Control")
+        XCTAssertEqual(VoiceShortcut.recordDefault.displayName, "Control + Option + Command")
         XCTAssertEqual(VoiceShortcut.retryDefault.displayName, "Fn + R")
 
         let suiteName = "VoiceShortcutPreferencesTests.\(UUID().uuidString)"


### PR DESCRIPTION
Solving the audio issue mentioned in #230.

- Sync the canonical dictation shortcut default (Control+Option+Command) across the bundled manifest and tests.
- Request microphone access from the shortcut flow when the status is undetermined, and guide to System Settings when denied.
- Version shortcut preferences and migrate the legacy Fn+Control default; custom shortcuts are preserved.
- Relax the hands-free double-tap gesture (wider window, superset match, key-press-only chord detection) and make push-to-talk resilient to transient modifier drops via a debounced hold state.
