### PR TITLE
Simplify navbar navigation

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3A4D3E1F9313D9896173130D /* VoiceShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */; };
 		3D7F718E2E136C35CD3509B4 /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
 		3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */; };
+		A3D3B002C249000000000001 /* DevHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D3B001C249000000000001 /* DevHubView.swift */; };
 		402FF67FA99A26739AA4A653 /* MCPCatalog.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C57E985705899CDD8DB5996 /* MCPCatalog.json */; };
 		41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
@@ -297,6 +298,7 @@
 		3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXImageModelResolverTests.swift; sourceTree = "<group>"; };
 		41417C210BF817681A8C6D87 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
 		4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperView.swift; sourceTree = "<group>"; };
+		A3D3B001C249000000000001 /* DevHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevHubView.swift; sourceTree = "<group>"; };
 		42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		46B469F1D62E2DB0DE8CFAF1 /* NativPermissionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativPermissionsCard.swift; sourceTree = "<group>"; };
 		46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSemanticSearch.swift; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 		1DE309DC3FB91D09768CD66E /* Developer */ = {
 			isa = PBXGroup;
 			children = (
+				A3D3B001C249000000000001 /* DevHubView.swift */,
 				4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */,
 			);
 			path = Developer;
@@ -1095,6 +1098,7 @@
 				FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */,
 				45BD4C408B9739ABC051A9E7 /* ControlPanelView.swift in Sources */,
 				802B1F569D3D9FBE951EC8EA /* DashboardViewModel.swift in Sources */,
+				A3D3B002C249000000000001 /* DevHubView.swift in Sources */,
 				3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */,
 				7C49B0A059A3495FF8BC8B66 /* EmbeddingModelPreparer.swift in Sources */,
 				C89558DC65CAAEC956198688 /* ExtensionsHubView.swift in Sources */,

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -11,9 +11,8 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
     case dashboard = "Dashboard"
     case system = "System"
     case models = "Models"
-    case integrations = "Integrations"
     case extensions = "Extensions"
-    case developer = "Developer"
+    case dev = "Dev"
     case settings = "Settings"
 
     static var allCases: [ControlPanelTab] {
@@ -24,9 +23,8 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
             .dashboard,
             .system,
             .models,
-            .integrations,
             .extensions,
-            .developer,
+            .dev,
         ]
     }
 
@@ -46,12 +44,10 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
             "gauge.open.with.lines.needle.33percent"
         case .models:
             "cube.transparent"
-        case .integrations:
-            "puzzlepiece.extension"
         case .extensions:
             "point.3.filled.connected.trianglepath.dotted"
-        case .developer:
-            "hammer"
+        case .dev:
+            "chevron.left.forwardslash.chevron.right"
         case .settings:
             "gearshape"
         }
@@ -355,6 +351,7 @@ struct ControlPanelView: View {
     @StateObject private var routineModelLibrary = LocalModelLibrary()
     @State private var schedulingRoutineDraft: RoutineDraft?
     @State private var isModelConfigurationVisible = false
+    @State private var selectedDevSection: DevHubView.Section = .integrations
     @State private var isFullScreen = false
     @State private var windowControlsRefreshTrigger = 0
     @State private var isNewChatHovering = false
@@ -1354,9 +1351,11 @@ struct ControlPanelView: View {
 
     private var showsModelConfigurationToggle: Bool {
         switch selectedTab {
-        case .chat, .models, .developer:
+        case .chat, .models:
             true
-        case .imageGeneration, .artifacts, .dashboard, .system, .integrations, .extensions, .settings:
+        case .dev:
+            selectedDevSection == .developer
+        case .imageGeneration, .artifacts, .dashboard, .system, .extensions, .settings:
             false
         }
     }
@@ -1989,23 +1988,18 @@ struct ControlPanelView: View {
                 titleLeadingInset: detailTitleLeadingInset,
                 speechModelDiscoveryRequest: navigation.speechModelDiscoveryRequest
             )
-        case .integrations:
-            IntegrationsView(
-                model: model,
-                titleLeadingInset: detailTitleLeadingInset
-            )
         case .extensions:
             ExtensionsHubView(
                 manager: extensionManager,
                 host: mcpHost,
                 model: model
             )
-        case .developer:
-            DeveloperView(
+        case .dev:
+            DevHubView(
+                section: $selectedDevSection,
                 model: model,
                 runtime: runtime,
-                showsConfiguration: $isModelConfigurationVisible,
-                titleLeadingInset: detailTitleLeadingInset
+                showsConfiguration: $isModelConfigurationVisible
             )
         case .settings:
             SettingsView(
@@ -2096,7 +2090,7 @@ struct ControlPanelView: View {
             return true
         }
         switch selectedTab {
-        case .dashboard, .system, .models, .integrations, .extensions, .developer:
+        case .dashboard, .system, .models, .extensions, .dev:
             return true
         case .chat, .imageGeneration, .artifacts, .settings:
             return false

--- a/Sources/Nativ/Features/Developer/DevHubView.swift
+++ b/Sources/Nativ/Features/Developer/DevHubView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct DevHubView: View {
+    enum Section: String, CaseIterable, Identifiable {
+        case integrations = "Integrations"
+        case developer = "Developer"
+
+        var id: String { rawValue }
+
+        var systemImage: String {
+            switch self {
+            case .integrations:
+                "puzzlepiece.extension"
+            case .developer:
+                "hammer"
+            }
+        }
+    }
+
+    @Binding var section: Section
+    @ObservedObject var model: NativModel
+    @ObservedObject var runtime: SystemRuntimeMonitor
+    @Binding var showsConfiguration: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            subnav
+            Divider()
+            detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var subnav: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Section.allCases) { item in
+                Button {
+                    section = item
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: item.systemImage)
+                            .frame(width: 18)
+                        Text(item.rawValue)
+                            .font(.system(size: 13, weight: .medium))
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .foregroundStyle(section == item ? Color.accentColor : Color.primary)
+                    .background(
+                        section == item ? Color.accentColor.opacity(0.12) : Color.clear,
+                        in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    )
+                    .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(width: 188)
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        switch section {
+        case .integrations:
+            IntegrationsView(model: model)
+        case .developer:
+            DeveloperView(
+                model: model,
+                runtime: runtime,
+                showsConfiguration: $showsConfiguration
+            )
+        }
+    }
+}


### PR DESCRIPTION
Simplifying navbar

Summary:
- Group Integrations and Developer under a collapsible Dev section.
- Keep the remaining navigation flat.
- Animate Dev rows through the leading edge in both directions.



https://github.com/user-attachments/assets/301a9786-7ee8-482d-8601-a8f8d62e17d8


