### PR TITLE
Report download progress on slow connections

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -1061,6 +1061,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
 
         let script = """
         import sys
+        import time
         from tqdm.auto import tqdm
         from huggingface_hub import snapshot_download
 
@@ -1081,6 +1082,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
             def __init__(self, *args, **kwargs):
                 self._mlx_reports_bytes = kwargs.get("unit") == "B"
                 self._mlx_last_progress = -1.0
+                self._mlx_last_report = 0.0
                 super().__init__(*args, **kwargs)
                 self._mlx_report()
 
@@ -1100,8 +1102,12 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
                 total = float(expected_bytes or self.total or 0)
                 value = float(self.n or 0)
                 progress = min(max(value / total, 0.0), 1.0) if total > 0 else 0.0
-                if abs(progress - self._mlx_last_progress) >= 0.01 or progress >= 1.0:
+                now = time.monotonic()
+                changed = abs(progress - self._mlx_last_progress)
+                stale = now - self._mlx_last_report >= 0.25
+                if progress >= 1.0 or changed >= 0.002 or (changed > 0.0 and stale):
                     self._mlx_last_progress = progress
+                    self._mlx_last_report = now
                     print(f"__MLX_PROGRESS__:{progress:.6f}", flush=True)
 
         snapshot_download(


### PR DESCRIPTION
3e059dd widened the download progress gate from 0.2% to 1% to cut UI churn, which on slow connections leaves the UI without an update for minutes on a large model — a 30 GB download at 500 KB/s reports once every 10 minutes, so a healthy download is indistinguishable from a stalled one (#232); this fires on ≥0.2% change or on any change ≥0.25 s since the last report, which is a strict superset of the current behavior and keeps churn bounded.

handles #232