### PR TITLE
Feature/custom kits

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		727CB29E8D7346C29E0DBB3F /* ServerProcessEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055942EF0A544CE88654E7F6 /* ServerProcessEnvironmentTests.swift */; };
 		000EAB97CDF74A172ED79748 /* ChatWebReadTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8158351DC9E135F30DA83A01 /* ChatWebReadTool.swift */; };
 		01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */; };
 		02571B1CDC31A5D168247CCD /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
@@ -59,6 +58,7 @@
 		2452C5D7B24CA5FF6FAA36E2 /* MCPHostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5D77458EF56DD1B8F4AE17 /* MCPHostManager.swift */; };
 		252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
 		256B07A9158557D2E3AD2A35 /* Manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AF8F6359E4523814FB0EFDA /* Manifest.json */; };
+		25D127CA91D6EF7FB3EF6514 /* NativKitEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D264F083A990A23BACB762 /* NativKitEditor.swift */; };
 		28197A70541BE1F1F482BCF4 /* PDFDocumentTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2C50E190D5DBA2E237FB2 /* PDFDocumentTextExtractor.swift */; };
 		28FA870CA6BE85C4BC41F77B /* FirecrawlBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195075F70CCB0E7DE02934DF /* FirecrawlBrowsingProvider.swift */; };
 		293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
@@ -109,6 +109,7 @@
 		467A79817882057E60D2E4ED /* PhosphorSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4982A746353A5B9FD44CD63C /* PhosphorSwift */; };
 		4681766DBDD49200E3A90BF0 /* ScheduledTasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5C104E12EEB90C4108DD86 /* ScheduledTasksView.swift */; };
 		4751D7C9F392C341E8921F58 /* ChatPromptRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */; };
+		47E56F0F2F4481FF900174E7 /* NativKitCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2E71BB3A1BBE574A64638B /* NativKitCatalog.swift */; };
 		482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */; };
 		487C0D234A1B2F700F3BB5DA /* DocumentTextExtractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D5CBFB467AADEE51EE098E /* DocumentTextExtractionTests.swift */; };
 		4882FE7E8C689152D428AB2E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 0D3574097911A448F62ED273 /* Sparkle */; };
@@ -120,20 +121,22 @@
 		4B3B371072FF015C6CA2CA61 /* NativKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780A9582305FC184F6C68D12 /* NativKitTests.swift */; };
 		4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */; };
 		4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B965B701714787B0A85AE6B /* AudioTests.swift */; };
+		4B95E0BE6589A1D63E696175 /* icon.json in Resources */ = {isa = PBXBuildFile; fileRef = 955320EDC1FB6B9B8DEFB43B /* icon.json */; };
 		4BD354A4C41C62B7F11E1686 /* WebSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2580C52ECE6D40D71E44463F /* WebSearchProvider.swift */; };
 		4CB31A9AACD344FA2CD1B6FD /* VoiceAnimationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632EB67BFAC2BCBE082A3E2B /* VoiceAnimationPreferences.swift */; };
 		4DB478CE9FB6079C7B55B097 /* DevHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E646A2A68BB20D0CD4933E2A /* DevHubView.swift */; };
 		4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */; };
 		4E81E2CBA8DBB61035A07C86 /* ChatDocumentExtractionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */; };
 		4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
+		4F615D6B17628FC3FCC7199D /* NativKitPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8500BF58CDA5C392E60DC8C /* NativKitPresentation.swift */; };
 		4FC9EEEC4DFDE7766C2526E2 /* ChatDocumentContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */; };
 		506A12DCE5B56E53208A8BA2 /* NativServerKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1651E057CC5D05857CF1595 /* NativServerKit.swift */; };
-		E0A20B5A8E804C60B8CF06A7 /* ServerProcessEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8C02FD662848C7AAE73808 /* ServerProcessEnvironment.swift */; };
 		5196EA3B5CC4CE166899FE19 /* ControlPanelActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD296E4B5897E7E46606B697 /* ControlPanelActions.swift */; };
 		52927A9A78C07E5E649AFDF6 /* FilePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C9FECAED1FB3E2D43716FF /* FilePreview.swift */; };
 		52E78D326199C2BF37D16F66 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = 8DD1E187A7659D46CDC76CF9 /* MCP */; };
 		530018C1D89BF63546715147 /* GitHubOAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FC738EB813B7B63847838B /* GitHubOAuth.swift */; };
 		54D53CD1A2BA96B2336C2406 /* KitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1B970F41F1B5612B791ABE /* KitsSectionView.swift */; };
+		561CF1D4C0CEA99417E18440 /* NativKitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B25DE635847F5B72CCFC5E /* NativKitStore.swift */; };
 		5620EDCF472DEF4388E8E526 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDD9C3FE179B2E8D76FC769 /* SettingsView.swift */; };
 		56B6A9EF8A305C95F9E81D06 /* Routine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F067B3DB861CF232820136 /* Routine.swift */; };
 		56D0E3D130B4DF4003811E6D /* VoiceDictationExtensionRuntime.appex in Embed ExtensionKit Extensions */ = {isa = PBXBuildFile; fileRef = 37408935D4EAA2CA89CC0A4C /* VoiceDictationExtensionRuntime.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -152,6 +155,7 @@
 		657DFF151F7E54EA66CC36F8 /* SystemSensorSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653E58FFA38742CD4D5D41F5 /* SystemSensorSampler.swift */; };
 		66745D5BB4D1454479FF6C9C /* RoutineScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C1220F03EC60874920E0CE /* RoutineScheduler.swift */; };
 		67560D2323090F583CCC39C6 /* NotificationAppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 6ABC782FB29B8C76EC8B60E6 /* NotificationAppIcon.icns */; };
+		685D0C1A9E3B12C90EA3D952 /* MCPCatalogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B2E989C1BBC9AFB45AE8D6 /* MCPCatalogEntry.swift */; };
 		686A83AD1E07A381F56F6D05 /* ChatDocumentContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */; };
 		690202C6E092ABA0A086955F /* NativKitRuntimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */; };
 		692EA024371CB249BE53DB86 /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
@@ -163,6 +167,7 @@
 		6EFBB86CDB0CCCF393D7598E /* ChatDocumentExtractionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */; };
 		6F59E4CC485E211A7E6BC943 /* ScheduledTaskViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7213B7C6CEA995B14EBAC99 /* ScheduledTaskViews.swift */; };
 		71659335E55225ABCBB4E993 /* IssueReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46B388273DDFAD7C6C0F4E1 /* IssueReport.swift */; };
+		727CB29E8AF1A50C063FD972 /* ServerProcessEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055942EFAB585BE493AC9AD7 /* ServerProcessEnvironmentTests.swift */; };
 		732D29870D9B330A520DF15C /* NativEmbeddingsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */; };
 		751C105813095FEC67349FBB /* NativNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577B24B3B022E78F7664C76E /* NativNotificationService.swift */; };
 		759391363423D786EF850BE3 /* RoutineEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */; };
@@ -170,7 +175,6 @@
 		76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */; };
 		7719AEDEE627A29CA30D6FE3 /* ChatReadFileTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60FD94BFE0DEFB5A1A21601 /* ChatReadFileTool.swift */; };
 		7748996AA574868ED694F974 /* AudioCaptureLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820A7EF6D7E1FA0F171A5A59 /* AudioCaptureLibrary.swift */; };
-		77B9284EE48D020C2B5A2DF3 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */; };
 		7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */; };
 		7A048032C24D04DFA07AC461 /* ChatConversationBranch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5FF4A08C2B33756121EE2C /* ChatConversationBranch.swift */; };
 		7A86AD9E2E640430F47B94D5 /* FileTypeIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677258B04E9BB7CA8B89E11E /* FileTypeIcon.swift */; };
@@ -197,6 +201,7 @@
 		8E16504AFD5457AC965426F2 /* FnControlShortcutMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D63523BA62CC95FDD8D51E /* FnControlShortcutMonitor.swift */; };
 		8E717C7364F8B9DA2BDF0E20 /* TextShimmerWave.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA5C785716081D2811DFD2D /* TextShimmerWave.swift */; };
 		902CD676AA3002459DF7ACAE /* ChatPromptRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */; };
+		906F2F48A734DEEDCA2BD633 /* NativKitCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2E71BB3A1BBE574A64638B /* NativKitCatalog.swift */; };
 		90A91F19C53567C017E37E28 /* RoutineRunCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50843C4D4ABCEC290EE626AF /* RoutineRunCoordinator.swift */; };
 		90EE7AA87400E84D947CBBF3 /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
 		94504A0DB46777F5DA8CDBD6 /* Parallel.png in Resources */ = {isa = PBXBuildFile; fileRef = 530CA8743FEBF843F79321A7 /* Parallel.png */; };
@@ -233,6 +238,7 @@
 		ACC7D165CE2E836C89EE9DA2 /* WebReadContentSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F15F7E180170C5FA55BD38F /* WebReadContentSelector.swift */; };
 		AD5DF112FF75CE5723332074 /* WebBrowsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B88001E3E22C2E592C0BA /* WebBrowsingError.swift */; };
 		ADDF36ABE66D5ACE3D765589 /* AudioView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E012B6E98DF6B992CDA591F /* AudioView.swift */; };
+		AF1502F763FAF5EA1839CC4D /* NativKitStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3665BF8FE325798A8A6F86 /* NativKitStoreTests.swift */; };
 		AFBC36570418275354CE129B /* ExaBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 769A36AA0753AB7F4CB1E371 /* ExaBrowsingProvider.swift */; };
 		B15353CDE6204176664DB3B2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E2EE61C1652C49ECC69658 /* AppDelegate.swift */; };
 		B2B154008527C6291C17AC93 /* MLXImageModelResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61126D4235AFF77D82F1F80B /* MLXImageModelResolver.swift */; };
@@ -263,7 +269,9 @@
 		C3D251E72388C59FFEA7E9C4 /* ChatAttachmentNoticesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51539FFC3A9D763AA1746318 /* ChatAttachmentNoticesView.swift */; };
 		C4381191592EC7C3B97E2C35 /* FilePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C9FECAED1FB3E2D43716FF /* FilePreview.swift */; };
 		C4A766A43FD62815D056BD93 /* ParallelBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8347D15B2595FF7819F7C /* ParallelBrowsingProvider.swift */; };
+		C51BF9D58C083736FDE958A3 /* NativKitCapabilityInventory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9865559C522A64A74DB709 /* NativKitCapabilityInventory.swift */; };
 		C5CE4EBDB988CF611FB2D6DA /* SystemMenuBarPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE1E26171E964D9769E65CB /* SystemMenuBarPreferences.swift */; };
+		C67D78D47124087E636B9B6A /* MCPCatalogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B2E989C1BBC9AFB45AE8D6 /* MCPCatalogEntry.swift */; };
 		C6DFA4F348008EDB924A3FC1 /* WebReadContentSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F15F7E180170C5FA55BD38F /* WebReadContentSelector.swift */; };
 		C7697F50D8F4E4628DFEE397 /* Tavily.png in Resources */ = {isa = PBXBuildFile; fileRef = BF65681C9FD920314BECC7D3 /* Tavily.png */; };
 		C84FA1A269F12B130EAEB57B /* ModelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EB7572F271F7D68DC3F97D /* ModelsView.swift */; };
@@ -275,6 +283,7 @@
 		C98474155E01AF49957443C9 /* NativNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577B24B3B022E78F7664C76E /* NativNotificationService.swift */; };
 		CB0D232F71771BF7F3EE2B53 /* FirecrawlBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195075F70CCB0E7DE02934DF /* FirecrawlBrowsingProvider.swift */; };
 		CEE42CCB57866B76CE85E588 /* MCPServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A7ACB288953FD476C47E8 /* MCPServerConfig.swift */; };
+		D0F22E819F25291E43F4230C /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6070B0D9BBE92BCB3195FC /* NativKit.swift */; };
 		D2D5168B1A4243EB55EB1D68 /* RealtimeAudioMeterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01D6D1C8C321F16B5FD31F8 /* RealtimeAudioMeterTests.swift */; };
 		D4AA61C3BEF5538E3DA9A54F /* OfficeArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE82B4EBA796206F12005498 /* OfficeArchive.swift */; };
 		D4F073244DE11FD98AD708E2 /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */; };
@@ -292,6 +301,7 @@
 		DE62F002578F2CB0176F5ECE /* ScheduledTaskChatLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCD9D4118F0B3580590998F /* ScheduledTaskChatLinker.swift */; };
 		DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */; };
 		E07244079BF415C89A76AC48 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
+		E0A20B5A3FC188AF0B13A943 /* ServerProcessEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8C02FD60255220A8DF3BE7 /* ServerProcessEnvironment.swift */; };
 		E0B07216A3D3638AA5FAA059 /* ParallelBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8347D15B2595FF7819F7C /* ParallelBrowsingProvider.swift */; };
 		E119D6964D35D4F49AD88EDF /* GitHubOAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FC738EB813B7B63847838B /* GitHubOAuth.swift */; };
 		E180E254213BCD770141B872 /* VoiceAnimationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632EB67BFAC2BCBE082A3E2B /* VoiceAnimationPreferences.swift */; };
@@ -317,14 +327,18 @@
 		F110515E63D4C200A8930120 /* Perplexity.png in Resources */ = {isa = PBXBuildFile; fileRef = F84C7B764CE1B6F63746E3BB /* Perplexity.png */; };
 		F14A3E893E8DE4DE035C3925 /* ChatConversationBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B059AF48F10F1B0502DC5E6F /* ChatConversationBranchTests.swift */; };
 		F173E87800BD20A7A0993FBD /* WebReadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C695753548A6C1F2F37C602 /* WebReadService.swift */; };
+		F24B4125B306826BDAE77EAC /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6070B0D9BBE92BCB3195FC /* NativKit.swift */; };
 		F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */; };
 		F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
 		F32A65A75BCD6911505114F4 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
 		F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */; };
+		F9B09901AC4BC489C613C82D /* RoutineKitResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE296201A4FF80537A926F9 /* RoutineKitResolver.swift */; };
 		F9B4AAA3C467240C00807753 /* ChatReadFileToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */; };
+		FB233D129B07C310113E13E1 /* Front.png in Resources */ = {isa = PBXBuildFile; fileRef = 54CAE400DE3E453F70CC7152 /* Front.png */; };
 		FC65EA7675E8441D11372F9C /* ChatDocumentContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */; };
+		FC9227079769F8BCDD7F3757 /* NativKitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B25DE635847F5B72CCFC5E /* NativKitStore.swift */; };
 		FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
 		FEAADABA1D25B153BE25E58F /* StatusMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85179B12862D6319C3F91027 /* StatusMenuController.swift */; };
 		FEB97639F6A1334E409830CF /* ChatWebSearchToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA5142DB692E378ADE8DFA0 /* ChatWebSearchToolTests.swift */; };
@@ -416,9 +430,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		055942EF0A544CE88654E7F6 /* ServerProcessEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessEnvironmentTests.swift; sourceTree = "<group>"; };
 		028A6EB95776995CFF6F82A9 /* ControlPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelState.swift; sourceTree = "<group>"; };
 		03496D30CE58F138CA30EB0D /* ControlPanelDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelDetail.swift; sourceTree = "<group>"; };
+		055942EFAB585BE493AC9AD7 /* ServerProcessEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessEnvironmentTests.swift; sourceTree = "<group>"; };
 		068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatServerStatsTool.swift; sourceTree = "<group>"; };
 		06D5CBFB467AADEE51EE098E /* DocumentTextExtractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTextExtractionTests.swift; sourceTree = "<group>"; };
 		06F067B3DB861CF232820136 /* Routine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routine.swift; sourceTree = "<group>"; };
@@ -442,9 +456,11 @@
 		27D63523BA62CC95FDD8D51E /* FnControlShortcutMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FnControlShortcutMonitor.swift; sourceTree = "<group>"; };
 		27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionStateStore.swift; sourceTree = "<group>"; };
 		2A1B515ECDF21B3616E5A3D1 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		2A9865559C522A64A74DB709 /* NativKitCapabilityInventory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitCapabilityInventory.swift; sourceTree = "<group>"; };
 		2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPrimaryTaskResolverTests.swift; sourceTree = "<group>"; };
 		2CF9F903E2609C4A522C19CF /* ChatConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatConfigurationView.swift; sourceTree = "<group>"; };
 		2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelReadmeTests.swift; sourceTree = "<group>"; };
+		2E6070B0D9BBE92BCB3195FC /* NativKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKit.swift; sourceTree = "<group>"; };
 		30D9C81870FB504D03D2A1D5 /* MCPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPClient.swift; sourceTree = "<group>"; };
 		30E2A903D604A57696674510 /* NativSystemPermissionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSystemPermissionController.swift; sourceTree = "<group>"; };
 		31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolRegistry.swift; sourceTree = "<group>"; };
@@ -482,11 +498,13 @@
 		530CA8743FEBF843F79321A7 /* Parallel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Parallel.png; sourceTree = "<group>"; };
 		530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionStore.swift; sourceTree = "<group>"; };
 		5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDocumentExtractionCache.swift; sourceTree = "<group>"; };
+		54CAE400DE3E453F70CC7152 /* Front.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Front.png; sourceTree = "<group>"; };
 		5682AEE2C7DF8C9A3AFAC3DF /* RealtimeAudioMeter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeAudioMeter.swift; sourceTree = "<group>"; };
 		577B24B3B022E78F7664C76E /* NativNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativNotificationService.swift; sourceTree = "<group>"; };
 		586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionHostBroker.swift; sourceTree = "<group>"; };
 		5919AB4E9488642C73886266 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
 		594711E024396C78703CE05A /* NativSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSettings.swift; sourceTree = "<group>"; };
+		5A8C02FD60255220A8DF3BE7 /* ServerProcessEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessEnvironment.swift; sourceTree = "<group>"; };
 		5AF8F6359E4523814FB0EFDA /* Manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Manifest.json; sourceTree = "<group>"; };
 		5D6BDF659A46F028B6203144 /* DocumentTextExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTextExtraction.swift; sourceTree = "<group>"; };
 		5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NativServerKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -503,7 +521,9 @@
 		6BF298015C5DDB04B72C29A9 /* ControlPanelSidebarRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarRows.swift; sourceTree = "<group>"; };
 		6CDD9C3FE179B2E8D76FC769 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		6D4ED7BDFBC000148E13EA19 /* PowerPointDocumentTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerPointDocumentTextExtractor.swift; sourceTree = "<group>"; };
+		6F3665BF8FE325798A8A6F86 /* NativKitStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitStoreTests.swift; sourceTree = "<group>"; };
 		711EAE65183E78E000DD3253 /* GitHubOAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubOAuthTests.swift; sourceTree = "<group>"; };
+		73B2E989C1BBC9AFB45AE8D6 /* MCPCatalogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPCatalogEntry.swift; sourceTree = "<group>"; };
 		7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceShortcut.swift; sourceTree = "<group>"; };
 		769A36AA0753AB7F4CB1E371 /* ExaBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExaBrowsingProvider.swift; sourceTree = "<group>"; };
 		76F460CC6B734041A8C60AAE /* ControlPanelSidebarModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarModels.swift; sourceTree = "<group>"; };
@@ -544,7 +564,10 @@
 		8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProviderTests.swift; sourceTree = "<group>"; };
 		90012E8ECF43A5A55BFD8787 /* RoutineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineSupport.swift; sourceTree = "<group>"; };
 		908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceCuratedModelLoaderTests.swift; sourceTree = "<group>"; };
+		92D264F083A990A23BACB762 /* NativKitEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitEditor.swift; sourceTree = "<group>"; };
 		9483127E124DE562AFFFAC94 /* ChatAttachmentValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentValidator.swift; sourceTree = "<group>"; };
+		94B25DE635847F5B72CCFC5E /* NativKitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitStore.swift; sourceTree = "<group>"; };
+		955320EDC1FB6B9B8DEFB43B /* icon.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = icon.json; sourceTree = "<group>"; };
 		96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativEmbeddingsClient.swift; sourceTree = "<group>"; };
 		982F3BB563023885587DC860 /* NativNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativNotificationTests.swift; sourceTree = "<group>"; };
 		995095FAF89C9D1DEC4158FB /* Exa.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Exa.png; sourceTree = "<group>"; };
@@ -599,7 +622,6 @@
 		CFA5C785716081D2811DFD2D /* TextShimmerWave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextShimmerWave.swift; sourceTree = "<group>"; };
 		D0952EC469768D8775A2D188 /* VoiceAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioRecorder.swift; sourceTree = "<group>"; };
 		D1651E057CC5D05857CF1595 /* NativServerKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativServerKit.swift; sourceTree = "<group>"; };
-		5A8C02FD662848C7AAE73808 /* ServerProcessEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessEnvironment.swift; sourceTree = "<group>"; };
 		D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputDevicePreferences.swift; sourceTree = "<group>"; };
 		D34FBE730C051EFF28B1323B /* RoutineLaunchAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineLaunchAgent.swift; sourceTree = "<group>"; };
 		D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineEditorView.swift; sourceTree = "<group>"; };
@@ -612,7 +634,6 @@
 		DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToolTests.swift; sourceTree = "<group>"; };
 		DB24BFEFF23914DA8BDB0E1C /* ModelProviderIcons */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ModelProviderIcons; path = Sources/Nativ/ModelProviderIcons; sourceTree = SOURCE_ROOT; };
 		DE575DB2DCD07A1864311714 /* Nativ.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nativ.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionTests.swift; sourceTree = "<group>"; };
 		E295CCB27C6CBD1025E62D11 /* WebSearchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchSettingsView.swift; sourceTree = "<group>"; };
 		E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineStore.swift; sourceTree = "<group>"; };
@@ -623,8 +644,10 @@
 		E5DE947E447EA3D80C8A69CD /* ScheduledTaskNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTaskNotification.swift; sourceTree = "<group>"; };
 		E60FD94BFE0DEFB5A1A21601 /* ChatReadFileTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReadFileTool.swift; sourceTree = "<group>"; };
 		E646A2A68BB20D0CD4933E2A /* DevHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevHubView.swift; sourceTree = "<group>"; };
+		E8500BF58CDA5C392E60DC8C /* NativKitPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitPresentation.swift; sourceTree = "<group>"; };
 		E902D6BB4117C3F240832FA3 /* ToolsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsSectionView.swift; sourceTree = "<group>"; };
 		E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceCache.swift; sourceTree = "<group>"; };
+		EB2E71BB3A1BBE574A64638B /* NativKitCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitCatalog.swift; sourceTree = "<group>"; };
 		EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NativExtensionSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE151F7A36DA21A32ABCFD63 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscovery.swift; sourceTree = "<group>"; };
@@ -635,6 +658,7 @@
 		F553434CA19B929108FF740F /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDocumentContextBuilderTests.swift; sourceTree = "<group>"; };
 		F84C7B764CE1B6F63746E3BB /* Perplexity.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Perplexity.png; sourceTree = "<group>"; };
+		FAE296201A4FF80537A926F9 /* RoutineKitResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineKitResolver.swift; sourceTree = "<group>"; };
 		FB10CC03A96A3EA80EF9343B /* ScheduledCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledCapabilityTests.swift; sourceTree = "<group>"; };
 		FB497800D0F8B237A1891EE1 /* WebBrowsingTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingTransport.swift; sourceTree = "<group>"; };
 		FD296E4B5897E7E46606B697 /* ControlPanelActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelActions.swift; sourceTree = "<group>"; };
@@ -691,6 +715,7 @@
 			children = (
 				06F067B3DB861CF232820136 /* Routine.swift */,
 				D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */,
+				FAE296201A4FF80537A926F9 /* RoutineKitResolver.swift */,
 				D34FBE730C051EFF28B1323B /* RoutineLaunchAgent.swift */,
 				50843C4D4ABCEC290EE626AF /* RoutineRunCoordinator.swift */,
 				9B95090B83C36E4F06C7C5E3 /* RoutineRunner.swift */,
@@ -724,7 +749,6 @@
 			isa = PBXGroup;
 			children = (
 				B0E2EE61C1652C49ECC69658 /* AppDelegate.swift */,
-				DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */,
 				6BB0CD839020E3F5FF4F8DED /* Assets.xcassets */,
 				677360D86DDAFAB194A995E7 /* Main.swift */,
 				DB24BFEFF23914DA8BDB0E1C /* ModelProviderIcons */,
@@ -734,12 +758,22 @@
 				822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */,
 				CFA5C785716081D2811DFD2D /* TextShimmerWave.swift */,
 				EE151F7A36DA21A32ABCFD63 /* WelcomeView.swift */,
+				18FB93E3846EA971A2CFD6B4 /* AppIcon.icon */,
 				A42368BA82350C2FA4CC12DF /* Features */,
 				C40EB30EE457C36AAA9B2427 /* IntegrationLogos */,
 				DD46C324A893EF724704AE92 /* Resources */,
 				10E8764499993A58BE194232 /* Utilities */,
 			);
 			path = Nativ;
+			sourceTree = "<group>";
+		};
+		18FB93E3846EA971A2CFD6B4 /* AppIcon.icon */ = {
+			isa = PBXGroup;
+			children = (
+				955320EDC1FB6B9B8DEFB43B /* icon.json */,
+				83D6BFB7D8EEB8B62FC3662A /* Assets */,
+			);
+			path = AppIcon.icon;
 			sourceTree = "<group>";
 		};
 		1DE309DC3FB91D09768CD66E /* Developer */ = {
@@ -793,7 +827,7 @@
 				96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */,
 				9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */,
 				D1651E057CC5D05857CF1595 /* NativServerKit.swift */,
-				5A8C02FD662848C7AAE73808 /* ServerProcessEnvironment.swift */,
+				5A8C02FD60255220A8DF3BE7 /* ServerProcessEnvironment.swift */,
 			);
 			path = NativServerKit;
 			sourceTree = "<group>";
@@ -953,6 +987,14 @@
 			);
 			sourceTree = "<group>";
 		};
+		83D6BFB7D8EEB8B62FC3662A /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				54CAE400DE3E453F70CC7152 /* Front.png */,
+			);
+			path = Assets;
+			sourceTree = "<group>";
+		};
 		8638AC147EE8B93EFB518172 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -1012,6 +1054,7 @@
 				374FD298864C11262A44F37B /* ImageGeneration */,
 				28D631CB7BF8B65D28E11E43 /* Integrations */,
 				40D3B01A6A8BFAE6E98FDD3C /* IssueReport */,
+				E184C3FEE20F9678A9A025CE /* Kits */,
 				5CE0523415094EB82A398A6A /* MCP */,
 				25C7AD3E2D01EE9231FA30DE /* Menu */,
 				BAC9F35045D83344BC059CB2 /* Models */,
@@ -1086,11 +1129,14 @@
 				C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */,
 				7D5BCE1A4769FE7823B5C79D /* ExtensionsHubView.swift */,
 				3B1B970F41F1B5612B791ABE /* KitsSectionView.swift */,
+				73B2E989C1BBC9AFB45AE8D6 /* MCPCatalogEntry.swift */,
 				86A814B8C04BCBF1C1F869A8 /* MCPSectionView.swift */,
 				586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */,
 				7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */,
 				27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */,
 				AA7F610FC8739BA80227DB26 /* NativKit.swift */,
+				92D264F083A990A23BACB762 /* NativKitEditor.swift */,
+				E8500BF58CDA5C392E60DC8C /* NativKitPresentation.swift */,
 				3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */,
 				CDDB4C89F8DD338E9209E7FF /* NativSkill.swift */,
 				E902D6BB4117C3F240832FA3 /* ToolsSectionView.swift */,
@@ -1124,6 +1170,17 @@
 				4E16AB8790E5F75C078C45F8 /* Browsing */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		E184C3FEE20F9678A9A025CE /* Kits */ = {
+			isa = PBXGroup;
+			children = (
+				2E6070B0D9BBE92BCB3195FC /* NativKit.swift */,
+				2A9865559C522A64A74DB709 /* NativKitCapabilityInventory.swift */,
+				EB2E71BB3A1BBE574A64638B /* NativKitCatalog.swift */,
+				94B25DE635847F5B72CCFC5E /* NativKitStore.swift */,
+			);
+			path = Kits;
 			sourceTree = "<group>";
 		};
 		E28674AAC64268B7E4C9554F /* Providers */ = {
@@ -1201,7 +1258,6 @@
 			isa = PBXGroup;
 			children = (
 				3B965B701714787B0A85AE6B /* AudioTests.swift */,
-				055942EF0A544CE88654E7F6 /* ServerProcessEnvironmentTests.swift */,
 				C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */,
 				B059AF48F10F1B0502DC5E6F /* ChatConversationBranchTests.swift */,
 				F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */,
@@ -1225,6 +1281,7 @@
 				3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */,
 				2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */,
 				E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */,
+				6F3665BF8FE325798A8A6F86 /* NativKitStoreTests.swift */,
 				780A9582305FC184F6C68D12 /* NativKitTests.swift */,
 				982F3BB563023885587DC860 /* NativNotificationTests.swift */,
 				E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */,
@@ -1232,6 +1289,7 @@
 				C01D6D1C8C321F16B5FD31F8 /* RealtimeAudioMeterTests.swift */,
 				FB10CC03A96A3EA80EF9343B /* ScheduledCapabilityTests.swift */,
 				0DBC23C0369758C056A8182D /* ScheduledTaskChatLinkerTests.swift */,
+				055942EFAB585BE493AC9AD7 /* ServerProcessEnvironmentTests.swift */,
 				3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */,
 			);
 			path = NativTests;
@@ -1377,6 +1435,7 @@
 				};
 			};
 			buildConfigurationList = 74C8B3C2A026CAD89583C154 /* Build configuration list for PBXProject "Nativ" */;
+			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -1393,7 +1452,6 @@
 				07F80B12D683EBF42228393D /* XCRemoteSwiftPackageReference "textual" */,
 			);
 			preferredProjectObjectVersion = 77;
-			productRefGroup = ACC7624E3BE7F661C3D130D0 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -1427,11 +1485,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				77B9284EE48D020C2B5A2DF3 /* AppIcon.icon in Resources */,
 				11A14C51AE4E0170FBA89709 /* Assets.xcassets in Resources */,
 				ED703AEACA9A247F6F7D6920 /* Brave.png in Resources */,
 				E77359B5F8F6AF656F2008C6 /* Exa.png in Resources */,
 				99CBBEE3F1E0092E70D172D4 /* Firecrawl.png in Resources */,
+				FB233D129B07C310113E13E1 /* Front.png in Resources */,
 				359208BE69EFF7BF033D4BA6 /* LICENSES.txt in Resources */,
 				402FF67FA99A26739AA4A653 /* MCPCatalog.json in Resources */,
 				0DF842E2BE07D345918F3D54 /* Manifest.json in Resources */,
@@ -1443,6 +1501,7 @@
 				C7697F50D8F4E4628DFEE397 /* Tavily.png in Resources */,
 				4B25C497C3E90EE13474F839 /* UISFXMinimalPlay.mp3 in Resources */,
 				6CFBB2F5B3720F1334BF3D47 /* UISFXMinimalStop.mp3 in Resources */,
+				4B95E0BE6589A1D63E696175 /* icon.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1501,7 +1560,7 @@
 				732D29870D9B330A520DF15C /* NativEmbeddingsClient.swift in Sources */,
 				DC1ED6C1A11081FB70F1F019 /* NativImageClient.swift in Sources */,
 				506A12DCE5B56E53208A8BA2 /* NativServerKit.swift in Sources */,
-				E0A20B5A8E804C60B8CF06A7 /* ServerProcessEnvironment.swift in Sources */,
+				E0A20B5A3FC188AF0B13A943 /* ServerProcessEnvironment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1594,6 +1653,7 @@
 				BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */,
 				1423FD497A75A14770FCA9E1 /* LocalModelDiscovery.swift in Sources */,
 				482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */,
+				685D0C1A9E3B12C90EA3D952 /* MCPCatalogEntry.swift in Sources */,
 				2452C5D7B24CA5FF6FAA36E2 /* MCPHostManager.swift in Sources */,
 				6C872B0124611E3D0297E2FD /* MCPSectionView.swift in Sources */,
 				4572BDBE09CB7D688B8838CA /* MCPServerCatalog.swift in Sources */,
@@ -1607,8 +1667,14 @@
 				39ADE4524CF22ED36D505546 /* NativExtensionHostBroker.swift in Sources */,
 				F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */,
 				2B988CEEF0FD7FCCD3862AF6 /* NativExtensionStateStore.swift in Sources */,
+				F24B4125B306826BDAE77EAC /* NativKit.swift in Sources */,
 				C03E948D1C7E27B27838C4C6 /* NativKit.swift in Sources */,
+				C51BF9D58C083736FDE958A3 /* NativKitCapabilityInventory.swift in Sources */,
+				47E56F0F2F4481FF900174E7 /* NativKitCatalog.swift in Sources */,
+				25D127CA91D6EF7FB3EF6514 /* NativKitEditor.swift in Sources */,
+				4F615D6B17628FC3FCC7199D /* NativKitPresentation.swift in Sources */,
 				690202C6E092ABA0A086955F /* NativKitRuntimeResolver.swift in Sources */,
+				561CF1D4C0CEA99417E18440 /* NativKitStore.swift in Sources */,
 				4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */,
 				751C105813095FEC67349FBB /* NativNotificationService.swift in Sources */,
 				7C9ADF2438B155D639E6A6F2 /* NativPermissionsCard.swift in Sources */,
@@ -1625,6 +1691,7 @@
 				330070AC18DC9F0752EB7138 /* RealtimeAudioMeter.swift in Sources */,
 				1EBCB9482DABA02FD039A795 /* Routine.swift in Sources */,
 				759391363423D786EF850BE3 /* RoutineEditorView.swift in Sources */,
+				F9B09901AC4BC489C613C82D /* RoutineKitResolver.swift in Sources */,
 				98086CE0CF71463BDF07F8A8 /* RoutineLaunchAgent.swift in Sources */,
 				90A91F19C53567C017E37E28 /* RoutineRunCoordinator.swift in Sources */,
 				81CA2499AF2C4701FC0C817B /* RoutineRunner.swift in Sources */,
@@ -1680,7 +1747,6 @@
 				01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */,
 				393DC62E524B83E0216268B8 /* AudioInputLevelMonitor.swift in Sources */,
 				4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */,
-				727CB29E8D7346C29E0DBB3F /* ServerProcessEnvironmentTests.swift in Sources */,
 				B3DE35DF177BB2B7A9D7690B /* BraveBrowsingProvider.swift in Sources */,
 				7ACEF87EDC19CB862FCF8840 /* ChatAttachmentKind.swift in Sources */,
 				6128B35157BF004E8A9E73F0 /* ChatAttachmentValidator.swift in Sources */,
@@ -1737,6 +1803,7 @@
 				4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */,
 				4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */,
 				9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */,
+				C67D78D47124087E636B9B6A /* MCPCatalogEntry.swift in Sources */,
 				0394DEE40DF5A06244F72794 /* MCPClientTests.swift in Sources */,
 				3583BC09DCAFC37BBB94749D /* MCPHostManager.swift in Sources */,
 				2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */,
@@ -1751,7 +1818,11 @@
 				ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */,
 				0E326825AE5A1A5EEA33D928 /* NativExtensionTests.swift in Sources */,
 				D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */,
+				D0F22E819F25291E43F4230C /* NativKit.swift in Sources */,
+				906F2F48A734DEEDCA2BD633 /* NativKitCatalog.swift in Sources */,
 				06C8B891576DC3051282D367 /* NativKitRuntimeResolver.swift in Sources */,
+				FC9227079769F8BCDD7F3757 /* NativKitStore.swift in Sources */,
+				AF1502F763FAF5EA1839CC4D /* NativKitStoreTests.swift in Sources */,
 				4B3B371072FF015C6CA2CA61 /* NativKitTests.swift in Sources */,
 				025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */,
 				C98474155E01AF49957443C9 /* NativNotificationService.swift in Sources */,
@@ -1776,6 +1847,7 @@
 				DE62F002578F2CB0176F5ECE /* ScheduledTaskChatLinker.swift in Sources */,
 				FF3A7CB3645D73897EE7535A /* ScheduledTaskChatLinkerTests.swift in Sources */,
 				7C67A70A0028625EA2BAA47E /* ScheduledTaskNotification.swift in Sources */,
+				727CB29E8AF1A50C063FD972 /* ServerProcessEnvironmentTests.swift in Sources */,
 				BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */,
 				36405D7EB30E430CF06956EB /* ShellEnvironmentTests.swift in Sources */,
 				293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */,

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import NativServerKit
 import SwiftUI
 import UserNotifications
@@ -15,6 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
     private let runtime = SystemRuntimeMonitor()
     private let routineStore = RoutineStore.shared
     private let routineSessionStore = ChatSessionStore()
+    private let kitStore = NativKitStore.shared
     private lazy var routineRunner = RoutineRunner(
         model: model,
         store: routineStore,
@@ -41,6 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
     private var didFinishDownloadShutdown = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        kitStore.migrateLegacySettings(mcpServers: model.settings.mcpServers)
         runtime.onUpdate = { [weak self] in
             self?.updateStatusItemButton()
         }
@@ -123,6 +126,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
     func applicationWillTerminate(_ notification: Notification) {
         statusMenuController.stop()
         extensionManager.shutdown()
+        mcpHost.shutdown()
         runtime.onUpdate = nil
         systemMenuBarPreferences.onChange = nil
         runtime.stop()
@@ -135,6 +139,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
             navigation: controlPanelNavigation,
             runtime: runtime,
             extensionManager: extensionManager,
+            mcpHost: mcpHost,
+            kitStore: kitStore,
             softwareUpdater: softwareUpdater,
             onComplete: { [weak self] modelID, serverAPIKey in
                 self?.completeWelcome(modelID: modelID, serverAPIKey: serverAPIKey)

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -98,6 +98,8 @@ struct ChatComposer: View {
     @ObservedObject var viewModel: ChatViewModel
     @ObservedObject var extensionManager: NativExtensionManager
     @Environment(\.openExtensionsHubSection) private var openExtensionsHubSection
+    @ObservedObject var kitStore: NativKitStore
+    @ObservedObject var mcpHost: MCPHostManager
     @StateObject private var localLibrary = LocalModelLibrary()
     let unavailableReason: String?
     let canCompose: Bool
@@ -222,6 +224,17 @@ struct ChatComposer: View {
                     ChatWorkspacePicker(
                         selection: workspaceMode,
                         onSelect: onSelectWorkspaceMode
+                    )
+
+                    ChatKitPicker(
+                        kits: kitStore.allKits,
+                        selectedKitID: viewModel.currentKitID,
+                        inventory: NativKitCapabilityInventory(
+                            settings: model.settings,
+                            host: mcpHost
+                        ),
+                        isDisabled: viewModel.hasPendingRequests,
+                        onSelect: viewModel.selectKit
                     )
 
                     Spacer(minLength: 12)
@@ -802,6 +815,66 @@ struct ChatComposer: View {
 
     private var editorHeight: CGFloat {
         min(max(editorContentHeight, editorMinimumHeight), editorMaximumHeight)
+    }
+}
+
+private struct ChatKitPicker: View {
+    let kits: [CustomNativKit]
+    let selectedKitID: String?
+    let inventory: NativKitCapabilityInventory
+    let isDisabled: Bool
+    let onSelect: (String?) -> Void
+
+    private var selectedKit: CustomNativKit? {
+        selectedKitID.flatMap { id in kits.first { $0.id == id } }
+    }
+
+    var body: some View {
+        Menu {
+            Button {
+                onSelect(nil)
+            } label: {
+                menuLabel("No Kit", selected: selectedKitID == nil)
+            }
+
+            if !kits.isEmpty {
+                Divider()
+                ForEach(kits) { kit in
+                    Button {
+                        onSelect(kit.id)
+                    } label: {
+                        menuLabel(kit.name, selected: kit.id == selectedKitID)
+                    }
+                    .help(inventory.evaluation(of: kit).summary ?? kit.inventory)
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: selectedKit?.symbol ?? "shippingbox")
+                Text(selectedKit?.name ?? "Kit")
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .font(.system(size: 11, weight: .medium))
+            .padding(.horizontal, 9)
+            .frame(height: 28)
+            .background(Color.primary.opacity(0.055), in: Capsule())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .disabled(isDisabled)
+        .help(isDisabled ? "Kit selection is unavailable while requests are active" : "Choose a Kit")
+    }
+
+    private func menuLabel(_ title: String, selected: Bool) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            if selected { Image(systemName: "checkmark") }
+        }
     }
 }
 

--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -23,6 +23,7 @@ struct ChatSession: Identifiable, Equatable, Codable {
     var folderID: UUID?
     var imageGenerationModelID: String?
     var scheduledTaskID: String?
+    var kitID: String?
 
     var summary: ChatSessionSummary {
         ChatSessionSummary(

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -75,6 +75,13 @@ enum ChatNativeToolConfiguration: Equatable {
             "doc.text"
         }
     }
+
+    var isReady: Bool {
+        switch self {
+        case .webSearch:
+            ChatWebSearchToolRegistry.isConfigured()
+        }
+    }
 }
 
 struct ChatNativeToolDescriptor {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -11,6 +11,7 @@ struct ChatView: View {
     let chat: ChatViewModel
     @ObservedObject var mcpHost: MCPHostManager
     @ObservedObject var extensionManager: NativExtensionManager
+    @ObservedObject var kitStore: NativKitStore
     let workspaceMode: ChatWorkspaceMode
     let onSelectWorkspaceMode: (ChatWorkspaceMode) -> Void
     @Binding var showsConfiguration: Bool
@@ -27,6 +28,8 @@ struct ChatView: View {
                 model: model,
                 chat: chat,
                 extensionManager: extensionManager,
+                mcpHost: mcpHost,
+                kitStore: kitStore,
                 workspaceMode: workspaceMode,
                 onSelectWorkspaceMode: onSelectWorkspaceMode,
                 onExploreImageModels: onExploreImageModels,
@@ -55,6 +58,7 @@ struct ChatView: View {
         }
         .onAppear {
             chat.mcpHost = mcpHost
+            chat.kitStore = kitStore
             mcpHost.reload(servers: model.settings.mcpServers)
             chat.refreshPendingImageModelSelections()
         }
@@ -108,6 +112,8 @@ private struct ChatTranscriptView: View {
     var model: NativModel
     @ObservedObject var chat: ChatViewModel
     @ObservedObject var extensionManager: NativExtensionManager
+    @ObservedObject var mcpHost: MCPHostManager
+    @ObservedObject var kitStore: NativKitStore
     let workspaceMode: ChatWorkspaceMode
     let onSelectWorkspaceMode: (ChatWorkspaceMode) -> Void
     let onExploreImageModels: (ChatImageOperation) -> Void
@@ -195,6 +201,8 @@ private struct ChatTranscriptView: View {
                     model: model,
                     chat: chat,
                     extensionManager: extensionManager,
+                    mcpHost: mcpHost,
+                    kitStore: kitStore,
                     workspaceMode: workspaceMode,
                     onSelectWorkspaceMode: onSelectWorkspaceMode,
                     onHeightChange: { height in
@@ -307,6 +315,8 @@ private struct ChatComposerContainer: View {
     var model: NativModel
     @ObservedObject var chat: ChatViewModel
     @ObservedObject var extensionManager: NativExtensionManager
+    @ObservedObject var mcpHost: MCPHostManager
+    @ObservedObject var kitStore: NativKitStore
     let workspaceMode: ChatWorkspaceMode
     let onSelectWorkspaceMode: (ChatWorkspaceMode) -> Void
     let onHeightChange: (CGFloat) -> Void
@@ -316,19 +326,33 @@ private struct ChatComposerContainer: View {
         model.settings.normalized().languageModelID
     }
 
+    private var kitUnavailableReason: String? {
+        guard let kitID = chat.currentKitID else { return nil }
+        guard let kit = kitStore.kit(id: kitID) else {
+            return "The selected Kit is no longer available."
+        }
+        return NativKitCapabilityInventory(settings: model.settings, host: mcpHost)
+            .evaluation(of: kit)
+            .summary
+    }
+
     var body: some View {
         ChatComposer(
             model: model,
             viewModel: chat,
             extensionManager: extensionManager,
+            kitStore: kitStore,
+            mcpHost: mcpHost,
             unavailableReason: model.modelLoadingStatusText
                 ?? chat.unavailableReason(isRunning: model.isRunning, selectedModelID: selectedModelID)
+                ?? kitUnavailableReason
                 ?? model.settings.structuredOutputValidationError,
             canCompose: (model.isRunning || model.isModelLoading)
                 && selectedModelID?.isEmpty == false
                 && model.settings.structuredOutputValidationError == nil,
             canSend: !model.isModelLoading
                 && model.settings.structuredOutputValidationError == nil
+                && kitUnavailableReason == nil
                 && chat.canSend(isRunning: model.isRunning, selectedModelID: selectedModelID),
             workspaceMode: workspaceMode,
             onSelectWorkspaceMode: onSelectWorkspaceMode,
@@ -1779,6 +1803,7 @@ private struct ChatEmptyTranscriptView: View {
         chat: ChatViewModel(),
         mcpHost: MCPHostManager(),
         extensionManager: NativExtensionManager(builtInExtensions: []),
+        kitStore: .init(),
         workspaceMode: .chat,
         onSelectWorkspaceMode: { _ in },
         showsConfiguration: .constant(true),

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -23,6 +23,7 @@ private struct ChatSessionBootstrap {
 final class ChatViewModel: ObservableObject {
     /// MCP tool host, set by ChatView. Provides MCP tool definitions + execution.
     weak var mcpHost: MCPHostManager?
+    weak var kitStore: NativKitStore?
     private static let liveDecodeRateRefreshInterval: TimeInterval = 0.25
     private static let streamFlushInterval: TimeInterval = 1.0 / 15.0
 
@@ -33,6 +34,7 @@ final class ChatViewModel: ObservableObject {
         let assistantMessageID: UUID
         let settings: NativSettings
         let imageGenerationModelID: String?
+        let kitID: String?
         let languageModelSupportsTools: Bool
         let languageModelSupportsVision: Bool
     }
@@ -56,6 +58,7 @@ final class ChatViewModel: ObservableObject {
     @Published private(set) var sessions: [ChatSessionSummary] = []
     @Published private(set) var folders: [ChatFolder] = []
     @Published private(set) var currentSessionID: UUID?
+    @Published private(set) var currentKitID: String?
     @Published private(set) var messages: [ChatTranscriptMessage] = []
     @Published private(set) var pendingImageAttachments: [ChatImageAttachment] = [] {
         didSet {
@@ -150,6 +153,13 @@ final class ChatViewModel: ObservableObject {
 
     var hasPendingRequests: Bool {
         activeRequestSessionID != nil || !requestQueue.isEmpty
+    }
+
+    func selectKit(_ id: String?) {
+        guard !hasPendingRequests else { return }
+        currentKitID = id
+        currentSession?.kitID = id
+        persistCurrentSession(updateTimestamp: false)
     }
 
     var visibleMessages: [ChatTranscriptMessage] {
@@ -730,6 +740,7 @@ final class ChatViewModel: ObservableObject {
             settings: settings,
             imageGenerationModelID: imageGenerationModelID(for: sessionID)
                 ?? settings.imageGenerationModelID,
+            kitID: currentSession?.kitID,
             languageModelSupportsTools: languageModelSupportsTools,
             languageModelSupportsVision: languageModelSupportsVision
         ))
@@ -1199,6 +1210,7 @@ final class ChatViewModel: ObservableObject {
         var activeSettings = queuedRequest.settings
         var activeImageModelID = queuedRequest.imageGenerationModelID
         let fileReadTracker = ChatReadFileTracker()
+        let kitPlan = try kitExecutionPlan(for: queuedRequest)
 
         guard let initialMessages = sessionMessages(for: queuedRequest.sessionID),
               let initialAssistantIndex = initialMessages.firstIndex(where: {
@@ -1243,7 +1255,8 @@ final class ChatViewModel: ObservableObject {
                 before: assistantMessageID,
                 advertisesTools: advertisesTools,
                 settings: activeSettings,
-                documentContexts: documentContext.result.contexts
+                documentContexts: documentContext.result.contexts,
+                kitPlan: kitPlan
             ) else {
                 throw NativChatError.invalidResponse
             }
@@ -1296,8 +1309,23 @@ final class ChatViewModel: ObservableObject {
                 }
                 insertionAnchor = toolMessageID
 
+                if let kitPlan,
+                   let toolName = toolCall.function?.name,
+                   !kitPlan.allowedToolNames.contains(toolName) {
+                    throw NativKitExecutionError.notReady(
+                        kitPlan.kit.name,
+                        [NativKitIssue(
+                            componentID: "tool:\(toolName)",
+                            componentName: toolName,
+                            capability: nil,
+                            reason: .componentRemoved
+                        )]
+                    )
+                }
+
                 let customTool = toolCall.function?.name.flatMap { toolName in
-                    queuedRequest.settings.customTools.first { $0.toolName == toolName }
+                    kitPlan?.customToolsByName[toolName]
+                        ?? queuedRequest.settings.customTools.first { $0.toolName == toolName }
                 }
                 if customTool?.kind == .script {
                     updateToolMessage(
@@ -1484,7 +1512,8 @@ final class ChatViewModel: ObservableObject {
                         outcome = ChatToolExecutionOutcome(content: result, attachments: [])
                     } else if let host = mcpHost,
                               let toolName = toolCall.function?.name,
-                              host.handlesTool(named: toolName) {
+                              (kitPlan?.mcpToolsByName[toolName] != nil
+                                || (kitPlan == nil && host.handlesTool(named: toolName))) {
                         let result = try await host.callTool(named: toolName, argumentsJSON: toolCall.function?.arguments)
                         outcome = ChatToolExecutionOutcome(content: result, attachments: [])
                     } else {
@@ -1634,7 +1663,8 @@ final class ChatViewModel: ObservableObject {
         before assistantMessageID: UUID,
         advertisesTools: Bool,
         settings: NativSettings,
-        documentContexts: [UUID: String]
+        documentContexts: [UUID: String],
+        kitPlan: NativKitExecutionPlan?
     ) -> MLXChatCompletionRequest? {
         guard let modelID = settings.languageModelID,
               let sessionMessages = sessionMessages(for: queuedRequest.sessionID),
@@ -1652,14 +1682,16 @@ final class ChatViewModel: ObservableObject {
         }
 
         let advertisesToolsForModel = advertisesTools && queuedRequest.languageModelSupportsTools
-        var toolDefinitions: [MLXChatToolDefinition] = advertisesToolsForModel
-            ? ChatToolRegistry.definitions(
+        var toolDefinitions: [MLXChatToolDefinition] = if advertisesToolsForModel {
+            kitPlan?.toolDefinitions ?? ChatToolRegistry.definitions(
                 canEditImage: precedingMessages.contains { message in
                     message.imageAttachments.contains { $0.chatAttachmentKind == .image }
                 }
             )
-            : []
-        if advertisesToolsForModel {
+        } else {
+            []
+        }
+        if advertisesToolsForModel, kitPlan == nil {
             toolDefinitions += settings.customTools.compactMap { try? $0.definition() }
             toolDefinitions += mcpHost?.toolDefinitions() ?? []
             let webSearchIsConfigured = ChatWebSearchToolRegistry.isConfigured()
@@ -1687,7 +1719,8 @@ final class ChatViewModel: ObservableObject {
         if !toolDefinitions.isEmpty {
             systemParts.append(NativSkill.builtInToolGuide.instructions)
         }
-        for skill in settings.skills where skill.isEnabled && !skill.instructions.isEmpty {
+        let skills = kitPlan?.skills ?? settings.skills.filter(\.isEnabled)
+        for skill in skills where !skill.instructions.isEmpty {
             systemParts.append(skill.instructions)
         }
         if !systemParts.isEmpty {
@@ -1718,6 +1751,27 @@ final class ChatViewModel: ObservableObject {
             toolChoice: tools == nil ? nil : "auto",
             stream: true
         )
+    }
+
+    private func kitExecutionPlan(
+        for queuedRequest: QueuedChatRequest
+    ) throws -> NativKitExecutionPlan? {
+        guard let kitID = queuedRequest.kitID else { return nil }
+        guard let kitStore, let mcpHost,
+              let kit = kitStore.kit(id: kitID)
+        else {
+            throw NativKitExecutionError.removed
+        }
+        let canEditImage = sessionMessages(for: queuedRequest.sessionID)?
+            .contains { !$0.imageAttachments.isEmpty } == true
+        let plan = NativKitCapabilityInventory(
+            settings: queuedRequest.settings,
+            host: mcpHost
+        ).plan(for: kit, context: .chat, canEditImage: canEditImage)
+        guard plan.isReady else {
+            throw NativKitExecutionError.notReady(kit.name, plan.issues)
+        }
+        return plan
     }
 
     private func insertAssistantMessage(for queuedRequest: QueuedChatRequest) -> Bool {
@@ -2187,6 +2241,7 @@ final class ChatViewModel: ObservableObject {
     private func applyCurrentSession(_ session: ChatSession) {
         currentSession = session
         currentSessionID = session.id
+        currentKitID = session.kitID
         messages = ChatSessionLoadPolicy.shouldNormalizeOnApply(
             sessionID: session.id,
             activeRequestSessionID: activeRequestSessionID
@@ -2253,6 +2308,7 @@ final class ChatViewModel: ObservableObject {
         }
 
         session.messages = messages
+        session.kitID = currentKitID
         session.title = ChatSession.defaultTitle(for: messages, createdAt: session.createdAt)
         if updateTimestamp {
             session.updatedAt = Date()

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -9,6 +9,7 @@ struct ExtensionsHubView: View {
     var model: NativModel
     @Binding var section: HubSection
     @State private var didLaunch = false
+    @ObservedObject private var kitStore = NativKitStore.shared
 
     enum HubSection: String, CaseIterable, Identifiable {
         case kits = "Kits"
@@ -84,7 +85,12 @@ struct ExtensionsHubView: View {
     private var detail: some View {
         switch section {
         case .kits:
-            KitsSectionView(manager: manager, model: model)
+            KitsSectionView(
+                host: host,
+                model: model,
+                store: kitStore,
+                onOpenCapability: openCapability
+            )
         case .extensions:
             ExtensionsSectionView(manager: manager)
         case .mcp:
@@ -93,6 +99,17 @@ struct ExtensionsHubView: View {
             ToolsSectionView(host: host, model: model)
         case .skills:
             SkillsSectionView(model: model)
+        }
+    }
+
+    private func openCapability(_ capability: NativKitCapabilityReference) {
+        switch capability {
+        case .mcp:
+            section = .mcp
+        case .mcpTool, .nativeTool, .customTool:
+            section = .tools
+        case .skill:
+            section = .skills
         }
     }
 }

--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -1,385 +1,225 @@
-import NativExtensionSDK
 import NativServerKit
 import SwiftUI
 
-private struct KitStateIcon: View {
-    let state: NativKitState
-
-    var body: some View {
-        Image(systemName: symbol)
-            .font(.caption.weight(.semibold))
-            .foregroundStyle(color)
-            .accessibilityLabel("Kit status: \(title)")
-            .help(title)
-    }
-
-    private var title: String {
-        switch state {
-        case .off: "Not enabled"
-        case .partial: "Partially enabled"
-        case .enabled: "Enabled"
-        }
-    }
-
-    private var symbol: String {
-        switch state {
-        case .off: "circle"
-        case .partial: "circle.lefthalf.filled"
-        case .enabled: "circle.fill"
-        }
-    }
-
-    private var color: Color {
-        switch state {
-        case .off: .secondary
-        case .partial: .orange
-        case .enabled: .green
-        }
-    }
-}
-
 struct KitsSectionView: View {
-    @ObservedObject var manager: NativExtensionManager
-    var model: NativModel
-    @State private var openKit: NativKit?
+    @ObservedObject var host: MCPHostManager
+    @ObservedObject var model: NativModel
+    @ObservedObject var store: NativKitStore
+    let onOpenCapability: (NativKitCapabilityReference) -> Void
 
-    private static let columns = [GridItem(.adaptive(minimum: 260, maximum: 360), spacing: 14)]
+    @State private var editingKit: CustomNativKit?
+    @State private var deletingKit: CustomNativKit?
+    @State private var capabilityPendingNavigation: NativKitCapabilityReference?
+
+    private let columns = [GridItem(.adaptive(minimum: 260, maximum: 340), spacing: 14)]
 
     var body: some View {
         HubSectionScaffold(
             title: "Kits",
-            subtitle: "Ready-made setups. Enable one to turn on the MCP servers, skills, and extensions for a way of working — then manage any piece on its own."
+            subtitle: "Bundle MCPs, tools, and skills for chat or routines."
         ) {
-            EmptyView()
+            Button(action: createKit) {
+                Label("Create Kit", systemImage: "plus")
+            }
         } content: {
-            LazyVGrid(columns: Self.columns, alignment: .leading, spacing: 14) {
-                ForEach(NativKitCatalog.bundled.kits) { kit in
-                    kitCard(for: kit)
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
+                ForEach(store.allKits) { kit in
+                    KitCard(
+                        kit: kit,
+                        evaluation: inventory.evaluation(of: kit),
+                        onSetEnabled: { store.setEnabled($0, id: kit.id) },
+                        onManage: { editingKit = kit },
+                        onOpenCapability: onOpenCapability,
+                        onDelete: kit.isBuiltIn ? nil : { deletingKit = kit }
+                    )
                 }
             }
         }
-        .sheet(item: $openKit) { kit in
-            KitDetailView(kit: kit, manager: manager, model: model)
+        .sheet(item: $editingKit, onDismiss: openPendingCapability) { kit in
+            NativKitEditor(
+                kit: kit,
+                host: host,
+                model: model,
+                onSave: {
+                    store.save($0)
+                    editingKit = nil
+                },
+                onCancel: { editingKit = nil },
+                onOpenCapability: { capability in
+                    capabilityPendingNavigation = capability
+                    editingKit = nil
+                },
+                onReset: kit.isBuiltIn ? {
+                    store.resetBuiltIn(id: kit.id)
+                    editingKit = nil
+                } : nil
+            )
+        }
+        .alert(
+            "Delete Kit?",
+            isPresented: Binding(
+                get: { deletingKit != nil },
+                set: { if !$0 { deletingKit = nil } }
+            ),
+            presenting: deletingKit
+        ) { kit in
+            Button("Delete", role: .destructive) {
+                if let id = UUID(uuidString: kit.id) {
+                    store.deleteUserKit(id: id)
+                }
+                deletingKit = nil
+            }
+            Button("Cancel", role: .cancel) { deletingKit = nil }
+        } message: { _ in
+            Text("The Kit will be removed. Its MCPs, tools, and skills will not be changed.")
         }
     }
 
-    private func kitCard(for kit: NativKit) -> some View {
-        let snapshot = NativKitActivation.snapshot(
-            of: kit,
-            model: model,
-            extensionName: extensionName,
-            isExtensionEnabled: manager.isEnabled(extensionID:)
-        )
-        return KitCard(
-            kit: kit,
-            snapshot: snapshot,
-            onOpen: { openKit = kit },
-            onEnable: { enableMissing(in: kit) }
-        )
+    private var inventory: NativKitCapabilityInventory {
+        NativKitCapabilityInventory(settings: model.settings, host: host)
     }
 
-    private func extensionName(_ id: String) -> String {
-        manager.records.first { $0.id == id }?.manifest.displayName ?? id
+    private func createKit() {
+        editingKit = UserNativKit(
+            name: "New Kit",
+            summary: "",
+            contents: NativKitContents()
+        ).resolved()
     }
 
-    private func enableMissing(in kit: NativKit) {
-        NativKitActivation.enableMissing(
-            in: kit,
-            model: model,
-            isExtensionEnabled: manager.isEnabled(extensionID:),
-            enableExtension: { manager.setEnabled(true, extensionID: $0) }
-        )
+    private func openPendingCapability() {
+        guard let capability = capabilityPendingNavigation else { return }
+        capabilityPendingNavigation = nil
+        onOpenCapability(capability)
     }
 }
 
 private struct KitCard: View {
-    let kit: NativKit
-    let snapshot: NativKitActivationSnapshot
-    let onOpen: () -> Void
-    let onEnable: () -> Void
+    let kit: CustomNativKit
+    let evaluation: NativKitEvaluation
+    let onSetEnabled: (Bool) -> Void
+    let onManage: () -> Void
+    let onOpenCapability: (NativKitCapabilityReference) -> Void
+    let onDelete: (() -> Void)?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 6) {
-                NativTintedIconTile(symbol: kit.symbol, tint: .nativTint(kit.tintName))
-                    .accessibilityHidden(true)
-                Spacer(minLength: 0)
-                NativStatusBadge(text: "Built-in")
-                    .help("Ships with Nativ")
-                KitStateIcon(state: snapshot.state)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                NativTintedIconTile(symbol: kit.symbol, tint: kit.tint, size: 34)
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 7) {
+                        Text(kit.name)
+                            .font(.system(size: 15, weight: .semibold))
+                            .lineLimit(1)
+                        if kit.isBuiltIn {
+                            Text("Built-in")
+                                .font(.system(size: 9, weight: .medium))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Text(kit.summary.isEmpty ? "A custom capability bundle." : kit.summary)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 6)
+                Toggle("", isOn: Binding(
+                    get: { kit.isEnabled },
+                    set: onSetEnabled
+                ))
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .labelsHidden()
+                .help(kit.isEnabled ? "Turn off this Kit" : "Turn on this Kit")
             }
-            VStack(alignment: .leading, spacing: 3) {
-                Text(kit.name)
-                    .font(.headline)
-                Text(kit.summary)
-                    .font(.subheadline)
+
+            HStack(spacing: 7) {
+                readinessControl
+                if !kit.inventory.isEmpty {
+                    Text(kit.inventory)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            if kit.isEnabled, let summary = evaluation.summary {
+                Text(summary)
+                    .font(.system(size: 10))
                     .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(2)
             }
-            Text(capabilitiesText)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 8) {
-                    actions
-                }
-                .fixedSize(horizontal: true, vertical: false)
-                VStack(alignment: .leading, spacing: 8) {
-                    actions
+
+            HStack {
+                Button("Manage", action: onManage)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+                Spacer()
+                if let onDelete {
+                    Button(role: .destructive, action: onDelete) {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .help("Delete Kit")
                 }
             }
-            .controlSize(.regular)
+            .font(.system(size: 11, weight: .medium))
         }
         .padding(14)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             Color(nsColor: .controlBackgroundColor),
-            in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+            in: RoundedRectangle(cornerRadius: 11, style: .continuous)
         )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
+        .overlay {
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        )
-        .accessibilityElement(children: .contain)
-    }
-
-    private var capabilitiesText: String {
-        if snapshot.state == .partial {
-            "Needs: \(snapshot.inactivePartNames.joined(separator: " · "))"
-        } else {
-            "Includes: \(kit.capabilityNames(in: .bundled).joined(separator: " · "))"
         }
     }
 
     @ViewBuilder
-    private var actions: some View {
-        if snapshot.state != .enabled {
-            Button(snapshot.state == .partial ? "Enable All" : "Enable", action: onEnable)
-                .buttonStyle(.borderedProminent)
-        }
-        Button(snapshot.state == .off ? "Details" : "Manage", action: onOpen)
-            .buttonStyle(.bordered)
-    }
-}
-
-private struct KitDetailView: View {
-    let kit: NativKit
-    @ObservedObject var manager: NativExtensionManager
-    var model: NativModel
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            header
-            Divider()
-            ScrollView {
-                VStack(alignment: .leading, spacing: 22) {
-                    mcpGroup
-                    if !kit.skills.isEmpty { skillsGroup }
-                    if !kit.extensionIDs.isEmpty { extensionsGroup }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(20)
-            }
-            .scrollBounceBehavior(.basedOnSize)
-        }
-        .presentationSizing(.fitted)
-        .frame(
-            minWidth: 600,
-            idealWidth: 680,
-            maxWidth: 920,
-            minHeight: 480,
-            idealHeight: 620,
-            maxHeight: 800
-        )
-    }
-
-    private var header: some View {
-        let snapshot = NativKitActivation.snapshot(
-            of: kit,
-            model: model,
-            extensionName: extensionName,
-            isExtensionEnabled: manager.isEnabled(extensionID:)
-        )
-        return HStack(alignment: .top, spacing: 12) {
-            NativTintedIconTile(symbol: kit.symbol, tint: .nativTint(kit.tintName), size: 40)
-                .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 8) {
-                    Text(kit.name)
-                        .font(.title3.weight(.semibold))
-                    KitStateIcon(state: snapshot.state)
-                }
-                Text(kit.summary)
-                    .font(.body)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                if snapshot.state != .enabled {
-                    Button("Enable All") {
-                        NativKitActivation.enableMissing(
-                            in: kit,
-                            model: model,
-                            isExtensionEnabled: manager.isEnabled(extensionID:),
-                            enableExtension: { manager.setEnabled(true, extensionID: $0) }
-                        )
+    private var readinessControl: some View {
+        if !kit.isEnabled {
+            NativStatusBadge(text: "Off")
+        } else {
+            switch evaluation.availability {
+            case .ready:
+                EmptyView()
+            case .needsSetup:
+                if let issue = evaluation.issues.first,
+                   let capability = issue.capability,
+                   let title = setupTitle(for: issue) {
+                    Button {
+                        onOpenCapability(capability)
+                    } label: {
+                        Label(title, systemImage: "arrow.up.right")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(.orange)
+                            .lineLimit(1)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.regular)
-                    .padding(.top, 4)
+                    .buttonStyle(.plain)
+                    .help(issue.message)
+                } else if let issue = evaluation.issues.first,
+                          case .connecting = issue.reason {
+                    NativStatusBadge(text: "Connecting", tone: .warning)
+                } else {
+                    NativStatusBadge(text: "Needs setup", tone: .warning)
                 }
-            }
-            Spacer(minLength: 12)
-            NativHoverCloseButton { dismiss() }
-        }
-        .padding(20)
-    }
-
-    // MARK: Groups
-
-    private var mcpGroup: some View {
-        KitGroup(title: "MCP servers & tools", caption: "Their tools become available in chat and appear under Tools.") {
-            ForEach(kit.mcpEntries(in: .bundled)) { entry in
-                KitPartRow(
-                    symbol: entry.symbol,
-                    tint: .nativTint(entry.tintName),
-                    logoAssetName: entry.logoAssetName,
-                    title: entry.name,
-                    subtitle: entry.summary,
-                    isOn: mcpBinding(entry)
-                )
+            case .unavailable:
+                NativStatusBadge(text: "Unavailable", tone: .warning)
             }
         }
     }
 
-    private var skillsGroup: some View {
-        KitGroup(title: "Skills", caption: "Guidance added to the model when tools are available.") {
-            ForEach(kit.skills) { skill in
-                KitPartRow(
-                    symbol: "sparkles",
-                    tint: .nativTint(kit.tintName),
-                    logoAssetName: nil,
-                    title: skill.name,
-                    subtitle: nil,
-                    isOn: skillBinding(skill)
-                )
-            }
+    private func setupTitle(for issue: NativKitIssue) -> String? {
+        switch issue.reason {
+        case .globallyOff:
+            "Turn on \(issue.componentName)"
+        case .needsConfiguration, .connectionFailed:
+            "Set up \(issue.componentName)"
+        default:
+            nil
         }
-    }
-
-    private var extensionsGroup: some View {
-        KitGroup(title: "Extensions", caption: nil) {
-            ForEach(kit.extensionIDs, id: \.self) { extensionID in
-                KitPartRow(
-                    symbol: "puzzlepiece.extension",
-                    tint: .nativTint(kit.tintName),
-                    logoAssetName: nil,
-                    title: extensionName(extensionID),
-                    subtitle: nil,
-                    isOn: extensionBinding(extensionID)
-                )
-            }
-        }
-    }
-
-    // MARK: Bindings
-
-    private func mcpBinding(_ entry: MCPCatalogEntry) -> Binding<Bool> {
-        let catalog = MCPServerCatalog.bundled
-        return Binding(
-            get: { catalog.isEnabled(entry, in: model.settings.mcpServers) },
-            set: { newValue in
-                var servers = model.settings.mcpServers
-                catalog.setEnabled(newValue, for: entry, in: &servers)
-                model.settings.mcpServers = servers
-            }
-        )
-    }
-
-    private func skillBinding(_ skill: NativSkill) -> Binding<Bool> {
-        Binding(
-            get: { model.settings.skills.first { $0.id == skill.id }?.isEnabled ?? false },
-            set: { newValue in
-                if let index = model.settings.skills.firstIndex(where: { $0.id == skill.id }) {
-                    model.settings.skills[index].isEnabled = newValue
-                } else if newValue {
-                    var enabled = skill
-                    enabled.isEnabled = true
-                    model.settings.skills.append(enabled)
-                }
-            }
-        )
-    }
-
-    private func extensionBinding(_ extensionID: String) -> Binding<Bool> {
-        Binding(
-            get: { manager.isEnabled(extensionID: extensionID) },
-            set: { manager.setEnabled($0, extensionID: extensionID) }
-        )
-    }
-
-    private func extensionName(_ extensionID: String) -> String {
-        manager.records.first { $0.id == extensionID }?.manifest.displayName ?? extensionID
-    }
-}
-
-private struct KitGroup<Content: View>: View {
-    let title: String
-    let caption: String?
-    @ViewBuilder var content: () -> Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.headline)
-                if let caption {
-                    Text(caption)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            VStack(spacing: 0) {
-                content()
-            }
-        }
-    }
-}
-
-private struct KitPartRow: View {
-    let symbol: String
-    let tint: Color
-    let logoAssetName: String?
-    let title: String
-    let subtitle: String?
-    @Binding var isOn: Bool
-
-    var body: some View {
-        Toggle(isOn: $isOn) {
-            HStack(spacing: 10) {
-                NativTintedIconTile(
-                    symbol: symbol,
-                    tint: tint,
-                    logoAssetName: logoAssetName,
-                    size: 30
-                )
-                .accessibilityHidden(true)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(title)
-                        .font(.body.weight(.medium))
-                    if let subtitle {
-                        Text(subtitle)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                Spacer(minLength: 12)
-            }
-        }
-        .toggleStyle(.switch)
-        .controlSize(.regular)
-        .padding(.vertical, 8)
     }
 }

--- a/Sources/Nativ/Features/Extensions/MCPCatalogEntry.swift
+++ b/Sources/Nativ/Features/Extensions/MCPCatalogEntry.swift
@@ -1,0 +1,58 @@
+import Foundation
+import NativServerKit
+
+struct MCPCatalogEntry: Identifiable, Decodable, Sendable {
+    let id: String
+    let name: String
+    let summary: String
+    let command: String
+    let arguments: [String]
+    let symbol: String
+    let tintName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, summary, command
+        case arguments = "args"
+        case symbol, tint
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        summary = try container.decode(String.self, forKey: .summary)
+        command = try container.decode(String.self, forKey: .command)
+        arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
+        symbol = try container.decodeIfPresent(String.self, forKey: .symbol) ?? "server.rack"
+        tintName = try container.decodeIfPresent(String.self, forKey: .tint) ?? "accent"
+    }
+
+    func makeConfig() -> MCPServerConfig {
+        MCPServerConfig(
+            name: name,
+            command: command,
+            arguments: arguments,
+            isEnabled: true,
+            catalogID: id
+        )
+    }
+
+    func configuredServer(in servers: [MCPServerConfig]) -> MCPServerConfig? {
+        servers.first { server in
+            server.catalogID == id
+                || (server.catalogID == nil
+                    && server.command == command
+                    && server.arguments == arguments)
+        }
+    }
+
+    static let catalog: [MCPCatalogEntry] = {
+        guard let url = Bundle.main.url(forResource: "MCPCatalog", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let entries = try? JSONDecoder().decode([MCPCatalogEntry].self, from: data)
+        else {
+            return []
+        }
+        return entries
+    }()
+}

--- a/Sources/Nativ/Features/Extensions/NativKitEditor.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitEditor.swift
@@ -1,0 +1,615 @@
+import NativServerKit
+import SwiftUI
+
+struct NativKitEditor: View {
+    private enum Category: String, CaseIterable, Identifiable {
+        case mcp = "MCPs"
+        case tools = "Tools"
+        case skills = "Skills"
+
+        var id: Self { self }
+    }
+
+    @ObservedObject var host: MCPHostManager
+    @ObservedObject var model: NativModel
+    let onSave: (CustomNativKit) -> Void
+    let onCancel: () -> Void
+    let onOpenCapability: (NativKitCapabilityReference) -> Void
+    let onReset: (() -> Void)?
+
+    @State private var draft: CustomNativKit
+    @State private var category: Category = .mcp
+    @State private var query = ""
+
+    init(
+        kit: CustomNativKit,
+        host: MCPHostManager,
+        model: NativModel,
+        onSave: @escaping (CustomNativKit) -> Void,
+        onCancel: @escaping () -> Void,
+        onOpenCapability: @escaping (NativKitCapabilityReference) -> Void,
+        onReset: (() -> Void)? = nil
+    ) {
+        _draft = State(initialValue: kit)
+        self.host = host
+        self.model = model
+        self.onSave = onSave
+        self.onCancel = onCancel
+        self.onOpenCapability = onOpenCapability
+        self.onReset = onReset
+    }
+
+    private var inventory: NativKitCapabilityInventory {
+        NativKitCapabilityInventory(settings: model.settings, host: host)
+    }
+
+    private var canSave: Bool {
+        !draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !draft.contents.normalized().isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            controls
+            Divider()
+            capabilityList
+            Divider()
+            footer
+        }
+        .frame(width: 570, height: 520)
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 14) {
+            NativTintedIconTile(symbol: draft.symbol, tint: draft.tint, size: 38)
+            VStack(alignment: .leading, spacing: 5) {
+                if draft.isBuiltIn {
+                    Text(draft.name)
+                        .font(.system(size: 17, weight: .semibold))
+                    Text(draft.summary)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                } else {
+                    TextField("Kit name", text: $draft.name)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 17, weight: .semibold))
+                    TextField("Description", text: $draft.summary)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 12)
+            NativHoverCloseButton { onCancel() }
+        }
+        .padding(18)
+    }
+
+    private var controls: some View {
+        VStack(spacing: 12) {
+            Picker("Capability type", selection: $category) {
+                ForEach(Category.allCases) { category in
+                    Text(category.rawValue).tag(category)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.tertiary)
+                TextField("Search \(category.rawValue.lowercased())", text: $query)
+                    .textFieldStyle(.plain)
+                if !query.isEmpty {
+                    Button { query = "" } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 30)
+            .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 7))
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 13)
+    }
+
+    private var capabilityList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                switch category {
+                case .mcp:
+                    mcpRows
+                case .tools:
+                    toolRows
+                case .skills:
+                    skillRows
+                }
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 8)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var mcpRows: some View {
+        let choices = inventory.mcpChoices.filter { matches($0.name, detail: $0.detail) }
+        if choices.isEmpty {
+            emptyState("No configured MCPs match this search.", symbol: "server.rack")
+        } else {
+            ForEach(Array(choices.enumerated()), id: \.element.id) { index, choice in
+                if index > 0 { Divider() }
+                mcpRow(choice)
+            }
+        }
+        unavailableMCPSelections(known: Set(inventory.mcpChoices.flatMap(\.allReferences)))
+    }
+
+    private func mcpRow(_ choice: NativKitMCPChoice) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CapabilitySelectionRow(
+                title: choice.name,
+                detail: choice.detail,
+                readiness: choice.readiness,
+                isOn: mcpIncludedBinding(choice),
+                onOpenCapability: { onOpenCapability(.mcp(choice.reference)) }
+            )
+            if choice.tools.isEmpty {
+                Text(mcpHint(choice))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                    .padding(.leading, 30)
+                    .padding(.bottom, 2)
+            } else {
+                VStack(alignment: .leading, spacing: 5) {
+                    Toggle("All tools", isOn: mcpAllBinding(choice))
+                        .toggleStyle(.checkbox)
+                        .font(.system(size: 12, weight: .medium))
+                    ForEach(choice.tools) { tool in
+                        Toggle(tool.name, isOn: mcpToolBinding(
+                            choice: choice,
+                            availableTools: choice.tools,
+                            toolName: tool.name
+                        ))
+                        .toggleStyle(.checkbox)
+                        .font(.system(size: 12, design: .monospaced))
+                    }
+                }
+                .padding(.leading, 30)
+                .padding(.bottom, 5)
+            }
+        }
+        .padding(.vertical, 9)
+    }
+
+    @ViewBuilder
+    private var toolRows: some View {
+        let choices = inventory.toolChoices.filter { matches($0.name, detail: $0.detail) }
+        if choices.isEmpty {
+            emptyState("No tools match this search.", symbol: "hammer")
+        } else {
+            ForEach(Array(choices.enumerated()), id: \.element.id) { index, choice in
+                if index > 0 { Divider() }
+                CapabilitySelectionRow(
+                    title: choice.name,
+                    detail: choice.detail,
+                    readiness: choice.readiness,
+                    isOn: toolBinding(choice),
+                    onOpenCapability: openCapabilityAction(for: choice)
+                )
+                .padding(.vertical, 9)
+            }
+        }
+        unavailableToolSelections(choices: inventory.toolChoices)
+    }
+
+    @ViewBuilder
+    private var skillRows: some View {
+        let choices = inventory.skillChoices.filter { matches($0.name, detail: $0.detail) }
+        if choices.isEmpty {
+            emptyState("No skills match this search.", symbol: "sparkles")
+        } else {
+            ForEach(Array(choices.enumerated()), id: \.element.id) { index, choice in
+                if index > 0 { Divider() }
+                CapabilitySelectionRow(
+                    title: choice.name,
+                    detail: choice.detail,
+                    readiness: choice.readiness,
+                    isOn: skillBinding(choice),
+                    onOpenCapability: { onOpenCapability(.skill(choice.reference)) }
+                )
+                .padding(.vertical, 9)
+            }
+        }
+        unavailableSkillSelections(known: Set(inventory.skillChoices.flatMap(\.allReferences)))
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Text(selectionSummary)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            if let onReset {
+                Button("Reset", action: onReset)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Cancel", action: onCancel)
+            Button("Save changes") { onSave(draft.normalized()) }
+                .buttonStyle(.borderedProminent)
+                .disabled(!canSave)
+        }
+        .padding(16)
+    }
+
+    private var selectionSummary: String {
+        let contents = draft.contents.normalized()
+        let count = contents.mcpSelections.count
+            + contents.nativeToolNames.count
+            + contents.customToolIDs.count
+            + contents.skillReferences.count
+        return "\(count) selected"
+    }
+
+    private func mcpHint(_ choice: NativKitMCPChoice) -> String {
+        if isMCPAllSelected(choice) {
+            return "All tools from this MCP are selected."
+        }
+        return choice.readiness == .ready
+            ? "This MCP did not advertise any tools."
+            : "Turn on and connect this MCP to choose individual tools."
+    }
+
+    private func mcpAllBinding(_ choice: NativKitMCPChoice) -> Binding<Bool> {
+        let references = Set(choice.allReferences)
+        return Binding(
+            get: { isMCPAllSelected(choice) },
+            set: { selected in
+                draft.contents.mcpSelections.removeAll { references.contains($0.server) }
+                if selected {
+                    draft.contents.mcpSelections.append(
+                        NativKitMCPSelection(server: choice.reference, tools: .all)
+                    )
+                }
+            }
+        )
+    }
+
+    private func mcpIncludedBinding(_ choice: NativKitMCPChoice) -> Binding<Bool> {
+        let references = Set(choice.allReferences)
+        return Binding(
+            get: { draft.contents.mcpSelections.contains { references.contains($0.server) } },
+            set: { selected in
+                if selected {
+                    if !draft.contents.mcpSelections.contains(where: { references.contains($0.server) }) {
+                        draft.contents.mcpSelections.append(
+                            NativKitMCPSelection(server: choice.reference, tools: .all)
+                        )
+                    }
+                } else {
+                    draft.contents.mcpSelections.removeAll { references.contains($0.server) }
+                }
+            }
+        )
+    }
+
+    private func mcpToolBinding(
+        choice: NativKitMCPChoice,
+        availableTools: [MCPHostedTool],
+        toolName: String
+    ) -> Binding<Bool> {
+        let references = Set(choice.allReferences)
+        return Binding(
+            get: {
+                guard let selection = draft.contents.mcpSelections.first(where: {
+                    references.contains($0.server)
+                }) else {
+                    return false
+                }
+                switch selection.tools {
+                case .all: return true
+                case .named(let names): return names.contains(toolName)
+                }
+            },
+            set: { selected in
+                let index = draft.contents.mcpSelections.firstIndex {
+                    references.contains($0.server)
+                }
+                let currentNames: [String]
+                if let index {
+                    switch draft.contents.mcpSelections[index].tools {
+                    case .all:
+                        currentNames = availableTools.map(\.name)
+                    case .named(let names):
+                        currentNames = names
+                    }
+                } else {
+                    currentNames = []
+                }
+                var names = Set(currentNames)
+                if selected { names.insert(toolName) } else { names.remove(toolName) }
+                draft.contents.mcpSelections.removeAll { references.contains($0.server) }
+                if !names.isEmpty {
+                    draft.contents.mcpSelections.append(
+                        NativKitMCPSelection(
+                            server: choice.reference,
+                            tools: .named(Array(names).sorted())
+                        )
+                    )
+                }
+            }
+        )
+    }
+
+    private func isMCPAllSelected(_ choice: NativKitMCPChoice) -> Bool {
+        let references = Set(choice.allReferences)
+        guard let selection = draft.contents.mcpSelections.first(where: {
+            references.contains($0.server)
+        }) else {
+            return false
+        }
+        if case .all = selection.tools { return true }
+        return false
+    }
+
+    private func toolBinding(_ choice: NativKitToolChoice) -> Binding<Bool> {
+        switch choice.source {
+        case .native:
+            let name = choice.id.replacingOccurrences(of: "native:", with: "")
+            return containsBinding(name, in: \NativKitContents.nativeToolNames)
+        case .custom:
+            guard let id = choice.customToolID else { return .constant(false) }
+            return containsBinding(id, in: \NativKitContents.customToolIDs)
+        }
+    }
+
+    private func capabilityReference(
+        for choice: NativKitToolChoice
+    ) -> NativKitCapabilityReference? {
+        switch choice.source {
+        case .native:
+            .nativeTool(String(choice.id.dropFirst("native:".count)))
+        case .custom:
+            choice.customToolID.map(NativKitCapabilityReference.customTool)
+        }
+    }
+
+    private func openCapabilityAction(for choice: NativKitToolChoice) -> (() -> Void)? {
+        guard let capability = capabilityReference(for: choice) else { return nil }
+        return { onOpenCapability(capability) }
+    }
+
+    private func skillBinding(_ choice: NativKitSkillChoice) -> Binding<Bool> {
+        let references = Set(choice.allReferences)
+        return Binding(
+            get: {
+                !references.isDisjoint(with: draft.contents.skillReferences)
+            },
+            set: { selected in
+                draft.contents.skillReferences.removeAll { references.contains($0) }
+                if selected {
+                    draft.contents.skillReferences.append(choice.reference)
+                }
+            }
+        )
+    }
+
+    private func containsBinding<Value: Hashable>(
+        _ value: Value,
+        in keyPath: WritableKeyPath<NativKitContents, [Value]>
+    ) -> Binding<Bool> {
+        Binding(
+            get: { draft.contents[keyPath: keyPath].contains(value) },
+            set: { selected in
+                if selected {
+                    if !draft.contents[keyPath: keyPath].contains(value) {
+                        draft.contents[keyPath: keyPath].append(value)
+                    }
+                } else {
+                    draft.contents[keyPath: keyPath].removeAll { $0 == value }
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func unavailableMCPSelections(known: Set<NativKitMCPServerReference>) -> some View {
+        let unavailable = draft.contents.mcpSelections.filter { !known.contains($0.server) }
+        if !unavailable.isEmpty {
+            VStack(alignment: .leading, spacing: 7) {
+                Text("UNAVAILABLE SELECTIONS")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                ForEach(unavailable) { selection in
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundStyle(.orange)
+                        Text(inventory.serverName(selection.server))
+                        Spacer()
+                        Button("Remove") {
+                            draft.contents.mcpSelections.removeAll { $0.server == selection.server }
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(Color.accentColor)
+                    }
+                    .font(.system(size: 12))
+                }
+            }
+            .padding(.vertical, 12)
+        }
+    }
+
+    @ViewBuilder
+    private func unavailableToolSelections(choices: [NativKitToolChoice]) -> some View {
+        let nativeNames = Set(choices.compactMap { choice -> String? in
+            guard case .native = choice.source else { return nil }
+            return String(choice.id.dropFirst("native:".count))
+        })
+        let customIDs = Set(choices.compactMap(\.customToolID))
+        let missingNative = draft.contents.nativeToolNames.filter { !nativeNames.contains($0) }
+        let missingCustom = draft.contents.customToolIDs.filter { !customIDs.contains($0) }
+        if !missingNative.isEmpty || !missingCustom.isEmpty {
+            unavailableHeader
+            ForEach(missingNative, id: \.self) { name in
+                unavailableRow(title: humanized(name)) {
+                    draft.contents.nativeToolNames.removeAll { $0 == name }
+                }
+            }
+            ForEach(missingCustom, id: \.self) { id in
+                unavailableRow(title: "Removed custom tool") {
+                    draft.contents.customToolIDs.removeAll { $0 == id }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func unavailableSkillSelections(known: Set<NativKitSkillReference>) -> some View {
+        let missing = draft.contents.skillReferences.filter { !known.contains($0) }
+        if !missing.isEmpty {
+            unavailableHeader
+            ForEach(missing, id: \.self) { reference in
+                unavailableRow(title: skillName(reference)) {
+                    draft.contents.skillReferences.removeAll { $0 == reference }
+                }
+            }
+        }
+    }
+
+    private var unavailableHeader: some View {
+        Text("UNAVAILABLE SELECTIONS")
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .padding(.top, 12)
+    }
+
+    private func unavailableRow(title: String, onRemove: @escaping () -> Void) -> some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+            Text(title)
+            Spacer()
+            Button("Remove", action: onRemove)
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.accentColor)
+        }
+        .font(.system(size: 12))
+        .padding(.vertical, 6)
+    }
+
+    private func skillName(_ reference: NativKitSkillReference) -> String {
+        switch reference {
+        case .builtIn(let id): CustomNativKitCatalog.builtInSkill(id: id)?.name ?? humanized(id)
+        case .configured: "Removed skill"
+        }
+    }
+
+    private func humanized(_ value: String) -> String {
+        value.replacingOccurrences(of: "_", with: " ")
+            .split(separator: " ")
+            .map { $0.capitalized }
+            .joined(separator: " ")
+    }
+
+    private func matches(_ title: String, detail: String) -> Bool {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return true }
+        return title.localizedCaseInsensitiveContains(query)
+            || detail.localizedCaseInsensitiveContains(query)
+    }
+
+    private func emptyState(_ text: String, symbol: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 20))
+                .foregroundStyle(.tertiary)
+            Text(text)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 44)
+    }
+}
+
+private struct CapabilitySelectionRow: View {
+    let title: String
+    let detail: String
+    let readiness: NativKitCapabilityReadiness
+    let isOn: Binding<Bool>
+    var onOpenCapability: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Toggle("", isOn: isOn)
+                .toggleStyle(.checkbox)
+                .labelsHidden()
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                if !detail.isEmpty {
+                    Text(detail)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 10)
+            NativKitReadinessLabel(
+                readiness: readiness,
+                onOpenCapability: onOpenCapability
+            )
+        }
+    }
+}
+
+struct NativKitReadinessLabel: View {
+    let readiness: NativKitCapabilityReadiness
+    var onOpenCapability: (() -> Void)?
+
+    @ViewBuilder
+    var body: some View {
+        switch readiness {
+        case .ready:
+            EmptyView()
+        case .needsConfiguration:
+            if let onOpenCapability {
+                Button(action: onOpenCapability) {
+                    label
+                }
+                .buttonStyle(.plain)
+                .help("Open setup")
+            } else {
+                label
+            }
+        default:
+            label
+        }
+    }
+
+    private var label: some View {
+        Text(readiness.label ?? "")
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(color)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.1), in: Capsule())
+    }
+
+    private var color: Color {
+        switch readiness {
+        case .ready: .green
+        case .connecting: .orange
+        case .off: Color(nsColor: .secondaryLabelColor)
+        case .needsConfiguration: .orange
+        case .unavailable: .red
+        }
+    }
+}

--- a/Sources/Nativ/Features/Extensions/NativKitPresentation.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitPresentation.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+extension CustomNativKit {
+    var symbol: String {
+        switch id {
+        case "engineering": "hammer"
+        case "research": "magnifyingglass"
+        default: "shippingbox"
+        }
+    }
+
+    var tint: Color {
+        switch id {
+        case "engineering": .blue
+        case "research": .purple
+        default: .indigo
+        }
+    }
+}

--- a/Sources/Nativ/Features/Kits/NativKit.swift
+++ b/Sources/Nativ/Features/Kits/NativKit.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+enum NativKitOrigin: String, Codable, Equatable, Sendable {
+    case builtIn
+    case user
+}
+
+enum NativKitMCPServerReference: Codable, Equatable, Hashable, Sendable {
+    case catalog(String)
+    case configured(UUID)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case catalogID
+        case serverID
+    }
+
+    private enum Kind: String, Codable {
+        case catalog
+        case configured
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .catalog:
+            self = .catalog(try container.decode(String.self, forKey: .catalogID))
+        case .configured:
+            self = .configured(try container.decode(UUID.self, forKey: .serverID))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .catalog(let id):
+            try container.encode(Kind.catalog, forKey: .kind)
+            try container.encode(id, forKey: .catalogID)
+        case .configured(let id):
+            try container.encode(Kind.configured, forKey: .kind)
+            try container.encode(id, forKey: .serverID)
+        }
+    }
+}
+
+enum NativKitMCPToolSelection: Codable, Equatable, Hashable, Sendable {
+    case all
+    case named([String])
+
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case names
+    }
+
+    private enum Mode: String, Codable {
+        case all
+        case named
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Mode.self, forKey: .mode) {
+        case .all:
+            self = .all
+        case .named:
+            self = .named(try container.decodeIfPresent([String].self, forKey: .names) ?? [])
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .all:
+            try container.encode(Mode.all, forKey: .mode)
+        case .named(let names):
+            try container.encode(Mode.named, forKey: .mode)
+            try container.encode(names, forKey: .names)
+        }
+    }
+
+    func normalized() -> Self {
+        switch self {
+        case .all:
+            return .all
+        case .named(let names):
+            return .named(Array(Set(names.map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            }).filter { !$0.isEmpty }).sorted())
+        }
+    }
+}
+
+struct NativKitMCPSelection: Codable, Equatable, Hashable, Sendable, Identifiable {
+    var server: NativKitMCPServerReference
+    var tools: NativKitMCPToolSelection
+
+    var id: NativKitMCPServerReference { server }
+}
+
+enum NativKitSkillReference: Codable, Equatable, Hashable, Sendable {
+    case builtIn(String)
+    case configured(UUID)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case builtInID
+        case skillID
+    }
+
+    private enum Kind: String, Codable {
+        case builtIn
+        case configured
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .builtIn:
+            self = .builtIn(try container.decode(String.self, forKey: .builtInID))
+        case .configured:
+            self = .configured(try container.decode(UUID.self, forKey: .skillID))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .builtIn(let id):
+            try container.encode(Kind.builtIn, forKey: .kind)
+            try container.encode(id, forKey: .builtInID)
+        case .configured(let id):
+            try container.encode(Kind.configured, forKey: .kind)
+            try container.encode(id, forKey: .skillID)
+        }
+    }
+}
+
+enum NativKitCapabilityReference: Equatable, Hashable, Sendable {
+    case mcp(NativKitMCPServerReference)
+    case mcpTool(server: NativKitMCPServerReference, name: String)
+    case nativeTool(String)
+    case customTool(UUID)
+    case skill(NativKitSkillReference)
+
+    var id: String {
+        switch self {
+        case .mcp(.catalog(let id)):
+            "mcp-catalog:\(id)"
+        case .mcp(.configured(let id)):
+            "mcp:\(id.uuidString)"
+        case .mcpTool(let server, let name):
+            "\(NativKitCapabilityReference.mcp(server).id):tool:\(name)"
+        case .nativeTool(let name):
+            "native:\(name)"
+        case .customTool(let id):
+            "custom:\(id.uuidString)"
+        case .skill(.builtIn(let id)):
+            "skill-builtin:\(id)"
+        case .skill(.configured(let id)):
+            "skill:\(id.uuidString)"
+        }
+    }
+}
+
+struct NativKitContents: Codable, Equatable, Sendable {
+    var mcpSelections: [NativKitMCPSelection] = []
+    var nativeToolNames: [String] = []
+    var customToolIDs: [UUID] = []
+    var skillReferences: [NativKitSkillReference] = []
+
+    var isEmpty: Bool {
+        mcpSelections.isEmpty
+            && nativeToolNames.isEmpty
+            && customToolIDs.isEmpty
+            && skillReferences.isEmpty
+    }
+
+    var inventory: String {
+        var parts: [String] = []
+        if !mcpSelections.isEmpty {
+            parts.append(Self.count(mcpSelections.count, singular: "MCP"))
+        }
+        let toolCount = nativeToolNames.count + customToolIDs.count
+            + mcpSelections.reduce(0) { partial, selection in
+                guard case .named(let names) = selection.tools else { return partial }
+                return partial + names.count
+            }
+        if toolCount > 0 {
+            parts.append(Self.count(toolCount, singular: "tool"))
+        }
+        if !skillReferences.isEmpty {
+            parts.append(Self.count(skillReferences.count, singular: "skill"))
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    func normalized() -> Self {
+        var result = self
+        var seenServers = Set<NativKitMCPServerReference>()
+        result.mcpSelections = mcpSelections.compactMap { selection in
+            guard seenServers.insert(selection.server).inserted else { return nil }
+            let tools = selection.tools.normalized()
+            if case .named(let names) = tools, names.isEmpty { return nil }
+            return NativKitMCPSelection(server: selection.server, tools: tools)
+        }
+        result.nativeToolNames = Array(Set(nativeToolNames)).sorted()
+        result.customToolIDs = customToolIDs.uniqued()
+        result.skillReferences = skillReferences.uniqued()
+        return result
+    }
+
+    private static func count(_ count: Int, singular: String) -> String {
+        "\(count) \(singular)\(count == 1 ? "" : "s")"
+    }
+}
+
+struct UserNativKit: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID = UUID()
+    var name: String = ""
+    var summary: String = ""
+    var isEnabled = true
+    var contents = NativKitContents()
+
+    var isComplete: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !contents.normalized().isEmpty
+    }
+
+    func normalized() -> Self {
+        var result = self
+        result.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        result.summary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        result.contents = contents.normalized()
+        return result
+    }
+
+    func resolved() -> CustomNativKit {
+        let value = normalized()
+        return CustomNativKit(
+            id: value.id.uuidString,
+            name: value.name,
+            summary: value.summary,
+            isEnabled: value.isEnabled,
+            origin: .user,
+            contents: value.contents
+        )
+    }
+}
+
+struct CustomNativKit: Identifiable, Equatable, Sendable {
+    let id: String
+    var name: String
+    var summary: String
+    var isEnabled: Bool
+    let origin: NativKitOrigin
+    var contents: NativKitContents
+
+    var isBuiltIn: Bool { origin == .builtIn }
+    var inventory: String { contents.inventory }
+
+    func normalized() -> Self {
+        var result = self
+        result.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        result.summary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        result.contents = contents.normalized()
+        return result
+    }
+}
+
+private extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}

--- a/Sources/Nativ/Features/Kits/NativKitCapabilityInventory.swift
+++ b/Sources/Nativ/Features/Kits/NativKitCapabilityInventory.swift
@@ -1,0 +1,518 @@
+import Foundation
+import NativServerKit
+
+enum NativKitCapabilityReadiness: Equatable {
+    case ready
+    case off
+    case connecting
+    case needsConfiguration(String)
+    case unavailable(String)
+
+    var isReady: Bool {
+        if case .ready = self { return true }
+        return false
+    }
+
+    var label: String? {
+        switch self {
+        case .ready: nil
+        case .off: "Off"
+        case .connecting: "Connecting"
+        case .needsConfiguration: "Needs setup"
+        case .unavailable: "Unavailable"
+        }
+    }
+}
+
+enum NativKitIssueReason: Equatable {
+    case kitDisabled
+    case componentRemoved
+    case globallyOff
+    case connecting
+    case needsConfiguration(String)
+    case connectionFailed(String)
+    case unsupportedInBackground
+}
+
+struct NativKitIssue: Equatable, Identifiable {
+    let componentID: String
+    let componentName: String
+    let capability: NativKitCapabilityReference?
+    let reason: NativKitIssueReason
+
+    var id: String { "\(componentID):\(String(describing: reason))" }
+
+    var message: String {
+        switch reason {
+        case .kitDisabled:
+            "\(componentName) is turned off."
+        case .componentRemoved:
+            "\(componentName) is no longer available."
+        case .globallyOff:
+            "Turn on \(componentName) before using this Kit."
+        case .connecting:
+            "\(componentName) is still connecting."
+        case .needsConfiguration(let detail):
+            detail.isEmpty ? "Set up \(componentName) before using this Kit." : detail
+        case .connectionFailed(let detail):
+            detail.isEmpty ? "\(componentName) failed to connect." : "\(componentName): \(detail)"
+        case .unsupportedInBackground:
+            "\(componentName) requires an interactive chat."
+        }
+    }
+}
+
+enum NativKitAvailability: Equatable {
+    case ready
+    case needsSetup(Int)
+    case unavailable(Int)
+}
+
+struct NativKitEvaluation: Equatable {
+    let availability: NativKitAvailability
+    let issues: [NativKitIssue]
+
+    var isReady: Bool { issues.isEmpty }
+
+    var summary: String? {
+        issues.first?.message
+    }
+}
+
+enum NativKitExecutionContext {
+    case chat
+    case routine
+}
+
+enum NativKitExecutionError: LocalizedError {
+    case removed
+    case notReady(String, [NativKitIssue])
+
+    var errorDescription: String? {
+        switch self {
+        case .removed:
+            return "The selected Kit is no longer available."
+        case .notReady(let name, let issues):
+            let details = issues.prefix(3).map(\.message).joined(separator: " ")
+            return details.isEmpty ? "\(name) is not ready." : "\(name) is not ready. \(details)"
+        }
+    }
+}
+
+struct NativKitExecutionPlan {
+    let kit: CustomNativKit
+    let allowedToolNames: Set<String>
+    let toolDefinitions: [MLXChatToolDefinition]
+    let skills: [NativSkill]
+    let customToolsByName: [String: CustomTool]
+    let mcpToolsByName: [String: MCPHostedTool]
+    let issues: [NativKitIssue]
+
+    var isReady: Bool { issues.isEmpty }
+}
+
+struct NativKitMCPChoice: Identifiable {
+    let reference: NativKitMCPServerReference
+    let aliases: [NativKitMCPServerReference]
+    let name: String
+    let detail: String
+    let readiness: NativKitCapabilityReadiness
+    let tools: [MCPHostedTool]
+
+    var id: NativKitMCPServerReference { reference }
+
+    var allReferences: [NativKitMCPServerReference] {
+        [reference] + aliases
+    }
+}
+
+struct NativKitToolChoice: Identifiable {
+    enum Source {
+        case native
+        case custom
+    }
+
+    let id: String
+    let name: String
+    let detail: String
+    let readiness: NativKitCapabilityReadiness
+    let source: Source
+    let customToolID: UUID?
+}
+
+struct NativKitSkillChoice: Identifiable {
+    let reference: NativKitSkillReference
+    let aliases: [NativKitSkillReference]
+    let name: String
+    let detail: String
+    let readiness: NativKitCapabilityReadiness
+
+    var id: NativKitSkillReference { reference }
+
+    var allReferences: [NativKitSkillReference] {
+        [reference] + aliases
+    }
+}
+
+@MainActor
+struct NativKitCapabilityInventory {
+    let settings: NativSettings
+    let host: MCPHostManager
+
+    var mcpChoices: [NativKitMCPChoice] {
+        let servers = settings.mcpServers
+            .filter { !$0.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        return servers.compactMap { server in
+            if let catalogEntry = MCPCatalogEntry.catalog.first(where: {
+                $0.configuredServer(in: [server]) != nil
+            }) {
+                guard catalogEntry.configuredServer(in: servers)?.id == server.id else {
+                    return nil
+                }
+                return NativKitMCPChoice(
+                    reference: .catalog(catalogEntry.id),
+                    aliases: servers
+                        .filter { catalogEntry.configuredServer(in: [$0]) != nil }
+                        .map { .configured($0.id) },
+                    name: server.name.isEmpty ? catalogEntry.name : server.name,
+                    detail: server.command,
+                    readiness: readiness(of: server),
+                    tools: host.hostedTools(forServer: server.id)
+                )
+            }
+            return NativKitMCPChoice(
+                reference: .configured(server.id),
+                aliases: [],
+                name: server.name.isEmpty ? server.command : server.name,
+                detail: server.command,
+                readiness: readiness(of: server),
+                tools: host.hostedTools(forServer: server.id)
+            )
+        }
+            .sorted {
+                $0.name.localizedStandardCompare($1.name) == .orderedAscending
+            }
+    }
+
+    var toolChoices: [NativKitToolChoice] {
+        let native = ChatToolRegistry.descriptors(canEditImage: true).map { descriptor in
+            let name = descriptor.definition.function.name
+            let ready = descriptor.configuration?.isReady ?? true
+            let readiness: NativKitCapabilityReadiness
+            if !ready {
+                readiness = .needsConfiguration("Configure \(descriptor.configuration?.displayName ?? name) before using it.")
+            } else if settings.disabledToolNames.contains(name) {
+                readiness = .off
+            } else {
+                readiness = .ready
+            }
+            return NativKitToolChoice(
+                id: "native:\(name)",
+                name: humanized(name),
+                detail: descriptor.definition.function.description,
+                readiness: readiness,
+                source: .native,
+                customToolID: nil
+            )
+        }
+        let custom = settings.customTools.map { tool in
+            let readiness: NativKitCapabilityReadiness
+            if (try? tool.definition()) == nil {
+                readiness = .needsConfiguration("Finish configuring \(tool.name) before using it.")
+            } else if settings.disabledToolNames.contains(tool.toolName) {
+                readiness = .off
+            } else {
+                readiness = .ready
+            }
+            return NativKitToolChoice(
+                id: "custom:\(tool.id.uuidString)",
+                name: tool.name,
+                detail: tool.displaySummary,
+                readiness: readiness,
+                source: .custom,
+                customToolID: tool.id
+            )
+        }
+        return (native + custom).sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+    }
+
+    var skillChoices: [NativKitSkillChoice] {
+        let builtInSkillIDs = Set(CustomNativKitCatalog.builtInSkills.map(\.skill.id))
+        let builtIn = CustomNativKitCatalog.builtInSkills.map { skill in
+            NativKitSkillChoice(
+                reference: .builtIn(skill.id),
+                aliases: settings.skills
+                    .filter { $0.id == skill.skill.id }
+                    .map { .configured($0.id) },
+                name: skill.name,
+                detail: "Included with Nativ",
+                readiness: .ready
+            )
+        }
+        let configured = settings.skills
+            .filter {
+                $0.id != NativSkill.builtInToolGuideID
+                    && !builtInSkillIDs.contains($0.id)
+            }
+            .map { skill in
+                NativKitSkillChoice(
+                    reference: .configured(skill.id),
+                    aliases: [],
+                    name: skill.name,
+                    detail: skill.instructions,
+                    readiness: skill.isEnabled ? .ready : .off
+                )
+            }
+        return (builtIn + configured).sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+    }
+
+    func evaluation(of kit: CustomNativKit) -> NativKitEvaluation {
+        let plan = plan(for: kit, context: .chat, canEditImage: true)
+        let unavailable = plan.issues.filter {
+            if case .componentRemoved = $0.reason { return true }
+            return false
+        }
+        let availability: NativKitAvailability
+        if plan.issues.isEmpty {
+            availability = .ready
+        } else if unavailable.isEmpty {
+            availability = .needsSetup(plan.issues.count)
+        } else {
+            availability = .unavailable(plan.issues.count)
+        }
+        return NativKitEvaluation(availability: availability, issues: plan.issues)
+    }
+
+    func plan(
+        for kit: CustomNativKit,
+        context: NativKitExecutionContext,
+        canEditImage: Bool
+    ) -> NativKitExecutionPlan {
+        var definitions: [MLXChatToolDefinition] = []
+        var skills: [NativSkill] = []
+        var customTools: [String: CustomTool] = [:]
+        var mcpTools: [String: MCPHostedTool] = [:]
+        var issues: [NativKitIssue] = []
+
+        if !kit.isEnabled {
+            issues.append(NativKitIssue(
+                componentID: kit.id,
+                componentName: kit.name,
+                capability: nil,
+                reason: .kitDisabled
+            ))
+        }
+
+        let nativeByName = Dictionary(
+            uniqueKeysWithValues: ChatToolRegistry.descriptors(canEditImage: canEditImage).map {
+                ($0.definition.function.name, $0)
+            }
+        )
+        for name in kit.contents.nativeToolNames {
+            guard let descriptor = nativeByName[name] else {
+                if name == ChatImageToolRegistry.editToolName, !canEditImage { continue }
+                issues.append(issue(.nativeTool(name), name: humanized(name), reason: .componentRemoved))
+                continue
+            }
+            if context == .routine && !Self.backgroundToolNames.contains(name) {
+                issues.append(issue(.nativeTool(name), name: humanized(name), reason: .unsupportedInBackground))
+            } else if descriptor.configuration?.isReady == false {
+                issues.append(issue(
+                    .nativeTool(name),
+                    name: humanized(name),
+                    reason: .needsConfiguration("Configure \(descriptor.configuration?.displayName ?? humanized(name)) before using this Kit.")
+                ))
+            } else if settings.disabledToolNames.contains(name) {
+                issues.append(issue(.nativeTool(name), name: humanized(name), reason: .globallyOff))
+            } else {
+                definitions.append(descriptor.definition)
+            }
+        }
+
+        for id in kit.contents.customToolIDs {
+            guard let tool = settings.customTools.first(where: { $0.id == id }) else {
+                issues.append(issue(.customTool(id), name: "Custom tool", reason: .componentRemoved))
+                continue
+            }
+            guard let definition = try? tool.definition() else {
+                issues.append(issue(
+                    .customTool(id),
+                    name: tool.name,
+                    reason: .needsConfiguration("Finish configuring \(tool.name) before using this Kit.")
+                ))
+                continue
+            }
+            if context == .routine && tool.kind == .script {
+                issues.append(issue(.customTool(id), name: tool.name, reason: .unsupportedInBackground))
+            } else if settings.disabledToolNames.contains(tool.toolName) {
+                issues.append(issue(.customTool(id), name: tool.name, reason: .globallyOff))
+            } else {
+                definitions.append(definition)
+                customTools[tool.toolName] = tool
+            }
+        }
+
+        for reference in kit.contents.skillReferences {
+            switch reference {
+            case .builtIn(let id):
+                guard let skill = CustomNativKitCatalog.builtInSkill(id: id)?.skill else {
+                    issues.append(issue(.skill(reference), name: "Skill", reason: .componentRemoved))
+                    continue
+                }
+                skills.append(skill)
+            case .configured(let id):
+                guard let skill = settings.skills.first(where: { $0.id == id }) else {
+                    issues.append(issue(.skill(reference), name: "Skill", reason: .componentRemoved))
+                    continue
+                }
+                if skill.isEnabled {
+                    skills.append(skill)
+                } else {
+                    issues.append(issue(.skill(reference), name: skill.name, reason: .globallyOff))
+                }
+            }
+        }
+
+        for selection in kit.contents.mcpSelections {
+            guard let server = configuredServer(for: selection.server) else {
+                issues.append(issue(
+                    .mcp(selection.server),
+                    name: serverName(selection.server),
+                    reason: .needsConfiguration("Add \(serverName(selection.server)) from MCP before using this Kit.")
+                ))
+                continue
+            }
+            let displayName = server.name.isEmpty ? server.command : server.name
+            guard server.isEnabled else {
+                issues.append(issue(.mcp(selection.server), name: displayName, reason: .globallyOff))
+                continue
+            }
+            switch host.states[server.id] {
+            case .connected:
+                let hosted = host.hostedTools(forServer: server.id)
+                let selected: [MCPHostedTool]
+                switch selection.tools {
+                case .all:
+                    selected = hosted
+                case .named(let names):
+                    selected = names.compactMap { name in
+                        guard let tool = hosted.first(where: { $0.name == name }) else {
+                            issues.append(issue(
+                                .mcp(selection.server),
+                                name: name,
+                                reason: .componentRemoved
+                            ))
+                            return nil
+                        }
+                        return tool
+                    }
+                }
+                for tool in selected {
+                    if settings.disabledToolNames.contains(tool.runtimeName) {
+                        issues.append(issue(
+                            .mcpTool(server: selection.server, name: tool.name),
+                            name: tool.name,
+                            reason: .globallyOff
+                        ))
+                    } else {
+                        definitions.append(tool.definition)
+                        mcpTools[tool.runtimeName] = tool
+                    }
+                }
+            case .connecting:
+                issues.append(issue(.mcp(selection.server), name: displayName, reason: .connecting))
+            case .failed(let detail):
+                issues.append(issue(.mcp(selection.server), name: displayName, reason: .connectionFailed(detail)))
+            case .disabled:
+                issues.append(issue(.mcp(selection.server), name: displayName, reason: .globallyOff))
+            case nil:
+                issues.append(issue(
+                    .mcp(selection.server),
+                    name: displayName,
+                    reason: .needsConfiguration("Connect \(displayName) before using this Kit.")
+                ))
+            }
+        }
+
+        let uniqueDefinitions = definitions.uniqued(by: { $0.function.name })
+        let allowed = Set(uniqueDefinitions.map { $0.function.name })
+        return NativKitExecutionPlan(
+            kit: kit,
+            allowedToolNames: allowed,
+            toolDefinitions: uniqueDefinitions,
+            skills: skills.uniqued(by: { $0.id }),
+            customToolsByName: customTools,
+            mcpToolsByName: mcpTools,
+            issues: issues.uniqued(by: { $0.id })
+        )
+    }
+
+    func configuredServer(for reference: NativKitMCPServerReference) -> MCPServerConfig? {
+        switch reference {
+        case .catalog(let id):
+            return MCPCatalogEntry.catalog.first(where: { $0.id == id })?
+                .configuredServer(in: settings.mcpServers)
+        case .configured(let id):
+            return settings.mcpServers.first { $0.id == id }
+        }
+    }
+
+    func serverName(_ reference: NativKitMCPServerReference) -> String {
+        if let server = configuredServer(for: reference) {
+            return server.name.isEmpty ? server.command : server.name
+        }
+        if case .catalog(let id) = reference {
+            return MCPCatalogEntry.catalog.first(where: { $0.id == id })?.name ?? id
+        }
+        return "MCP server"
+    }
+
+    private func readiness(of server: MCPServerConfig) -> NativKitCapabilityReadiness {
+        guard server.isEnabled else { return .off }
+        switch host.states[server.id] {
+        case .connected: return .ready
+        case .connecting: return .connecting
+        case .failed(let detail): return .unavailable(detail)
+        case .disabled: return .off
+        case nil: return .needsConfiguration("Not connected")
+        }
+    }
+
+    private func issue(
+        _ capability: NativKitCapabilityReference,
+        name: String,
+        reason: NativKitIssueReason
+    ) -> NativKitIssue {
+        NativKitIssue(
+            componentID: capability.id,
+            componentName: name,
+            capability: capability,
+            reason: reason
+        )
+    }
+
+    private func humanized(_ value: String) -> String {
+        value.replacingOccurrences(of: "_", with: " ")
+            .split(separator: " ")
+            .map { $0.capitalized }
+            .joined(separator: " ")
+    }
+
+    private static let backgroundToolNames: Set<String> = [
+        ChatSystemMonitorToolRegistry.toolName,
+        ChatModelLibraryToolRegistry.toolName,
+        ChatServerStatsToolRegistry.toolName,
+        ChatWebSearchToolRegistry.toolName,
+    ]
+}
+
+private extension Array {
+    func uniqued<ID: Hashable>(by identifier: (Element) -> ID) -> [Element] {
+        var seen = Set<ID>()
+        return filter { seen.insert(identifier($0)).inserted }
+    }
+}

--- a/Sources/Nativ/Features/Kits/NativKitCatalog.swift
+++ b/Sources/Nativ/Features/Kits/NativKitCatalog.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct NativKitBuiltInSkill: Identifiable, Equatable, Sendable {
+    let id: String
+    let name: String
+    let instructions: String
+
+    var skill: NativSkill {
+        NativSkill(
+            id: Self.stableUUID(for: id),
+            name: name,
+            instructions: instructions,
+            isEnabled: true
+        )
+    }
+
+    private static func stableUUID(for id: String) -> UUID {
+        switch id {
+        case "working-in-codebase":
+            UUID(uuidString: "A1000000-0000-4000-8000-000000000001")!
+        case "researching-with-sources":
+            UUID(uuidString: "A2000000-0000-4000-8000-000000000002")!
+        default:
+            preconditionFailure("Missing stable UUID for built-in skill \(id)")
+        }
+    }
+}
+
+enum CustomNativKitCatalog {
+    static let builtInSkills: [NativKitBuiltInSkill] = [
+        NativKitBuiltInSkill(
+            id: "working-in-codebase",
+            name: "Working in a codebase",
+            instructions: """
+            You're helping with software. Ground every answer in the actual repository, not assumptions.
+
+            - Use Git and filesystem tools to read real files, history, and diffs before proposing changes.
+            - Prefer read-only GitHub queries and summarize concrete findings.
+            - Match the project's existing style and keep changes focused.
+            - Fetch documentation when an API or library detail is uncertain.
+            """
+        ),
+        NativKitBuiltInSkill(
+            id: "researching-with-sources",
+            name: "Researching with sources",
+            instructions: """
+            You're doing careful research. Prioritize accuracy and traceability.
+
+            - Read primary sources and connect claims to where they came from.
+            - Record durable findings before repeating work.
+            - Query the user's data instead of estimating.
+            - Separate sourced facts from inference and flag uncertainty.
+            """
+        ),
+    ]
+
+    static let builtInKits: [CustomNativKit] = [
+        CustomNativKit(
+            id: "engineering",
+            name: "Engineering",
+            summary: "A focused set of code, Git, and documentation capabilities.",
+            isEnabled: true,
+            origin: .builtIn,
+            contents: NativKitContents(
+                mcpSelections: ["git", "github", "filesystem", "fetch"].map {
+                    NativKitMCPSelection(server: .catalog($0), tools: .all)
+                },
+                skillReferences: [.builtIn("working-in-codebase")]
+            )
+        ),
+        CustomNativKit(
+            id: "research",
+            name: "Research",
+            summary: "Sources, durable notes, and structured data for careful research.",
+            isEnabled: true,
+            origin: .builtIn,
+            contents: NativKitContents(
+                mcpSelections: ["fetch", "memory", "sqlite"].map {
+                    NativKitMCPSelection(server: .catalog($0), tools: .all)
+                },
+                skillReferences: [.builtIn("researching-with-sources")]
+            )
+        ),
+    ]
+
+    static func builtInSkill(id: String) -> NativKitBuiltInSkill? {
+        builtInSkills.first { $0.id == id }
+    }
+}

--- a/Sources/Nativ/Features/Kits/NativKitStore.swift
+++ b/Sources/Nativ/Features/Kits/NativKitStore.swift
@@ -1,0 +1,312 @@
+import Combine
+import Foundation
+import NativServerKit
+
+@MainActor
+final class NativKitStore: ObservableObject {
+    static let shared = NativKitStore()
+
+    @Published private(set) var userKits: [UserNativKit]
+    @Published private(set) var builtInOverrides: [String: BuiltInOverride]
+
+    struct BuiltInOverride: Codable, Equatable {
+        var isEnabled: Bool
+        var contents: NativKitContents
+    }
+
+    private struct Payload: Codable {
+        let schemaVersion: Int
+        var userKits: [UserNativKit]
+        var builtInOverrides: [String: BuiltInOverride]
+    }
+
+    private let fileURL: URL
+
+    init(fileURL: URL? = nil) {
+        self.fileURL = fileURL ?? Self.defaultFileURL
+        let loaded = Self.load(from: self.fileURL)
+        userKits = loaded.userKits
+        builtInOverrides = loaded.builtInOverrides
+    }
+
+    var allKits: [CustomNativKit] {
+        CustomNativKitCatalog.builtInKits.map { kit in
+            guard let override = builtInOverrides[kit.id] else { return kit }
+            var resolved = kit
+            resolved.isEnabled = override.isEnabled
+            resolved.contents = override.contents
+            return resolved.normalized()
+        } + userKits.map { $0.resolved() }
+    }
+
+    var enabledKits: [CustomNativKit] {
+        allKits.filter(\.isEnabled)
+    }
+
+    func kit(id: String) -> CustomNativKit? {
+        allKits.first { $0.id == id }
+    }
+
+    func save(_ kit: CustomNativKit) {
+        let kit = kit.normalized()
+        guard !kit.name.isEmpty, !kit.contents.isEmpty else { return }
+        if kit.isBuiltIn {
+            builtInOverrides[kit.id] = BuiltInOverride(
+                isEnabled: kit.isEnabled,
+                contents: kit.contents
+            )
+        } else if let id = UUID(uuidString: kit.id) {
+            let userKit = UserNativKit(
+                id: id,
+                name: kit.name,
+                summary: kit.summary,
+                isEnabled: kit.isEnabled,
+                contents: kit.contents
+            ).normalized()
+            if let index = userKits.firstIndex(where: { $0.id == id }) {
+                userKits[index] = userKit
+            } else {
+                userKits.append(userKit)
+            }
+        }
+        persist()
+    }
+
+    func create(_ kit: UserNativKit) {
+        let kit = kit.normalized()
+        guard kit.isComplete else { return }
+        if let index = userKits.firstIndex(where: { $0.id == kit.id }) {
+            userKits[index] = kit
+        } else {
+            userKits.append(kit)
+        }
+        persist()
+    }
+
+    func setEnabled(_ enabled: Bool, id: String) {
+        guard var kit = kit(id: id) else { return }
+        kit.isEnabled = enabled
+        save(kit)
+    }
+
+    func resetBuiltIn(id: String) {
+        builtInOverrides[id] = nil
+        persist()
+    }
+
+    func deleteUserKit(id: UUID) {
+        userKits.removeAll { $0.id == id }
+        persist()
+    }
+
+    func migrateLegacySettings(
+        mcpServers: [MCPServerConfig],
+        from settingsURL: URL? = nil
+    ) {
+        guard !FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        let settingsURL = settingsURL ?? Self.legacySettingsURL
+        guard let data = try? Data(contentsOf: settingsURL),
+              let payload = try? PropertyListDecoder().decode(LegacySettings.self, from: data),
+              let legacyKits = payload.userKits
+        else {
+            return
+        }
+        userKits = legacyKits.map { legacy in
+            let migrated = Self.migrate(
+                id: legacy.id,
+                name: legacy.name,
+                summary: legacy.summary,
+                isEnabled: true,
+                mcpServerIDs: legacy.mcpServerIDs,
+                mcpTools: legacy.toolNames.compactMap {
+                    Self.parseLegacyMCPTool($0, servers: mcpServers)
+                },
+                builtInToolNames: legacy.toolNames.filter { !$0.hasPrefix("mcp__") },
+                customToolIDs: [],
+                skillIDs: legacy.skillIDs
+            )
+            return migrated
+        }
+        persist()
+    }
+
+    private func persist() {
+        let payload = Payload(
+            schemaVersion: 2,
+            userKits: userKits,
+            builtInOverrides: builtInOverrides
+        )
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        try? FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    private static func load(from url: URL) -> Payload {
+        guard let data = try? Data(contentsOf: url) else {
+            return Payload(schemaVersion: 2, userKits: [], builtInOverrides: [:])
+        }
+        if let payload = try? JSONDecoder().decode(Payload.self, from: data) {
+            return Payload(
+                schemaVersion: 2,
+                userKits: payload.userKits.map { $0.normalized() },
+                builtInOverrides: payload.builtInOverrides
+            )
+        }
+        if let legacy = try? JSONDecoder().decode([LegacyStoredKit].self, from: data) {
+            return Payload(
+                schemaVersion: 2,
+                userKits: legacy.map {
+                    migrate(
+                        id: $0.id,
+                        name: $0.name,
+                        summary: $0.summary,
+                        isEnabled: $0.isEnabled ?? true,
+                        mcpServerIDs: $0.mcpServerIDs,
+                        mcpTools: $0.mcpTools,
+                        builtInToolNames: $0.builtInToolNames,
+                        customToolIDs: $0.customToolIDs,
+                        skillIDs: $0.skillIDs
+                    )
+                },
+                builtInOverrides: [:]
+            )
+        }
+        return Payload(schemaVersion: 2, userKits: [], builtInOverrides: [:])
+    }
+
+    private static func migrate(
+        id: UUID,
+        name: String,
+        summary: String,
+        isEnabled: Bool,
+        mcpServerIDs: [UUID],
+        mcpTools: [LegacyMCPTool],
+        builtInToolNames: [String],
+        customToolIDs: [UUID],
+        skillIDs: [UUID]
+    ) -> UserNativKit {
+        let toolsByServer = Dictionary(grouping: mcpTools, by: \.serverID)
+        let serverIDs = Set(mcpServerIDs).union(toolsByServer.keys)
+        let selections = serverIDs.map { serverID -> NativKitMCPSelection in
+            let names = toolsByServer[serverID]?.map(\.name) ?? []
+            return NativKitMCPSelection(
+                server: .configured(serverID),
+                tools: names.isEmpty ? .all : .named(names)
+            )
+        }
+        return UserNativKit(
+            id: id,
+            name: name,
+            summary: summary,
+            isEnabled: isEnabled,
+            contents: NativKitContents(
+                mcpSelections: selections,
+                nativeToolNames: builtInToolNames,
+                customToolIDs: customToolIDs,
+                skillReferences: skillIDs.map(NativKitSkillReference.configured)
+            )
+        ).normalized()
+    }
+
+    private static func parseLegacyMCPTool(
+        _ runtimeName: String,
+        servers: [MCPServerConfig]
+    ) -> LegacyMCPTool? {
+        guard runtimeName.hasPrefix("mcp__") else { return nil }
+        let remainder = runtimeName.dropFirst("mcp__".count)
+        guard let separator = remainder.range(of: "__") else { return nil }
+        let runtimeSlug = String(remainder[..<separator.lowerBound])
+        let toolName = String(remainder[separator.upperBound...])
+        guard !toolName.isEmpty,
+              let server = servers.first(where: {
+                  let base = slug($0.name.isEmpty ? $0.command : $0.name)
+                  return runtimeSlug == base || runtimeSlug.hasPrefix("\(base)_")
+              })
+        else {
+            return nil
+        }
+        return LegacyMCPTool(serverID: server.id, name: toolName)
+    }
+
+    private static func slug(_ value: String) -> String {
+        let characters = value.unicodeScalars.map { scalar in
+            CharacterSet.alphanumerics.contains(scalar) ? Character(scalar) : Character("_")
+        }
+        let result = String(characters)
+        return result.isEmpty ? "server" : result
+    }
+
+    private static var defaultFileURL: URL {
+        let base = (try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? FileManager.default.homeDirectoryForCurrentUser
+        return base
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("Kits", isDirectory: true)
+            .appendingPathComponent("kits.json")
+    }
+
+    private static var legacySettingsURL: URL {
+        let base = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.homeDirectoryForCurrentUser
+        return base
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("Settings.plist")
+    }
+
+    private struct LegacyMCPTool: Codable {
+        let serverID: UUID
+        let name: String
+    }
+
+    private struct LegacyStoredKit: Decodable {
+        let id: UUID
+        let name: String
+        let summary: String
+        let isEnabled: Bool?
+        let mcpServerIDs: [UUID]
+        let mcpTools: [LegacyMCPTool]
+        let builtInToolNames: [String]
+        let customToolIDs: [UUID]
+        let skillIDs: [UUID]
+
+        private enum CodingKeys: String, CodingKey {
+            case id, name, summary, isEnabled, mcpServerIDs, mcpTools
+            case builtInToolNames, customToolIDs, skillIDs
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+            name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            summary = try container.decodeIfPresent(String.self, forKey: .summary) ?? ""
+            isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled)
+            mcpServerIDs = try container.decodeIfPresent([UUID].self, forKey: .mcpServerIDs) ?? []
+            mcpTools = try container.decodeIfPresent([LegacyMCPTool].self, forKey: .mcpTools) ?? []
+            builtInToolNames = try container.decodeIfPresent([String].self, forKey: .builtInToolNames) ?? []
+            customToolIDs = try container.decodeIfPresent([UUID].self, forKey: .customToolIDs) ?? []
+            skillIDs = try container.decodeIfPresent([UUID].self, forKey: .skillIDs) ?? []
+        }
+    }
+
+    private struct LegacySettings: Decodable {
+        let userKits: [LegacySettingsKit]?
+    }
+
+    private struct LegacySettingsKit: Decodable {
+        let id: UUID
+        let name: String
+        let summary: String
+        let mcpServerIDs: [UUID]
+        let toolNames: [String]
+        let skillIDs: [UUID]
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineKitResolver.swift
+++ b/Sources/Nativ/Features/Routines/RoutineKitResolver.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum RoutineKitError: LocalizedError, Equatable {
+    case unavailable(String)
+    case incomplete(String, [String])
+    case unsupportedBackgroundTool(String)
+    case invalidToolCall
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let name):
+            "The selected Kit “\(name)” is no longer available. Choose another Kit before running this routine."
+        case .incomplete(let name, let components):
+            "The Kit “\(name)” is not fully available: \(components.joined(separator: ", "))."
+        case .unsupportedBackgroundTool(let name):
+            "The tool “\(name)” requires an interactive chat and cannot run in a routine."
+        case .invalidToolCall:
+            "The model returned an invalid tool call."
+        }
+    }
+}
+
+enum RoutineKitResolver {
+    static func resolve(id: String, from kits: [CustomNativKit]) throws -> CustomNativKit {
+        guard let kit = kits.first(where: { $0.id == id }) else {
+            throw RoutineKitError.unavailable(id)
+        }
+        return kit
+    }
+}

--- a/Sources/NativServerKit/MCPServerConfig.swift
+++ b/Sources/NativServerKit/MCPServerConfig.swift
@@ -10,6 +10,7 @@ public struct MCPServerConfig: Codable, Equatable, Identifiable, Sendable {
     public var arguments: [String]
     public var environment: [String: String]
     public var isEnabled: Bool
+    public var catalogID: String?
 
     public init(
         id: UUID = UUID(),
@@ -18,7 +19,8 @@ public struct MCPServerConfig: Codable, Equatable, Identifiable, Sendable {
         command: String = "",
         arguments: [String] = [],
         environment: [String: String] = [:],
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        catalogID: String? = nil
     ) {
         self.id = id
         self.catalogID = catalogID
@@ -27,6 +29,7 @@ public struct MCPServerConfig: Codable, Equatable, Identifiable, Sendable {
         self.arguments = arguments
         self.environment = environment
         self.isEnabled = isEnabled
+        self.catalogID = catalogID
     }
 }
 

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -163,6 +163,11 @@ final class ChatToolRegistryTests: XCTestCase {
         XCTAssertEqual(names.count, Set(names).count)
     }
 
+    func testDefinitionsDoNotExposeKitSelectionToTheModel() {
+        let names = ChatToolRegistry.definitions(canEditImage: false).map(\.function.name)
+        XCTAssertFalse(names.contains("use_kit"))
+    }
+
     func testImageToolSchemasAreGoldenPinned() throws {
         let golden = #"""
             [{"function":{"description":"Create one or more new images from a detailed text prompt. Image-model selection is handled by the app; do not ask for or provide a model identifier.","name":"generate_image","parameters":{"additionalProperties":false,"properties":{"count":{"maximum":4,"minimum":1,"type":"integer"},"height":{"maximum":2048,"minimum":256,"type":"integer"},"prompt":{"description":"A specific visual description or edit instruction.","type":"string"},"seed":{"type":["integer","null"]},"width":{"maximum":2048,"minimum":256,"type":"integer"}},"required":["prompt"],"type":"object"}},"type":"function"},{"function":{"description":"Edit the most recently attached or generated image using a text instruction. Image-model selection is handled by the app; do not ask for or provide a model identifier.","name":"edit_image","parameters":{"additionalProperties":false,"properties":{"count":{"maximum":4,"minimum":1,"type":"integer"},"height":{"maximum":2048,"minimum":256,"type":"integer"},"prompt":{"description":"A specific visual description or edit instruction.","type":"string"},"seed":{"type":["integer","null"]},"width":{"maximum":2048,"minimum":256,"type":"integer"}},"required":["prompt"],"type":"object"}},"type":"function"}]

--- a/Tests/NativTests/NativKitStoreTests.swift
+++ b/Tests/NativTests/NativKitStoreTests.swift
@@ -1,0 +1,144 @@
+import NativServerKit
+import XCTest
+
+@MainActor
+final class NativKitStoreTests: XCTestCase {
+    private var directory: URL!
+    private var fileURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NativKitStoreTests-\(UUID().uuidString)", isDirectory: true)
+        fileURL = directory.appendingPathComponent("kits.json")
+    }
+
+    override func tearDown() {
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        super.tearDown()
+    }
+
+    func testMCPToolSelectionIncludesItsServerReference() throws {
+        let serverID = UUID()
+        let store = NativKitStore(fileURL: fileURL)
+        store.create(UserNativKit(
+            name: "Research",
+            contents: NativKitContents(mcpSelections: [
+                NativKitMCPSelection(
+                    server: .configured(serverID),
+                    tools: .named(["search"])
+                ),
+            ])
+        ))
+
+        let selection = try XCTUnwrap(store.userKits.first?.contents.mcpSelections.first)
+        XCTAssertEqual(selection.server, .configured(serverID))
+        XCTAssertEqual(selection.tools, .named(["search"]))
+    }
+
+    func testStableReferencesRoundTripWithoutRuntimeNames() {
+        let serverID = UUID()
+        let store = NativKitStore(fileURL: fileURL)
+        store.create(UserNativKit(
+            name: "Files",
+            contents: NativKitContents(mcpSelections: [
+                NativKitMCPSelection(
+                    server: .configured(serverID),
+                    tools: .named(["read_file"])
+                ),
+            ])
+        ))
+
+        let reloaded = NativKitStore(fileURL: fileURL)
+        XCTAssertEqual(
+            reloaded.userKits.first?.contents.mcpSelections.first?.tools,
+            .named(["read_file"])
+        )
+    }
+
+    func testDeletedKitIsNoLongerResolvable() {
+        let store = NativKitStore(fileURL: fileURL)
+        let kit = UserNativKit(
+            name: "Temporary",
+            contents: NativKitContents(nativeToolNames: ["list_models"])
+        )
+        store.create(kit)
+        XCTAssertNotNil(store.kit(id: kit.id.uuidString))
+
+        store.deleteUserKit(id: kit.id)
+        XCTAssertNil(store.kit(id: kit.id.uuidString))
+    }
+
+    func testContentsNormalizeDuplicateStableIdentifiers() {
+        let toolID = UUID()
+        let skillID = UUID()
+        let store = NativKitStore(fileURL: fileURL)
+        store.create(UserNativKit(
+            name: "Deploy",
+            contents: NativKitContents(
+                customToolIDs: [toolID, toolID],
+                skillReferences: [.configured(skillID), .configured(skillID)]
+            )
+        ))
+
+        XCTAssertEqual(store.userKits.first?.contents.customToolIDs, [toolID])
+        XCTAssertEqual(store.userKits.first?.contents.skillReferences, [.configured(skillID)])
+    }
+
+    func testMigratesLegacyRuntimeToolNameToStableReference() throws {
+        struct LegacyKit: Encodable {
+            let id: UUID
+            let name: String
+            let summary: String
+            let mcpServerIDs: [UUID]
+            let toolNames: [String]
+            let skillIDs: [UUID]
+        }
+        struct LegacySettings: Encodable { let userKits: [LegacyKit] }
+
+        let server = MCPServerConfig(name: "My Files", command: "files")
+        let legacyURL = directory.appendingPathComponent("Settings.plist")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try PropertyListEncoder().encode(LegacySettings(userKits: [
+            LegacyKit(
+                id: UUID(),
+                name: "Files",
+                summary: "",
+                mcpServerIDs: [],
+                toolNames: ["mcp__My_Files__read_file"],
+                skillIDs: []
+            ),
+        ]))
+        try data.write(to: legacyURL)
+        let store = NativKitStore(fileURL: fileURL)
+
+        store.migrateLegacySettings(mcpServers: [server], from: legacyURL)
+
+        XCTAssertEqual(
+            store.userKits.first?.contents.mcpSelections,
+            [NativKitMCPSelection(
+                server: .configured(server.id),
+                tools: .named(["read_file"])
+            )]
+        )
+    }
+
+    func testBuiltInCatalogHasOnlyCurrentKits() {
+        XCTAssertEqual(CustomNativKitCatalog.builtInKits.map(\.id), ["engineering", "research"])
+    }
+
+    func testBuiltInEnableStateIsStoredAsAnOverride() {
+        let store = NativKitStore(fileURL: fileURL)
+        store.setEnabled(false, id: "engineering")
+
+        let reloaded = NativKitStore(fileURL: fileURL)
+        XCTAssertEqual(reloaded.kit(id: "engineering")?.isEnabled, false)
+        XCTAssertEqual(reloaded.kit(id: "research")?.isEnabled, true)
+    }
+
+    func testRoutineResolutionFailsWhenSelectedKitWasRemoved() {
+        XCTAssertThrowsError(try RoutineKitResolver.resolve(id: "removed", from: [])) { error in
+            XCTAssertEqual(error as? RoutineKitError, .unavailable("removed"))
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -178,6 +178,10 @@ targets:
       - path: Sources/Nativ/Features/Extensions/NativKit.swift
       - path: Sources/Nativ/Features/Extensions/NativKitRuntimeResolver.swift
       - path: Sources/Nativ/Features/Extensions/CustomTool.swift
+      - path: Sources/Nativ/Features/Extensions/MCPCatalogEntry.swift
+      - path: Sources/Nativ/Features/Kits/NativKit.swift
+      - path: Sources/Nativ/Features/Kits/NativKitCatalog.swift
+      - path: Sources/Nativ/Features/Kits/NativKitStore.swift
       - path: Sources/Nativ/Features/Routines/Routine.swift
       - path: Sources/Nativ/Features/Routines/ScheduledTaskChatLinker.swift
       - path: Sources/Nativ/Features/Routines/ScheduledTaskNotification.swift


### PR DESCRIPTION
Allows people to use custom kits, this pr does several things:

- Add user-created Kits composed from extensions, MCP servers, tools, and skills.
- Redesign Kit creation and component selection for a compact, tag-based workflow.
- Let tool-capable models discover and use both built-in and user-created Kits.
- Require confirmation before a model activates a Kit.
- Apply Kit settings immediately and wait for MCP connections so newly enabled MCP tools are available on the next model turn.