### PR TITLE
Fix Discover model search responsiveness

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -259,7 +259,10 @@ struct ControlPanelView: View {
     @Environment(\.displayScale) private var displayScale
     @ObservedObject var model: NativModel
     @ObservedObject var navigation: ControlPanelNavigation
-    @ObservedObject var runtime: SystemRuntimeMonitor
+    // Only the Developer page observes live runtime values. Keeping this as a
+    // plain reference prevents its one-second polling cycle from invalidating
+    // the entire control panel (including the Models result list).
+    let runtime: SystemRuntimeMonitor
     @ObservedObject var extensionManager: NativExtensionManager
     let softwareUpdater: SoftwareUpdater
     @StateObject private var chat = ChatViewModel()

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -154,40 +154,6 @@ private enum ControlPanelOnboarding {
         "nativ.control-panel.extensions-new-badge-dismissed.v1"
 }
 
-/// Overlays full-size pages without asking each page for an intrinsic size when
-/// the parent has already supplied both dimensions. Unlike `ZStack`, this keeps
-/// a page-order change from walking every retained page's layout hierarchy.
-private struct ControlPanelPageStackLayout: Layout {
-    func sizeThatFits(
-        proposal: ProposedViewSize,
-        subviews: Subviews,
-        cache: inout ()
-    ) -> CGSize {
-        var width = proposal.width.flatMap { $0.isFinite ? max(0, $0) : nil }
-        var height = proposal.height.flatMap { $0.isFinite ? max(0, $0) : nil }
-        if width == nil || height == nil {
-            for subview in subviews {
-                let size = subview.sizeThatFits(proposal)
-                width = max(width ?? 0, size.width)
-                height = max(height ?? 0, size.height)
-            }
-        }
-        return CGSize(width: width ?? 0, height: height ?? 0)
-    }
-
-    func placeSubviews(
-        in bounds: CGRect,
-        proposal: ProposedViewSize,
-        subviews: Subviews,
-        cache: inout ()
-    ) {
-        let pageProposal = ProposedViewSize(width: bounds.width, height: bounds.height)
-        for subview in subviews {
-            subview.place(at: bounds.origin, anchor: .topLeading, proposal: pageProposal)
-        }
-    }
-}
-
 extension Color {
     static let nativMainContentBackground = Color(
         nsColor: NSColor(name: NSColor.Name("NativMainContentBackground")) { appearance in
@@ -377,9 +343,6 @@ struct ControlPanelView: View {
     private var isExtensionsBadgeDismissed = false
     @State private var sidebarSelection: ControlPanelSidebarSelection = .tab(.chat)
     @State private var selectedTab: ControlPanelTab = .chat
-    @State private var hasPreparedModelsPage = false
-    @State private var retainedNonModelsSelection: ControlPanelSidebarSelection = .tab(.chat)
-    @State private var retainedNonModelsTab: ControlPanelTab = .chat
     @State private var hoveredFooterControl: FooterControl?
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .all
     @State private var sidebarWidth = ControlPanelLayout.sidebarIdealWidth
@@ -496,12 +459,6 @@ struct ControlPanelView: View {
                     )
                 }
             }
-        }
-        .task {
-            guard !hasPreparedModelsPage else { return }
-            try? await Task.sleep(for: .milliseconds(300))
-            guard !Task.isCancelled else { return }
-            hasPreparedModelsPage = true
         }
         .onReceive(navigation.$requestedTab) { tab in
             guard let tab else { return }
@@ -1931,29 +1888,11 @@ struct ControlPanelView: View {
 
     private var detail: some View {
         VStack(spacing: 0) {
-            ControlPanelPageStackLayout {
-                Group {
-                    if case .extensionPage(let pageID) = retainedNonModelsSelection {
-                        extensionPage(pageID)
-                    } else {
-                        corePage(retainedNonModelsTab)
-                    }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.nativMainContentBackground)
-                .allowsHitTesting(selectedTab != .models)
-                .accessibilityHidden(selectedTab == .models)
-                .accessibilityElement(children: selectedTab == .models ? .ignore : .contain)
-                .zIndex(selectedTab == .models ? 0 : 1)
-
-                if hasPreparedModelsPage || selectedTab == .models {
-                    modelsPage
-                        .allowsHitTesting(selectedTab == .models)
-                        .accessibilityHidden(selectedTab != .models)
-                        .accessibilityElement(
-                            children: selectedTab == .models ? .contain : .ignore
-                        )
-                        .zIndex(selectedTab == .models ? 1 : 0)
+            Group {
+                if case .extensionPage(let pageID) = sidebarSelection {
+                    extensionPage(pageID)
+                } else {
+                    corePage
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1989,8 +1928,8 @@ struct ControlPanelView: View {
     }
 
     @ViewBuilder
-    private func corePage(_ tab: ControlPanelTab) -> some View {
-        switch tab {
+    private var corePage: some View {
+        switch selectedTab {
         case .chat:
             ChatView(
                 model: model,
@@ -2043,7 +1982,12 @@ struct ControlPanelView: View {
                 titleLeadingInset: detailTitleLeadingInset
             )
         case .models:
-            EmptyView()
+            ModelsView(
+                model: model,
+                showsConfiguration: $isModelConfigurationVisible,
+                titleLeadingInset: detailTitleLeadingInset,
+                speechModelDiscoveryRequest: navigation.speechModelDiscoveryRequest
+            )
         case .integrations:
             IntegrationsView(
                 model: model,
@@ -2069,18 +2013,6 @@ struct ControlPanelView: View {
                 launchAtLogin: launchAtLogin
             )
         }
-    }
-
-    private var modelsPage: some View {
-        ModelsView(
-            model: model,
-            showsConfiguration: Binding(
-                get: { selectedTab == .models && isModelConfigurationVisible },
-                set: { isModelConfigurationVisible = $0 }
-            ),
-            titleLeadingInset: detailTitleLeadingInset,
-            speechModelDiscoveryRequest: navigation.speechModelDiscoveryRequest
-        )
     }
 
     @ViewBuilder
@@ -2129,8 +2061,6 @@ struct ControlPanelView: View {
             ) else {
                 sidebarSelection = .tab(.extensions)
                 selectedTab = .extensions
-                retainedNonModelsSelection = sidebarSelection
-                retainedNonModelsTab = selectedTab
                 return
             }
             sidebarSelection = selection
@@ -2151,11 +2081,6 @@ struct ControlPanelView: View {
                 sidebarSelection = .tab(.imageGeneration)
             }
             selectedTab = .imageGeneration
-        }
-
-        if selectedTab != .models {
-            retainedNonModelsSelection = sidebarSelection
-            retainedNonModelsTab = selectedTab
         }
     }
 

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -154,6 +154,40 @@ private enum ControlPanelOnboarding {
         "nativ.control-panel.extensions-new-badge-dismissed.v1"
 }
 
+/// Overlays full-size pages without asking each page for an intrinsic size when
+/// the parent has already supplied both dimensions. Unlike `ZStack`, this keeps
+/// a page-order change from walking every retained page's layout hierarchy.
+private struct ControlPanelPageStackLayout: Layout {
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        var width = proposal.width.flatMap { $0.isFinite ? max(0, $0) : nil }
+        var height = proposal.height.flatMap { $0.isFinite ? max(0, $0) : nil }
+        if width == nil || height == nil {
+            for subview in subviews {
+                let size = subview.sizeThatFits(proposal)
+                width = max(width ?? 0, size.width)
+                height = max(height ?? 0, size.height)
+            }
+        }
+        return CGSize(width: width ?? 0, height: height ?? 0)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let pageProposal = ProposedViewSize(width: bounds.width, height: bounds.height)
+        for subview in subviews {
+            subview.place(at: bounds.origin, anchor: .topLeading, proposal: pageProposal)
+        }
+    }
+}
+
 extension Color {
     static let nativMainContentBackground = Color(
         nsColor: NSColor(name: NSColor.Name("NativMainContentBackground")) { appearance in
@@ -343,6 +377,9 @@ struct ControlPanelView: View {
     private var isExtensionsBadgeDismissed = false
     @State private var sidebarSelection: ControlPanelSidebarSelection = .tab(.chat)
     @State private var selectedTab: ControlPanelTab = .chat
+    @State private var hasPreparedModelsPage = false
+    @State private var retainedNonModelsSelection: ControlPanelSidebarSelection = .tab(.chat)
+    @State private var retainedNonModelsTab: ControlPanelTab = .chat
     @State private var hoveredFooterControl: FooterControl?
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .all
     @State private var sidebarWidth = ControlPanelLayout.sidebarIdealWidth
@@ -459,6 +496,12 @@ struct ControlPanelView: View {
                     )
                 }
             }
+        }
+        .task {
+            guard !hasPreparedModelsPage else { return }
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            hasPreparedModelsPage = true
         }
         .onReceive(navigation.$requestedTab) { tab in
             guard let tab else { return }
@@ -1888,11 +1931,29 @@ struct ControlPanelView: View {
 
     private var detail: some View {
         VStack(spacing: 0) {
-            Group {
-                if case .extensionPage(let pageID) = sidebarSelection {
-                    extensionPage(pageID)
-                } else {
-                    corePage
+            ControlPanelPageStackLayout {
+                Group {
+                    if case .extensionPage(let pageID) = retainedNonModelsSelection {
+                        extensionPage(pageID)
+                    } else {
+                        corePage(retainedNonModelsTab)
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.nativMainContentBackground)
+                .allowsHitTesting(selectedTab != .models)
+                .accessibilityHidden(selectedTab == .models)
+                .accessibilityElement(children: selectedTab == .models ? .ignore : .contain)
+                .zIndex(selectedTab == .models ? 0 : 1)
+
+                if hasPreparedModelsPage || selectedTab == .models {
+                    modelsPage
+                        .allowsHitTesting(selectedTab == .models)
+                        .accessibilityHidden(selectedTab != .models)
+                        .accessibilityElement(
+                            children: selectedTab == .models ? .contain : .ignore
+                        )
+                        .zIndex(selectedTab == .models ? 1 : 0)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1928,8 +1989,8 @@ struct ControlPanelView: View {
     }
 
     @ViewBuilder
-    private var corePage: some View {
-        switch selectedTab {
+    private func corePage(_ tab: ControlPanelTab) -> some View {
+        switch tab {
         case .chat:
             ChatView(
                 model: model,
@@ -1982,12 +2043,7 @@ struct ControlPanelView: View {
                 titleLeadingInset: detailTitleLeadingInset
             )
         case .models:
-            ModelsView(
-                model: model,
-                showsConfiguration: $isModelConfigurationVisible,
-                titleLeadingInset: detailTitleLeadingInset,
-                speechModelDiscoveryRequest: navigation.speechModelDiscoveryRequest
-            )
+            EmptyView()
         case .integrations:
             IntegrationsView(
                 model: model,
@@ -2013,6 +2069,18 @@ struct ControlPanelView: View {
                 launchAtLogin: launchAtLogin
             )
         }
+    }
+
+    private var modelsPage: some View {
+        ModelsView(
+            model: model,
+            showsConfiguration: Binding(
+                get: { selectedTab == .models && isModelConfigurationVisible },
+                set: { isModelConfigurationVisible = $0 }
+            ),
+            titleLeadingInset: detailTitleLeadingInset,
+            speechModelDiscoveryRequest: navigation.speechModelDiscoveryRequest
+        )
     }
 
     @ViewBuilder
@@ -2061,6 +2129,8 @@ struct ControlPanelView: View {
             ) else {
                 sidebarSelection = .tab(.extensions)
                 selectedTab = .extensions
+                retainedNonModelsSelection = sidebarSelection
+                retainedNonModelsTab = selectedTab
                 return
             }
             sidebarSelection = selection
@@ -2081,6 +2151,11 @@ struct ControlPanelView: View {
                 sidebarSelection = .tab(.imageGeneration)
             }
             selectedTab = .imageGeneration
+        }
+
+        if selectedTab != .models {
+            retainedNonModelsSelection = sidebarSelection
+            retainedNonModelsTab = selectedTab
         }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -47,31 +47,27 @@ struct ModelConfigurationLayout<Content: View>: View {
             }
             .animation(nil, value: isConfigurationVisible)
 
-            ModelConfigurationView(
-                settings: $model.settings,
-                settingsRequireRestart: model.settingsRequireRestart,
-                onReset: model.resetSettings
-            )
-            .frame(width: ModelConfigurationLayoutMetrics.configurationWidth)
-            .ignoresSafeArea(.container, edges: .top)
-            .overlay(alignment: .leading) {
-                Rectangle()
-                    .fill(Color(nsColor: .separatorColor))
-                    .frame(width: 1)
-                    .ignoresSafeArea(.container, edges: [.top, .bottom])
+            if isConfigurationVisible {
+                ModelConfigurationView(
+                    settings: $model.settings,
+                    settingsRequireRestart: model.settingsRequireRestart,
+                    onReset: model.resetSettings
+                )
+                .frame(width: ModelConfigurationLayoutMetrics.configurationWidth)
+                .ignoresSafeArea(.container, edges: .top)
+                .overlay(alignment: .leading) {
+                    Rectangle()
+                        .fill(Color(nsColor: .separatorColor))
+                        .frame(width: 1)
+                        .ignoresSafeArea(.container, edges: [.top, .bottom])
+                }
+                .transition(.move(edge: .trailing))
             }
-            .offset(
-                x: isConfigurationVisible
-                    ? 0
-                    : ModelConfigurationLayoutMetrics.configurationWidth + 5
-            )
-            .allowsHitTesting(isConfigurationVisible)
-            .accessibilityHidden(!isConfigurationVisible)
-            .animation(
-                .smooth(duration: ModelConfigurationLayoutMetrics.transitionDuration),
-                value: isConfigurationVisible
-            )
         }
+        .animation(
+            .smooth(duration: ModelConfigurationLayoutMetrics.transitionDuration),
+            value: isConfigurationVisible
+        )
     }
 }
 

--- a/Sources/Nativ/Features/Models/HubModelSizeResolver.swift
+++ b/Sources/Nativ/Features/Models/HubModelSizeResolver.swift
@@ -1,32 +1,33 @@
 import Foundation
 
 @MainActor
-final class HubModelSizeResolver: ObservableObject {
+final class HubModelSizeResolver {
     static let shared = HubModelSizeResolver()
 
-    @Published private(set) var sizes: [String: Int64] = [:]
-    private var inFlight: Set<String> = []
+    private var sizes: [String: Int64] = [:]
 
-    func resolvedSize(for repoID: String) -> Int64? {
-        sizes[repoID]
-    }
+    func resolveSize(for repoID: String) async -> Int64? {
+        if let size = sizes[repoID] {
+            return size
+        }
 
-    func prefetch(_ repoID: String) async {
-        if sizes[repoID] != nil || inFlight.contains(repoID) {
-            return
+        do {
+            try await Task.sleep(nanoseconds: 250_000_000)
+        } catch {
+            return nil
         }
-        try? await Task.sleep(nanoseconds: 250_000_000)
-        if Task.isCancelled || sizes[repoID] != nil || inFlight.contains(repoID) {
-            return
+        guard !Task.isCancelled else { return nil }
+
+        if let size = sizes[repoID] {
+            return size
         }
-        inFlight.insert(repoID)
-        Task {
-            let bytes = await Self.fetchTotalBytes(repoID: repoID)
-            inFlight.remove(repoID)
-            if let bytes {
-                sizes[repoID] = bytes
-            }
+
+        let bytes = await Self.fetchTotalBytes(repoID: repoID)
+        guard !Task.isCancelled else { return nil }
+        if let bytes {
+            sizes[repoID] = bytes
         }
+        return bytes
     }
 
     private nonisolated static func fetchTotalBytes(repoID: String) async -> Int64? {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -63,6 +63,7 @@ struct ModelsView: View {
     // progress tick, which makes Discover scroll janky during downloads.
     private var downloadManager: HuggingFaceDownloadManager { .shared }
     @State private var section: ModelsPageSection = .installed
+    @State private var renderedSection: ModelsPageSection = .installed
     @State private var typeFilter: ModelsTypeFilter = .all
     @State private var localQuery = ""
     @State private var hubQuery = ""
@@ -83,12 +84,7 @@ struct ModelsView: View {
                 activeDownloadBanner
                 modelLoadFailureBanner
 
-                switch section {
-                case .installed:
-                    installedPage
-                case .discover:
-                    discoverPage
-                }
+                modelsPage
             }
         }
         .background(Color.nativMainContentBackground)
@@ -104,8 +100,21 @@ struct ModelsView: View {
         .onChange(of: speechModelDiscoveryRequest) { _, _ in
             openSpeechModelDiscoveryIfRequested()
         }
+        .onChange(of: section) { _, newSection in
+            // Let the segmented control commit before replacing the toolbar
+            // and active rows. This queues one main-loop turn with no fixed
+            // delay and keeps only one section's content mounted at a time.
+            DispatchQueue.main.async {
+                guard section == newSection else { return }
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    renderedSection = newSection
+                }
+            }
+        }
         .task(id: hubSearchTaskID) {
-            guard section == .discover else { return }
+            guard renderedSection == .discover else { return }
             let searchTaskID = hubSearchTaskID
             guard searchTaskID != lastStartedHubSearchTaskID else { return }
             lastStartedHubSearchTaskID = searchTaskID
@@ -176,121 +185,165 @@ struct ModelsView: View {
         .padding(.bottom, 16)
     }
 
-    private var installedPage: some View {
-        let visibleModels = filteredLocalModels
-        let normalizedSettings = model.settings.normalized()
-
-        return VStack(spacing: 0) {
-            installedToolbar
+    private var modelsPage: some View {
+        VStack(spacing: 0) {
+            sectionToolbar
                 .padding(.horizontal, 22)
                 .padding(.vertical, 14)
 
-            List {
-                if let error = localLibrary.error {
-                    ModelsNotice(
-                        title: "Couldn’t read the model cache",
-                        message: error,
-                        systemImage: "exclamationmark.triangle.fill",
-                        color: .orange
-                    )
-                    .modelsListRow()
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    sectionRows
+
+                    Color.clear
+                        .frame(height: 12)
+                        .modelsListRow(top: 0, bottom: 0)
                 }
-
-                if localLibrary.isScanning && localLibrary.models.isEmpty {
-                    ModelsLoadingState(title: "Scanning your Hugging Face cache…")
-                        .modelsListRow()
-                } else if visibleModels.isEmpty {
-                    ModelsEmptyState(
-                        systemImage: installedFilterIsActive
-                            ? "line.3.horizontal.decrease.circle" : "shippingbox",
-                        title: installedFilterIsActive
-                            ? "No models match your filter" : "No MLX models installed",
-                        message: installedFilterIsActive
-                            ? "Try a different search or model type."
-                            : "Discover an MLX model on Hugging Face and download it to this cache.",
-                        actionTitle: installedFilterIsActive ? nil : "Discover models",
-                        action: { section = .discover }
-                    )
-                    .modelsListRow()
-                } else {
-                    HStack {
-                        Text(
-                            "\(visibleModels.count) \(visibleModels.count == 1 ? "model" : "models")"
-                        )
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        if localLibrary.isScanning {
-                            ProgressView().controlSize(.small)
-                        }
-                    }
-                    .modelsListRow(top: 0)
-
-                    ForEach(visibleModels) { localModel in
-                        let preloadSlots = preloadSlots(for: localModel)
-                        let selectedSlots = Set(
-                            ModelPreloadSlot.allCases.filter {
-                                normalizedSettings.modelID(for: $0) == localModel.repoID
-                            }
-                        )
-                        InstalledModelRow(
-                            localModel: localModel,
-                            preloadSlots: preloadSlots,
-                            selectedPreloadSlots: selectedSlots,
-                            preferredPreloadSlot: preferredPreloadSlot(
-                                among: preloadSlots
-                            ),
-                            isSelectionDisabled: model.modelSwitchInProgress,
-                            isModelLoading: model.modelLoadingID
-                                == localModel.repoID,
-                            modelLoadingPercentage: model.modelLoadingPercentage,
-                            isDeleting: localLibrary.deletingModelIDs.contains(
-                                localModel.repoID),
-                            canDelete: localModel.isDeletable && !model.modelSwitchInProgress
-                                && !isModelInUse(localModel.repoID),
-                            onSetPreload: { slot, isEnabled in
-                                if isEnabled {
-                                    model.requestPreloadedModelSwitch(
-                                        to: localModel,
-                                        for: slot,
-                                        availableModels: localLibrary.models
-                                    )
-                                } else {
-                                    model.switchPreloadedModel(to: nil, for: slot)
-                                }
-                            },
-                            onDelete: { deleteInstalledModel(localModel) }
-                        )
-                        .modelsListRow()
-                    }
-                }
-
-                Color.clear
-                    .frame(height: 12)
-                    .modelsListRow(top: 0, bottom: 0)
             }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .environment(\.defaultMinListRowHeight, 0)
         }
     }
 
-    private var installedToolbar: some View {
+    private var sectionToolbar: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 10) {
+                DebouncedModelsSearchField(
+                    prompt: renderedSection == .installed
+                        ? "Search installed models" : "Search models on Hugging Face",
+                    text: activeSearchQuery,
+                    identity: renderedSection,
+                    debounceMilliseconds: renderedSection == .installed ? 0 : 350
+                )
+                .frame(height: 32)
+
+                if renderedSection == .discover, hubLibrary.isSearching {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 28)
+                }
+            }
+
+            switch renderedSection {
+            case .installed:
+                installedFilterBar
+            case .discover:
+                discoverFilterBar
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var sectionRows: some View {
+        if section != renderedSection {
+            Text("Opening \(section.rawValue)…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 120)
+                .modelsListRow(top: 0)
+        } else {
+            switch renderedSection {
+            case .installed:
+                installedRows
+            case .discover:
+                discoverRows
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var installedRows: some View {
+        let visibleModels = filteredLocalModels
+        let normalizedSettings = model.settings.normalized()
+
+        if let error = localLibrary.error {
+            ModelsNotice(
+                title: "Couldn’t read the model cache",
+                message: error,
+                systemImage: "exclamationmark.triangle.fill",
+                color: .orange
+            )
+            .modelsListRow()
+        }
+
+        if localLibrary.isScanning && localLibrary.models.isEmpty {
+            ModelsLoadingState(title: "Scanning your Hugging Face cache…")
+                .modelsListRow()
+        } else if visibleModels.isEmpty {
+            ModelsEmptyState(
+                systemImage: installedFilterIsActive
+                    ? "line.3.horizontal.decrease.circle" : "shippingbox",
+                title: installedFilterIsActive
+                    ? "No models match your filter" : "No MLX models installed",
+                message: installedFilterIsActive
+                    ? "Try a different search or model type."
+                    : "Discover an MLX model on Hugging Face and download it to this cache.",
+                actionTitle: installedFilterIsActive ? nil : "Discover models",
+                action: { section = .discover }
+            )
+            .modelsListRow()
+        } else {
+            HStack {
+                Text(
+                    "\(visibleModels.count) \(visibleModels.count == 1 ? "model" : "models")"
+                )
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if localLibrary.isScanning {
+                    ProgressView().controlSize(.small)
+                }
+            }
+            .modelsListRow(top: 0)
+
+            ForEach(visibleModels) { localModel in
+                let preloadSlots = preloadSlots(for: localModel)
+                let selectedSlots = Set(
+                    ModelPreloadSlot.allCases.filter {
+                        normalizedSettings.modelID(for: $0) == localModel.repoID
+                    }
+                )
+                InstalledModelRow(
+                    localModel: localModel,
+                    preloadSlots: preloadSlots,
+                    selectedPreloadSlots: selectedSlots,
+                    preferredPreloadSlot: preferredPreloadSlot(
+                        among: preloadSlots
+                    ),
+                    isSelectionDisabled: model.modelSwitchInProgress,
+                    isModelLoading: model.modelLoadingID
+                        == localModel.repoID,
+                    modelLoadingPercentage: model.modelLoadingPercentage,
+                    isDeleting: localLibrary.deletingModelIDs.contains(
+                        localModel.repoID),
+                    canDelete: localModel.isDeletable && !model.modelSwitchInProgress
+                        && !isModelInUse(localModel.repoID),
+                    onSetPreload: { slot, isEnabled in
+                        if isEnabled {
+                            model.requestPreloadedModelSwitch(
+                                to: localModel,
+                                for: slot,
+                                availableModels: localLibrary.models
+                            )
+                        } else {
+                            model.switchPreloadedModel(to: nil, for: slot)
+                        }
+                    },
+                    onDelete: { deleteInstalledModel(localModel) }
+                )
+                .modelsListRow()
+            }
+        }
+    }
+
+    private var installedFilterBar: some View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: 10) {
-                ModelsSearchField(prompt: "Search installed models", text: $localQuery)
-                    .frame(minWidth: 180)
-
                 typeFilterPicker
-
                 sourcesMenu
-
+                Spacer(minLength: 0)
                 refreshButton
             }
 
-            VStack(spacing: 10) {
-                ModelsSearchField(prompt: "Search installed models", text: $localQuery)
-
+            VStack(alignment: .leading, spacing: 10) {
                 HStack(spacing: 10) {
                     typeFilterPicker
                     sourcesMenu
@@ -309,6 +362,7 @@ struct ModelsView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var refreshButton: some View {
@@ -323,132 +377,102 @@ struct ModelsView: View {
         .accessibilityLabel("Refresh installed models")
     }
 
-    private var discoverPage: some View {
+    @ViewBuilder
+    private var discoverRows: some View {
         let installedIDs = installedModelIDs
 
-        return VStack(spacing: 0) {
-            VStack(spacing: 10) {
-                HStack(spacing: 10) {
-                    DebouncedModelsSearchField(
-                        prompt: "Search models on Hugging Face",
-                        text: $hubQuery
-                    )
-                    .frame(height: 32)
-
-                    if hubLibrary.isSearching {
-                        ProgressView()
-                            .controlSize(.small)
-                            .frame(width: 28)
-                    }
-                }
-
-                discoverFilterBar
+        if let error = hubLibrary.error {
+            ModelsNotice(
+                title: "Hugging Face is unavailable",
+                message: error,
+                systemImage: "wifi.exclamationmark",
+                color: .orange
+            )
+            .modelsListRow()
+        } else if hubLibrary.isSearching && hubLibrary.models.isEmpty {
+            ModelsLoadingState(
+                title: hubQuery.isEmpty
+                    ? "Finding popular Safetensors models…" : "Searching Hugging Face…")
+                .modelsListRow()
+        } else if hubLibrary.models.isEmpty {
+            if hubCapabilityFilters.isEmpty && hubAccessFilter == .all {
+                ModelsEmptyState(
+                    systemImage: "magnifyingglass",
+                    title: "No Safetensors models found",
+                    message: "Try a model family, provider, or repository name.",
+                    actionTitle: nil,
+                    action: {}
+                )
+                .modelsListRow()
+            } else {
+                ModelsEmptyState(
+                    systemImage: "line.3.horizontal.decrease.circle",
+                    title: "No models match these filters",
+                    message:
+                        "Try another model type, capability, or access filter, or continue to the next page.",
+                    actionTitle: nil,
+                    action: {}
+                )
+                .modelsListRow()
             }
-            .padding(.horizontal, 22)
-            .padding(.vertical, 14)
+        } else {
+            discoverResultsHeader
+                .modelsListRow(top: 0)
 
-            List {
-                if let error = hubLibrary.error {
-                    ModelsNotice(
-                        title: "Hugging Face is unavailable",
-                        message: error,
-                        systemImage: "wifi.exclamationmark",
-                        color: .orange
-                    )
-                    .modelsListRow()
-                } else if hubLibrary.isSearching && hubLibrary.models.isEmpty {
-                    ModelsLoadingState(
-                        title: hubQuery.isEmpty
-                            ? "Finding popular Safetensors models…" : "Searching Hugging Face…")
-                        .modelsListRow()
-                } else if hubLibrary.models.isEmpty {
-                    if hubCapabilityFilters.isEmpty && hubAccessFilter == .all {
-                        ModelsEmptyState(
-                            systemImage: "magnifyingglass",
-                            title: "No Safetensors models found",
-                            message: "Try a model family, provider, or repository name.",
-                            actionTitle: nil,
-                            action: {}
-                        )
-                        .modelsListRow()
-                    } else {
-                        ModelsEmptyState(
-                            systemImage: "line.3.horizontal.decrease.circle",
-                            title: "No models match these filters",
-                            message:
-                                "Try another model type, capability, or access filter, or continue to the next page.",
-                            actionTitle: nil,
-                            action: {}
-                        )
-                        .modelsListRow()
-                    }
-                } else {
-                    discoverResultsHeader
-                        .modelsListRow(top: 0)
-
-                    ForEach(filteredHubModels) { hubModel in
-                        HubModelRowContainer(
-                            model: hubModel,
-                            isInstalled: installedIDs.contains(hubModel.id),
+            ForEach(filteredHubModels) { hubModel in
+                HubModelRowContainer(
+                    model: hubModel,
+                    isInstalled: installedIDs.contains(hubModel.id),
+                    cachePath: model.settings.modelSearchPath,
+                    onDownload: { downloadSizeBytes in
+                        downloadManager.download(
+                            repoID: hubModel.id,
+                            sizeBytes: downloadSizeBytes,
                             cachePath: model.settings.modelSearchPath,
-                            onDownload: { downloadSizeBytes in
-                                downloadManager.download(
-                                    repoID: hubModel.id,
-                                    sizeBytes: downloadSizeBytes,
-                                    cachePath: model.settings.modelSearchPath,
-                                    token: model.effectiveHuggingFaceToken
-                                ) {}
-                            },
-                            onPauseResume: {
-                                if downloadManager.isPaused(for: hubModel.id) {
-                                    downloadManager.resumeDownload(hubModel.id)
-                                } else {
-                                    downloadManager.pauseDownload(hubModel.id)
-                                }
-                            },
-                            onRemoveDownload: {
-                                downloadManager.removeDownload(hubModel.id)
-                            }
-                        )
-                        .modelsListRow()
-                    }
-
-                    HStack(spacing: 12) {
-                        Spacer()
-
-                        Button {
-                            hubLibrary.goToPreviousPage()
-                        } label: {
-                            Label("Previous", systemImage: "chevron.left")
+                            token: model.effectiveHuggingFaceToken
+                        ) {}
+                    },
+                    onPauseResume: {
+                        if downloadManager.isPaused(for: hubModel.id) {
+                            downloadManager.resumeDownload(hubModel.id)
+                        } else {
+                            downloadManager.pauseDownload(hubModel.id)
                         }
-                        .disabled(!hubLibrary.canGoToPreviousPage)
-
-                        Text("Page \(hubLibrary.pageNumber) of up to 5")
-                            .font(.callout.weight(.medium))
-                            .foregroundStyle(.secondary)
-                            .frame(minWidth: 122)
-
-                        Button {
-                            hubLibrary.goToNextPage(token: model.effectiveHuggingFaceToken)
-                        } label: {
-                            Label("Next", systemImage: "chevron.right")
-                                .labelStyle(.titleAndIcon)
-                        }
-                        .disabled(!hubLibrary.canGoToNextPage)
-
-                        Spacer()
+                    },
+                    onRemoveDownload: {
+                        downloadManager.removeDownload(hubModel.id)
                     }
-                    .buttonStyle(.bordered)
-                    .modelsListRow(top: 13)
-                }
-
-                Color.clear
-                    .frame(height: 12)
-                    .modelsListRow(top: 0, bottom: 0)
+                )
+                .modelsListRow()
             }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .environment(\.defaultMinListRowHeight, 0)
+
+            HStack(spacing: 12) {
+                Spacer()
+
+                Button {
+                    hubLibrary.goToPreviousPage()
+                } label: {
+                    Label("Previous", systemImage: "chevron.left")
+                }
+                .disabled(!hubLibrary.canGoToPreviousPage)
+
+                Text("Page \(hubLibrary.pageNumber) of up to 5")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: 122)
+
+                Button {
+                    hubLibrary.goToNextPage(token: model.effectiveHuggingFaceToken)
+                } label: {
+                    Label("Next", systemImage: "chevron.right")
+                        .labelStyle(.titleAndIcon)
+                }
+                .disabled(!hubLibrary.canGoToNextPage)
+
+                Spacer()
+            }
+            .buttonStyle(.bordered)
+            .modelsListRow(top: 13)
         }
     }
 
@@ -583,6 +607,19 @@ struct ModelsView: View {
         .labelsHidden()
         .pickerStyle(.segmented)
         .frame(width: 230, alignment: .leading)
+    }
+
+    private var activeSearchQuery: Binding<String> {
+        Binding(
+            get: { renderedSection == .installed ? localQuery : hubQuery },
+            set: { newValue in
+                if renderedSection == .installed {
+                    localQuery = newValue
+                } else {
+                    hubQuery = newValue
+                }
+            }
+        )
     }
 
     private var typeFilterPicker: some View {
@@ -853,7 +890,7 @@ struct ModelsView: View {
 
     private var hubSearchTaskID: HubSearchTaskID {
         HubSearchTaskID(
-            section: section,
+            section: renderedSection,
             query: hubQuery,
             sort: hubSort,
             capabilities: hubCapabilityFilters,
@@ -895,48 +932,21 @@ struct ModelsView: View {
 
 }
 
-private struct ModelsSearchField: View {
-    let prompt: String
-    @Binding var text: String
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
-            TextField(prompt, text: $text)
-                .textFieldStyle(.plain)
-            if !text.isEmpty {
-                Button {
-                    text = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.tertiary)
-                }
-                .buttonStyle(.plain)
-                .help("Clear search")
-            }
-        }
-        .padding(.horizontal, 10)
-        .frame(height: 32)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color(nsColor: .controlBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        )
-    }
-}
-
 /// Keeps the editor buffer inside AppKit so typing does not start a SwiftUI
-/// transaction. Only the debounced, committed query reaches the Models view.
+/// transaction. Only a committed query reaches the Models view; remote search
+/// uses a debounce while the local filter commits on the next main-actor turn.
 private struct DebouncedModelsSearchField: NSViewRepresentable {
     let prompt: String
     @Binding var text: String
+    let identity: ModelsPageSection
+    let debounceMilliseconds: Int
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        Coordinator(
+            text: $text,
+            identity: identity,
+            debounceMilliseconds: debounceMilliseconds
+        )
     }
 
     func makeNSView(context: Context) -> NSSearchField {
@@ -954,12 +964,21 @@ private struct DebouncedModelsSearchField: NSViewRepresentable {
     }
 
     func updateNSView(_ searchField: NSSearchField, context: Context) {
+        let identityChanged = context.coordinator.identity != identity
+        if identityChanged {
+            context.coordinator.cancelPendingCommit()
+            context.coordinator.identity = identity
+        }
         context.coordinator.text = $text
+        context.coordinator.debounceMilliseconds = debounceMilliseconds
         searchField.placeholderString = prompt
 
         // Do not overwrite an in-progress AppKit edit when an unrelated parent
         // update arrives before the query's debounce interval has elapsed.
-        if searchField.currentEditor() == nil, searchField.stringValue != text {
+        if identityChanged {
+            searchField.stringValue = text
+            searchField.currentEditor()?.string = text
+        } else if searchField.currentEditor() == nil, searchField.stringValue != text {
             searchField.stringValue = text
         }
     }
@@ -970,10 +989,18 @@ private struct DebouncedModelsSearchField: NSViewRepresentable {
 
     final class Coordinator: NSObject, NSSearchFieldDelegate {
         var text: Binding<String>
+        var identity: ModelsPageSection
+        var debounceMilliseconds: Int
         private var pendingCommit: Task<Void, Never>?
 
-        init(text: Binding<String>) {
+        init(
+            text: Binding<String>,
+            identity: ModelsPageSection,
+            debounceMilliseconds: Int
+        ) {
             self.text = text
+            self.identity = identity
+            self.debounceMilliseconds = debounceMilliseconds
         }
 
         func controlTextDidChange(_ notification: Notification) {
@@ -998,10 +1025,15 @@ private struct DebouncedModelsSearchField: NSViewRepresentable {
         private func scheduleCommit(_ value: String) {
             cancelPendingCommit()
             pendingCommit = Task { @MainActor [weak self] in
-                do {
-                    try await Task.sleep(for: .milliseconds(350))
-                } catch {
-                    return
+                if let debounceMilliseconds = self?.debounceMilliseconds,
+                    debounceMilliseconds > 0
+                {
+                    do {
+                        try await Task.sleep(
+                            for: .milliseconds(Int64(debounceMilliseconds)))
+                    } catch {
+                        return
+                    }
                 }
                 guard !Task.isCancelled else { return }
                 self?.commit(value)
@@ -1776,9 +1808,9 @@ extension View {
         top: CGFloat = 5,
         bottom: CGFloat = 5
     ) -> some View {
-        listRowInsets(EdgeInsets(top: top, leading: 22, bottom: bottom, trailing: 22))
-            .listRowSeparator(.hidden)
-            .listRowBackground(Color.clear)
+        padding(.horizontal, 22)
+            .padding(.top, top)
+            .padding(.bottom, bottom)
     }
 }
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -51,6 +51,40 @@ private struct HubSearchTaskID: Hashable {
     let authenticationToken: String?
 }
 
+/// Both model pages stay mounted for fast section changes. Their container is
+/// already constrained by the window, so avoid `ZStack`'s intrinsic-size pass
+/// through both row hierarchies whenever their z-order changes.
+private struct ModelsPageStackLayout: Layout {
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        var width = proposal.width.flatMap { $0.isFinite ? max(0, $0) : nil }
+        var height = proposal.height.flatMap { $0.isFinite ? max(0, $0) : nil }
+        if width == nil || height == nil {
+            for subview in subviews {
+                let size = subview.sizeThatFits(proposal)
+                width = max(width ?? 0, size.width)
+                height = max(height ?? 0, size.height)
+            }
+        }
+        return CGSize(width: width ?? 0, height: height ?? 0)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let pageProposal = ProposedViewSize(width: bounds.width, height: bounds.height)
+        for subview in subviews {
+            subview.place(at: bounds.origin, anchor: .topLeading, proposal: pageProposal)
+        }
+    }
+}
+
 struct ModelsView: View {
     @ObservedObject var model: NativModel
     @Binding var showsConfiguration: Bool
@@ -83,7 +117,7 @@ struct ModelsView: View {
                 activeDownloadBanner
                 modelLoadFailureBanner
 
-                ZStack {
+                ModelsPageStackLayout {
                     installedPage
                         .opacity(section == .installed ? 1 : 0)
                         .allowsHitTesting(section == .installed)

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -104,9 +104,10 @@ struct ModelsView: View {
             openSpeechModelDiscoveryIfRequested()
         }
         .task(id: hubSearchTaskID) {
-            guard section == .discover else { return }
-            try? await Task.sleep(for: .milliseconds(350))
-            guard !Task.isCancelled else { return }
+            guard section == .discover else {
+                hubLibrary.cancel()
+                return
+            }
             hubLibrary.search(
                 query: hubQuery,
                 sort: hubSort,
@@ -310,7 +311,11 @@ struct ModelsView: View {
         VStack(spacing: 0) {
             VStack(spacing: 10) {
                 HStack(spacing: 10) {
-                    ModelsSearchField(prompt: "Search models on Hugging Face", text: $hubQuery)
+                    DebouncedModelsSearchField(
+                        prompt: "Search models on Hugging Face",
+                        text: $hubQuery
+                    )
+                    .frame(height: 32)
 
                     if hubLibrary.isSearching {
                         ProgressView()
@@ -364,11 +369,10 @@ struct ModelsView: View {
                                 model: hubModel,
                                 isInstalled: installedModelIDs.contains(hubModel.id),
                                 cachePath: model.settings.modelSearchPath,
-                                onDownload: {
+                                onDownload: { downloadSizeBytes in
                                     downloadManager.download(
                                         repoID: hubModel.id,
-                                        sizeBytes: HubModelSizeResolver.shared
-                                            .resolvedSize(for: hubModel.id) ?? hubModel.estimatedDownloadBytes,
+                                        sizeBytes: downloadSizeBytes,
                                         cachePath: model.settings.modelSearchPath,
                                         token: model.effectiveHuggingFaceToken
                                     ) {}
@@ -908,6 +912,93 @@ private struct ModelsSearchField: View {
     }
 }
 
+/// Keeps the editor buffer inside AppKit so typing does not start a SwiftUI
+/// transaction. Only the debounced, committed query reaches the Models view.
+private struct DebouncedModelsSearchField: NSViewRepresentable {
+    let prompt: String
+    @Binding var text: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let searchField = NSSearchField()
+        searchField.placeholderString = prompt
+        searchField.stringValue = text
+        searchField.delegate = context.coordinator
+        searchField.target = context.coordinator
+        searchField.action = #selector(Coordinator.commitFromAction(_:))
+        searchField.sendsWholeSearchString = true
+        searchField.sendsSearchStringImmediately = false
+        searchField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        searchField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return searchField
+    }
+
+    func updateNSView(_ searchField: NSSearchField, context: Context) {
+        context.coordinator.text = $text
+        searchField.placeholderString = prompt
+
+        // Do not overwrite an in-progress AppKit edit when an unrelated parent
+        // update arrives before the query's debounce interval has elapsed.
+        if searchField.currentEditor() == nil, searchField.stringValue != text {
+            searchField.stringValue = text
+        }
+    }
+
+    static func dismantleNSView(_ searchField: NSSearchField, coordinator: Coordinator) {
+        coordinator.cancelPendingCommit()
+    }
+
+    final class Coordinator: NSObject, NSSearchFieldDelegate {
+        var text: Binding<String>
+        private var pendingCommit: Task<Void, Never>?
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let searchField = notification.object as? NSSearchField else { return }
+            scheduleCommit(searchField.stringValue)
+        }
+
+        func controlTextDidEndEditing(_ notification: Notification) {
+            guard let searchField = notification.object as? NSSearchField else { return }
+            commit(searchField.stringValue)
+        }
+
+        @objc func commitFromAction(_ searchField: NSSearchField) {
+            commit(searchField.stringValue)
+        }
+
+        func cancelPendingCommit() {
+            pendingCommit?.cancel()
+            pendingCommit = nil
+        }
+
+        private func scheduleCommit(_ value: String) {
+            cancelPendingCommit()
+            pendingCommit = Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(for: .milliseconds(350))
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                self?.commit(value)
+            }
+        }
+
+        private func commit(_ value: String) {
+            cancelPendingCommit()
+            guard text.wrappedValue != value else { return }
+            text.wrappedValue = value
+        }
+    }
+}
+
 private struct InstalledModelRow: View {
     let localModel: LocalModel
     let preloadSlots: [ModelPreloadSlot]
@@ -1328,17 +1419,17 @@ private struct HubModelRow: View, Equatable {
 /// Discover view remains stable while a download reports progress.
 private struct HubModelRowContainer: View {
     @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
-    @ObservedObject private var sizeResolver = HubModelSizeResolver.shared
+    @State private var resolvedDownloadSizeBytes: Int64?
 
     let model: HuggingFaceModel
     let isInstalled: Bool
     let cachePath: String
-    let onDownload: () -> Void
+    let onDownload: (Int64?) -> Void
     let onPauseResume: () -> Void
     let onRemoveDownload: () -> Void
 
     var body: some View {
-        let downloadSizeBytes = sizeResolver.resolvedSize(for: model.id) ?? model.estimatedDownloadBytes
+        let downloadSizeBytes = resolvedDownloadSizeBytes ?? model.estimatedDownloadBytes
         HubModelRow(
             model: model,
             downloadSizeBytes: downloadSizeBytes,
@@ -1351,13 +1442,19 @@ private struct HubModelRowContainer: View {
                 cachePath: cachePath
             ),
             downloadError: downloadManager.errorByModelID[model.id],
-            onDownload: onDownload,
+            onDownload: { onDownload(downloadSizeBytes) },
             onPauseResume: onPauseResume,
             onRemoveDownload: onRemoveDownload
         )
         .equatable()
         .task(id: model.id) {
-            await sizeResolver.prefetch(model.id)
+            resolvedDownloadSizeBytes = nil
+            guard let size = await HubModelSizeResolver.shared.resolveSize(for: model.id),
+                  !Task.isCancelled
+            else {
+                return
+            }
+            resolvedDownloadSizeBytes = size
         }
     }
 }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -63,6 +63,7 @@ struct ModelsView: View {
     // progress tick, which makes Discover scroll janky during downloads.
     private var downloadManager: HuggingFaceDownloadManager { .shared }
     @State private var section: ModelsPageSection = .installed
+    @State private var renderedSection: ModelsPageSection = .installed
     @State private var typeFilter: ModelsTypeFilter = .all
     @State private var localQuery = ""
     @State private var hubQuery = ""
@@ -70,6 +71,7 @@ struct ModelsView: View {
     @State private var hubCapabilityFilters = Set<LocalModelCapability>()
     @State private var hubAccessFilter: HubAccessFilter = .all
     @State private var handledSpeechModelDiscoveryRequest = 0
+    @State private var lastStartedHubSearchTaskID: HubSearchTaskID?
 
     var body: some View {
         ModelConfigurationLayout(
@@ -82,7 +84,7 @@ struct ModelsView: View {
                 activeDownloadBanner
                 modelLoadFailureBanner
 
-                switch section {
+                switch renderedSection {
                 case .installed:
                     installedPage
                 case .discover:
@@ -103,11 +105,23 @@ struct ModelsView: View {
         .onChange(of: speechModelDiscoveryRequest) { _, _ in
             openSpeechModelDiscoveryIfRequested()
         }
-        .task(id: hubSearchTaskID) {
-            guard section == .discover else {
-                hubLibrary.cancel()
+        .task(id: section) {
+            guard renderedSection != section else { return }
+            do {
+                // Give the segmented control time to draw its new selection
+                // before replacing the heavier model-row hierarchy.
+                try await Task.sleep(for: .milliseconds(40))
+            } catch {
                 return
             }
+            guard !Task.isCancelled else { return }
+            renderedSection = section
+        }
+        .task(id: hubSearchTaskID) {
+            guard section == .discover else { return }
+            let searchTaskID = hubSearchTaskID
+            guard searchTaskID != lastStartedHubSearchTaskID else { return }
+            lastStartedHubSearchTaskID = searchTaskID
             hubLibrary.search(
                 query: hubQuery,
                 sort: hubSort,
@@ -119,6 +133,7 @@ struct ModelsView: View {
         .onDisappear {
             localLibrary.cancel()
             hubLibrary.cancel()
+            lastStartedHubSearchTaskID = nil
         }
     }
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -63,7 +63,6 @@ struct ModelsView: View {
     // progress tick, which makes Discover scroll janky during downloads.
     private var downloadManager: HuggingFaceDownloadManager { .shared }
     @State private var section: ModelsPageSection = .installed
-    @State private var renderedSection: ModelsPageSection = .installed
     @State private var typeFilter: ModelsTypeFilter = .all
     @State private var localQuery = ""
     @State private var hubQuery = ""
@@ -84,12 +83,20 @@ struct ModelsView: View {
                 activeDownloadBanner
                 modelLoadFailureBanner
 
-                switch renderedSection {
-                case .installed:
+                ZStack {
                     installedPage
-                case .discover:
+                        .opacity(section == .installed ? 1 : 0)
+                        .allowsHitTesting(section == .installed)
+                        .accessibilityHidden(section != .installed)
+                        .zIndex(section == .installed ? 1 : 0)
+
                     discoverPage
+                        .opacity(section == .discover ? 1 : 0)
+                        .allowsHitTesting(section == .discover)
+                        .accessibilityHidden(section != .discover)
+                        .zIndex(section == .discover ? 1 : 0)
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .background(Color.nativMainContentBackground)
@@ -104,18 +111,6 @@ struct ModelsView: View {
         }
         .onChange(of: speechModelDiscoveryRequest) { _, _ in
             openSpeechModelDiscoveryIfRequested()
-        }
-        .task(id: section) {
-            guard renderedSection != section else { return }
-            do {
-                // Give the segmented control time to draw its new selection
-                // before replacing the heavier model-row hierarchy.
-                try await Task.sleep(for: .milliseconds(40))
-            } catch {
-                return
-            }
-            guard !Task.isCancelled else { return }
-            renderedSection = section
         }
         .task(id: hubSearchTaskID) {
             guard section == .discover else { return }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -51,40 +51,6 @@ private struct HubSearchTaskID: Hashable {
     let authenticationToken: String?
 }
 
-/// Both model pages stay mounted for fast section changes. Their container is
-/// already constrained by the window, so avoid `ZStack`'s intrinsic-size pass
-/// through both row hierarchies whenever their z-order changes.
-private struct ModelsPageStackLayout: Layout {
-    func sizeThatFits(
-        proposal: ProposedViewSize,
-        subviews: Subviews,
-        cache: inout ()
-    ) -> CGSize {
-        var width = proposal.width.flatMap { $0.isFinite ? max(0, $0) : nil }
-        var height = proposal.height.flatMap { $0.isFinite ? max(0, $0) : nil }
-        if width == nil || height == nil {
-            for subview in subviews {
-                let size = subview.sizeThatFits(proposal)
-                width = max(width ?? 0, size.width)
-                height = max(height ?? 0, size.height)
-            }
-        }
-        return CGSize(width: width ?? 0, height: height ?? 0)
-    }
-
-    func placeSubviews(
-        in bounds: CGRect,
-        proposal: ProposedViewSize,
-        subviews: Subviews,
-        cache: inout ()
-    ) {
-        let pageProposal = ProposedViewSize(width: bounds.width, height: bounds.height)
-        for subview in subviews {
-            subview.place(at: bounds.origin, anchor: .topLeading, proposal: pageProposal)
-        }
-    }
-}
-
 struct ModelsView: View {
     @ObservedObject var model: NativModel
     @Binding var showsConfiguration: Bool
@@ -117,20 +83,12 @@ struct ModelsView: View {
                 activeDownloadBanner
                 modelLoadFailureBanner
 
-                ModelsPageStackLayout {
+                switch section {
+                case .installed:
                     installedPage
-                        .opacity(section == .installed ? 1 : 0)
-                        .allowsHitTesting(section == .installed)
-                        .accessibilityHidden(section != .installed)
-                        .zIndex(section == .installed ? 1 : 0)
-
+                case .discover:
                     discoverPage
-                        .opacity(section == .discover ? 1 : 0)
-                        .allowsHitTesting(section == .discover)
-                        .accessibilityHidden(section != .discover)
-                        .zIndex(section == .discover ? 1 : 0)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .background(Color.nativMainContentBackground)

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -177,87 +177,101 @@ struct ModelsView: View {
     }
 
     private var installedPage: some View {
-        VStack(spacing: 0) {
+        let visibleModels = filteredLocalModels
+        let normalizedSettings = model.settings.normalized()
+
+        return VStack(spacing: 0) {
             installedToolbar
                 .padding(.horizontal, 22)
                 .padding(.vertical, 14)
 
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 10) {
-                    if let error = localLibrary.error {
-                        ModelsNotice(
-                            title: "Couldn’t read the model cache",
-                            message: error,
-                            systemImage: "exclamationmark.triangle.fill",
-                            color: .orange
+            List {
+                if let error = localLibrary.error {
+                    ModelsNotice(
+                        title: "Couldn’t read the model cache",
+                        message: error,
+                        systemImage: "exclamationmark.triangle.fill",
+                        color: .orange
+                    )
+                    .modelsListRow()
+                }
+
+                if localLibrary.isScanning && localLibrary.models.isEmpty {
+                    ModelsLoadingState(title: "Scanning your Hugging Face cache…")
+                        .modelsListRow()
+                } else if visibleModels.isEmpty {
+                    ModelsEmptyState(
+                        systemImage: installedFilterIsActive
+                            ? "line.3.horizontal.decrease.circle" : "shippingbox",
+                        title: installedFilterIsActive
+                            ? "No models match your filter" : "No MLX models installed",
+                        message: installedFilterIsActive
+                            ? "Try a different search or model type."
+                            : "Discover an MLX model on Hugging Face and download it to this cache.",
+                        actionTitle: installedFilterIsActive ? nil : "Discover models",
+                        action: { section = .discover }
+                    )
+                    .modelsListRow()
+                } else {
+                    HStack {
+                        Text(
+                            "\(visibleModels.count) \(visibleModels.count == 1 ? "model" : "models")"
                         )
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        if localLibrary.isScanning {
+                            ProgressView().controlSize(.small)
+                        }
                     }
+                    .modelsListRow(top: 0)
 
-                    if localLibrary.isScanning && localLibrary.models.isEmpty {
-                        ModelsLoadingState(title: "Scanning your Hugging Face cache…")
-                    } else if filteredLocalModels.isEmpty {
-                        ModelsEmptyState(
-                            systemImage: installedFilterIsActive
-                                ? "line.3.horizontal.decrease.circle" : "shippingbox",
-                            title: installedFilterIsActive
-                                ? "No models match your filter" : "No MLX models installed",
-                            message: installedFilterIsActive
-                                ? "Try a different search or model type."
-                                : "Discover an MLX model on Hugging Face and download it to this cache.",
-                            actionTitle: installedFilterIsActive ? nil : "Discover models",
-                            action: { section = .discover }
-                        )
-                    } else {
-                        HStack {
-                            Text(
-                                "\(filteredLocalModels.count) \(filteredLocalModels.count == 1 ? "model" : "models")"
-                            )
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            if localLibrary.isScanning {
-                                ProgressView().controlSize(.small)
+                    ForEach(visibleModels) { localModel in
+                        let preloadSlots = preloadSlots(for: localModel)
+                        let selectedSlots = Set(
+                            ModelPreloadSlot.allCases.filter {
+                                normalizedSettings.modelID(for: $0) == localModel.repoID
                             }
-                        }
-
-                        ForEach(filteredLocalModels) { localModel in
-                            let preloadSlots = preloadSlots(for: localModel)
-                            InstalledModelRow(
-                                localModel: localModel,
-                                preloadSlots: preloadSlots,
-                                selectedPreloadSlots: selectedPreloadSlots(
-                                    for: localModel.repoID
-                                ),
-                                preferredPreloadSlot: preferredPreloadSlot(
-                                    among: preloadSlots
-                                ),
-                                isSelectionDisabled: model.modelSwitchInProgress,
-                                isModelLoading: model.modelLoadingID
-                                    == localModel.repoID,
-                                modelLoadingPercentage: model.modelLoadingPercentage,
-                                isDeleting: localLibrary.deletingModelIDs.contains(
-                                    localModel.repoID),
-                                canDelete: localModel.isDeletable && !model.modelSwitchInProgress
-                                    && !isModelInUse(localModel.repoID),
-                                onSetPreload: { slot, isEnabled in
-                                    if isEnabled {
-                                        model.requestPreloadedModelSwitch(
-                                            to: localModel,
-                                            for: slot,
-                                            availableModels: localLibrary.models
-                                        )
-                                    } else {
-                                        model.switchPreloadedModel(to: nil, for: slot)
-                                    }
-                                },
-                                onDelete: { deleteInstalledModel(localModel) }
-                            )
-                        }
+                        )
+                        InstalledModelRow(
+                            localModel: localModel,
+                            preloadSlots: preloadSlots,
+                            selectedPreloadSlots: selectedSlots,
+                            preferredPreloadSlot: preferredPreloadSlot(
+                                among: preloadSlots
+                            ),
+                            isSelectionDisabled: model.modelSwitchInProgress,
+                            isModelLoading: model.modelLoadingID
+                                == localModel.repoID,
+                            modelLoadingPercentage: model.modelLoadingPercentage,
+                            isDeleting: localLibrary.deletingModelIDs.contains(
+                                localModel.repoID),
+                            canDelete: localModel.isDeletable && !model.modelSwitchInProgress
+                                && !isModelInUse(localModel.repoID),
+                            onSetPreload: { slot, isEnabled in
+                                if isEnabled {
+                                    model.requestPreloadedModelSwitch(
+                                        to: localModel,
+                                        for: slot,
+                                        availableModels: localLibrary.models
+                                    )
+                                } else {
+                                    model.switchPreloadedModel(to: nil, for: slot)
+                                }
+                            },
+                            onDelete: { deleteInstalledModel(localModel) }
+                        )
+                        .modelsListRow()
                     }
                 }
-                .padding(.horizontal, 22)
-                .padding(.bottom, 22)
+
+                Color.clear
+                    .frame(height: 12)
+                    .modelsListRow(top: 0, bottom: 0)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .environment(\.defaultMinListRowHeight, 0)
         }
     }
 
@@ -310,7 +324,9 @@ struct ModelsView: View {
     }
 
     private var discoverPage: some View {
-        VStack(spacing: 0) {
+        let installedIDs = installedModelIDs
+
+        return VStack(spacing: 0) {
             VStack(spacing: 10) {
                 HStack(spacing: 10) {
                     DebouncedModelsSearchField(
@@ -331,99 +347,108 @@ struct ModelsView: View {
             .padding(.horizontal, 22)
             .padding(.vertical, 14)
 
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 10) {
-                    if let error = hubLibrary.error {
-                        ModelsNotice(
-                            title: "Hugging Face is unavailable",
-                            message: error,
-                            systemImage: "wifi.exclamationmark",
-                            color: .orange
+            List {
+                if let error = hubLibrary.error {
+                    ModelsNotice(
+                        title: "Hugging Face is unavailable",
+                        message: error,
+                        systemImage: "wifi.exclamationmark",
+                        color: .orange
+                    )
+                    .modelsListRow()
+                } else if hubLibrary.isSearching && hubLibrary.models.isEmpty {
+                    ModelsLoadingState(
+                        title: hubQuery.isEmpty
+                            ? "Finding popular Safetensors models…" : "Searching Hugging Face…")
+                        .modelsListRow()
+                } else if hubLibrary.models.isEmpty {
+                    if hubCapabilityFilters.isEmpty && hubAccessFilter == .all {
+                        ModelsEmptyState(
+                            systemImage: "magnifyingglass",
+                            title: "No Safetensors models found",
+                            message: "Try a model family, provider, or repository name.",
+                            actionTitle: nil,
+                            action: {}
                         )
-                    } else if hubLibrary.isSearching && hubLibrary.models.isEmpty {
-                        ModelsLoadingState(
-                            title: hubQuery.isEmpty
-                                ? "Finding popular Safetensors models…" : "Searching Hugging Face…")
-                    } else if hubLibrary.models.isEmpty {
-                        if hubCapabilityFilters.isEmpty && hubAccessFilter == .all {
-                            ModelsEmptyState(
-                                systemImage: "magnifyingglass",
-                                title: "No Safetensors models found",
-                                message: "Try a model family, provider, or repository name.",
-                                actionTitle: nil,
-                                action: {}
-                            )
-                        } else {
-                            ModelsEmptyState(
-                                systemImage: "line.3.horizontal.decrease.circle",
-                                title: "No models match these filters",
-                                message:
-                                    "Try another model type, capability, or access filter, or continue to the next page.",
-                                actionTitle: nil,
-                                action: {}
-                            )
-                        }
+                        .modelsListRow()
                     } else {
-                        discoverResultsHeader
-
-                        ForEach(filteredHubModels) { hubModel in
-                            HubModelRowContainer(
-                                model: hubModel,
-                                isInstalled: installedModelIDs.contains(hubModel.id),
-                                cachePath: model.settings.modelSearchPath,
-                                onDownload: { downloadSizeBytes in
-                                    downloadManager.download(
-                                        repoID: hubModel.id,
-                                        sizeBytes: downloadSizeBytes,
-                                        cachePath: model.settings.modelSearchPath,
-                                        token: model.effectiveHuggingFaceToken
-                                    ) {}
-                                },
-                                onPauseResume: {
-                                    if downloadManager.isPaused(for: hubModel.id) {
-                                        downloadManager.resumeDownload(hubModel.id)
-                                    } else {
-                                        downloadManager.pauseDownload(hubModel.id)
-                                    }
-                                },
-                                onRemoveDownload: {
-                                    downloadManager.removeDownload(hubModel.id)
-                                }
-                            )
-                        }
-
-                        HStack(spacing: 12) {
-                            Spacer()
-
-                            Button {
-                                hubLibrary.goToPreviousPage()
-                            } label: {
-                                Label("Previous", systemImage: "chevron.left")
-                            }
-                            .disabled(!hubLibrary.canGoToPreviousPage)
-
-                            Text("Page \(hubLibrary.pageNumber) of up to 5")
-                                .font(.callout.weight(.medium))
-                                .foregroundStyle(.secondary)
-                                .frame(minWidth: 122)
-
-                            Button {
-                                hubLibrary.goToNextPage(token: model.effectiveHuggingFaceToken)
-                            } label: {
-                                Label("Next", systemImage: "chevron.right")
-                                    .labelStyle(.titleAndIcon)
-                            }
-                            .disabled(!hubLibrary.canGoToNextPage)
-
-                            Spacer()
-                        }
-                        .buttonStyle(.bordered)
-                        .padding(.top, 8)
+                        ModelsEmptyState(
+                            systemImage: "line.3.horizontal.decrease.circle",
+                            title: "No models match these filters",
+                            message:
+                                "Try another model type, capability, or access filter, or continue to the next page.",
+                            actionTitle: nil,
+                            action: {}
+                        )
+                        .modelsListRow()
                     }
+                } else {
+                    discoverResultsHeader
+                        .modelsListRow(top: 0)
+
+                    ForEach(filteredHubModels) { hubModel in
+                        HubModelRowContainer(
+                            model: hubModel,
+                            isInstalled: installedIDs.contains(hubModel.id),
+                            cachePath: model.settings.modelSearchPath,
+                            onDownload: { downloadSizeBytes in
+                                downloadManager.download(
+                                    repoID: hubModel.id,
+                                    sizeBytes: downloadSizeBytes,
+                                    cachePath: model.settings.modelSearchPath,
+                                    token: model.effectiveHuggingFaceToken
+                                ) {}
+                            },
+                            onPauseResume: {
+                                if downloadManager.isPaused(for: hubModel.id) {
+                                    downloadManager.resumeDownload(hubModel.id)
+                                } else {
+                                    downloadManager.pauseDownload(hubModel.id)
+                                }
+                            },
+                            onRemoveDownload: {
+                                downloadManager.removeDownload(hubModel.id)
+                            }
+                        )
+                        .modelsListRow()
+                    }
+
+                    HStack(spacing: 12) {
+                        Spacer()
+
+                        Button {
+                            hubLibrary.goToPreviousPage()
+                        } label: {
+                            Label("Previous", systemImage: "chevron.left")
+                        }
+                        .disabled(!hubLibrary.canGoToPreviousPage)
+
+                        Text("Page \(hubLibrary.pageNumber) of up to 5")
+                            .font(.callout.weight(.medium))
+                            .foregroundStyle(.secondary)
+                            .frame(minWidth: 122)
+
+                        Button {
+                            hubLibrary.goToNextPage(token: model.effectiveHuggingFaceToken)
+                        } label: {
+                            Label("Next", systemImage: "chevron.right")
+                                .labelStyle(.titleAndIcon)
+                        }
+                        .disabled(!hubLibrary.canGoToNextPage)
+
+                        Spacer()
+                    }
+                    .buttonStyle(.bordered)
+                    .modelsListRow(top: 13)
                 }
-                .padding(.horizontal, 22)
-                .padding(.bottom, 22)
+
+                Color.clear
+                    .frame(height: 12)
+                    .modelsListRow(top: 0, bottom: 0)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .environment(\.defaultMinListRowHeight, 0)
         }
     }
 
@@ -458,16 +483,6 @@ struct ModelsView: View {
             slots.append(.embeddings)
         }
         return slots
-    }
-
-    private func selectedPreloadSlots(
-        for repoID: String
-    ) -> Set<ModelPreloadSlot> {
-        let settings = model.settings.normalized()
-        return Set(
-            ModelPreloadSlot.allCases.filter {
-                settings.modelID(for: $0) == repoID
-            })
     }
 
     private func preferredPreloadSlot(
@@ -1755,6 +1770,15 @@ private struct ModelRowBackground: ViewModifier {
 extension View {
     fileprivate func modelRowBackground(isHighlighted: Bool, isHovered: Bool = false) -> some View {
         modifier(ModelRowBackground(isHighlighted: isHighlighted, isHovered: isHovered))
+    }
+
+    fileprivate func modelsListRow(
+        top: CGFloat = 5,
+        bottom: CGFloat = 5
+    ) -> some View {
+        listRowInsets(EdgeInsets(top: top, leading: 22, bottom: bottom, trailing: 22))
+            .listRowSeparator(.hidden)
+            .listRowBackground(Color.clear)
     }
 }
 


### PR DESCRIPTION
## Summary

- keep a single native `NSSearchField` mounted across Installed and Discover
- commit Discover queries after the requested 350 ms debounce while local filtering commits on the next main-actor turn
- separate the native segmented-control selection from toolbar, filter, row, and network work by one main-loop turn with no fixed delay
- show a lightweight active-section transition state so outgoing row tasks unmount instead of contending with the click
- use one `ScrollView` / `LazyVStack` host for both sections and mount only the active section's content
- remove the zero-minimum-height `List` configuration that caused repeated AppKit row-height errors
- preserve Hub result/request deduplication and localize model-size/download-progress observation
- construct the Model Configuration panel only while it is visible and avoid unrelated control-panel invalidations

## Root cause

The Discover query was originally bound directly to the top-level SwiftUI view, so each keystroke rebuilt the result hierarchy. Model-size publications, download progress, and one-second runtime updates amplified those invalidations.

Installed/Discover selection was also coupled to rebuilding a card-heavy row hierarchy and starting or cancelling Hub work in the same SwiftUI transaction. The later virtualized `List` implementation added an invalid zero minimum row height, producing repeated AppKit layout errors and extra main-thread work.

## User impact

The native segmented control now acknowledges the click independently of page construction. The outgoing section unmounts immediately, then the toolbar, filters, and lazy rows switch on the next main-loop turn. First-time Hugging Face loading remains asynchronous and does not define click latency.

Only one section's row hierarchy is mounted. Leaving Models still releases the Models view and its state objects, so there is no hidden-page or prewarming memory tradeoff.

## Validation

- Debug build succeeds with `xcodebuild`
- app smoke test exits successfully
- populated Installed and Discover layouts and controls verified through macOS UI automation
- six consecutive cached back-and-forth transitions verified for selection/content synchronization
- temporary in-app timing probe measured the isolated Discover selection-to-handoff path at 35.8 ms after the synchronous work was removed; the probe was removed before commit
- confirmed the repeated AppKit negative-row-height errors disappear after replacing the invalid List configuration
