### PR TITLE
Fix debug signing and simplify hands-free shortcut

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build verify clean
-.PHONY: xcode-generate xcode-build xcode-run xcode-smoke xcode-lifecycle-smoke
+.PHONY: xcode-generate xcode-build xcode-sign xcode-run xcode-smoke xcode-lifecycle-smoke
 
 XCODE_DERIVED_DATA ?= build/NativDevelopmentDerivedData
 export DEVELOPER_DIR ?= /Applications/Xcode.app/Contents/Developer
@@ -22,7 +22,10 @@ xcode-generate:
 xcode-build: xcode-generate
 	xcodebuild -project Nativ.xcodeproj -scheme Nativ -configuration Debug -derivedDataPath $(XCODE_DERIVED_DATA) CODE_SIGNING_ALLOWED=NO build
 
-xcode-run: xcode-build
+xcode-sign: xcode-build
+	./scripts/sign_macos_debug.sh $(abspath $(XCODE_DERIVED_DATA)/Build/Products/Debug/Nativ.app)
+
+xcode-run: xcode-sign
 	./scripts/open_macos_debug.sh $(abspath $(XCODE_DERIVED_DATA)/Build/Products/Debug/Nativ.app)
 
 xcode-smoke: xcode-build

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -1800,7 +1800,7 @@ struct AudioView: View {
             return "Hold while speaking; release to transcribe."
         }
         return shortcuts.recordShortcut.keyCode == nil
-            ? "Double-tap to start; double-tap again to transcribe."
+            ? "Tap once to start; tap again to transcribe."
             : "Press once to start; press again to transcribe."
     }
 

--- a/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
@@ -27,16 +27,12 @@ struct FnRetryShortcutState {
 }
 
 struct VoiceModifierToggleShortcutState {
-    static let doubleTapWindow: TimeInterval = 0.6
-
     private(set) var isHeld = false
     private(set) var wasUsedAsChord = false
-    private var lastCleanTapTime: Date?
 
     mutating func update(
         activeModifiers: VoiceShortcutModifiers,
-        shortcutModifiers: VoiceShortcutModifiers,
-        now: Date = Date()
+        shortcutModifiers: VoiceShortcutModifiers
     ) -> Bool {
         guard !shortcutModifiers.isEmpty else {
             reset()
@@ -50,17 +46,7 @@ struct VoiceModifierToggleShortcutState {
                 let wasCleanTap = !wasUsedAsChord
                 isHeld = false
                 wasUsedAsChord = false
-                guard wasCleanTap else {
-                    lastCleanTapTime = nil
-                    return false
-                }
-                if let previous = lastCleanTapTime,
-                   now.timeIntervalSince(previous) <= Self.doubleTapWindow {
-                    lastCleanTapTime = nil
-                    return true
-                }
-                lastCleanTapTime = now
-                return false
+                return wasCleanTap
             }
             return false
         }
@@ -81,7 +67,6 @@ struct VoiceModifierToggleShortcutState {
     mutating func reset() {
         isHeld = false
         wasUsedAsChord = false
-        lastCleanTapTime = nil
     }
 }
 

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -274,71 +274,57 @@ final class FnRetryShortcutStateTests: XCTestCase {
 }
 
 final class VoiceModifierToggleShortcutStateTests: XCTestCase {
-    private let origin = Date(timeIntervalSinceReferenceDate: 0)
-
     @discardableResult
     private func tap(
         _ state: inout VoiceModifierToggleShortcutState,
-        shortcut: VoiceShortcutModifiers = [.option],
-        at time: Date
+        shortcut: VoiceShortcutModifiers = [.option]
     ) -> Bool {
-        _ = state.update(activeModifiers: shortcut, shortcutModifiers: shortcut, now: time)
-        return state.update(activeModifiers: [], shortcutModifiers: shortcut, now: time)
+        _ = state.update(activeModifiers: shortcut, shortcutModifiers: shortcut)
+        return state.update(activeModifiers: [], shortcutModifiers: shortcut)
     }
 
-    func testSingleTapDoesNotToggle() {
+    func testSingleTapToggles() {
         var state = VoiceModifierToggleShortcutState()
-        XCTAssertFalse(tap(&state, at: origin))
+        XCTAssertTrue(tap(&state))
         XCTAssertFalse(state.isHeld)
     }
 
-    func testDoubleTapWithinWindowToggles() {
+    func testEachCleanTapToggles() {
         var state = VoiceModifierToggleShortcutState()
-        XCTAssertFalse(tap(&state, at: origin))
-        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(0.2)))
+        XCTAssertTrue(tap(&state))
+        XCTAssertTrue(tap(&state))
     }
 
-    func testSecondTapAfterWindowDoesNotToggle() {
-        var state = VoiceModifierToggleShortcutState()
-        XCTAssertFalse(tap(&state, at: origin))
-        XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(1.0)))
-    }
-
-    func testExtraModifierDoesNotInvalidateDoubleTap() {
+    func testExtraModifierDoesNotInvalidateTap() {
         var state = VoiceModifierToggleShortcutState()
 
         XCTAssertFalse(
             state.update(
                 activeModifiers: [.option],
-                shortcutModifiers: [.option],
-                now: origin
+                shortcutModifiers: [.option]
             )
         )
         XCTAssertFalse(
             state.update(
                 activeModifiers: [.option, .shift],
-                shortcutModifiers: [.option],
-                now: origin
+                shortcutModifiers: [.option]
             )
         )
-        XCTAssertFalse(
+        XCTAssertTrue(
             state.update(
                 activeModifiers: [],
-                shortcutModifiers: [.option],
-                now: origin
+                shortcutModifiers: [.option]
             )
         )
-        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(0.1)))
     }
 
-    func testKeyPressDoesNotArmDoubleTap() {
+    func testKeyPressDoesNotToggle() {
         var state = VoiceModifierToggleShortcutState()
 
         XCTAssertFalse(
             state.update(
                 activeModifiers: [.option],
-                shortcutModifiers: [.option],
-                now: origin
+                shortcutModifiers: [.option]
             )
         )
         state.noteKeyDown()
@@ -346,26 +332,10 @@ final class VoiceModifierToggleShortcutStateTests: XCTestCase {
         XCTAssertFalse(
             state.update(
                 activeModifiers: [],
-                shortcutModifiers: [.option],
-                now: origin
+                shortcutModifiers: [.option]
             )
         )
-        XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(0.1)))
-    }
-
-    func testCanToggleAgainAfterCompletingDoubleTap() {
-        var state = VoiceModifierToggleShortcutState()
-        XCTAssertFalse(tap(&state, at: origin))
-        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(0.2)))
-
-        XCTAssertFalse(tap(&state, at: origin.addingTimeInterval(2)))
-        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(2.2)))
-    }
-
-    func testDoubleTapWithinWidenedWindowToggles() {
-        var state = VoiceModifierToggleShortcutState()
-        XCTAssertFalse(tap(&state, at: origin))
-        XCTAssertTrue(tap(&state, at: origin.addingTimeInterval(0.5)))
+        XCTAssertTrue(tap(&state))
     }
 
     func testEntersHeldWithExtraModifier() {
@@ -374,15 +344,14 @@ final class VoiceModifierToggleShortcutStateTests: XCTestCase {
         XCTAssertFalse(
             state.update(
                 activeModifiers: [.control, .option, .command, .shift],
-                shortcutModifiers: shortcut,
-                now: origin
+                shortcutModifiers: shortcut
             )
         )
         XCTAssertTrue(state.isHeld)
-        XCTAssertFalse(
-            state.update(activeModifiers: [], shortcutModifiers: shortcut, now: origin)
+        XCTAssertTrue(
+            state.update(activeModifiers: [], shortcutModifiers: shortcut)
         )
-        XCTAssertTrue(tap(&state, shortcut: shortcut, at: origin.addingTimeInterval(0.2)))
+        XCTAssertTrue(tap(&state, shortcut: shortcut))
     }
 }
 

--- a/scripts/sign_macos_release.sh
+++ b/scripts/sign_macos_release.sh
@@ -238,14 +238,21 @@ resolve_app_entitlements() {
 
     resolved_entitlements_file="$(mktemp "${TMPDIR:-/tmp}/nativ-entitlements.XXXXXX.plist")"
     cp "$source_entitlements" "$resolved_entitlements_file"
-    /usr/libexec/PlistBuddy \
-        -c "Set :keychain-access-groups:0 $signing_team_id.$app_bundle_identifier" \
-        "$resolved_entitlements_file"
 
     if [[ "$is_developer_id" == true || -n "$provisioning_profile" ]]; then
         /usr/libexec/PlistBuddy \
+            -c "Set :keychain-access-groups:0 $signing_team_id.$app_bundle_identifier" \
+            "$resolved_entitlements_file"
+        /usr/libexec/PlistBuddy \
             -c "Add :com.apple.application-identifier string $signing_team_id.$app_bundle_identifier" \
             -c "Add :com.apple.developer.team-identifier string $signing_team_id" \
+            "$resolved_entitlements_file"
+    else
+        # A profile-less Apple Development signature cannot claim a restricted
+        # keychain sharing group. Nativ's local Keychain queries do not request
+        # an access group, so use the normal macOS Keychain behavior instead.
+        /usr/libexec/PlistBuddy \
+            -c "Delete :keychain-access-groups" \
             "$resolved_entitlements_file"
     fi
 
@@ -276,7 +283,11 @@ prepare_provisioning_profile() {
             fail "could not decode the Developer ID provisioning profile"
         resolved_provisioning_profile="$decoded_profile_file"
     else
-        return
+        # Apple Development signatures do not require an embedded Developer ID
+        # provisioning profile. Return success explicitly: a bare `return`
+        # inherits the failed `is_developer_id` test above, and `set -e` would
+        # abort before the app is signed with its entitlements.
+        return 0
     fi
 
     decoded_profile_plist="$(mktemp "${TMPDIR:-/tmp}/nativ-profile.XXXXXX.plist")"
@@ -443,7 +454,8 @@ fi
 if [[ "$app_entitlements" != *"com.apple.security.device.audio-input"* ]]; then
     fail "the signed app is missing the audio-input entitlement"
 fi
-if [[ "$app_entitlements" != *"keychain-access-groups"* ]]; then
+if [[ ("$is_developer_id" == true || -n "$provisioning_profile") && \
+      "$app_entitlements" != *"keychain-access-groups"* ]]; then
     fail "the signed app is missing its keychain access group"
 fi
 if [[ "$is_developer_id" == true ]]; then


### PR DESCRIPTION
## Summary

- sign local Debug builds before opening them
- preserve microphone access while omitting profile-backed keychain sharing from profile-less Apple Development signatures
- restore hands-free modifier shortcuts to one tap to start and another tap to stop
- update the shortcut UI copy and state tests

## Root cause

The local signing script used a bare `return` after a failed Developer ID condition. Under `set -e`, that propagated a failure and stopped before the outer app was signed with its microphone entitlement. Once that was corrected, the profile-less Apple Development build still claimed a restricted keychain access group, causing macOS to terminate it at launch.

The double-tap requirement was introduced in response to issue #210, where the default modifier-only shortcut conflicted with macOS Spaces navigation. This change intentionally restores the original one-tap hands-free interaction: tap once to start and tap again to transcribe. Users who encounter a conflict can disable the global shortcut or assign a custom shortcut from the Audio shortcuts page.

## Impact

`make xcode-run` now builds, signs, verifies, and opens the exact Debug app. macOS can prompt that build for microphone access, and hands-free dictation uses one clean shortcut tap per toggle.

## Validation

- `make xcode-build`
- `make xcode-run`
- deep code-signature verification and successful launch of `dev.local.Nativ`
- focused shortcut tests were updated; their run is currently blocked by existing NativTests target errors for missing System Monitor sensor types
