### PR TITLE
Improve image model selection for chat tool calls

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
 		ED6BDF238125ABAB48A4227D /* RoutineSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90012E8ECF43A5A55BFD8787 /* RoutineSupport.swift */; };
 		EF3678F684519D8ADC625B20 /* MLXImageModelResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */; };
+		F00A6B0D29C84971B97C6F9D /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */; };
 		F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
 		F32A65A75BCD6911505114F4 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
@@ -1186,6 +1187,7 @@
 				8E16504AFD5457AC965426F2 /* FnControlShortcutMonitor.swift in Sources */,
 				D4F073244DE11FD98AD708E2 /* Formatting.swift in Sources */,
 				A2DF29E907CC0CEF6EF86FBD /* HuggingFaceCache.swift in Sources */,
+				F00A6B0D29C84971B97C6F9D /* HubModelSizeResolver.swift in Sources */,
 				0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */,
 				D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */,
 				237BB8D2F99FFE536CF0421B /* ImageGenerationViewModel.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		137BF3A5342405863C49CC10 /* ModelProviderIcons in Resources */ = {isa = PBXBuildFile; fileRef = DB24BFEFF23914DA8BDB0E1C /* ModelProviderIcons */; };
 		1423FD497A75A14770FCA9E1 /* LocalModelDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */; };
 		145464A2B098437667795AFB /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB9D1D0FC24AC771442B628 /* Artifact.swift */; };
+		14CEDB8ACA6EB7BCF8A3430C /* SystemSensorSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653E58FFA38742CD4D5D41F5 /* SystemSensorSampler.swift */; };
 		197EBBED5CC651E6364617B5 /* VoiceCaptureOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C93856381B1D89C4DE61DCC /* VoiceCaptureOverlay.swift */; };
 		1A6F5207528E44EA9FF8F831 /* NativChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E6FD97A66F91B3B667B3FE /* NativChatClient.swift */; };
 		1C6295D830FE941FDCE3ECCC /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
@@ -120,6 +121,7 @@
 		9954F8086FE0A7A9B3378EC9 /* NativComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EE1CE9AAE5A3B9A2D4669C /* NativComponents.swift */; };
 		9A1E1FD2D597C682F4A8D2A9 /* AudioInputLevelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DDA5274474AC8D54DFDF71 /* AudioInputLevelMonitor.swift */; };
 		9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */; };
+		9E5AB6D42F995E0A78C4EA79 /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		9E6B93B1603C4E964422E09B /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A0D30C905A2788C3BD2149BF /* ChatScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */; };
 		A1492AA9B1D71B4E57310EF6 /* MLXImageModelResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61126D4235AFF77D82F1F80B /* MLXImageModelResolver.swift */; };
@@ -175,7 +177,6 @@
 		ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
 		ED6BDF238125ABAB48A4227D /* RoutineSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90012E8ECF43A5A55BFD8787 /* RoutineSupport.swift */; };
 		EF3678F684519D8ADC625B20 /* MLXImageModelResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */; };
-		F00A6B0D29C84971B97C6F9D /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */; };
 		F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
 		F32A65A75BCD6911505114F4 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
@@ -1190,8 +1191,8 @@
 				1C6295D830FE941FDCE3ECCC /* CodexCLIProfile.swift in Sources */,
 				8E16504AFD5457AC965426F2 /* FnControlShortcutMonitor.swift in Sources */,
 				D4F073244DE11FD98AD708E2 /* Formatting.swift in Sources */,
+				9E5AB6D42F995E0A78C4EA79 /* HubModelSizeResolver.swift in Sources */,
 				A2DF29E907CC0CEF6EF86FBD /* HuggingFaceCache.swift in Sources */,
-				F00A6B0D29C84971B97C6F9D /* HubModelSizeResolver.swift in Sources */,
 				0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */,
 				D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */,
 				237BB8D2F99FFE536CF0421B /* ImageGenerationViewModel.swift in Sources */,
@@ -1216,6 +1217,7 @@
 				BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */,
 				36405D7EB30E430CF06956EB /* ShellEnvironmentTests.swift in Sources */,
 				293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */,
+				14CEDB8ACA6EB7BCF8A3430C /* SystemSensorSampler.swift in Sources */,
 				E180E254213BCD770141B872 /* VoiceAnimationPreferences.swift in Sources */,
 				A6E043CD0C3AD882D0D0AE66 /* VoiceAudioRecorder.swift in Sources */,
 				3A4D3E1F9313D9896173130D /* VoiceShortcut.swift in Sources */,

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -65,6 +65,8 @@ final class ControlPanelNavigation: ObservableObject {
     @Published private(set) var newChatRequest = 0
     @Published private(set) var toggleSidebarRequest = 0
     @Published private(set) var speechModelDiscoveryRequest = 0
+    @Published private(set) var imageModelDiscoveryRequest = 0
+    @Published private(set) var imageModelDiscoveryCapability: LocalModelCapability = .imageGeneration
     @Published private(set) var collapseAllSectionsRequest = 0
     private var consumedNewChatRequest = 0
     private var consumedToggleSidebarRequest = 0
@@ -82,6 +84,12 @@ final class ControlPanelNavigation: ObservableObject {
 
     func openSpeechModelDiscovery() {
         speechModelDiscoveryRequest += 1
+        requestedTab = .models
+    }
+
+    func openImageModelDiscovery(for operation: ChatImageOperation) {
+        imageModelDiscoveryCapability = operation.requiredCapability
+        imageModelDiscoveryRequest += 1
         requestedTab = .models
     }
 
@@ -1942,7 +1950,8 @@ struct ControlPanelView: View {
                 showsConfiguration: $isModelConfigurationVisible,
                 conversationWidthReduction: isFullScreen
                     ? 0
-                    : ControlPanelLayout.titlebarHeight
+                    : ControlPanelLayout.titlebarHeight,
+                onExploreImageModels: navigation.openImageModelDiscovery
             )
         case .imageGeneration:
             ImageGenerationView(model: model, viewModel: imageGeneration)
@@ -1990,7 +1999,9 @@ struct ControlPanelView: View {
                 model: model,
                 showsConfiguration: $isModelConfigurationVisible,
                 titleLeadingInset: detailTitleLeadingInset,
-                speechModelDiscoveryRequest: navigation.speechModelDiscoveryRequest
+                speechModelDiscoveryRequest: navigation.speechModelDiscoveryRequest,
+                imageModelDiscoveryRequest: navigation.imageModelDiscoveryRequest,
+                imageModelDiscoveryCapability: navigation.imageModelDiscoveryCapability
             )
         case .integrations:
             IntegrationsView(

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -12,6 +12,7 @@ struct ChatToolExecutionContext {
     let imageReferences: [ChatImageAttachment]
     let modelSearchPath: String
     let additionalModelSearchPaths: [String]
+    var huggingFaceToken: String? = nil
     var analyticsDatabaseURL: URL? = nil
     var imageToolDependencies = ChatImageToolDependencies.live
     var imageModelSelection: ChatImageModelSelectionHandler? = nil
@@ -96,21 +97,26 @@ enum ChatToolDispatcher {
             call: call,
             hasImageReference: !context.imageReferences.isEmpty
         )
-        let installedModels = try await context.imageToolDependencies.discoverModels(
+        let availableModels = try await context.imageToolDependencies.discoverModels(
+            imageRequest.operation,
             context.modelSearchPath,
-            context.additionalModelSearchPaths
+            context.additionalModelSearchPaths,
+            context.huggingFaceToken,
+            context.imageGenerationModelID
         )
         let imageModelID: String
         switch ChatImageModelSelection.resolve(
             operation: imageRequest.operation,
             selectedModelID: context.imageGenerationModelID,
-            installedModels: installedModels
+            availableModels: availableModels
         ) {
         case .selected(let model):
             imageModelID = model.modelID
         case .selectionRequired(let selectionRequest):
             guard let requestSelection = context.imageModelSelection else {
-                throw ChatImageToolError.modelSelectionUnavailable(imageRequest.operation)
+                throw selectionRequest.models.isEmpty
+                    ? ChatImageToolError.noCompatibleModels(imageRequest.operation)
+                    : ChatImageToolError.modelSelectionUnavailable(imageRequest.operation)
             }
             let selectedModelID = try await requestSelection(selectionRequest)
             guard let selectedModel = ChatImageModelSelection.selectedModel(
@@ -120,8 +126,6 @@ enum ChatToolDispatcher {
                 throw ChatImageToolError.modelSelectionUnavailable(imageRequest.operation)
             }
             imageModelID = selectedModel.modelID
-        case .installationRequired:
-            throw ChatImageToolError.noCompatibleModels(imageRequest.operation)
         }
         await context.imageExecutionWillStart?(imageModelID)
         let result = try await context.imageToolDependencies.execute(

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -27,6 +27,7 @@ struct ChatView: View {
     @ObservedObject var mcpHost: MCPHostManager
     @Binding var showsConfiguration: Bool
     let conversationWidthReduction: CGFloat
+    let onExploreImageModels: (ChatImageOperation) -> Void
     @State private var isDropTargeted = false
 
     var body: some View {
@@ -37,7 +38,8 @@ struct ChatView: View {
             ChatTranscriptView(
                 model: model,
                 chat: chat,
-                conversationWidthReduction: conversationWidthReduction
+                conversationWidthReduction: conversationWidthReduction,
+                onExploreImageModels: onExploreImageModels
             )
             .dropDestination(for: URL.self) { urls, _ in
                 chat.attachImages(fromURLs: urls)
@@ -52,9 +54,15 @@ struct ChatView: View {
             .animation(.easeInOut(duration: 0.15), value: isDropTargeted)
         }
         .background(Color.nativMainContentBackground)
-        .onAppear { chat.mcpHost = mcpHost }
+        .onAppear {
+            chat.mcpHost = mcpHost
+            chat.refreshPendingImageModelSelections()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .routineDidSaveChatSession)) { _ in
             chat.reloadPersistedSessions()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
+            chat.refreshPendingImageModelSelections()
         }
         .environment(\.chatFontScale, model.settings.chatFontScale)
     }
@@ -92,6 +100,7 @@ private struct ChatTranscriptView: View {
     @ObservedObject var model: NativModel
     @ObservedObject var chat: ChatViewModel
     let conversationWidthReduction: CGFloat
+    let onExploreImageModels: (ChatImageOperation) -> Void
     @State private var transcriptScrollPosition = ScrollPosition(edge: .bottom)
     @State private var composerHeight: CGFloat = 0
     @State private var followsLatestMessage = true
@@ -129,7 +138,8 @@ private struct ChatTranscriptView: View {
                             onConfirmToolConsent: chat.confirmToolConsent,
                             onDenyToolConsent: chat.denyToolConsent,
                             onSelectImageModel: chat.selectImageModel,
-                            onCancelImageModelSelection: chat.cancelImageModelSelection
+                            onCancelImageModelSelection: chat.cancelImageModelSelection,
+                            onExploreImageModels: onExploreImageModels
                         )
                         .equatable()
                         .id(message.id)
@@ -293,6 +303,12 @@ final class ChatViewModel: ObservableObject {
         let attachments: [ChatImageAttachment]
     }
 
+    private struct ImageModelPreparationContext {
+        let modelSearchPath: String
+        let additionalModelSearchPaths: [String]
+        let huggingFaceToken: String?
+    }
+
     @Published private(set) var sessions: [ChatSessionSummary] = []
     @Published private(set) var folders: [ChatFolder] = []
     @Published private(set) var currentSessionID: UUID?
@@ -327,6 +343,9 @@ final class ChatViewModel: ObservableObject {
     private weak var appModel: NativModel?
     private let toolConsentGate = ChatToolConsentGate()
     private let imageModelSelectionGate = ChatImageModelSelectionGate()
+    private var imageModelPreparationTasks: [UUID: Task<Void, Never>] = [:]
+    private var imageModelPreparationContexts: [UUID: ImageModelPreparationContext] = [:]
+    private var imageModelRefreshTask: Task<Void, Never>?
     private var composerSnapshot: ComposerSnapshot?
 
     init() {
@@ -879,21 +898,113 @@ final class ChatViewModel: ObservableObject {
 
     func selectImageModel(_ toolMessageID: UUID, _ modelID: String) {
         guard let request = imageModelSelectionRequests[toolMessageID],
-              ChatImageModelSelection.selectedModel(
+              let selectedModel = ChatImageModelSelection.selectedModel(
                   withID: modelID,
                   from: request
-              ) != nil
+              )
         else {
             return
         }
-        imageModelSelectionGate.select(modelID: modelID, for: toolMessageID)
+
+        guard !selectedModel.isInstalled else {
+            imageModelSelectionGate.select(modelID: modelID, for: toolMessageID)
+            return
+        }
+        guard let preparationContext = imageModelPreparationContexts[toolMessageID] else {
+            return
+        }
+
+        imageModelPreparationTasks[toolMessageID]?.cancel()
+        imageModelPreparationTasks[toolMessageID] = Task { @MainActor [weak self] in
+            defer {
+                self?.imageModelPreparationTasks.removeValue(forKey: toolMessageID)
+            }
+            do {
+                try await HuggingFaceDownloadManager.shared.downloadIfNeeded(
+                    repoID: selectedModel.modelID,
+                    sizeBytes: selectedModel.downloadSizeBytes,
+                    cachePath: preparationContext.modelSearchPath,
+                    token: preparationContext.huggingFaceToken
+                )
+                try Task.checkCancellation()
+                let installedModels = try await ChatImageModelSelection.installedOptions(
+                    modelSearchPath: preparationContext.modelSearchPath,
+                    additionalModelSearchPaths: preparationContext.additionalModelSearchPaths
+                )
+                guard ChatImageModelSelection.isPrepared(
+                    modelID: selectedModel.modelID,
+                    for: request.operation,
+                    installedModels: installedModels
+                ) else {
+                    HuggingFaceDownloadManager.shared.reportError(
+                        "The downloaded model is not compatible with \(request.operation.capabilityName).",
+                        for: selectedModel.modelID
+                    )
+                    return
+                }
+                guard self?.imageModelSelectionRequests[toolMessageID] != nil else {
+                    return
+                }
+                self?.imageModelSelectionGate.select(
+                    modelID: selectedModel.modelID,
+                    for: toolMessageID
+                )
+            } catch is CancellationError {
+                return
+            } catch {
+                HuggingFaceDownloadManager.shared.reportError(
+                    error.localizedDescription,
+                    for: selectedModel.modelID
+                )
+            }
+        }
     }
 
     func cancelImageModelSelection(_ toolMessageID: UUID) {
         guard imageModelSelectionRequests[toolMessageID] != nil else {
             return
         }
+        imageModelPreparationTasks.removeValue(forKey: toolMessageID)?.cancel()
         imageModelSelectionGate.cancel(toolMessageID)
+    }
+
+    func refreshPendingImageModelSelections() {
+        guard !imageModelSelectionRequests.isEmpty else {
+            return
+        }
+
+        let pendingRequests = imageModelSelectionRequests.compactMap { id, request in
+            imageModelPreparationContexts[id].map { (id, request.operation, $0) }
+        }
+        imageModelRefreshTask?.cancel()
+        imageModelRefreshTask = Task { @MainActor [weak self] in
+            for (toolMessageID, operation, context) in pendingRequests {
+                do {
+                    let models = try await ChatImageModelSelection.availableOptions(
+                        for: operation,
+                        modelSearchPath: context.modelSearchPath,
+                        additionalModelSearchPaths: context.additionalModelSearchPaths,
+                        huggingFaceToken: context.huggingFaceToken
+                    )
+                    try Task.checkCancellation()
+                    guard self?.imageModelSelectionRequests[toolMessageID]?.operation
+                            == operation
+                    else {
+                        continue
+                    }
+                    self?.imageModelSelectionRequests[toolMessageID] =
+                        ChatImageModelSelectionRequest(
+                            operation: operation,
+                            models: models
+                        )
+                } catch is CancellationError {
+                    return
+                } catch {
+                    // Keep the last known choices if the local cache cannot be
+                    // scanned. Hub failures are already handled as offline mode.
+                }
+            }
+        }
     }
 
     private func awaitToolConsent(for toolMessageID: UUID) async -> Bool {
@@ -1242,6 +1353,11 @@ final class ChatViewModel: ObservableObject {
                         beforeOrAt: toolMessageID,
                         in: queuedRequest.sessionID
                     )
+                    let imageModelPreparationContext = ImageModelPreparationContext(
+                        modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
+                        additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
+                        huggingFaceToken: appModel?.effectiveHuggingFaceToken
+                    )
                     let context = ChatToolExecutionContext(
                         imageGenerationModelID: activeImageModelID,
                         baseURL: queuedRequest.settings.serverBaseURL,
@@ -1249,12 +1365,19 @@ final class ChatViewModel: ObservableObject {
                         imageReferences: references,
                         modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
                         additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
+                        huggingFaceToken: imageModelPreparationContext.huggingFaceToken,
                         imageModelSelection: { [weak self] request in
                             guard let self else {
                                 throw CancellationError()
                             }
                             defer {
+                                self.imageModelPreparationTasks
+                                    .removeValue(forKey: toolMessageID)?
+                                    .cancel()
                                 self.imageModelSelectionRequests.removeValue(
+                                    forKey: toolMessageID
+                                )
+                                self.imageModelPreparationContexts.removeValue(
                                     forKey: toolMessageID
                                 )
                             }
@@ -1262,6 +1385,8 @@ final class ChatViewModel: ObservableObject {
                             let selectedModelID = await self.imageModelSelectionGate
                                 .awaitSelection(for: toolMessageID) {
                                     self.imageModelSelectionRequests[toolMessageID] = request
+                                    self.imageModelPreparationContexts[toolMessageID] =
+                                        imageModelPreparationContext
                                     self.setToolMessageStatus(
                                         toolMessageID,
                                         in: queuedRequest.sessionID,
@@ -1534,6 +1659,7 @@ final class ChatViewModel: ObservableObject {
         }
         if status != .awaitingImageModelSelection {
             imageModelSelectionRequests.removeValue(forKey: id)
+            imageModelPreparationContexts.removeValue(forKey: id)
         }
         persistSession(sessionID, updateTimestamp: true)
         if currentSessionID == sessionID {
@@ -1551,6 +1677,7 @@ final class ChatViewModel: ObservableObject {
         }
         if status != .awaitingImageModelSelection {
             imageModelSelectionRequests.removeValue(forKey: id)
+            imageModelPreparationContexts.removeValue(forKey: id)
         }
         persistSession(sessionID, updateTimestamp: true)
         if currentSessionID == sessionID {
@@ -1648,6 +1775,7 @@ final class ChatViewModel: ObservableObject {
             message.toolStatus = .running
         }
         imageModelSelectionRequests.removeValue(forKey: toolMessageID)
+        imageModelPreparationContexts.removeValue(forKey: toolMessageID)
         persistSession(sessionID, updateTimestamp: true)
         if currentSessionID == sessionID {
             bumpScroll()
@@ -2061,6 +2189,7 @@ private struct ChatMessageRow: View, Equatable {
     let onDenyToolConsent: (UUID) -> Void
     let onSelectImageModel: (UUID, String) -> Void
     let onCancelImageModelSelection: (UUID) -> Void
+    let onExploreImageModels: (ChatImageOperation) -> Void
     @State private var didCopyMessage = false
     @State private var isHoveringMessage = false
 
@@ -2087,7 +2216,8 @@ private struct ChatMessageRow: View, Equatable {
                     onConfirm: onConfirmToolConsent,
                     onDeny: onDenyToolConsent,
                     onSelectImageModel: onSelectImageModel,
-                    onCancelImageModelSelection: onCancelImageModelSelection
+                    onCancelImageModelSelection: onCancelImageModelSelection,
+                    onExploreImageModels: onExploreImageModels
                 )
             }
 
@@ -2362,6 +2492,7 @@ private struct ChatAgentStepCell: View {
     let onDeny: (UUID) -> Void
     let onSelectImageModel: (UUID, String) -> Void
     let onCancelImageModelSelection: (UUID) -> Void
+    let onExploreImageModels: (ChatImageOperation) -> Void
     @State private var isExpanded = false
 
     private var isAwaitingConsent: Bool {
@@ -2497,54 +2628,57 @@ private struct ChatAgentStepCell: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    ForEach(request.models) { model in
-                        Button {
-                            onSelectImageModel(message.id, model.modelID)
-                        } label: {
-                            HStack(spacing: 10) {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(model.displayName)
-                                        .font(.callout.weight(.medium))
-                                        .foregroundStyle(.primary)
-                                    Text(model.modelID)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
-                                }
-                                Spacer(minLength: 12)
-                                Image(systemName: "chevron.right")
-                                    .font(.caption.weight(.semibold))
-                                    .foregroundStyle(.tertiary)
-                            }
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 8)
-                            .contentShape(.rect)
-                            .background(
-                                Color(nsColor: .controlBackgroundColor),
-                                in: RoundedRectangle(cornerRadius: 7)
-                            )
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 7)
-                                    .stroke(
-                                        Color(nsColor: .separatorColor),
-                                        lineWidth: 0.5
-                                    )
-                            }
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Use \(model.displayName)")
-                    }
+                if request.models.isEmpty {
+                    Text("No compatible downloaded models are available.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
                 }
 
-                Button("Cancel") {
-                    onCancelImageModelSelection(message.id)
+                if !request.installedModels.isEmpty {
+                    imageModelSection(
+                        title: "Downloaded",
+                        models: request.installedModels
+                    )
                 }
-                .buttonStyle(.bordered)
+
+                if !request.downloadableModels.isEmpty {
+                    imageModelSection(
+                        title: "Available to download",
+                        models: request.downloadableModels
+                    )
+                }
+
+                HStack(spacing: 8) {
+                    Button("Cancel") {
+                        onCancelImageModelSelection(message.id)
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("Explore models") {
+                        onExploreImageModels(request.operation)
+                    }
+                    .buttonStyle(.bordered)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top, 7)
+        }
+    }
+
+    private func imageModelSection(
+        title: String,
+        models: [ChatImageModelOption]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+
+            ForEach(models) { model in
+                ChatImageModelOptionRow(model: model) {
+                    onSelectImageModel(message.id, model.modelID)
+                }
+            }
         }
     }
 
@@ -2655,6 +2789,92 @@ private struct ChatAgentStepCell: View {
             return nil
         }
         return object["error"] as? String
+    }
+}
+
+private struct ChatImageModelOptionRow: View {
+    private static let downloadButtonLabelWidth: CGFloat = 180
+
+    @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
+
+    let model: ChatImageModelOption
+    let onChoose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(model.displayName)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(.primary)
+                    Text(model.modelID)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer(minLength: 12)
+                trailingControl
+            }
+
+            if let error = downloadManager.errorByModelID[model.modelID] {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            Color(nsColor: .controlBackgroundColor),
+            in: RoundedRectangle(cornerRadius: 7)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        if model.isInstalled {
+            Button(action: onChoose) {
+                Label("Use", systemImage: "chevron.right")
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Use \(model.displayName)")
+        } else if downloadManager.isDownloading(model.modelID) {
+            ModelDownloadProgressControl(
+                progress: downloadManager.progress(for: model.modelID),
+                isPaused: downloadManager.isPaused(for: model.modelID),
+                onPauseResume: {
+                    if downloadManager.isPaused(for: model.modelID) {
+                        downloadManager.resumeDownload(model.modelID)
+                    } else {
+                        downloadManager.pauseDownload(model.modelID)
+                    }
+                },
+                onRemove: { downloadManager.removeDownload(model.modelID) }
+            )
+        } else {
+            Button(action: onChoose) {
+                Label(downloadTitle, systemImage: "arrow.down.circle")
+                    .frame(width: Self.downloadButtonLabelWidth)
+            }
+            .buttonStyle(.borderedProminent)
+            .accessibilityLabel("Download and use \(model.displayName)")
+        }
+    }
+
+    private var downloadTitle: String {
+        guard let sizeBytes = model.downloadSizeBytes else {
+            return "Download"
+        }
+        let size = ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
+        return "Download · \(size)"
     }
 }
 
@@ -3308,6 +3528,7 @@ private struct ChatEmptyTranscriptView: View {
         chat: ChatViewModel(),
         mcpHost: MCPHostManager(),
         showsConfiguration: .constant(true),
-        conversationWidthReduction: 0
+        conversationWidthReduction: 0,
+        onExploreImageModels: { _ in }
     )
 }

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NativServerKit
 
 enum ChatImageOperation: String, Equatable, Sendable {
     case generate
@@ -31,46 +32,161 @@ enum ChatImageOperation: String, Equatable, Sendable {
 }
 
 struct ChatImageModelOption: Identifiable, Equatable, Sendable {
+    enum Availability: Equatable, Sendable {
+        case installed
+        case downloadable(sizeBytes: Int64?)
+    }
+
     var id: String { modelID }
 
     let displayName: String
     let modelID: String
     let capabilities: Set<LocalModelCapability>
+    let availability: Availability
+
+    var isInstalled: Bool {
+        availability == .installed
+    }
+
+    var downloadSizeBytes: Int64? {
+        guard case .downloadable(let sizeBytes) = availability else {
+            return nil
+        }
+        return sizeBytes
+    }
 
     init(model: LocalModel) {
         let repositoryName = model.repoID.split(separator: "/").last.map(String.init)
         displayName = repositoryName ?? model.displayName
         modelID = model.repoID
         capabilities = model.capabilities
+        availability = .installed
+    }
+
+    init(
+        downloadableModel model: HuggingFaceModel,
+        capabilities: Set<LocalModelCapability>,
+        sizeBytes: Int64
+    ) {
+        displayName = Self.repositoryName(from: model.id)
+        modelID = model.id
+        self.capabilities = capabilities
+        availability = .downloadable(sizeBytes: sizeBytes)
     }
 
     init(
         displayName: String,
         modelID: String,
-        capabilities: Set<LocalModelCapability>
+        capabilities: Set<LocalModelCapability>,
+        availability: Availability = .installed
     ) {
         self.displayName = displayName
         self.modelID = modelID
         self.capabilities = capabilities
+        self.availability = availability
     }
 
     func supports(_ operation: ChatImageOperation) -> Bool {
         capabilities.contains(operation.requiredCapability)
+    }
+
+    private static func repositoryName(from modelID: String) -> String {
+        modelID.split(separator: "/").last.map(String.init) ?? modelID
     }
 }
 
 struct ChatImageModelSelectionRequest: Equatable, Sendable {
     let operation: ChatImageOperation
     let models: [ChatImageModelOption]
+
+    var installedModels: [ChatImageModelOption] {
+        models.filter(\.isInstalled)
+    }
+
+    var downloadableModels: [ChatImageModelOption] {
+        models.filter { !$0.isInstalled }
+    }
 }
 
 enum ChatImageModelResolution: Equatable, Sendable {
     case selected(ChatImageModelOption)
     case selectionRequired(ChatImageModelSelectionRequest)
-    case installationRequired(ChatImageOperation)
 }
 
 enum ChatImageModelSelection {
+    typealias RecommendationLoader = @Sendable (
+        LocalModelCapability,
+        String?
+    ) async throws -> [HuggingFaceModel]
+
+    static let recommendedModelCount = 3
+    private static let supportedDownloadableModelFamilies =
+        (try? Nativ.imageGenerationModelTypes()) ?? []
+
+    static func availableOptions(
+        for operation: ChatImageOperation,
+        modelSearchPath: String,
+        additionalModelSearchPaths: [String],
+        huggingFaceToken: String?,
+        preferredInstalledModelID: String? = nil,
+        recommendationLoader: RecommendationLoader = { capability, token in
+            try await HuggingFaceModelCatalog.popularModels(
+                with: capability,
+                token: token
+            )
+        }
+    ) async throws -> [ChatImageModelOption] {
+        let installedModels = try await installedOptions(
+            modelSearchPath: modelSearchPath,
+            additionalModelSearchPaths: additionalModelSearchPaths
+        )
+        let compatibleInstalledModels = compatibleModels(
+            for: operation,
+            in: installedModels
+        )
+
+        guard needsRecommendations(
+            preferredInstalledModelID: preferredInstalledModelID,
+            installedModels: compatibleInstalledModels
+        ) else {
+            return compatibleInstalledModels
+        }
+
+        let downloadableModels: [ChatImageModelOption]
+        do {
+            let installedModelIDs = Set(compatibleInstalledModels.map(\.modelID))
+            let candidates = try await recommendationLoader(
+                operation.requiredCapability,
+                huggingFaceToken
+            )
+            .filter { !$0.isPrivate && !$0.isGated }
+            .compactMap { model -> (HuggingFaceModel, Set<LocalModelCapability>)? in
+                let capabilities = downloadableCapabilities(
+                    modelID: model.id,
+                    tags: model.tags
+                )
+                guard capabilities.contains(operation.requiredCapability) else {
+                    return nil
+                }
+                return (model, capabilities)
+            }
+            .filter { !installedModelIDs.contains($0.0.id) }
+            downloadableModels = await resolvedDownloadOptions(
+                Array(candidates.prefix(recommendedModelCount))
+            )
+        } catch {
+            // Hub access is optional. When the device is offline, the picker
+            // remains useful and shows only models already on the device.
+            downloadableModels = []
+        }
+
+        return displayOptions(
+            for: operation,
+            installedModels: compatibleInstalledModels,
+            downloadableModels: downloadableModels
+        )
+    }
+
     static func installedOptions(
         modelSearchPath: String,
         additionalModelSearchPaths: [String]
@@ -94,16 +210,12 @@ enum ChatImageModelSelection {
     static func resolve(
         operation: ChatImageOperation,
         selectedModelID: String?,
-        installedModels: [ChatImageModelOption]
+        availableModels: [ChatImageModelOption]
     ) -> ChatImageModelResolution {
-        let compatibleModels = compatibleModels(for: operation, in: installedModels)
-        guard !compatibleModels.isEmpty else {
-            return .installationRequired(operation)
-        }
-
+        let compatibleModels = compatibleModels(for: operation, in: availableModels)
         if let selectedModelID = normalized(selectedModelID),
            let selectedModel = compatibleModels.first(where: {
-               $0.modelID == selectedModelID
+               $0.modelID == selectedModelID && $0.isInstalled
            }) {
             return .selected(selectedModel)
         }
@@ -116,9 +228,107 @@ enum ChatImageModelSelection {
 
     static func compatibleModels(
         for operation: ChatImageOperation,
-        in installedModels: [ChatImageModelOption]
+        in models: [ChatImageModelOption]
     ) -> [ChatImageModelOption] {
-        installedModels.filter { $0.supports(operation) }
+        models.filter { $0.supports(operation) }
+    }
+
+    static func downloadableCapabilities(
+        modelID: String,
+        tags: [String]
+    ) -> Set<LocalModelCapability> {
+        let descriptors = ([modelID] + tags).joined(separator: " ").lowercased()
+        guard !["gguf", "lora", "adapter", "controlnet"].contains(where: {
+            descriptors.contains($0)
+        }) else {
+            return []
+        }
+        let name = modelID.split(separator: "/").last.map(String.init)?
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_") ?? ""
+        let family: String? = if name.contains("flux2") || name.contains("flux_2") {
+            "flux2"
+        } else if name.contains("bonsai") {
+            "bonsai"
+        } else if name.contains("ideogram_4") || name.contains("ideogram4") {
+            "ideogram4"
+        } else if name.contains("mage_flow") {
+            "mage_flow"
+        } else {
+            nil
+        }
+        guard let family, supportedDownloadableModelFamilies.contains(family) else {
+            return []
+        }
+        if family == "flux2" {
+            return [.imageGeneration, .imageEditing]
+        }
+        if family == "mage_flow", MLXImageModelResolver.isKnownImageEditOnlyModelID(modelID) {
+            return [.imageEditing]
+        }
+        return [.imageGeneration]
+    }
+
+    private static func resolvedDownloadOptions(
+        _ candidates: [(HuggingFaceModel, Set<LocalModelCapability>)]
+    ) async -> [ChatImageModelOption] {
+        await withTaskGroup(of: (Int, ChatImageModelOption?).self) { group in
+            for (index, candidate) in candidates.enumerated() {
+                group.addTask {
+                    let size: Int64?
+                    if let estimate = candidate.0.estimatedDownloadBytes {
+                        size = estimate
+                    } else {
+                        size = await HubModelSizeResolver.shared.resolveSize(for: candidate.0.id)
+                    }
+                    guard let size else { return (index, nil) }
+                    return (index, ChatImageModelOption(
+                        downloadableModel: candidate.0,
+                        capabilities: candidate.1,
+                        sizeBytes: size
+                    ))
+                }
+            }
+            return await group.reduce(into: []) { $0.append($1) }
+                .sorted { $0.0 < $1.0 }
+                .compactMap(\.1)
+        }
+    }
+
+    static func displayOptions(
+        for operation: ChatImageOperation,
+        installedModels: [ChatImageModelOption],
+        downloadableModels: [ChatImageModelOption]
+    ) -> [ChatImageModelOption] {
+        let installed = compatibleModels(for: operation, in: installedModels)
+            .sorted(by: modelOrder)
+
+        var includedModelIDs = Set(installed.map(\.modelID))
+        var recommendations: [ChatImageModelOption] = []
+        for option in compatibleModels(for: operation, in: downloadableModels) {
+            guard !option.isInstalled,
+                  includedModelIDs.insert(option.modelID).inserted
+            else {
+                continue
+            }
+            recommendations.append(option)
+            if recommendations.count == recommendedModelCount {
+                break
+            }
+        }
+
+        return installed + recommendations
+    }
+
+    static func needsRecommendations(
+        preferredInstalledModelID: String?,
+        installedModels: [ChatImageModelOption]
+    ) -> Bool {
+        if let preferredInstalledModelID = normalized(preferredInstalledModelID),
+           installedModels.contains(where: { $0.modelID == preferredInstalledModelID }) {
+            return false
+        }
+        return true
     }
 
     static func selectedModel(
@@ -126,6 +336,14 @@ enum ChatImageModelSelection {
         from request: ChatImageModelSelectionRequest
     ) -> ChatImageModelOption? {
         request.models.first { $0.modelID == modelID }
+    }
+
+    static func isPrepared(
+        modelID: String,
+        for operation: ChatImageOperation,
+        installedModels: [ChatImageModelOption]
+    ) -> Bool {
+        installedModels.contains { $0.modelID == modelID && $0.supports(operation) }
     }
 
     private static func normalized(_ value: String?) -> String? {

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
@@ -138,8 +138,11 @@ struct ChatImageToolExecution: Sendable {
 
 struct ChatImageToolDependencies: Sendable {
     typealias ModelDiscovery = @Sendable (
+        ChatImageOperation,
         String,
-        [String]
+        [String],
+        String?,
+        String?
     ) async throws -> [ChatImageModelOption]
     typealias Execution = @Sendable (
         ChatImageToolRequest,
@@ -153,10 +156,13 @@ struct ChatImageToolDependencies: Sendable {
     let execute: Execution
 
     static let live = Self(
-        discoverModels: { path, additionalPaths in
-            try await ChatImageModelSelection.installedOptions(
+        discoverModels: { operation, path, additionalPaths, token, preferredModelID in
+            try await ChatImageModelSelection.availableOptions(
+                for: operation,
                 modelSearchPath: path,
-                additionalModelSearchPaths: additionalPaths
+                additionalModelSearchPaths: additionalPaths,
+                huggingFaceToken: token,
+                preferredInstalledModelID: preferredModelID
             )
         },
         execute: { request, modelID, baseURL, apiKey, references in

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -494,6 +494,23 @@ private struct HuggingFaceModelPage: Sendable {
     let nextPageURL: URL?
 }
 
+enum HuggingFaceModelCatalog {
+    static func popularModels(
+        with capability: LocalModelCapability,
+        token: String?
+    ) async throws -> [HuggingFaceModel] {
+        let hubCapability: LocalModelCapability = capability == .imageEditing
+            ? .imageGeneration
+            : capability
+        return try await HuggingFaceHubClient().search(
+            query: "mlx",
+            sort: .downloads,
+            capabilities: [hubCapability],
+            token: token
+        ).models
+    }
+}
+
 private struct HubErrorPayload: Decodable {
     let error: String
 }
@@ -770,6 +787,10 @@ final class HuggingFaceDownloadManager: ObservableObject {
 
     func state(for modelID: String) -> DownloadState? {
         downloads.first { $0.modelID == modelID }?.state
+    }
+
+    func reportError(_ message: String, for modelID: String) {
+        errorByModelID[modelID] = message
     }
 
     func capacityBlocker(sizeBytes: Int64?, cachePath: String) -> String? {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -56,6 +56,8 @@ struct ModelsView: View {
     @Binding var showsConfiguration: Bool
     var titleLeadingInset: CGFloat = 0
     var speechModelDiscoveryRequest = 0
+    var imageModelDiscoveryRequest = 0
+    var imageModelDiscoveryCapability: LocalModelCapability = .imageGeneration
     @StateObject private var localLibrary = LocalModelLibrary()
     @StateObject private var hubLibrary = HuggingFaceModelLibrary()
     // Keep download progress observation in the banner and individual rows.
@@ -71,6 +73,7 @@ struct ModelsView: View {
     @State private var hubCapabilityFilters = Set<LocalModelCapability>()
     @State private var hubAccessFilter: HubAccessFilter = .all
     @State private var handledSpeechModelDiscoveryRequest = 0
+    @State private var handledImageModelDiscoveryRequest = 0
     @State private var lastStartedHubSearchTaskID: HubSearchTaskID?
 
     var body: some View {
@@ -96,9 +99,13 @@ struct ModelsView: View {
         }
         .onAppear {
             openSpeechModelDiscoveryIfRequested()
+            openImageModelDiscoveryIfRequested()
         }
         .onChange(of: speechModelDiscoveryRequest) { _, _ in
             openSpeechModelDiscoveryIfRequested()
+        }
+        .onChange(of: imageModelDiscoveryRequest) { _, _ in
+            openImageModelDiscoveryIfRequested()
         }
         .onChange(of: section) { _, newSection in
             // Let the segmented control commit before replacing the toolbar
@@ -142,6 +149,18 @@ struct ModelsView: View {
         typeFilter = .speech
         hubQuery = ""
         hubCapabilityFilters = [.speechToText]
+        hubAccessFilter = .all
+    }
+
+    private func openImageModelDiscoveryIfRequested() {
+        guard imageModelDiscoveryRequest > handledImageModelDiscoveryRequest else {
+            return
+        }
+        handledImageModelDiscoveryRequest = imageModelDiscoveryRequest
+        section = .discover
+        typeFilter = .image
+        hubQuery = ""
+        hubCapabilityFilters = [imageModelDiscoveryCapability]
         hubAccessFilter = .all
     }
 
@@ -1518,7 +1537,7 @@ private struct HubModelRowContainer: View {
     }
 }
 
-private struct ModelDownloadProgressControl: View {
+struct ModelDownloadProgressControl: View {
     let progress: Double
     let isPaused: Bool
     let onPauseResume: () -> Void

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -151,12 +151,16 @@ struct ModelsViewHost: View, Equatable {
     @Binding var showsConfiguration: Bool
     var titleLeadingInset: CGFloat = 0
     var speechModelDiscoveryRequest = 0
+    var imageModelDiscoveryRequest = 0
+    var imageModelDiscoveryCapability: LocalModelCapability = .imageGeneration
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.model === rhs.model
             && lhs.showsConfiguration == rhs.showsConfiguration
             && lhs.titleLeadingInset == rhs.titleLeadingInset
             && lhs.speechModelDiscoveryRequest == rhs.speechModelDiscoveryRequest
+            && lhs.imageModelDiscoveryRequest == rhs.imageModelDiscoveryRequest
+            && lhs.imageModelDiscoveryCapability == rhs.imageModelDiscoveryCapability
     }
 
     var body: some View {
@@ -164,7 +168,9 @@ struct ModelsViewHost: View, Equatable {
             model: model,
             showsConfiguration: $showsConfiguration,
             titleLeadingInset: titleLeadingInset,
-            speechModelDiscoveryRequest: speechModelDiscoveryRequest
+            speechModelDiscoveryRequest: speechModelDiscoveryRequest,
+            imageModelDiscoveryRequest: imageModelDiscoveryRequest,
+            imageModelDiscoveryCapability: imageModelDiscoveryCapability
         )
     }
 }
@@ -199,12 +205,16 @@ struct ModelsView: View {
         model: NativModel,
         showsConfiguration: Binding<Bool>,
         titleLeadingInset: CGFloat = 0,
-        speechModelDiscoveryRequest: Int = 0
+        speechModelDiscoveryRequest: Int = 0,
+        imageModelDiscoveryRequest: Int = 0,
+        imageModelDiscoveryCapability: LocalModelCapability = .imageGeneration
     ) {
         self.model = model
         _showsConfiguration = showsConfiguration
         self.titleLeadingInset = titleLeadingInset
         self.speechModelDiscoveryRequest = speechModelDiscoveryRequest
+        self.imageModelDiscoveryRequest = imageModelDiscoveryRequest
+        self.imageModelDiscoveryCapability = imageModelDiscoveryCapability
         _modelState = StateObject(wrappedValue: ModelsNativState(model: model))
     }
 

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -124,7 +124,7 @@ final class ChatToolRegistryTests: XCTestCase {
         let resolution = ChatImageModelSelection.resolve(
             operation: .generate,
             selectedModelID: "org/generator",
-            installedModels: imageModelOptions
+            availableModels: imageModelOptions
         )
 
         guard case .selected(let model) = resolution else {
@@ -137,7 +137,7 @@ final class ChatToolRegistryTests: XCTestCase {
         let resolution = ChatImageModelSelection.resolve(
             operation: .generate,
             selectedModelID: nil,
-            installedModels: imageModelOptions
+            availableModels: imageModelOptions
         )
 
         guard case .selectionRequired(let request) = resolution else {
@@ -157,7 +157,7 @@ final class ChatToolRegistryTests: XCTestCase {
         let resolution = ChatImageModelSelection.resolve(
             operation: .generate,
             selectedModelID: nil,
-            installedModels: [onlyModel]
+            availableModels: [onlyModel]
         )
 
         guard case .selectionRequired(let request) = resolution else {
@@ -183,7 +183,7 @@ final class ChatToolRegistryTests: XCTestCase {
         let resolution = ChatImageModelSelection.resolve(
             operation: .generate,
             selectedModelID: "org/not-installed",
-            installedModels: imageModelOptions
+            availableModels: imageModelOptions
         )
 
         guard case .selectionRequired(let request) = resolution else {
@@ -196,7 +196,7 @@ final class ChatToolRegistryTests: XCTestCase {
         let resolution = ChatImageModelSelection.resolve(
             operation: .edit,
             selectedModelID: "org/generator",
-            installedModels: imageModelOptions
+            availableModels: imageModelOptions
         )
 
         guard case .selectionRequired(let request) = resolution else {
@@ -205,16 +205,187 @@ final class ChatToolRegistryTests: XCTestCase {
         XCTAssertEqual(request.models.map(\.modelID), ["org/editor", "org/both"])
     }
 
-    func testNoInstalledImageModelRequiresInstallation() {
+    func testNoInstalledImageModelStillPresentsExploreFlow() {
         let resolution = ChatImageModelSelection.resolve(
             operation: .generate,
             selectedModelID: nil,
-            installedModels: []
+            availableModels: []
         )
 
-        guard case .installationRequired(.generate) = resolution else {
-            return XCTFail("expected installationRequired(.generate)")
+        guard case .selectionRequired(let request) = resolution else {
+            return XCTFail("an empty picker must remain available for model discovery")
         }
+        XCTAssertEqual(request.operation, .generate)
+        XCTAssertTrue(request.models.isEmpty)
+    }
+
+    func testPickerShowsAllDownloadedModelsAndThreeHubRecommendations() {
+        let installed = [
+            imageModelOption("org/local-b"),
+            imageModelOption("org/local-a"),
+        ]
+        let downloadable = (1...5).map {
+            imageModelOption(
+                "org/remote-\($0)",
+                availability: .downloadable(sizeBytes: Int64($0) * 1_000)
+            )
+        }
+
+        let options = ChatImageModelSelection.displayOptions(
+            for: .generate,
+            installedModels: installed,
+            downloadableModels: downloadable
+        )
+
+        XCTAssertEqual(options.count, 5)
+        XCTAssertEqual(Array(options.prefix(2).map(\.modelID)), ["org/local-a", "org/local-b"])
+        XCTAssertEqual(options.filter { !$0.isInstalled }.count, 3)
+    }
+
+    func testPickerAlwaysShowsEveryDownloadedModel() {
+        let installed = (1...7).map { imageModelOption("org/local-\($0)") }
+        let downloadable = (1...5).map {
+            imageModelOption(
+                "org/remote-\($0)",
+                availability: .downloadable(sizeBytes: Int64($0) * 1_000)
+            )
+        }
+
+        let options = ChatImageModelSelection.displayOptions(
+            for: .generate,
+            installedModels: installed,
+            downloadableModels: downloadable
+        )
+
+        XCTAssertEqual(options.count, 10)
+        XCTAssertEqual(options.filter(\.isInstalled).count, 7)
+        XCTAssertEqual(options.filter { !$0.isInstalled }.count, 3)
+    }
+
+    func testOfflinePickerShowsOnlyDownloadedModels() {
+        let installed = [imageModelOption("org/local")]
+
+        let options = ChatImageModelSelection.displayOptions(
+            for: .generate,
+            installedModels: installed,
+            downloadableModels: []
+        )
+
+        XCTAssertEqual(options, installed)
+    }
+
+    func testOfflineRecommendationFailureReturnsAnEmptyPicker() async throws {
+        let missingPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .path
+        let options = try await ChatImageModelSelection.availableOptions(
+            for: .generate,
+            modelSearchPath: missingPath,
+            additionalModelSearchPaths: [],
+            huggingFaceToken: nil,
+            recommendationLoader: { _, _ in
+                throw URLError(.notConnectedToInternet)
+            }
+        )
+
+        XCTAssertTrue(options.isEmpty)
+    }
+
+    func testRecommendationsOnlyAcceptSupportedMLXImageFamilies() {
+        XCTAssertEqual(
+            ChatImageModelSelection.downloadableCapabilities(
+                modelID: "mlx-community/flux2-klein-4b-8bit",
+                tags: ["mlx"]
+            ),
+            [.imageGeneration, .imageEditing]
+        )
+        XCTAssertEqual(
+            ChatImageModelSelection.downloadableCapabilities(
+                modelID: "mlx-community/stable-diffusion-xl",
+                tags: ["mlx"]
+            ),
+            []
+        )
+        XCTAssertEqual(
+            ChatImageModelSelection.downloadableCapabilities(
+                modelID: "MLXBits/ideogram-4-mlx-q4",
+                tags: ["gguf"]
+            ),
+            []
+        )
+    }
+
+    func testDownloadedModelIsValidatedBeforeToolExecution() {
+        let model = imageModelOption("org/generator")
+
+        XCTAssertTrue(ChatImageModelSelection.isPrepared(
+            modelID: model.modelID,
+            for: .generate,
+            installedModels: [model]
+        ))
+        XCTAssertFalse(ChatImageModelSelection.isPrepared(
+            modelID: model.modelID,
+            for: .edit,
+            installedModels: [model]
+        ))
+    }
+
+    func testExploreModelsUsesTheRequestedImageCapability() {
+        XCTAssertEqual(ChatImageOperation.generate.requiredCapability, .imageGeneration)
+        XCTAssertEqual(ChatImageOperation.edit.requiredCapability, .imageEditing)
+    }
+
+    func testPickerDoesNotRecommendAnAlreadyDownloadedModel() {
+        let installed = [imageModelOption("org/shared")]
+        let downloadable = [
+            imageModelOption(
+                "org/shared",
+                availability: .downloadable(sizeBytes: nil)
+            ),
+            imageModelOption(
+                "org/remote",
+                availability: .downloadable(sizeBytes: nil)
+            ),
+        ]
+
+        let options = ChatImageModelSelection.displayOptions(
+            for: .generate,
+            installedModels: installed,
+            downloadableModels: downloadable
+        )
+
+        XCTAssertEqual(options.map(\.modelID), ["org/shared", "org/remote"])
+    }
+
+    func testSavedDownloadableModelStillRequiresUserSelection() {
+        let downloadable = imageModelOption(
+            "org/remote",
+            availability: .downloadable(sizeBytes: nil)
+        )
+
+        let resolution = ChatImageModelSelection.resolve(
+            operation: .generate,
+            selectedModelID: downloadable.modelID,
+            availableModels: [downloadable]
+        )
+
+        guard case .selectionRequired(let request) = resolution else {
+            return XCTFail("a remote recommendation must not download without consent")
+        }
+        XCTAssertEqual(request.models, [downloadable])
+    }
+
+    func testPreselectedDownloadedModelSkipsHubRecommendations() {
+        let installed = [imageModelOption("org/local")]
+
+        XCTAssertFalse(ChatImageModelSelection.needsRecommendations(
+            preferredInstalledModelID: "org/local",
+            installedModels: installed
+        ))
+        XCTAssertTrue(ChatImageModelSelection.needsRecommendations(
+            preferredInstalledModelID: "org/missing",
+            installedModels: installed
+        ))
     }
 
     func testNativeSelectionRejectsAnIdentifierOutsideItsRequest() throws {
@@ -255,6 +426,17 @@ final class ChatToolRegistryTests: XCTestCase {
             .path
         var didStartExecution = false
         var imageContext = makeContext(modelSearchPath: missingPath)
+        imageContext.imageToolDependencies = ChatImageToolDependencies(
+            discoverModels: { _, path, additionalPaths, _, _ in
+                try await ChatImageModelSelection.installedOptions(
+                    modelSearchPath: path,
+                    additionalModelSearchPaths: additionalPaths
+                )
+            },
+            execute: { _, _, _, _, _ in
+                throw FakeToolError()
+            }
+        )
         imageContext.imageExecutionWillStart = { _ in
             didStartExecution = true
         }
@@ -293,7 +475,7 @@ final class ChatToolRegistryTests: XCTestCase {
         var sessionModelID: String?
         var context = makeContext()
         context.imageToolDependencies = ChatImageToolDependencies(
-            discoverModels: { _, _ in [selectedModel, languageModel] },
+            discoverModels: { _, _, _, _, _ in [selectedModel, languageModel] },
             execute: { _, modelID, _, _, _ in
                 await recorder.record(modelID: modelID)
                 return ChatImageToolExecution(content: #"{"ok":true}"#, attachments: [])
@@ -446,6 +628,18 @@ final class ChatToolRegistryTests: XCTestCase {
                 capabilities: [.text, .tools]
             ),
         ]
+    }
+
+    private func imageModelOption(
+        _ modelID: String,
+        availability: ChatImageModelOption.Availability = .installed
+    ) -> ChatImageModelOption {
+        ChatImageModelOption(
+            displayName: modelID.split(separator: "/").last.map(String.init) ?? modelID,
+            modelID: modelID,
+            capabilities: [.imageGeneration],
+            availability: availability
+        )
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -154,6 +154,7 @@ targets:
       - path: Sources/Nativ/Features/Extensions/NativSkill.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioInputDevicePreferences.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
+      - path: Sources/Nativ/Features/Models/HubModelSizeResolver.swift
       - path: Sources/Nativ/Features/Models/LocalModelDiscovery.swift
       - path: Sources/Nativ/Features/Models/LocalModelProvider.swift
       - path: Sources/Nativ/Features/Models/MLXImageModelResolver.swift
@@ -179,6 +180,7 @@ targets:
       - path: Sources/Nativ/Features/Chat/ChatSessionStore.swift
       - path: Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
       - path: Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
+      - path: Sources/Nativ/Features/SystemMonitor/SystemSensorSampler.swift
       - path: Sources/Nativ/Features/Dashboard/NativAnalyticsStore.swift
       - path: Sources/Nativ/NativModel.swift
       - path: Sources/Nativ/Utilities/Formatting.swift


### PR DESCRIPTION
Updates the image-generation model picker used during chat tool calls.
Displays all compatible downloaded image models.
Adds up to three compatible Hugging Face models.
Shows only downloaded models when offline.
Displays the download size for every recommended model.
Prevents already downloaded models from appearing as recommendations.
Adds an “Explore models” action with the appropriate image-model filters.
Preserves the existing UI and behavior of other services.