### PR TITLE
Rework custom kits for chat and routines

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
 		04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */; };
+		086BC5B6FF02F0305536333B /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
 		088297CDFEFECD2787806AD7 /* VoiceCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */; };
 		0935A0AC0D6A6298D551EEAE /* ArtifactSemanticSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */; };
 		0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */; };
@@ -33,7 +34,9 @@
 		2452C5D7B24CA5FF6FAA36E2 /* MCPHostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5D77458EF56DD1B8F4AE17 /* MCPHostManager.swift */; };
 		252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
 		256B07A9158557D2E3AD2A35 /* Manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AF8F6359E4523814FB0EFDA /* Manifest.json */; };
+		25D127CA91D6EF7FB3EF6514 /* NativKitEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D264F083A990A23BACB762 /* NativKitEditor.swift */; };
 		293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
+		295E9FAAF1664D30FEA915E1 /* NativKitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF782B5343C96328B33F488 /* NativKitStore.swift */; };
 		2B89F9E09ABB37B82AC2FEB5 /* NativAudioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9B712CAFE08083D1679354E /* NativAudioClient.swift */; };
 		2B988CEEF0FD7FCCD3862AF6 /* NativExtensionStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */; };
 		2BF78B0A20ED752102326A38 /* ChatImageModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */; };
@@ -49,6 +52,7 @@
 		361D948B1B76F41B63A0B832 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
 		36405D7EB30E430CF06956EB /* ShellEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */; };
 		37733336E268AC8DFE5AEC6C /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
+		397F07839D065C33F1BEBB99 /* ChatUseKitTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E35C14AD675ED9AF873943B /* ChatUseKitTool.swift */; };
 		39ADE4524CF22ED36D505546 /* NativExtensionHostBroker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */; };
 		39DF704E9F1D23E2F8248F02 /* LocalModelDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */; };
 		39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
@@ -59,7 +63,9 @@
 		41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */; };
+		44F8A17BDE2610C6E90CE53F /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
 		45BD4C408B9739ABC051A9E7 /* ControlPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C7712D68B2782589312766 /* ControlPanelView.swift */; };
+		460F4917F3201B118559EBD5 /* ChatUseKitTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E35C14AD675ED9AF873943B /* ChatUseKitTool.swift */; };
 		463870509178CCD59287E1BE /* VoiceTranscriptInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23155DB5E733D8887D83AFD0 /* VoiceTranscriptInserter.swift */; };
 		482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */; };
 		4882FE7E8C689152D428AB2E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 0D3574097911A448F62ED273 /* Sparkle */; };
@@ -68,10 +74,13 @@
 		4B25C497C3E90EE13474F839 /* UISFXMinimalPlay.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 9FB275767AC2B912FA2FEDEE /* UISFXMinimalPlay.mp3 */; };
 		4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */; };
 		4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B965B701714787B0A85AE6B /* AudioTests.swift */; };
+		4B95E0BE6589A1D63E696175 /* icon.json in Resources */ = {isa = PBXBuildFile; fileRef = 955320EDC1FB6B9B8DEFB43B /* icon.json */; };
+		4C6C8A4C2BBFF28D26EF1D2D /* NativKitActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E258B26CC0082AB2EAD59CB /* NativKitActivation.swift */; };
 		4CB31A9AACD344FA2CD1B6FD /* VoiceAnimationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632EB67BFAC2BCBE082A3E2B /* VoiceAnimationPreferences.swift */; };
 		4DB478CE9FB6079C7B55B097 /* DevHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E646A2A68BB20D0CD4933E2A /* DevHubView.swift */; };
 		4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */; };
 		4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
+		4F615D6B17628FC3FCC7199D /* NativKitPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8500BF58CDA5C392E60DC8C /* NativKitPresentation.swift */; };
 		506A12DCE5B56E53208A8BA2 /* NativServerKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1651E057CC5D05857CF1595 /* NativServerKit.swift */; };
 		52E78D326199C2BF37D16F66 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = 8DD1E187A7659D46CDC76CF9 /* MCP */; };
 		54D53CD1A2BA96B2336C2406 /* KitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1B970F41F1B5612B791ABE /* KitsSectionView.swift */; };
@@ -88,6 +97,7 @@
 		63D4D3774994EAE5F5ABB7E9 /* AudioInputVolumeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A118DF27AE0EF852DC458BB7 /* AudioInputVolumeController.swift */; };
 		657DFF151F7E54EA66CC36F8 /* SystemSensorSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653E58FFA38742CD4D5D41F5 /* SystemSensorSampler.swift */; };
 		66745D5BB4D1454479FF6C9C /* RoutineScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C1220F03EC60874920E0CE /* RoutineScheduler.swift */; };
+		685D0C1A9E3B12C90EA3D952 /* MCPCatalogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B2E989C1BBC9AFB45AE8D6 /* MCPCatalogEntry.swift */; };
 		692EA024371CB249BE53DB86 /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
 		6B5A139573E38850CE9C1E3F /* AudioInputDevicePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */; };
 		6C872B0124611E3D0297E2FD /* MCPSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A814B8C04BCBF1C1F869A8 /* MCPSectionView.swift */; };
@@ -98,7 +108,6 @@
 		759391363423D786EF850BE3 /* RoutineEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */; };
 		76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */; };
 		7748996AA574868ED694F974 /* AudioCaptureLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820A7EF6D7E1FA0F171A5A59 /* AudioCaptureLibrary.swift */; };
-		77B9284EE48D020C2B5A2DF3 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */; };
 		7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */; };
 		7A86AD9E2E640430F47B94D5 /* FileTypeIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677258B04E9BB7CA8B89E11E /* FileTypeIcon.swift */; };
 		7C49B0A059A3495FF8BC8B66 /* EmbeddingModelPreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B205BC53F36B8200F5D5FD8 /* EmbeddingModelPreparer.swift */; };
@@ -119,6 +128,7 @@
 		98086CE0CF71463BDF07F8A8 /* RoutineLaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34FBE730C051EFF28B1323B /* RoutineLaunchAgent.swift */; };
 		9954F8086FE0A7A9B3378EC9 /* NativComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EE1CE9AAE5A3B9A2D4669C /* NativComponents.swift */; };
 		9A1E1FD2D597C682F4A8D2A9 /* AudioInputLevelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DDA5274474AC8D54DFDF71 /* AudioInputLevelMonitor.swift */; };
+		9A5A36AD3202DB5A57319947 /* RoutineKitResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE296201A4FF80537A926F9 /* RoutineKitResolver.swift */; };
 		9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */; };
 		9E6B93B1603C4E964422E09B /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A0D30C905A2788C3BD2149BF /* ChatScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */; };
@@ -130,9 +140,11 @@
 		A6E043CD0C3AD882D0D0AE66 /* VoiceAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0952EC469768D8775A2D188 /* VoiceAudioRecorder.swift */; };
 		A9B82EFAD4FD8C57E045721B /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB9D1D0FC24AC771442B628 /* Artifact.swift */; };
 		AB1C4B8494B46754E6E8BE24 /* AudioAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0BD007DAD141D50E1BAA4 /* AudioAnalyticsStore.swift */; };
+		AB4C49A5BFDAA9352BD257B7 /* CustomToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */; };
 		ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */; };
 		ACBA3EAEE7677FCAD4977850 /* NativSkill.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDB4C89F8DD338E9209E7FF /* NativSkill.swift */; };
 		ADDF36ABE66D5ACE3D765589 /* AudioView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E012B6E98DF6B992CDA591F /* AudioView.swift */; };
+		AF1502F763FAF5EA1839CC4D /* NativKitStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3665BF8FE325798A8A6F86 /* NativKitStoreTests.swift */; };
 		B15353CDE6204176664DB3B2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E2EE61C1652C49ECC69658 /* AppDelegate.swift */; };
 		B2B154008527C6291C17AC93 /* MLXImageModelResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61126D4235AFF77D82F1F80B /* MLXImageModelResolver.swift */; };
 		B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EF3E0B4A9EEC293EFD5F8A /* ChatImageTool.swift */; };
@@ -160,8 +172,10 @@
 		D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */; };
 		D74F92EBE05FADCD813CD8B9 /* AudioAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0BD007DAD141D50E1BAA4 /* AudioAnalyticsStore.swift */; };
 		D76DC0072E523E6409DF1176 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 730B64747E8A780CD14AF88F /* Textual */; };
+		D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7F610FC8739BA80227DB26 /* NativKit.swift */; };
 		D8838254D03112C2EABE37AC /* ModelPrimaryTaskResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */; };
 		D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
+		D9BF672FBAC1FDF94B550E39 /* NativKitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF782B5343C96328B33F488 /* NativKitStore.swift */; };
 		DC1ED6C1A11081FB70F1F019 /* NativImageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */; };
 		DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677360D86DDAFAB194A995E7 /* Main.swift */; };
 		DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */; };
@@ -181,6 +195,8 @@
 		F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */; };
+		F9B09901AC4BC489C613C82D /* RoutineKitResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE296201A4FF80537A926F9 /* RoutineKitResolver.swift */; };
+		FB233D129B07C310113E13E1 /* Front.png in Resources */ = {isa = PBXBuildFile; fileRef = 54CAE400DE3E453F70CC7152 /* Front.png */; };
 		FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
 /* End PBXBuildFile section */
 
@@ -294,6 +310,7 @@
 		3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironmentTests.swift; sourceTree = "<group>"; };
 		3B1B970F41F1B5612B791ABE /* KitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KitsSectionView.swift; sourceTree = "<group>"; };
 		3B965B701714787B0A85AE6B /* AudioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTests.swift; sourceTree = "<group>"; };
+		3E35C14AD675ED9AF873943B /* ChatUseKitTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUseKitTool.swift; sourceTree = "<group>"; };
 		3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorStore.swift; sourceTree = "<group>"; };
 		3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXImageModelResolverTests.swift; sourceTree = "<group>"; };
 		41417C210BF817681A8C6D87 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
@@ -306,6 +323,7 @@
 		50843C4D4ABCEC290EE626AF /* RoutineRunCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineRunCoordinator.swift; sourceTree = "<group>"; };
 		52EB7572F271F7D68DC3F97D /* ModelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsView.swift; sourceTree = "<group>"; };
 		530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionStore.swift; sourceTree = "<group>"; };
+		54CAE400DE3E453F70CC7152 /* Front.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Front.png; sourceTree = "<group>"; };
 		586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionHostBroker.swift; sourceTree = "<group>"; };
 		5919AB4E9488642C73886266 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
 		594711E024396C78703CE05A /* NativSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSettings.swift; sourceTree = "<group>"; };
@@ -320,6 +338,8 @@
 		677360D86DDAFAB194A995E7 /* Main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Main.swift; sourceTree = "<group>"; };
 		6BB0CD839020E3F5FF4F8DED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6CDD9C3FE179B2E8D76FC769 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		6F3665BF8FE325798A8A6F86 /* NativKitStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitStoreTests.swift; sourceTree = "<group>"; };
+		73B2E989C1BBC9AFB45AE8D6 /* MCPCatalogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPCatalogEntry.swift; sourceTree = "<group>"; };
 		7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceShortcut.swift; sourceTree = "<group>"; };
 		7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontScale.swift; sourceTree = "<group>"; };
 		7B205BC53F36B8200F5D5FD8 /* EmbeddingModelPreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddingModelPreparer.swift; sourceTree = "<group>"; };
@@ -342,8 +362,11 @@
 		8BB9D1D0FC24AC771442B628 /* Artifact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artifact.swift; sourceTree = "<group>"; };
 		8C5D77458EF56DD1B8F4AE17 /* MCPHostManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPHostManager.swift; sourceTree = "<group>"; };
 		8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureCoordinator.swift; sourceTree = "<group>"; };
+		8E258B26CC0082AB2EAD59CB /* NativKitActivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitActivation.swift; sourceTree = "<group>"; };
 		8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProviderTests.swift; sourceTree = "<group>"; };
 		90012E8ECF43A5A55BFD8787 /* RoutineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineSupport.swift; sourceTree = "<group>"; };
+		92D264F083A990A23BACB762 /* NativKitEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitEditor.swift; sourceTree = "<group>"; };
+		955320EDC1FB6B9B8DEFB43B /* icon.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = icon.json; sourceTree = "<group>"; };
 		96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativEmbeddingsClient.swift; sourceTree = "<group>"; };
 		9A7A7ACB288953FD476C47E8 /* MCPServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerConfig.swift; sourceTree = "<group>"; };
 		9AF7F0D894C4EB6521F21D4D /* SystemMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorView.swift; sourceTree = "<group>"; };
@@ -369,6 +392,7 @@
 		BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormatting.swift; sourceTree = "<group>"; };
 		C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscoveryTests.swift; sourceTree = "<group>"; };
 		C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSwitchModelTool.swift; sourceTree = "<group>"; };
+		C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTool.swift; sourceTree = "<group>"; };
 		C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolRegistryTests.swift; sourceTree = "<group>"; };
 		CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTypes.swift; sourceTree = "<group>"; };
 		CDDB4C89F8DD338E9209E7FF /* NativSkill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSkill.swift; sourceTree = "<group>"; };
@@ -382,9 +406,10 @@
 		D941186B3A4BA46FB90201DE /* NativExtensionMessaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionMessaging.swift; sourceTree = "<group>"; };
 		D97F637262DB138A253DEA6F /* ChatComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatComposer.swift; sourceTree = "<group>"; };
 		D9B712CAFE08083D1679354E /* NativAudioClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativAudioClient.swift; sourceTree = "<group>"; };
+		DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToolTests.swift; sourceTree = "<group>"; };
 		DB24BFEFF23914DA8BDB0E1C /* ModelProviderIcons */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ModelProviderIcons; path = Sources/Nativ/ModelProviderIcons; sourceTree = SOURCE_ROOT; };
+		DBF782B5343C96328B33F488 /* NativKitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitStore.swift; sourceTree = "<group>"; };
 		DE575DB2DCD07A1864311714 /* Nativ.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nativ.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionTests.swift; sourceTree = "<group>"; };
 		E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineStore.swift; sourceTree = "<group>"; };
 		E2DDA5274474AC8D54DFDF71 /* AudioInputLevelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputLevelMonitor.swift; sourceTree = "<group>"; };
@@ -392,6 +417,7 @@
 		E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSettingsTests.swift; sourceTree = "<group>"; };
 		E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentMenuActionView.swift; sourceTree = "<group>"; };
 		E646A2A68BB20D0CD4933E2A /* DevHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevHubView.swift; sourceTree = "<group>"; };
+		E8500BF58CDA5C392E60DC8C /* NativKitPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitPresentation.swift; sourceTree = "<group>"; };
 		E902D6BB4117C3F240832FA3 /* ToolsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsSectionView.swift; sourceTree = "<group>"; };
 		E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceCache.swift; sourceTree = "<group>"; };
 		EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NativExtensionSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -401,6 +427,7 @@
 		F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProvider.swift; sourceTree = "<group>"; };
 		F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPromptRevision.swift; sourceTree = "<group>"; };
 		F553434CA19B929108FF740F /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
+		FAE296201A4FF80537A926F9 /* RoutineKitResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineKitResolver.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -448,6 +475,7 @@
 			children = (
 				06F067B3DB861CF232820136 /* Routine.swift */,
 				D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */,
+				FAE296201A4FF80537A926F9 /* RoutineKitResolver.swift */,
 				D34FBE730C051EFF28B1323B /* RoutineLaunchAgent.swift */,
 				50843C4D4ABCEC290EE626AF /* RoutineRunCoordinator.swift */,
 				9B95090B83C36E4F06C7C5E3 /* RoutineRunner.swift */,
@@ -476,7 +504,6 @@
 			isa = PBXGroup;
 			children = (
 				B0E2EE61C1652C49ECC69658 /* AppDelegate.swift */,
-				DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */,
 				6BB0CD839020E3F5FF4F8DED /* Assets.xcassets */,
 				B7C7712D68B2782589312766 /* ControlPanelView.swift */,
 				677360D86DDAFAB194A995E7 /* Main.swift */,
@@ -486,12 +513,22 @@
 				822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */,
 				CFA5C785716081D2811DFD2D /* TextShimmerWave.swift */,
 				EE151F7A36DA21A32ABCFD63 /* WelcomeView.swift */,
+				18FB93E3846EA971A2CFD6B4 /* AppIcon.icon */,
 				A42368BA82350C2FA4CC12DF /* Features */,
 				C40EB30EE457C36AAA9B2427 /* IntegrationLogos */,
 				DD46C324A893EF724704AE92 /* Resources */,
 				10E8764499993A58BE194232 /* Utilities */,
 			);
 			path = Nativ;
+			sourceTree = "<group>";
+		};
+		18FB93E3846EA971A2CFD6B4 /* AppIcon.icon */ = {
+			isa = PBXGroup;
+			children = (
+				955320EDC1FB6B9B8DEFB43B /* icon.json */,
+				83D6BFB7D8EEB8B62FC3662A /* Assets */,
+			);
+			path = AppIcon.icon;
 			sourceTree = "<group>";
 		};
 		1DE309DC3FB91D09768CD66E /* Developer */ = {
@@ -648,6 +685,14 @@
 			);
 			sourceTree = "<group>";
 		};
+		83D6BFB7D8EEB8B62FC3662A /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				54CAE400DE3E453F70CC7152 /* Front.png */,
+			);
+			path = Assets;
+			sourceTree = "<group>";
+		};
 		8638AC147EE8B93EFB518172 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -665,6 +710,7 @@
 				068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */,
 				C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */,
 				A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */,
+				3E35C14AD675ED9AF873943B /* ChatUseKitTool.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -749,13 +795,19 @@
 		D4E162E7B624C8A42FCF6A30 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */,
 				7D5BCE1A4769FE7823B5C79D /* ExtensionsHubView.swift */,
 				3B1B970F41F1B5612B791ABE /* KitsSectionView.swift */,
+				73B2E989C1BBC9AFB45AE8D6 /* MCPCatalogEntry.swift */,
 				86A814B8C04BCBF1C1F869A8 /* MCPSectionView.swift */,
 				586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */,
 				7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */,
 				27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */,
 				AA7F610FC8739BA80227DB26 /* NativKit.swift */,
+				8E258B26CC0082AB2EAD59CB /* NativKitActivation.swift */,
+				92D264F083A990A23BACB762 /* NativKitEditor.swift */,
+				E8500BF58CDA5C392E60DC8C /* NativKitPresentation.swift */,
+				DBF782B5343C96328B33F488 /* NativKitStore.swift */,
 				CDDB4C89F8DD338E9209E7FF /* NativSkill.swift */,
 				E902D6BB4117C3F240832FA3 /* ToolsSectionView.swift */,
 				49B4556627CCB5BD1D3DE5F8 /* VoiceDictationExtension.swift */,
@@ -825,6 +877,7 @@
 			children = (
 				3B965B701714787B0A85AE6B /* AudioTests.swift */,
 				C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */,
+				DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */,
 				A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */,
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
@@ -832,6 +885,7 @@
 				3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */,
 				2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */,
 				E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */,
+				6F3665BF8FE325798A8A6F86 /* NativKitStoreTests.swift */,
 				E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */,
 				3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */,
 			);
@@ -973,6 +1027,7 @@
 				};
 			};
 			buildConfigurationList = 74C8B3C2A026CAD89583C154 /* Build configuration list for PBXProject "Nativ" */;
+			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -987,15 +1042,14 @@
 				07F80B12D683EBF42228393D /* XCRemoteSwiftPackageReference "textual" */,
 			);
 			preferredProjectObjectVersion = 77;
-			productRefGroup = ACC7624E3BE7F661C3D130D0 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				ED4CB78AB93E015D0BE21F7B /* NativExtensionSDK */,
 				1622B274F4DF5A85C2FDB081 /* NativServerKit */,
-				465C23BB3ADA415A5004AAD9 /* Nativ */,
-				7082E254E8272A5E8D13E6F0 /* VoiceDictationExtensionRuntime */,
 				51AD42FA29E71F2450386688 /* NativTests */,
+				7082E254E8272A5E8D13E6F0 /* VoiceDictationExtensionRuntime */,
 			);
 		};
 /* End PBXProject section */
@@ -1013,14 +1067,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				77B9284EE48D020C2B5A2DF3 /* AppIcon.icon in Resources */,
 				11A14C51AE4E0170FBA89709 /* Assets.xcassets in Resources */,
+				FB233D129B07C310113E13E1 /* Front.png in Resources */,
 				359208BE69EFF7BF033D4BA6 /* LICENSES.txt in Resources */,
 				402FF67FA99A26739AA4A653 /* MCPCatalog.json in Resources */,
 				0DF842E2BE07D345918F3D54 /* Manifest.json in Resources */,
 				137BF3A5342405863C49CC10 /* ModelProviderIcons in Resources */,
 				4B25C497C3E90EE13474F839 /* UISFXMinimalPlay.mp3 in Resources */,
 				6CFBB2F5B3720F1334BF3D47 /* UISFXMinimalStop.mp3 in Resources */,
+				4B95E0BE6589A1D63E696175 /* icon.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1094,9 +1149,11 @@
 				1DCBC70AA972310D3FBC22CC /* ChatSwitchModelTool.swift in Sources */,
 				3D7F718E2E136C35CD3509B4 /* ChatSystemStatsTool.swift in Sources */,
 				444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */,
+				460F4917F3201B118559EBD5 /* ChatUseKitTool.swift in Sources */,
 				B47F34B1273BEEAA4D5DD314 /* ChatView.swift in Sources */,
 				FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */,
 				45BD4C408B9739ABC051A9E7 /* ControlPanelView.swift in Sources */,
+				086BC5B6FF02F0305536333B /* CustomTool.swift in Sources */,
 				802B1F569D3D9FBE951EC8EA /* DashboardViewModel.swift in Sources */,
 				4DB478CE9FB6079C7B55B097 /* DevHubView.swift in Sources */,
 				3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */,
@@ -1118,6 +1175,7 @@
 				BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */,
 				1423FD497A75A14770FCA9E1 /* LocalModelDiscovery.swift in Sources */,
 				482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */,
+				685D0C1A9E3B12C90EA3D952 /* MCPCatalogEntry.swift in Sources */,
 				2452C5D7B24CA5FF6FAA36E2 /* MCPHostManager.swift in Sources */,
 				6C872B0124611E3D0297E2FD /* MCPSectionView.swift in Sources */,
 				A1492AA9B1D71B4E57310EF6 /* MLXImageModelResolver.swift in Sources */,
@@ -1131,6 +1189,10 @@
 				F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */,
 				2B988CEEF0FD7FCCD3862AF6 /* NativExtensionStateStore.swift in Sources */,
 				C03E948D1C7E27B27838C4C6 /* NativKit.swift in Sources */,
+				4C6C8A4C2BBFF28D26EF1D2D /* NativKitActivation.swift in Sources */,
+				25D127CA91D6EF7FB3EF6514 /* NativKitEditor.swift in Sources */,
+				4F615D6B17628FC3FCC7199D /* NativKitPresentation.swift in Sources */,
+				D9BF672FBAC1FDF94B550E39 /* NativKitStore.swift in Sources */,
 				4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */,
 				7C9ADF2438B155D639E6A6F2 /* NativPermissionsCard.swift in Sources */,
 				ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */,
@@ -1139,6 +1201,7 @@
 				E407C7F9CE883C978DE7D716 /* PersistentMenuActionView.swift in Sources */,
 				1EBCB9482DABA02FD039A795 /* Routine.swift in Sources */,
 				759391363423D786EF850BE3 /* RoutineEditorView.swift in Sources */,
+				F9B09901AC4BC489C613C82D /* RoutineKitResolver.swift in Sources */,
 				98086CE0CF71463BDF07F8A8 /* RoutineLaunchAgent.swift in Sources */,
 				90A91F19C53567C017E37E28 /* RoutineRunCoordinator.swift in Sources */,
 				81CA2499AF2C4701FC0C817B /* RoutineRunner.swift in Sources */,
@@ -1186,7 +1249,10 @@
 				37733336E268AC8DFE5AEC6C /* ChatSystemStatsTool.swift in Sources */,
 				62CAD81D603FF4AC296279CB /* ChatToolRegistry.swift in Sources */,
 				BEA11D430947F6C01177EDE8 /* ChatToolRegistryTests.swift in Sources */,
+				397F07839D065C33F1BEBB99 /* ChatUseKitTool.swift in Sources */,
 				1C6295D830FE941FDCE3ECCC /* CodexCLIProfile.swift in Sources */,
+				44F8A17BDE2610C6E90CE53F /* CustomTool.swift in Sources */,
+				AB4C49A5BFDAA9352BD257B7 /* CustomToolTests.swift in Sources */,
 				8E16504AFD5457AC965426F2 /* FnControlShortcutMonitor.swift in Sources */,
 				D4F073244DE11FD98AD708E2 /* Formatting.swift in Sources */,
 				A2DF29E907CC0CEF6EF86FBD /* HuggingFaceCache.swift in Sources */,
@@ -1207,10 +1273,14 @@
 				252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */,
 				ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */,
 				0E326825AE5A1A5EEA33D928 /* NativExtensionTests.swift in Sources */,
+				D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */,
+				295E9FAAF1664D30FEA915E1 /* NativKitStore.swift in Sources */,
+				AF1502F763FAF5EA1839CC4D /* NativKitStoreTests.swift in Sources */,
 				025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */,
 				90EE7AA87400E84D947CBBF3 /* NativSettings.swift in Sources */,
 				DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */,
 				ACBA3EAEE7677FCAD4977850 /* NativSkill.swift in Sources */,
+				9A5A36AD3202DB5A57319947 /* RoutineKitResolver.swift in Sources */,
 				BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */,
 				36405D7EB30E430CF06956EB /* ShellEnvironmentTests.swift in Sources */,
 				293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */,

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import NativServerKit
 import SwiftUI
 import UserNotifications
@@ -350,10 +351,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     private let controlPanelNavigation = ControlPanelNavigation()
     private let runtime = SystemRuntimeMonitor()
     private let routineStore = RoutineStore.shared
+    private let kitStore = NativKitStore.shared
+    private let mcpHost = MCPHostManager()
     private lazy var routineRunner = RoutineRunner(
         model: model,
         store: routineStore,
-        sessionStore: ChatSessionStore()
+        sessionStore: ChatSessionStore(),
+        kitStore: kitStore,
+        extensionManager: extensionManager,
+        mcpHost: mcpHost
     )
     private lazy var routineScheduler = RoutineScheduler(
         store: routineStore,
@@ -372,8 +378,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     private var modelScanError: String?
     private var lastScannedModelPath: String?
     private weak var highlightedMenuItem: NSMenuItem?
+    private var mcpSettingsObservation: AnyCancellable?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        kitStore.migrateLegacySettings(mcpServers: model.settings.mcpServers)
         runtime.onUpdate = { [weak self] in
             self?.updateStatusItemButton()
         }
@@ -423,6 +431,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
                 }
             )
         )
+        mcpHost.reload(servers: model.settings.mcpServers)
+        mcpSettingsObservation = model.$settings
+            .map(\.mcpServers)
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] servers in
+                self?.mcpHost.reload(servers: servers)
+            }
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(localModelLibraryDidChange(_:)),
@@ -450,6 +466,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     func applicationWillTerminate(_ notification: Notification) {
         modelScanTask?.cancel()
         extensionManager.shutdown()
+        mcpHost.shutdown()
         runtime.onUpdate = nil
         systemMenuBarPreferences.onChange = nil
         runtime.stop()
@@ -554,6 +571,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
             navigation: controlPanelNavigation,
             runtime: runtime,
             extensionManager: extensionManager,
+            mcpHost: mcpHost,
+            kitStore: kitStore,
             softwareUpdater: softwareUpdater,
             onComplete: { [weak self] modelID, serverAPIKey in
                 self?.completeWelcome(modelID: modelID, serverAPIKey: serverAPIKey)

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -260,9 +260,10 @@ struct ControlPanelView: View {
     // the entire control panel (including the Models result list).
     let runtime: SystemRuntimeMonitor
     @ObservedObject var extensionManager: NativExtensionManager
+    @ObservedObject var mcpHost: MCPHostManager
+    @ObservedObject var kitStore: NativKitStore
     let softwareUpdater: SoftwareUpdater
     @StateObject private var chat = ChatViewModel()
-    @StateObject private var mcpHost = MCPHostManager()
     @StateObject private var imageGeneration = ImageGenerationViewModel()
     @StateObject private var artifacts = ArtifactStore()
     @StateObject private var dashboard = DashboardViewModel()
@@ -641,6 +642,7 @@ struct ControlPanelView: View {
             RoutineEditor(
                 draft: draft,
                 availableModelIDs: availableModelIDs,
+                kitStore: kitStore,
                 onSave: { routine in
                     saveScheduledRoutine(routine)
                     schedulingRoutineDraft = nil
@@ -1938,6 +1940,8 @@ struct ControlPanelView: View {
                 model: model,
                 chat: chat,
                 mcpHost: mcpHost,
+                extensionManager: extensionManager,
+                kitStore: kitStore,
                 showsConfiguration: $isModelConfigurationVisible,
                 conversationWidthReduction: isFullScreen
                     ? 0
@@ -1996,7 +2000,8 @@ struct ControlPanelView: View {
             ExtensionsHubView(
                 manager: extensionManager,
                 host: mcpHost,
-                model: model
+                model: model,
+                kitStore: kitStore
             )
         case .dev:
             DevHubView(
@@ -4186,6 +4191,8 @@ private extension View {
         navigation: .init(),
         runtime: .init(),
         extensionManager: .init(builtInExtensions: []),
+        mcpHost: .init(),
+        kitStore: .init(),
         softwareUpdater: .init()
     )
 }

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -32,12 +32,16 @@ enum ChatToolRoundGate {
 }
 
 enum ChatToolRegistry {
-    static func definitions(canEditImage: Bool) -> [MLXChatToolDefinition] {
+    static func definitions(
+        canEditImage: Bool,
+        kits: [ChatKitDescriptor] = []
+    ) -> [MLXChatToolDefinition] {
         var tools = ChatImageToolRegistry.definitions(canEdit: canEditImage)
         tools.append(contentsOf: ChatSystemMonitorToolRegistry.definitions())
         tools.append(contentsOf: ChatModelLibraryToolRegistry.definitions())
         tools.append(contentsOf: ChatServerStatsToolRegistry.definitions())
         tools.append(contentsOf: ChatSwitchModelToolRegistry.definitions())
+        tools.append(contentsOf: ChatUseKitToolRegistry.definitions(kits: kits))
         return tools
     }
 }
@@ -68,6 +72,9 @@ enum ChatToolDispatcher {
         },
         ChatSwitchModelToolRegistry.toolName: { name, error in
             ChatSwitchModelToolExecutor().failurePayload(operation: name, error: error)
+        },
+        ChatUseKitToolRegistry.toolName: { name, error in
+            ChatUseKitToolExecutor().failurePayload(operation: name, error: error)
         },
     ]
 
@@ -228,6 +235,8 @@ enum ChatToolPresentation {
             return serverStatsTitle(status: status)
         case ChatSwitchModelToolRegistry.toolName:
             return switchModelTitle(status: status)
+        case ChatUseKitToolRegistry.toolName:
+            return useKitTitle(status: status)
         default:
             return genericTitle(toolName: toolName, status: status)
         }
@@ -258,6 +267,8 @@ enum ChatToolPresentation {
                 return "chart.line.uptrend.xyaxis"
             case ChatSwitchModelToolRegistry.toolName:
                 return "arrow.triangle.2.circlepath"
+            case ChatUseKitToolRegistry.toolName:
+                return "shippingbox"
             default:
                 return "wrench.and.screwdriver"
             }
@@ -336,6 +347,23 @@ enum ChatToolPresentation {
             return "Model switch"
         case nil:
             return "Model switch tool"
+        }
+    }
+
+    private static func useKitTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {
+        switch status {
+        case .awaitingConsent:
+            return "Use Kit?"
+        case .preparing, .running:
+            return "Making Kit available…"
+        case .succeeded:
+            return "Kit available"
+        case .declined:
+            return "Kit activation declined"
+        case .failed, .cancelled, .awaitingImageModelSelection:
+            return "Use Kit"
+        case nil:
+            return "Kit tool"
         }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -25,6 +25,8 @@ struct ChatView: View {
     @ObservedObject var model: NativModel
     let chat: ChatViewModel
     @ObservedObject var mcpHost: MCPHostManager
+    @ObservedObject var extensionManager: NativExtensionManager
+    @ObservedObject var kitStore: NativKitStore
     @Binding var showsConfiguration: Bool
     let conversationWidthReduction: CGFloat
     @State private var isDropTargeted = false
@@ -52,7 +54,11 @@ struct ChatView: View {
             .animation(.easeInOut(duration: 0.15), value: isDropTargeted)
         }
         .background(Color.nativMainContentBackground)
-        .onAppear { chat.mcpHost = mcpHost }
+        .onAppear {
+            chat.mcpHost = mcpHost
+            chat.extensionManager = extensionManager
+            chat.kitStore = kitStore
+        }
         .onReceive(NotificationCenter.default.publisher(for: .routineDidSaveChatSession)) { _ in
             chat.reloadPersistedSessions()
         }
@@ -275,6 +281,8 @@ private struct ChatComposerContainer: View {
 final class ChatViewModel: ObservableObject {
     /// MCP tool host, set by ChatView. Provides MCP tool definitions + execution.
     weak var mcpHost: MCPHostManager?
+    weak var extensionManager: NativExtensionManager?
+    weak var kitStore: NativKitStore?
     private static let liveDecodeRateRefreshInterval: TimeInterval = 0.25
     private static let streamFlushInterval: TimeInterval = 1.0 / 15.0
 
@@ -900,6 +908,46 @@ final class ChatViewModel: ObservableObject {
         await toolConsentGate.awaitDecision(for: toolMessageID)
     }
 
+    private func requestToolConsent(
+        for toolMessageID: UUID,
+        call: MLXChatToolCall,
+        remainingCalls: [MLXChatToolCall],
+        after insertionAnchor: UUID,
+        in sessionID: UUID,
+        promptContent: String = ""
+    ) async throws -> Bool {
+        updateToolMessage(
+            toolMessageID,
+            in: sessionID,
+            status: .awaitingConsent,
+            content: promptContent,
+            attachments: []
+        )
+        let approved = await awaitToolConsent(for: toolMessageID)
+        switch ChatToolConsentRouter.outcome(approved: approved, isCancelled: Task.isCancelled) {
+        case .cancelled:
+            cancelToolMessages(
+                currentID: toolMessageID,
+                currentCall: call,
+                remainingCalls: remainingCalls,
+                after: insertionAnchor,
+                in: sessionID
+            )
+            throw CancellationError()
+        case .declined:
+            return false
+        case .approved:
+            updateToolMessage(
+                toolMessageID,
+                in: sessionID,
+                status: .running,
+                content: "",
+                attachments: []
+            )
+            return true
+        }
+    }
+
     func cancel() {
         activeTask?.cancel()
     }
@@ -1165,25 +1213,14 @@ final class ChatViewModel: ObservableObject {
                     queuedRequest.settings.customTools.first { $0.toolName == toolName }
                 }
                 if customTool?.kind == .script {
-                    updateToolMessage(
-                        toolMessageID,
-                        in: queuedRequest.sessionID,
-                        status: .awaitingConsent,
-                        content: "",
-                        attachments: []
+                    let approved = try await requestToolConsent(
+                        for: toolMessageID,
+                        call: toolCall,
+                        remainingCalls: Array(toolCalls.dropFirst(index + 1)),
+                        after: insertionAnchor,
+                        in: queuedRequest.sessionID
                     )
-                    let approved = await awaitToolConsent(for: toolMessageID)
-                    switch ChatToolConsentRouter.outcome(approved: approved, isCancelled: Task.isCancelled) {
-                    case .cancelled:
-                        cancelToolMessages(
-                            currentID: toolMessageID,
-                            currentCall: toolCall,
-                            remainingCalls: Array(toolCalls.dropFirst(index + 1)),
-                            after: insertionAnchor,
-                            in: queuedRequest.sessionID
-                        )
-                        throw CancellationError()
-                    case .declined:
+                    guard approved else {
                         updateToolMessage(
                             toolMessageID,
                             in: queuedRequest.sessionID,
@@ -1192,37 +1229,109 @@ final class ChatViewModel: ObservableObject {
                             attachments: []
                         )
                         continue
-                    case .approved:
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .running,
-                            content: "",
-                            attachments: []
-                        )
                     }
                 }
 
-                if toolCall.function?.name == ChatSwitchModelToolRegistry.toolName {
-                    updateToolMessage(
-                        toolMessageID,
-                        in: queuedRequest.sessionID,
-                        status: .awaitingConsent,
-                        content: "",
-                        attachments: []
-                    )
-                    let approved = await awaitToolConsent(for: toolMessageID)
-                    switch ChatToolConsentRouter.outcome(approved: approved, isCancelled: Task.isCancelled) {
-                    case .cancelled:
-                        cancelToolMessages(
-                            currentID: toolMessageID,
-                            currentCall: toolCall,
-                            remainingCalls: Array(toolCalls.dropFirst(index + 1)),
-                            after: insertionAnchor,
-                            in: queuedRequest.sessionID
+                if toolCall.function?.name == ChatUseKitToolRegistry.toolName {
+                    let descriptors = kitDescriptors()
+                    let selected: ChatKitDescriptor
+                    do {
+                        selected = try ChatUseKitToolExecutor().selectedKit(
+                            call: toolCall,
+                            kits: descriptors
                         )
-                        throw CancellationError()
-                    case .declined:
+                    } catch {
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .failed,
+                            content: ChatUseKitToolExecutor().failurePayload(
+                                operation: ChatUseKitToolRegistry.toolName,
+                                error: error
+                            ),
+                            attachments: []
+                        )
+                        continue
+                    }
+
+                    let approved = try await requestToolConsent(
+                        for: toolMessageID,
+                        call: toolCall,
+                        remainingCalls: Array(toolCalls.dropFirst(index + 1)),
+                        after: insertionAnchor,
+                        in: queuedRequest.sessionID,
+                        promptContent: selected.name
+                    )
+                    guard approved else {
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .declined,
+                            content: ChatUseKitToolExecutor().declinedPayload(),
+                            attachments: []
+                        )
+                        continue
+                    }
+
+                    guard let appModel, let extensionManager, let mcpHost, let kitStore else {
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .failed,
+                            content: ChatUseKitToolExecutor().failurePayload(
+                                operation: ChatUseKitToolRegistry.toolName,
+                                error: ChatUseKitToolError.activationUnavailable
+                            ),
+                            attachments: []
+                        )
+                        continue
+                    }
+
+                    do {
+                        guard let kit = kitStore.kit(id: selected.id) else {
+                            throw ChatUseKitToolError.unknownKit(selected.id)
+                        }
+                        let result = await NativKitActivationCoordinator(
+                            model: appModel,
+                            manager: extensionManager,
+                            host: mcpHost
+                        ).activate(kit)
+                        activeSettings = appModel.settings
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .succeeded,
+                            content: ChatUseKitToolExecutor().enabledPayload(
+                                kit: selected,
+                                componentsEnabled: result.enabledComponentCount,
+                                unavailableComponents: result.unavailableComponents
+                            ),
+                            attachments: []
+                        )
+                    } catch {
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .failed,
+                            content: ChatUseKitToolExecutor().failurePayload(
+                                operation: ChatUseKitToolRegistry.toolName,
+                                error: error
+                            ),
+                            attachments: []
+                        )
+                    }
+                    continue
+                }
+
+                if toolCall.function?.name == ChatSwitchModelToolRegistry.toolName {
+                    let approved = try await requestToolConsent(
+                        for: toolMessageID,
+                        call: toolCall,
+                        remainingCalls: Array(toolCalls.dropFirst(index + 1)),
+                        after: insertionAnchor,
+                        in: queuedRequest.sessionID
+                    )
+                    guard approved else {
                         updateToolMessage(
                             toolMessageID,
                             in: queuedRequest.sessionID,
@@ -1231,14 +1340,6 @@ final class ChatViewModel: ObservableObject {
                             attachments: []
                         )
                         continue
-                    case .approved:
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .running,
-                            content: "",
-                            attachments: []
-                        )
                     }
                     guard let appModel else {
                         updateToolMessage(
@@ -1412,7 +1513,8 @@ final class ChatViewModel: ObservableObject {
         let advertisesToolsForModel = advertisesTools && queuedRequest.languageModelSupportsTools
         var toolDefinitions: [MLXChatToolDefinition] = advertisesToolsForModel
             ? ChatToolRegistry.definitions(
-                canEditImage: precedingMessages.contains { !$0.imageAttachments.isEmpty }
+                canEditImage: precedingMessages.contains { !$0.imageAttachments.isEmpty },
+                kits: kitDescriptors()
             )
             : []
         if advertisesToolsForModel {
@@ -1463,6 +1565,12 @@ final class ChatViewModel: ObservableObject {
             toolChoice: tools == nil ? nil : "auto",
             stream: true
         )
+    }
+
+    private func kitDescriptors() -> [ChatKitDescriptor] {
+        (kitStore?.availableKits ?? []).map {
+            ChatKitDescriptor(id: $0.id, name: $0.name, summary: $0.summary)
+        }
     }
 
     private func insertAssistantMessage(for queuedRequest: QueuedChatRequest) -> Bool {
@@ -3365,6 +3473,8 @@ private struct ChatEmptyTranscriptView: View {
         model: .init(),
         chat: ChatViewModel(),
         mcpHost: MCPHostManager(),
+        extensionManager: .init(builtInExtensions: []),
+        kitStore: .init(),
         showsConfiguration: .constant(true),
         conversationWidthReduction: 0
     )

--- a/Sources/Nativ/Features/Chat/Tools/ChatUseKitTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatUseKitTool.swift
@@ -1,0 +1,141 @@
+import Foundation
+import NativServerKit
+
+struct ChatKitDescriptor: Equatable {
+    let id: String
+    let name: String
+    let summary: String
+}
+
+enum ChatUseKitToolRegistry {
+    static let toolName = "use_kit"
+
+    static func definitions(kits: [ChatKitDescriptor]) -> [MLXChatToolDefinition] {
+        guard !kits.isEmpty else { return [] }
+        let choices = kits.map { "\($0.id) (\($0.name)): \($0.summary)" }.joined(separator: "; ")
+        return [MLXChatToolDefinition(function: MLXChatFunctionDefinition(
+            name: toolName,
+            description: "Make an available Kit's capabilities ready for this chat. Use only when the user explicitly asks to use or enable a Kit. Available Kits: \(choices). Nativ asks for confirmation before changing anything.",
+            parameters: .object([
+                "type": .string("object"),
+                "additionalProperties": .bool(false),
+                "properties": .object([
+                    "kit_id": .object([
+                        "type": .string("string"),
+                        "enum": .array(kits.map { .string($0.id) }),
+                        "description": .string("Identifier of the Kit to make available.")
+                    ])
+                ]),
+                "required": .array([.string("kit_id")])
+            ])
+        ))]
+    }
+}
+
+private struct ChatUseKitToolArguments: Decodable {
+    let kitID: String
+
+    enum CodingKeys: String, CodingKey {
+        case kitID = "kit_id"
+    }
+}
+
+private struct ChatUseKitToolResultPayload: Encodable {
+    let ok: Bool
+    let kitID: String?
+    let kitName: String?
+    let componentsEnabled: Int?
+    let unavailableComponents: [String]?
+    let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case kitID = "kit_id"
+        case kitName = "kit_name"
+        case componentsEnabled = "components_enabled"
+        case unavailableComponents = "unavailable_components"
+        case error
+    }
+}
+
+enum ChatUseKitToolError: LocalizedError, Equatable {
+    case invalidArguments
+    case unknownKit(String)
+    case activationUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidArguments:
+            "The use_kit arguments were not valid JSON."
+        case .unknownKit(let id):
+            "The Kit “\(id)” is no longer available."
+        case .activationUnavailable:
+            "Kit activation is unavailable in this chat."
+        }
+    }
+}
+
+struct ChatUseKitToolExecutor {
+    func selectedKit(call: MLXChatToolCall, kits: [ChatKitDescriptor]) throws -> ChatKitDescriptor {
+        guard call.function?.name == ChatUseKitToolRegistry.toolName else {
+            throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
+        }
+        guard let data = call.function?.arguments?.data(using: .utf8),
+              let arguments = try? JSONDecoder().decode(ChatUseKitToolArguments.self, from: data)
+        else {
+            throw ChatUseKitToolError.invalidArguments
+        }
+        guard let kit = kits.first(where: { $0.id == arguments.kitID }) else {
+            throw ChatUseKitToolError.unknownKit(arguments.kitID)
+        }
+        return kit
+    }
+
+    func enabledPayload(
+        kit: ChatKitDescriptor,
+        componentsEnabled: Int,
+        unavailableComponents: [String]
+    ) -> String {
+        encodedPayload(ChatUseKitToolResultPayload(
+            ok: true,
+            kitID: kit.id,
+            kitName: kit.name,
+            componentsEnabled: componentsEnabled,
+            unavailableComponents: unavailableComponents.isEmpty
+                ? nil
+                : unavailableComponents,
+            error: nil
+        ))
+    }
+
+    func declinedPayload() -> String {
+        encodedPayload(ChatUseKitToolResultPayload(
+            ok: false,
+            kitID: nil,
+            kitName: nil,
+            componentsEnabled: nil,
+            unavailableComponents: nil,
+            error: "The user declined to make this Kit available."
+        ))
+    }
+
+    func failurePayload(operation: String, error: Error) -> String {
+        encodedPayload(ChatUseKitToolResultPayload(
+            ok: false,
+            kitID: nil,
+            kitName: nil,
+            componentsEnabled: nil,
+            unavailableComponents: nil,
+            error: error.localizedDescription
+        ))
+    }
+
+    private func encodedPayload(_ payload: ChatUseKitToolResultPayload) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(payload) else {
+            return #"{"ok":false,"error":"Kit activation failed."}"#
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -7,8 +7,8 @@ struct ExtensionsHubView: View {
     @ObservedObject var manager: NativExtensionManager
     @ObservedObject var host: MCPHostManager
     @ObservedObject var model: NativModel
+    @ObservedObject var kitStore: NativKitStore
     @State private var section: HubSection = .kits
-    @State private var didLaunch = false
 
     enum HubSection: String, CaseIterable, Identifiable {
         case kits = "Kits"
@@ -36,21 +36,6 @@ struct ExtensionsHubView: View {
             Divider()
             detail
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        .task {
-            guard !didLaunch else { return }
-            didLaunch = true
-            manager.launch(
-                context: NativExtensionHostContext(
-                    transcriptionConfiguration: { nil },
-                    openSpeechModels: {},
-                    showMainWindow: {}
-                )
-            )
-            host.reload(servers: model.settings.mcpServers)
-        }
-        .onChange(of: model.settings.mcpServers) { _, servers in
-            host.reload(servers: servers)
         }
     }
 
@@ -88,7 +73,7 @@ struct ExtensionsHubView: View {
     private var detail: some View {
         switch section {
         case .kits:
-            KitsSectionView(manager: manager, host: host, model: model)
+            KitsSectionView(manager: manager, host: host, model: model, store: kitStore)
         case .extensions:
             ExtensionsSectionView(manager: manager)
         case .mcp:

--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -1,8 +1,6 @@
-import NativExtensionSDK
 import NativServerKit
 import SwiftUI
 
-/// The badge shown on a kit card/header for its derived activation state.
 @ViewBuilder
 private func kitStateBadge(_ state: NativKitState) -> some View {
     switch state {
@@ -19,55 +17,140 @@ struct KitsSectionView: View {
     @ObservedObject var manager: NativExtensionManager
     @ObservedObject var host: MCPHostManager
     @ObservedObject var model: NativModel
+    @ObservedObject var store: NativKitStore
     @State private var openKit: NativKit?
+    @State private var editingKit: UserNativKit?
+    @State private var deletingKit: UserNativKit?
 
     private let columns = [GridItem(.adaptive(minimum: 240, maximum: 340), spacing: 14)]
 
     var body: some View {
         HubSectionScaffold(
             title: "Kits",
-            subtitle: "Ready-made setups. Enable one to turn on the MCP servers, skills, and extensions for a way of working — then manage any piece on its own."
+            subtitle: "Set up a way of working once, then make its capabilities available together."
         ) {
-            EmptyView()
+            Button {
+                editingKit = UserNativKit()
+            } label: {
+                Label("Create kit", systemImage: "plus")
+            }
         } content: {
+            VStack(alignment: .leading, spacing: 22) {
+                if !store.userKits.isEmpty {
+                    kitGroup(title: "Your kits", kits: store.userKits.map { $0.resolved() })
+                }
+                kitGroup(title: "Built-in kits", kits: NativKit.builtIns)
+            }
+        }
+        .sheet(item: $openKit) { kit in
+            KitDetailView(
+                kit: kit,
+                manager: manager,
+                host: host,
+                model: model,
+                onEdit: kit.isBuiltIn ? nil : { edit(kit) },
+                onDelete: kit.isBuiltIn ? nil : { confirmDelete(kit) }
+            )
+        }
+        .sheet(item: $editingKit) { kit in
+            NativKitEditor(
+                kit: kit,
+                manager: manager,
+                host: host,
+                model: model,
+                onSave: { saved in
+                    store.upsert(saved)
+                    editingKit = nil
+                },
+                onCancel: { editingKit = nil }
+            )
+        }
+        .alert(
+            "Delete kit?",
+            isPresented: Binding(
+                get: { deletingKit != nil },
+                set: { if !$0 { deletingKit = nil } }
+            ),
+            presenting: deletingKit
+        ) { kit in
+            Button("Delete", role: .destructive) {
+                store.delete(id: kit.id)
+                deletingKit = nil
+            }
+            .keyboardShortcut(.defaultAction)
+            Button("Cancel", role: .cancel) {
+                deletingKit = nil
+            }
+        } message: { _ in
+            Text("The kit is removed, but its components stay configured. Routines that selected it will fail until you choose another kit.")
+        }
+    }
+
+    private var activation: NativKitActivationCoordinator {
+        NativKitActivationCoordinator(model: model, manager: manager, host: host)
+    }
+
+    @ViewBuilder
+    private func kitGroup(title: String, kits: [NativKit]) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text(title.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
             LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
-                ForEach(NativKit.all) { kit in
+                ForEach(kits) { kit in
                     KitCard(
                         kit: kit,
-                        state: NativKitActivation.state(of: kit, model: model, manager: manager),
-                        inactiveParts: NativKitActivation.inactivePartNames(of: kit, model: model, manager: manager),
+                        state: activation.state(of: kit),
+                        capabilityNames: activation.componentNames(of: kit),
+                        inactiveParts: activation.inactiveComponentNames(of: kit),
                         onOpen: { openKit = kit },
-                        onEnable: { NativKitActivation.setEnabled(true, kit: kit, model: model, manager: manager) }
+                        onEnable: { Task { await activation.activate(kit) } },
+                        onEdit: kit.isBuiltIn ? nil : { edit(kit) },
+                        onDelete: kit.isBuiltIn ? nil : { confirmDelete(kit) }
                     )
                 }
             }
         }
-        .sheet(item: $openKit) { kit in
-            KitDetailView(kit: kit, manager: manager, host: host, model: model)
-        }
+    }
+
+    private func edit(_ kit: NativKit) {
+        guard let id = UUID(uuidString: kit.id), let userKit = store.userKit(id: id) else { return }
+        openKit = nil
+        Task { @MainActor in editingKit = userKit }
+    }
+
+    private func confirmDelete(_ kit: NativKit) {
+        guard let id = UUID(uuidString: kit.id), let userKit = store.userKit(id: id) else { return }
+        openKit = nil
+        deletingKit = userKit
     }
 }
 
 private struct KitCard: View {
     let kit: NativKit
     let state: NativKitState
+    let capabilityNames: [String]
     let inactiveParts: [String]
     let onOpen: () -> Void
     let onEnable: () -> Void
+    let onEdit: (() -> Void)?
+    let onDelete: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 6) {
                 NativTintedIconTile(symbol: kit.symbol, tint: kit.tint)
                 Spacer(minLength: 0)
-                NativStatusBadge(text: "Built-in")
-                    .help("Ships with Nativ")
+                if kit.isBuiltIn {
+                    NativStatusBadge(text: "Built-in")
+                        .help("Ships with Nativ")
+                }
                 kitStateBadge(state)
             }
             VStack(alignment: .leading, spacing: 3) {
                 Text(kit.name)
                     .font(.system(size: 15, weight: .semibold))
-                Text(kit.summary)
+                Text(kit.summary.isEmpty ? "A personal setup." : kit.summary)
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -92,6 +175,17 @@ private struct KitCard: View {
                         .controlSize(.small)
                 }
                 Spacer(minLength: 0)
+                if let onEdit, let onDelete {
+                    Menu {
+                        Button("Edit", action: onEdit)
+                        Button("Delete", role: .destructive, action: onDelete)
+                    } label: {
+                        Image(systemName: "ellipsis")
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .frame(width: 22)
+                }
             }
             .font(.system(size: 12))
         }
@@ -101,19 +195,19 @@ private struct KitCard: View {
             Color(nsColor: .controlBackgroundColor),
             in: RoundedRectangle(cornerRadius: 10, style: .continuous)
         )
-        .overlay(
+        .overlay {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        )
+        }
         .contentShape(.rect)
         .onTapGesture(perform: onOpen)
     }
 
     private var capabilitiesText: String {
-        if state == .partial {
+        if case .partial = state {
             return "Off: \(inactiveParts.joined(separator: " · "))"
         }
-        return "Includes: \(kit.capabilityNames.joined(separator: " · "))"
+        return "Includes: \(capabilityNames.joined(separator: " · "))"
     }
 }
 
@@ -122,203 +216,110 @@ private struct KitDetailView: View {
     @ObservedObject var manager: NativExtensionManager
     @ObservedObject var host: MCPHostManager
     @ObservedObject var model: NativModel
+    let onEdit: (() -> Void)?
+    let onDelete: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
 
-    private var state: NativKitState { NativKitActivation.state(of: kit, model: model, manager: manager) }
+    private var activation: NativKitActivationCoordinator {
+        NativKitActivationCoordinator(model: model, manager: manager, host: host)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            header
+            HStack(alignment: .top, spacing: 12) {
+                NativTintedIconTile(symbol: kit.symbol, tint: kit.tint, size: 40)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 8) {
+                        Text(kit.name).font(.system(size: 17, weight: .semibold))
+                        kitStateBadge(activation.state(of: kit))
+                    }
+                    Text(kit.summary.isEmpty ? "A personal setup." : kit.summary)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    HStack(spacing: 8) {
+                        Button("Make available") {
+                            Task { await activation.activate(kit) }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        if let onEdit { Button("Edit", action: onEdit).controlSize(.small) }
+                        if let onDelete {
+                            Button("Delete", role: .destructive, action: onDelete)
+                                .controlSize(.small)
+                        }
+                    }
+                    .padding(.top, 4)
+                }
+                Spacer(minLength: 12)
+                NativHoverCloseButton { dismiss() }
+            }
+            .padding(20)
+
             Divider()
+
             ScrollView {
-                VStack(alignment: .leading, spacing: 22) {
-                    mcpGroup
-                    if !kit.skills.isEmpty { skillsGroup }
-                    if !kit.extensionIDs.isEmpty { extensionsGroup }
+                VStack(alignment: .leading, spacing: 18) {
+                    if !kit.extensionIDs.isEmpty {
+                        componentGroup("Extensions", values: kit.extensionIDs.map(extensionName))
+                    }
+                    if !kit.mcpServers.isEmpty {
+                        componentGroup("MCP servers", values: kit.mcpServers.map(serverName))
+                    }
+                    if !kit.mcpTools.isEmpty {
+                        componentGroup("MCP tools", values: kit.mcpTools.map { $0.name })
+                    }
+                    if !kit.builtInToolNames.isEmpty {
+                        componentGroup("Built-in tools", values: kit.builtInToolNames)
+                    }
+                    if !kit.customToolIDs.isEmpty {
+                        componentGroup("Custom tools", values: kit.customToolIDs.map(customToolName))
+                    }
+                    if !kit.skills.isEmpty {
+                        componentGroup("Skills", values: kit.skills.map(skillName))
+                    }
                 }
                 .padding(20)
             }
         }
-        .frame(width: 560, height: 560)
+        .frame(width: 560, height: 520)
     }
 
-    private var header: some View {
-        HStack(alignment: .top, spacing: 12) {
-            NativTintedIconTile(symbol: kit.symbol, tint: kit.tint, size: 40)
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 8) {
-                    Text(kit.name)
-                        .font(.system(size: 17, weight: .semibold))
-                    kitStateBadge(state)
-                }
-                Text(kit.summary)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                HStack(spacing: 8) {
-                    Button("Enable all") {
-                        NativKitActivation.setEnabled(true, kit: kit, model: model, manager: manager)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    Button("Disable all") {
-                        NativKitActivation.setEnabled(false, kit: kit, model: model, manager: manager)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                }
-                .padding(.top, 4)
-            }
-            Spacer(minLength: 12)
-            NativHoverCloseButton { dismiss() }
-        }
-        .padding(20)
-    }
-
-    // MARK: Groups
-
-    private var mcpGroup: some View {
-        KitGroup(title: "MCP servers & tools", caption: "Their tools become available in chat and appear under Tools.") {
-            ForEach(kit.mcpEntries) { entry in
-                KitPartRow(
-                    symbol: entry.symbol,
-                    tint: entry.tint,
-                    logoAssetName: entry.logoAssetName,
-                    title: entry.name,
-                    subtitle: entry.summary,
-                    isOn: mcpBinding(entry)
-                )
+    private func componentGroup(_ title: String, values: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(title.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+            ForEach(Array(values.enumerated()), id: \.offset) { _, value in
+                Text(value)
+                    .font(.system(size: 13))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 5)
             }
         }
     }
 
-    private var skillsGroup: some View {
-        KitGroup(title: "Skills", caption: "Guidance added to the model when tools are available.") {
-            ForEach(kit.skills) { skill in
-                KitPartRow(
-                    symbol: "sparkles",
-                    tint: kit.tint,
-                    logoAssetName: nil,
-                    title: skill.name,
-                    subtitle: nil,
-                    isOn: skillBinding(skill)
-                )
-            }
+    private func serverName(_ reference: NativKitMCPServer) -> String {
+        switch reference {
+        case .catalog(let id):
+            return MCPCatalogEntry.catalog.first(where: { $0.id == id })?.name ?? "Unavailable server"
+        case .configured(let id):
+            return model.settings.mcpServers.first(where: { $0.id == id })?.name ?? "Unavailable server"
         }
     }
 
-    private var extensionsGroup: some View {
-        KitGroup(title: "Extensions", caption: nil) {
-            ForEach(kit.extensionIDs, id: \.self) { extensionID in
-                KitPartRow(
-                    symbol: "puzzlepiece.extension",
-                    tint: kit.tint,
-                    logoAssetName: nil,
-                    title: extensionName(extensionID),
-                    subtitle: nil,
-                    isOn: extensionBinding(extensionID)
-                )
-            }
+    private func skillName(_ reference: NativKitSkillReference) -> String {
+        switch reference {
+        case .builtIn(let skill): skill.name
+        case .configured(let id):
+            model.settings.skills.first(where: { $0.id == id })?.name ?? "Unavailable skill"
         }
     }
 
-    // MARK: Bindings
-
-    private func mcpBinding(_ entry: MCPCatalogEntry) -> Binding<Bool> {
-        // Match by launch identity (command + arguments), not name, so the
-        // toggle never targets an unrelated server that shares a name.
-        func matches(_ server: MCPServerConfig) -> Bool {
-            server.command == entry.command && server.arguments == entry.arguments
-        }
-        return Binding(
-            get: { model.settings.mcpServers.first(where: matches)?.isEnabled ?? false },
-            set: { newValue in
-                if let index = model.settings.mcpServers.firstIndex(where: matches) {
-                    model.settings.mcpServers[index].isEnabled = newValue
-                } else if newValue {
-                    model.settings.mcpServers.append(entry.makeConfig())
-                }
-            }
-        )
+    private func extensionName(_ id: String) -> String {
+        manager.records.first(where: { $0.id == id })?.manifest.displayName ?? "Unavailable extension"
     }
 
-    private func skillBinding(_ skill: NativSkill) -> Binding<Bool> {
-        Binding(
-            get: { model.settings.skills.first { $0.id == skill.id }?.isEnabled ?? false },
-            set: { newValue in
-                if let index = model.settings.skills.firstIndex(where: { $0.id == skill.id }) {
-                    model.settings.skills[index].isEnabled = newValue
-                } else if newValue {
-                    var enabled = skill
-                    enabled.isEnabled = true
-                    model.settings.skills.append(enabled)
-                }
-            }
-        )
-    }
-
-    private func extensionBinding(_ extensionID: String) -> Binding<Bool> {
-        Binding(
-            get: { manager.isEnabled(extensionID: extensionID) },
-            set: { manager.setEnabled($0, extensionID: extensionID) }
-        )
-    }
-
-    private func extensionName(_ extensionID: String) -> String {
-        manager.records.first { $0.id == extensionID }?.manifest.displayName ?? extensionID
-    }
-}
-
-private struct KitGroup<Content: View>: View {
-    let title: String
-    let caption: String?
-    @ViewBuilder var content: () -> Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.system(size: 13, weight: .semibold))
-                if let caption {
-                    Text(caption)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                }
-            }
-            VStack(spacing: 0) {
-                content()
-            }
-        }
-    }
-}
-
-private struct KitPartRow: View {
-    let symbol: String
-    let tint: Color
-    let logoAssetName: String?
-    let title: String
-    let subtitle: String?
-    @Binding var isOn: Bool
-
-    var body: some View {
-        HStack(spacing: 10) {
-            NativTintedIconTile(symbol: symbol, tint: tint, logoAssetName: logoAssetName, size: 30)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(title)
-                    .font(.system(size: 13, weight: .medium))
-                if let subtitle {
-                    Text(subtitle)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-            Spacer(minLength: 12)
-            Toggle("", isOn: $isOn)
-                .labelsHidden()
-                .toggleStyle(.switch)
-                .controlSize(.small)
-        }
-        .padding(.vertical, 8)
+    private func customToolName(_ id: UUID) -> String {
+        model.settings.customTools.first(where: { $0.id == id })?.name ?? "Unavailable custom tool"
     }
 }

--- a/Sources/Nativ/Features/Extensions/MCPCatalogEntry.swift
+++ b/Sources/Nativ/Features/Extensions/MCPCatalogEntry.swift
@@ -1,0 +1,48 @@
+import Foundation
+import NativServerKit
+
+struct MCPCatalogEntry: Identifiable, Decodable, Sendable {
+    let id: String
+    let name: String
+    let summary: String
+    let command: String
+    let arguments: [String]
+    let symbol: String
+    let tintName: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, summary, command
+        case arguments = "args"
+        case symbol, tint
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        summary = try container.decode(String.self, forKey: .summary)
+        command = try container.decode(String.self, forKey: .command)
+        arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
+        symbol = try container.decodeIfPresent(String.self, forKey: .symbol) ?? "server.rack"
+        tintName = try container.decodeIfPresent(String.self, forKey: .tint) ?? "accent"
+    }
+
+    func makeConfig() -> MCPServerConfig {
+        MCPServerConfig(
+            name: name,
+            command: command,
+            arguments: arguments,
+            isEnabled: true
+        )
+    }
+
+    static let catalog: [MCPCatalogEntry] = {
+        guard let url = Bundle.main.url(forResource: "MCPCatalog", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let entries = try? JSONDecoder().decode([MCPCatalogEntry].self, from: data)
+        else {
+            return []
+        }
+        return entries
+    }()
+}

--- a/Sources/Nativ/Features/Extensions/MCPSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/MCPSectionView.swift
@@ -401,46 +401,9 @@ private struct MCPServerEditor: View {
 // one tool — before it can merge. Until a logo asset exists we render a tinted
 // glyph tile so the grid always looks complete. See Docs/mcp-catalog.md.
 
-struct MCPCatalogEntry: Identifiable, Decodable {
-    let id: String
-    let name: String
-    let summary: String
-    let command: String
-    let arguments: [String]
-    let symbol: String
-    let tint: Color
+private extension MCPCatalogEntry {
+    var tint: Color { .nativTint(tintName) }
     var logoAssetName: String { "MCPLogo-\(name)" }
-
-    private enum CodingKeys: String, CodingKey {
-        case id, name, summary, command
-        case arguments = "args"
-        case symbol, tint
-    }
-
-    init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        id = try c.decode(String.self, forKey: .id)
-        name = try c.decode(String.self, forKey: .name)
-        summary = try c.decode(String.self, forKey: .summary)
-        command = try c.decode(String.self, forKey: .command)
-        arguments = try c.decodeIfPresent([String].self, forKey: .arguments) ?? []
-        symbol = try c.decodeIfPresent(String.self, forKey: .symbol) ?? "server.rack"
-        let tintName = try c.decodeIfPresent(String.self, forKey: .tint) ?? "accent"
-        tint = .nativTint(tintName)
-    }
-
-    func makeConfig() -> MCPServerConfig {
-        MCPServerConfig(name: name, command: command, arguments: arguments, isEnabled: true)
-    }
-
-    /// The community catalog, decoded once from the bundled `MCPCatalog.json`.
-    static let catalog: [MCPCatalogEntry] = {
-        guard let url = Bundle.main.url(forResource: "MCPCatalog", withExtension: "json"),
-              let data = try? Data(contentsOf: url),
-              let entries = try? JSONDecoder().decode([MCPCatalogEntry].self, from: data)
-        else { return [] }
-        return entries
-    }()
 }
 
 private let mcpCatalog = MCPCatalogEntry.catalog

--- a/Sources/Nativ/Features/Extensions/NativKit.swift
+++ b/Sources/Nativ/Features/Extensions/NativKit.swift
@@ -1,192 +1,225 @@
-import NativServerKit
-import SwiftUI
+import Foundation
 
-// A Kit is a ready-made setup: a curated bundle of MCP servers, their tools,
-// skills, and extensions for a role or use-case. Enabling one fans out across
-// all four primitives at once; each part stays individually manageable after.
+enum NativKitMCPServer: Equatable, Sendable {
+    case catalog(String)
+    case configured(UUID)
+}
 
-struct NativKit: Identifiable {
+struct NativKitMCPTool: Codable, Equatable, Hashable, Sendable {
+    let serverID: UUID
+    let name: String
+}
+
+enum NativKitSkillReference: Equatable, Sendable {
+    case builtIn(NativSkill)
+    case configured(UUID)
+}
+
+struct UserNativKit: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var name: String
+    var summary: String
+    var mcpServerIDs: [UUID]
+    var mcpTools: [NativKitMCPTool]
+    var builtInToolNames: [String]
+    var customToolIDs: [UUID]
+    var skillIDs: [UUID]
+    var extensionIDs: [String]
+
+    init(
+        id: UUID = UUID(),
+        name: String = "",
+        summary: String = "",
+        mcpServerIDs: [UUID] = [],
+        mcpTools: [NativKitMCPTool] = [],
+        builtInToolNames: [String] = [],
+        customToolIDs: [UUID] = [],
+        skillIDs: [UUID] = [],
+        extensionIDs: [String] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.summary = summary
+        self.mcpServerIDs = mcpServerIDs
+        self.mcpTools = mcpTools
+        self.builtInToolNames = builtInToolNames
+        self.customToolIDs = customToolIDs
+        self.skillIDs = skillIDs
+        self.extensionIDs = extensionIDs
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, summary, mcpServerIDs, mcpTools, builtInToolNames
+        case customToolIDs, skillIDs, extensionIDs
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        summary = try container.decodeIfPresent(String.self, forKey: .summary) ?? ""
+        mcpServerIDs = try container.decodeIfPresent([UUID].self, forKey: .mcpServerIDs) ?? []
+        mcpTools = try container.decodeIfPresent([NativKitMCPTool].self, forKey: .mcpTools) ?? []
+        builtInToolNames = try container.decodeIfPresent([String].self, forKey: .builtInToolNames) ?? []
+        customToolIDs = try container.decodeIfPresent([UUID].self, forKey: .customToolIDs) ?? []
+        skillIDs = try container.decodeIfPresent([UUID].self, forKey: .skillIDs) ?? []
+        extensionIDs = try container.decodeIfPresent([String].self, forKey: .extensionIDs) ?? []
+    }
+
+    var isComplete: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (!mcpServerIDs.isEmpty
+                || !mcpTools.isEmpty
+                || !builtInToolNames.isEmpty
+                || !customToolIDs.isEmpty
+                || !skillIDs.isEmpty
+                || !extensionIDs.isEmpty)
+    }
+
+    func normalized() -> UserNativKit {
+        var kit = self
+        kit.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        kit.summary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        kit.mcpTools = mcpTools.uniqued()
+        kit.mcpServerIDs = (mcpServerIDs + kit.mcpTools.map(\.serverID)).uniqued()
+        kit.builtInToolNames = builtInToolNames.uniqued()
+        kit.customToolIDs = customToolIDs.uniqued()
+        kit.skillIDs = skillIDs.uniqued()
+        kit.extensionIDs = extensionIDs.uniqued()
+        return kit
+    }
+
+    func resolved() -> NativKit {
+        let normalized = normalized()
+        return NativKit(
+            id: normalized.id.uuidString,
+            name: normalized.name,
+            summary: normalized.summary,
+            isBuiltIn: false,
+            mcpServers: normalized.mcpServerIDs.map(NativKitMCPServer.configured),
+            mcpTools: normalized.mcpTools,
+            builtInToolNames: normalized.builtInToolNames,
+            customToolIDs: normalized.customToolIDs,
+            skills: normalized.skillIDs.map(NativKitSkillReference.configured),
+            extensionIDs: normalized.extensionIDs
+        )
+    }
+}
+
+struct NativKit: Identifiable, Equatable, Sendable {
     let id: String
     let name: String
     let summary: String
-    let symbol: String
-    let tint: Color
-    let mcpServerIDs: [String]
+    let isBuiltIn: Bool
+    let mcpServers: [NativKitMCPServer]
+    let mcpTools: [NativKitMCPTool]
+    let builtInToolNames: [String]
+    let customToolIDs: [UUID]
+    let skills: [NativKitSkillReference]
     let extensionIDs: [String]
-    let skills: [NativSkill]
 
-    /// Catalog MCP entries this kit references, in listed order.
-    var mcpEntries: [MCPCatalogEntry] {
-        mcpServerIDs.compactMap { id in MCPCatalogEntry.catalog.first { $0.id == id } }
-    }
-
-    /// A one-line inventory of what the kit turns on.
     var inventory: String {
         var parts: [String] = []
-        let servers = mcpEntries.count
-        if servers > 0 { parts.append("\(servers) MCP server\(servers == 1 ? "" : "s")") }
-        if !skills.isEmpty { parts.append("\(skills.count) skill\(skills.count == 1 ? "" : "s")") }
-        if !extensionIDs.isEmpty { parts.append("\(extensionIDs.count) extension\(extensionIDs.count == 1 ? "" : "s")") }
+        if !extensionIDs.isEmpty {
+            parts.append(Self.count(extensionIDs.count, singular: "extension"))
+        }
+        if !mcpServers.isEmpty {
+            parts.append(Self.count(mcpServers.count, singular: "MCP server"))
+        }
+        let toolCount = mcpTools.count + builtInToolNames.count + customToolIDs.count
+        if toolCount > 0 {
+            parts.append(Self.count(toolCount, singular: "tool"))
+        }
+        if !skills.isEmpty {
+            parts.append(Self.count(skills.count, singular: "skill"))
+        }
         return parts.joined(separator: " · ")
     }
 
-    /// The abilities a person gets when every part of this kit is enabled.
-    var capabilityNames: [String] {
-        mcpEntries.map(\.name) + skills.map(\.name) + extensionIDs
+    private static func count(_ count: Int, singular: String) -> String {
+        "\(count) \(singular)\(count == 1 ? "" : "s")"
     }
 }
 
 private extension NativSkill {
-    /// A kit skill with a stable identity so enabling a kit twice never duplicates it.
     static func kit(_ uuid: String, _ name: String, _ instructions: String) -> NativSkill {
-        NativSkill(id: UUID(uuidString: uuid)!, name: name, instructions: instructions, isEnabled: true)
+        NativSkill(
+            id: UUID(uuidString: uuid)!,
+            name: name,
+            instructions: instructions,
+            isEnabled: true
+        )
     }
 }
 
 extension NativKit {
-    /// The curated kits shown at the top of the Extensions hub.
-    static let all: [NativKit] = [
-        NativKit(
-            id: "engineering",
-            name: "Engineering",
-            summary: "Read code, work with Git and GitHub, and pull in docs while you build.",
-            symbol: "chevron.left.forwardslash.chevron.right",
-            tint: .indigo,
-            mcpServerIDs: ["git", "github", "filesystem", "fetch"],
-            extensionIDs: [],
-            skills: [
-                .kit(
-                    "A1000000-0000-4000-8000-000000000001",
-                    "Working in a codebase",
-                    """
-                    You're helping with software. Ground every answer in the actual \
-                    repository, not assumptions.
+    static let builtIns: [NativKit] = [engineering, research]
 
-                    - Use the Git and filesystem tools to read real files, history, and \
-                    diffs before proposing changes; cite concrete paths and symbols.
-                    - When you touch GitHub, prefer read-only queries (issues, PRs, code \
-                    search) and summarize findings precisely.
-                    - Match the project's existing style and conventions. Keep changes \
-                    minimal and explain the reasoning.
-                    - Fetch documentation when an API or library detail is uncertain \
-                    rather than guessing.
-                    """
-                )
-            ]
-        ),
-        NativKit(
-            id: "research",
-            name: "Research",
-            summary: "Gather sources from the web, keep notes, and query your own data.",
-            symbol: "magnifyingglass",
-            tint: .purple,
-            mcpServerIDs: ["fetch", "memory", "sqlite"],
-            extensionIDs: [],
-            skills: [
-                .kit(
-                    "A2000000-0000-4000-8000-000000000002",
-                    "Researching with sources",
-                    """
-                    You're doing careful research. Prioritize accuracy and traceability.
+    private static let engineering = NativKit(
+        id: "engineering",
+        name: "Engineering",
+        summary: "Read code, work with Git and GitHub, and pull in docs while you build.",
+        isBuiltIn: true,
+        mcpServers: ["git", "github", "filesystem", "fetch"].map(NativKitMCPServer.catalog),
+        mcpTools: [],
+        builtInToolNames: [],
+        customToolIDs: [],
+        skills: [
+            .builtIn(.kit(
+                "A1000000-0000-4000-8000-000000000001",
+                "Working in a codebase",
+                """
+                You're helping with software. Ground every answer in the actual \
+                repository, not assumptions.
 
-                    - Use the fetch tool to read primary sources; quote or paraphrase \
-                    with a link back to where each claim came from.
-                    - Record durable findings in the memory tool so they carry across \
-                    the conversation, and recall them before re-fetching.
-                    - Query the SQLite tool for anything in the user's own dataset \
-                    instead of estimating.
-                    - Separate what the sources say from your own inference, and flag \
-                    uncertainty plainly.
-                    """
-                )
-            ]
-        ),
-    ]
+                - Use the Git and filesystem tools to read real files, history, and \
+                diffs before proposing changes; cite concrete paths and symbols.
+                - When you touch GitHub, prefer read-only queries (issues, PRs, code \
+                search) and summarize findings precisely.
+                - Match the project's existing style and conventions. Keep changes \
+                minimal and explain the reasoning.
+                - Fetch documentation when an API or library detail is uncertain \
+                rather than guessing.
+                """
+            )),
+        ],
+        extensionIDs: []
+    )
+
+    private static let research = NativKit(
+        id: "research",
+        name: "Research",
+        summary: "Gather sources from the web, keep notes, and query your own data.",
+        isBuiltIn: true,
+        mcpServers: ["fetch", "memory", "sqlite"].map(NativKitMCPServer.catalog),
+        mcpTools: [],
+        builtInToolNames: [],
+        customToolIDs: [],
+        skills: [
+            .builtIn(.kit(
+                "A2000000-0000-4000-8000-000000000002",
+                "Researching with sources",
+                """
+                You're doing careful research. Prioritize accuracy and traceability.
+
+                - Use the fetch tool to read primary sources; quote or paraphrase \
+                with a link back to where each claim came from.
+                - Record durable findings in the memory tool so they carry across \
+                the conversation, and recall them before re-fetching.
+                - Query the SQLite tool for anything in the user's own dataset \
+                instead of estimating.
+                - Separate what the sources say from your own inference, and flag \
+                uncertainty plainly.
+                """
+            )),
+        ],
+        extensionIDs: []
+    )
 }
 
-// MARK: - Activation
-
-/// How much of a kit is currently switched on, derived from its live pieces.
-enum NativKitState: Equatable {
-    case off
-    case partial
-    case enabled
-}
-
-/// Turns a kit's MCP servers, skills, and extensions on or off together, driving
-/// the same settings the individual sections do. Enabling appends any missing
-/// pieces; disabling switches them off without deleting the user's edits.
-@MainActor
-enum NativKitActivation {
-    static func setEnabled(
-        _ enabled: Bool,
-        kit: NativKit,
-        model: NativModel,
-        manager: NativExtensionManager
-    ) {
-        for entry in kit.mcpEntries {
-            if let index = matchingServerIndex(for: entry, in: model.settings.mcpServers) {
-                model.settings.mcpServers[index].isEnabled = enabled
-            } else if enabled {
-                model.settings.mcpServers.append(entry.makeConfig())
-            }
-        }
-
-        for skill in kit.skills {
-            if let index = model.settings.skills.firstIndex(where: { $0.id == skill.id }) {
-                model.settings.skills[index].isEnabled = enabled
-            } else if enabled {
-                model.settings.skills.append(skill)
-            }
-        }
-
-        for extensionID in kit.extensionIDs {
-            manager.setEnabled(enabled, extensionID: extensionID)
-        }
-    }
-
-    /// The kit's activation derived from the actual state of its pieces, so the UI
-    /// cannot drift out of sync with the individual switches.
-    static func state(of kit: NativKit, model: NativModel, manager: NativExtensionManager) -> NativKitState {
-        let inactive = inactivePartNames(of: kit, model: model, manager: manager)
-        guard inactive.count < kit.capabilityNames.count else { return .off }
-        return inactive.isEmpty ? .enabled : .partial
-    }
-
-    /// Names the parts a person still needs to turn on for this kit.
-    static func inactivePartNames(
-        of kit: NativKit,
-        model: NativModel,
-        manager: NativExtensionManager
-    ) -> [String] {
-        var names: [String] = []
-
-        for entry in kit.mcpEntries where !isServerEnabled(entry, in: model) {
-            names.append(entry.name)
-        }
-        for skill in kit.skills where model.settings.skills.first(where: { $0.id == skill.id })?.isEnabled != true {
-            names.append(skill.name)
-        }
-        for extensionID in kit.extensionIDs where !manager.isEnabled(extensionID: extensionID) {
-            let name = manager.records.first { $0.id == extensionID }?.manifest.displayName ?? extensionID
-            names.append(name)
-        }
-
-        return names
-    }
-
-    /// Matches a catalog entry to a configured server by launch identity
-    /// (command + arguments), so a kit never toggles an unrelated server that
-    /// merely shares a name.
-    private static func matchingServerIndex(
-        for entry: MCPCatalogEntry,
-        in servers: [MCPServerConfig]
-    ) -> Int? {
-        servers.firstIndex { $0.command == entry.command && $0.arguments == entry.arguments }
-    }
-
-    private static func isServerEnabled(_ entry: MCPCatalogEntry, in model: NativModel) -> Bool {
-        guard let index = matchingServerIndex(for: entry, in: model.settings.mcpServers) else { return false }
-        return model.settings.mcpServers[index].isEnabled
+private extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
     }
 }

--- a/Sources/Nativ/Features/Extensions/NativKitActivation.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitActivation.swift
@@ -1,0 +1,387 @@
+import Foundation
+import NativServerKit
+
+enum NativKitState: Equatable {
+    case off
+    case partial(active: Int, total: Int)
+    case enabled
+}
+
+struct NativKitActivationResult {
+    let kit: NativKit
+    let enabledComponentCount: Int
+    let skills: [NativSkill]
+    let mcpTools: [MCPHostedTool]
+    let builtInToolNames: [String]
+    let customTools: [CustomTool]
+    let unavailableComponents: [String]
+
+    var toolDefinitions: [MLXChatToolDefinition] {
+        mcpTools.map(\.definition)
+    }
+}
+
+@MainActor
+struct NativKitActivationCoordinator {
+    let model: NativModel
+    let manager: NativExtensionManager
+    let host: MCPHostManager
+
+    func activate(_ kit: NativKit) async -> NativKitActivationResult {
+        var settings = model.settings
+        var enabledCount = 0
+        var unavailable: [String] = []
+        var resolvedServerIDs: [UUID] = []
+        var resolvedSkills: [NativSkill] = []
+        var resolvedCustomTools: [CustomTool] = []
+
+        for extensionID in kit.extensionIDs {
+            guard manager.records.contains(where: { $0.id == extensionID && !$0.isRemoved }) else {
+                unavailable.append("Extension \(extensionID)")
+                continue
+            }
+            manager.setEnabled(true, extensionID: extensionID)
+            if manager.isEnabled(extensionID: extensionID) {
+                enabledCount += 1
+            } else {
+                unavailable.append("Extension \(extensionID)")
+            }
+        }
+
+        for reference in kit.mcpServers {
+            if let serverID = enableServer(reference, settings: &settings, unavailable: &unavailable) {
+                resolvedServerIDs.append(serverID)
+                enabledCount += 1
+            }
+        }
+
+        for tool in kit.mcpTools where !resolvedServerIDs.contains(tool.serverID) {
+            if enableServer(.configured(tool.serverID), settings: &settings, unavailable: &unavailable) != nil {
+                resolvedServerIDs.append(tool.serverID)
+            }
+        }
+
+        for reference in kit.skills {
+            guard let skill = enableSkill(reference, settings: &settings) else {
+                unavailable.append("Skill \(skillName(reference))")
+                continue
+            }
+            resolvedSkills.append(skill)
+            enabledCount += 1
+        }
+
+        for name in kit.builtInToolNames {
+            guard availableBuiltInToolNames.contains(name) else {
+                unavailable.append("Built-in tool \(name)")
+                continue
+            }
+            settings.disabledToolNames.removeAll { $0 == name }
+            enabledCount += 1
+        }
+
+        for id in kit.customToolIDs {
+            guard let tool = settings.customTools.first(where: { $0.id == id }),
+                  (try? tool.definition()) != nil
+            else {
+                unavailable.append("Custom tool \(id.uuidString)")
+                continue
+            }
+            settings.disabledToolNames.removeAll { $0 == tool.toolName }
+            resolvedCustomTools.append(tool)
+            enabledCount += 1
+        }
+
+        model.settings = settings
+        await host.ensureReloaded(servers: settings.mcpServers)
+
+        let selectedToolsByServer = Dictionary(grouping: kit.mcpTools, by: \.serverID)
+        var resolvedTools: [MCPHostedTool] = []
+        for serverID in resolvedServerIDs.uniqued() {
+            if let selectedTools = selectedToolsByServer[serverID], !selectedTools.isEmpty {
+                for tool in selectedTools {
+                    guard let hostedTool = host.hostedTool(serverID: serverID, name: tool.name) else {
+                        unavailable.append("MCP tool \(tool.name)")
+                        continue
+                    }
+                    settings.disabledToolNames.removeAll { $0 == hostedTool.runtimeName }
+                    resolvedTools.append(hostedTool)
+                    enabledCount += 1
+                }
+            } else {
+                resolvedTools.append(contentsOf: host.hostedTools(forServer: serverID))
+            }
+        }
+
+        if settings.disabledToolNames != model.settings.disabledToolNames {
+            model.settings = settings
+        }
+
+        for serverID in resolvedServerIDs {
+            if case .failed(let message) = host.states[serverID] {
+                unavailable.append("MCP server: \(message)")
+            }
+        }
+
+        return NativKitActivationResult(
+            kit: kit,
+            enabledComponentCount: enabledCount,
+            skills: resolvedSkills.uniqued(by: \.id),
+            mcpTools: resolvedTools.uniqued(by: \.id),
+            builtInToolNames: kit.builtInToolNames,
+            customTools: resolvedCustomTools,
+            unavailableComponents: unavailable.uniqued()
+        )
+    }
+
+    func state(of kit: NativKit) -> NativKitState {
+        var active = 0
+        var total = 0
+
+        for extensionID in kit.extensionIDs {
+            total += 1
+            if manager.isEnabled(extensionID: extensionID) { active += 1 }
+        }
+        for reference in kit.mcpServers {
+            total += 1
+            if serverID(for: reference, in: model.settings).flatMap({ id in
+                model.settings.mcpServers.first { $0.id == id }
+            })?.isEnabled == true {
+                active += 1
+            }
+        }
+        for tool in kit.mcpTools {
+            total += 1
+            if let hostedTool = host.hostedTool(serverID: tool.serverID, name: tool.name),
+               !model.settings.disabledToolNames.contains(hostedTool.runtimeName) {
+                active += 1
+            }
+        }
+        for name in kit.builtInToolNames {
+            total += 1
+            if availableBuiltInToolNames.contains(name),
+               !model.settings.disabledToolNames.contains(name) {
+                active += 1
+            }
+        }
+        for id in kit.customToolIDs {
+            total += 1
+            if let tool = model.settings.customTools.first(where: { $0.id == id }),
+               !model.settings.disabledToolNames.contains(tool.toolName) {
+                active += 1
+            }
+        }
+        for reference in kit.skills {
+            total += 1
+            switch reference {
+            case .builtIn(let builtIn):
+                if model.settings.skills.first(where: { $0.id == builtIn.id })?.isEnabled == true {
+                    active += 1
+                }
+            case .configured(let id):
+                if model.settings.skills.first(where: { $0.id == id })?.isEnabled == true {
+                    active += 1
+                }
+            }
+        }
+
+        guard total > 0, active > 0 else { return .off }
+        return active == total ? .enabled : .partial(active: active, total: total)
+    }
+
+    func componentNames(of kit: NativKit) -> [String] {
+        var names = kit.extensionIDs.map { extensionID in
+            manager.records.first(where: { $0.id == extensionID })?.manifest.displayName
+                ?? extensionID
+        }
+        names.append(contentsOf: kit.mcpServers.map(serverName))
+        names.append(contentsOf: kit.mcpTools.map(\.name))
+        names.append(contentsOf: kit.builtInToolNames)
+        names.append(contentsOf: kit.customToolIDs.map { id in
+            model.settings.customTools.first(where: { $0.id == id })?.name ?? id.uuidString
+        })
+        names.append(contentsOf: kit.skills.map(skillName))
+        return names.uniqued()
+    }
+
+    func inactiveComponentNames(of kit: NativKit) -> [String] {
+        var names: [String] = []
+        for extensionID in kit.extensionIDs where !manager.isEnabled(extensionID: extensionID) {
+            names.append(
+                manager.records.first(where: { $0.id == extensionID })?.manifest.displayName
+                    ?? extensionID
+            )
+        }
+        for reference in kit.mcpServers {
+            let enabled = serverID(for: reference, in: model.settings).flatMap { id in
+                model.settings.mcpServers.first(where: { $0.id == id })
+            }?.isEnabled == true
+            if !enabled { names.append(serverName(reference)) }
+        }
+        for tool in kit.mcpTools {
+            guard let hostedTool = host.hostedTool(serverID: tool.serverID, name: tool.name),
+                  !model.settings.disabledToolNames.contains(hostedTool.runtimeName)
+            else {
+                names.append(tool.name)
+                continue
+            }
+        }
+        for name in kit.builtInToolNames {
+            if !availableBuiltInToolNames.contains(name)
+                || model.settings.disabledToolNames.contains(name) {
+                names.append(name)
+            }
+        }
+        for id in kit.customToolIDs {
+            guard let tool = model.settings.customTools.first(where: { $0.id == id }),
+                  !model.settings.disabledToolNames.contains(tool.toolName)
+            else {
+                names.append(
+                    model.settings.customTools.first(where: { $0.id == id })?.name
+                        ?? id.uuidString
+                )
+                continue
+            }
+        }
+        for reference in kit.skills {
+            let enabled: Bool
+            switch reference {
+            case .builtIn(let builtIn):
+                enabled = model.settings.skills.first(where: { $0.id == builtIn.id })?.isEnabled == true
+            case .configured(let id):
+                enabled = model.settings.skills.first(where: { $0.id == id })?.isEnabled == true
+            }
+            if !enabled { names.append(skillName(reference)) }
+        }
+        return names.uniqued()
+    }
+
+    func server(for reference: NativKitMCPServer) -> MCPServerConfig? {
+        serverID(for: reference, in: model.settings).flatMap { id in
+            model.settings.mcpServers.first { $0.id == id }
+        }
+    }
+
+    func skill(for reference: NativKitSkillReference) -> NativSkill? {
+        skill(reference, in: model.settings)
+    }
+
+    private func enableServer(
+        _ reference: NativKitMCPServer,
+        settings: inout NativSettings,
+        unavailable: inout [String]
+    ) -> UUID? {
+        switch reference {
+        case .catalog(let catalogID):
+            guard let entry = MCPCatalogEntry.catalog.first(where: { $0.id == catalogID }) else {
+                unavailable.append("MCP catalog server \(catalogID)")
+                return nil
+            }
+            if let index = matchingServerIndex(for: entry, in: settings.mcpServers) {
+                settings.mcpServers[index].isEnabled = true
+                return settings.mcpServers[index].id
+            }
+            let config = entry.makeConfig()
+            settings.mcpServers.append(config)
+            return config.id
+        case .configured(let id):
+            guard let index = settings.mcpServers.firstIndex(where: { $0.id == id }) else {
+                unavailable.append("MCP server \(id.uuidString)")
+                return nil
+            }
+            settings.mcpServers[index].isEnabled = true
+            return id
+        }
+    }
+
+    private func enableSkill(
+        _ reference: NativKitSkillReference,
+        settings: inout NativSettings
+    ) -> NativSkill? {
+        switch reference {
+        case .builtIn(var skill):
+            skill.isEnabled = true
+            if let index = settings.skills.firstIndex(where: { $0.id == skill.id }) {
+                settings.skills[index].isEnabled = true
+                return settings.skills[index]
+            }
+            settings.skills.append(skill)
+            return skill
+        case .configured(let id):
+            guard let index = settings.skills.firstIndex(where: { $0.id == id }) else {
+                return nil
+            }
+            settings.skills[index].isEnabled = true
+            return settings.skills[index]
+        }
+    }
+
+    private func serverID(for reference: NativKitMCPServer, in settings: NativSettings) -> UUID? {
+        switch reference {
+        case .catalog(let catalogID):
+            guard let entry = MCPCatalogEntry.catalog.first(where: { $0.id == catalogID }),
+                  let index = matchingServerIndex(for: entry, in: settings.mcpServers)
+            else {
+                return nil
+            }
+            return settings.mcpServers[index].id
+        case .configured(let id):
+            return settings.mcpServers.contains(where: { $0.id == id }) ? id : nil
+        }
+    }
+
+    private func skill(_ reference: NativKitSkillReference, in settings: NativSettings) -> NativSkill? {
+        switch reference {
+        case .builtIn(let builtIn):
+            return settings.skills.first(where: { $0.id == builtIn.id }) ?? builtIn
+        case .configured(let id):
+            return settings.skills.first { $0.id == id }
+        }
+    }
+
+    private func skillName(_ reference: NativKitSkillReference) -> String {
+        switch reference {
+        case .builtIn(let skill): skill.name
+        case .configured(let id): id.uuidString
+        }
+    }
+
+    private func serverName(_ reference: NativKitMCPServer) -> String {
+        switch reference {
+        case .catalog(let catalogID):
+            return MCPCatalogEntry.catalog.first(where: { $0.id == catalogID })?.name
+                ?? catalogID
+        case .configured(let id):
+            guard let server = model.settings.mcpServers.first(where: { $0.id == id }) else {
+                return id.uuidString
+            }
+            return server.name.isEmpty ? server.command : server.name
+        }
+    }
+
+    private func matchingServerIndex(
+        for entry: MCPCatalogEntry,
+        in servers: [MCPServerConfig]
+    ) -> Int? {
+        servers.firstIndex {
+            $0.command == entry.command && $0.arguments == entry.arguments
+        }
+    }
+
+    private var availableBuiltInToolNames: Set<String> {
+        Set(ChatToolRegistry.definitions(canEditImage: true).map(\.function.name))
+    }
+}
+
+private extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}
+
+private extension Array {
+    func uniqued<ID: Hashable>(by keyPath: KeyPath<Element, ID>) -> [Element] {
+        var seen = Set<ID>()
+        return filter { seen.insert($0[keyPath: keyPath]).inserted }
+    }
+}

--- a/Sources/Nativ/Features/Extensions/NativKitEditor.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitEditor.swift
@@ -1,0 +1,320 @@
+import NativServerKit
+import SwiftUI
+
+struct NativKitEditor: View {
+    @ObservedObject var manager: NativExtensionManager
+    @ObservedObject var host: MCPHostManager
+    @ObservedObject var model: NativModel
+    let onSave: (UserNativKit) -> Void
+    let onCancel: () -> Void
+
+    @State private var draft: UserNativKit
+
+    init(
+        kit: UserNativKit,
+        manager: NativExtensionManager,
+        host: MCPHostManager,
+        model: NativModel,
+        onSave: @escaping (UserNativKit) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        _draft = State(initialValue: kit)
+        self.manager = manager
+        self.host = host
+        self.model = model
+        self.onSave = onSave
+        self.onCancel = onCancel
+    }
+
+    private var canSave: Bool { draft.normalized().isComplete }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(draft.name.isEmpty ? "New kit" : draft.name)
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+                NativHoverCloseButton { onCancel() }
+            }
+            .padding(18)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    identityFields
+                    components
+                }
+                .padding(20)
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Save") { onSave(draft.normalized()) }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canSave)
+            }
+            .padding(16)
+        }
+        .frame(width: 620, height: 680)
+    }
+
+    private var identityFields: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            editorField("Name") {
+                TextField("Kit name", text: $draft.name)
+                    .textFieldStyle(.plain)
+            }
+            editorField("Description") {
+                TextField("What is this kit for?", text: $draft.summary)
+                    .textFieldStyle(.plain)
+            }
+        }
+    }
+
+    private var components: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Capabilities")
+                .font(.system(size: 15, weight: .semibold))
+
+            if !availableExtensions.isEmpty {
+                componentSection(
+                    title: "Extensions",
+                    caption: "Extension features this kit makes available."
+                ) {
+                    ForEach(availableExtensions) { record in
+                        componentToggle(
+                            record.manifest.displayName,
+                            isOn: containsBinding(record.id, in: \UserNativKit.extensionIDs)
+                        )
+                    }
+                }
+            }
+
+            if !configuredServers.isEmpty {
+                componentSection(
+                    title: "MCP servers and tools",
+                    caption: "Selecting a tool also includes the server it needs."
+                ) {
+                    ForEach(configuredServers) { server in
+                        VStack(alignment: .leading, spacing: 5) {
+                            componentToggle(
+                                server.name.isEmpty ? server.command : server.name,
+                                isOn: serverBinding(server.id)
+                            )
+                            let tools = host.hostedTools(forServer: server.id)
+                            if tools.isEmpty, server.isEnabled {
+                                Text("No connected tools are available right now.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .padding(.leading, 24)
+                            } else {
+                                ForEach(tools) { tool in
+                                    Toggle(tool.name, isOn: mcpToolBinding(serverID: server.id, name: tool.name))
+                                        .toggleStyle(.checkbox)
+                                        .font(.system(size: 12, design: .monospaced))
+                                        .padding(.leading, 24)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            componentSection(
+                title: "Built-in tools",
+                caption: "Tools provided directly by Nativ."
+            ) {
+                ForEach(builtInToolNames, id: \.self) { name in
+                    componentToggle(
+                        name,
+                        isOn: containsBinding(name, in: \UserNativKit.builtInToolNames)
+                    )
+                }
+            }
+
+            if !model.settings.customTools.isEmpty {
+                componentSection(
+                    title: "Custom tools",
+                    caption: "Endpoint tools can run in routines. Script tools still require an interactive chat."
+                ) {
+                    ForEach(model.settings.customTools) { tool in
+                        componentToggle(
+                            tool.name,
+                            isOn: containsBinding(tool.id, in: \UserNativKit.customToolIDs)
+                        )
+                    }
+                }
+            }
+
+            if !availableSkills.isEmpty {
+                componentSection(
+                    title: "Skills",
+                    caption: "Instructions added while the kit is in use."
+                ) {
+                    ForEach(availableSkills) { skill in
+                        componentToggle(
+                            skill.name,
+                            isOn: containsBinding(skill.id, in: \UserNativKit.skillIDs)
+                        )
+                    }
+                }
+            }
+
+            unavailableSelections
+        }
+    }
+
+    @ViewBuilder
+    private var unavailableSelections: some View {
+        let serverIDs = Set(configuredServers.map(\.id))
+        let unavailableServers = draft.mcpServerIDs.filter { !serverIDs.contains($0) }
+        let availableTools = Set(configuredServers.flatMap { server in
+            host.hostedTools(forServer: server.id).map {
+                NativKitMCPTool(serverID: server.id, name: $0.name)
+            }
+        })
+        let unavailableTools = draft.mcpTools.filter { tool in
+            guard serverIDs.contains(tool.serverID) else { return true }
+            guard case .connected = host.states[tool.serverID] else { return false }
+            return !availableTools.contains(tool)
+        }
+        let skillIDs = Set(availableSkills.map(\.id))
+        let unavailableSkills = draft.skillIDs.filter { !skillIDs.contains($0) }
+        let customToolIDs = Set(model.settings.customTools.map(\.id))
+        let unavailableCustomTools = draft.customToolIDs.filter { !customToolIDs.contains($0) }
+        let extensionIDs = Set(availableExtensions.map(\.id))
+        let unavailableExtensions = draft.extensionIDs.filter { !extensionIDs.contains($0) }
+        if !unavailableServers.isEmpty
+            || !unavailableTools.isEmpty
+            || !unavailableSkills.isEmpty
+            || !unavailableCustomTools.isEmpty
+            || !unavailableExtensions.isEmpty {
+            VStack(alignment: .leading, spacing: 5) {
+                Label("Some saved capabilities are no longer available", systemImage: "exclamationmark.triangle")
+                    .font(.system(size: 12, weight: .medium))
+                Text("You can keep their identifiers in case they are reinstalled, or remove them from this kit.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button("Remove unavailable") {
+                    draft.mcpServerIDs.removeAll { unavailableServers.contains($0) }
+                    draft.mcpTools.removeAll {
+                        unavailableServers.contains($0.serverID) || unavailableTools.contains($0)
+                    }
+                    draft.skillIDs.removeAll { unavailableSkills.contains($0) }
+                    draft.customToolIDs.removeAll { unavailableCustomTools.contains($0) }
+                    draft.extensionIDs.removeAll { unavailableExtensions.contains($0) }
+                }
+                .controlSize(.small)
+            }
+            .padding(10)
+            .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    private var availableExtensions: [NativExtensionRecord] {
+        manager.records.filter { !$0.isRemoved }
+    }
+
+    private var configuredServers: [MCPServerConfig] {
+        model.settings.mcpServers.filter {
+            !$0.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    private var availableSkills: [NativSkill] {
+        model.settings.skills.filter { $0.id != NativSkill.builtInToolGuideID }
+    }
+
+    private var builtInToolNames: [String] {
+        ChatToolRegistry.definitions(canEditImage: false).map(\.function.name)
+    }
+
+    private func serverBinding(_ id: UUID) -> Binding<Bool> {
+        Binding(
+            get: { draft.mcpServerIDs.contains(id) },
+            set: { selected in
+                if selected {
+                    if !draft.mcpServerIDs.contains(id) { draft.mcpServerIDs.append(id) }
+                } else {
+                    draft.mcpServerIDs.removeAll { $0 == id }
+                    draft.mcpTools.removeAll { $0.serverID == id }
+                }
+            }
+        )
+    }
+
+    private func mcpToolBinding(serverID: UUID, name: String) -> Binding<Bool> {
+        let reference = NativKitMCPTool(serverID: serverID, name: name)
+        return Binding(
+            get: { draft.mcpTools.contains(reference) },
+            set: { selected in
+                if selected {
+                    if !draft.mcpTools.contains(reference) { draft.mcpTools.append(reference) }
+                    if !draft.mcpServerIDs.contains(serverID) { draft.mcpServerIDs.append(serverID) }
+                } else {
+                    draft.mcpTools.removeAll { $0 == reference }
+                }
+            }
+        )
+    }
+
+    private func containsBinding<Value: Hashable>(
+        _ value: Value,
+        in keyPath: WritableKeyPath<UserNativKit, [Value]>
+    ) -> Binding<Bool> {
+        Binding(
+            get: { draft[keyPath: keyPath].contains(value) },
+            set: { selected in
+                if selected {
+                    if !draft[keyPath: keyPath].contains(value) {
+                        draft[keyPath: keyPath].append(value)
+                    }
+                } else {
+                    draft[keyPath: keyPath].removeAll { $0 == value }
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func editorField<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(title).font(.system(size: 12, weight: .semibold))
+            content()
+                .padding(10)
+                .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    @ViewBuilder
+    private func componentSection<Content: View>(
+        title: String,
+        caption: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.system(size: 13, weight: .semibold))
+                Text(caption).font(.caption).foregroundStyle(.secondary)
+            }
+            VStack(alignment: .leading, spacing: 7) { content() }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    private func componentToggle(_ title: String, isOn: Binding<Bool>) -> some View {
+        Toggle(title, isOn: isOn)
+            .toggleStyle(.checkbox)
+            .font(.system(size: 13))
+    }
+}

--- a/Sources/Nativ/Features/Extensions/NativKitPresentation.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitPresentation.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+extension NativKit {
+    var symbol: String {
+        switch id {
+        case "engineering": "chevron.left.forwardslash.chevron.right"
+        case "research": "magnifyingglass"
+        default: "shippingbox"
+        }
+    }
+
+    var tint: Color {
+        switch id {
+        case "engineering": .indigo
+        case "research": .purple
+        default: .teal
+        }
+    }
+}

--- a/Sources/Nativ/Features/Extensions/NativKitStore.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitStore.swift
@@ -1,0 +1,179 @@
+import Combine
+import Foundation
+import NativServerKit
+
+@MainActor
+final class NativKitStore: ObservableObject {
+    static let shared = NativKitStore()
+
+    @Published private(set) var userKits: [UserNativKit]
+
+    private let fileURL: URL
+
+    init(fileURL: URL? = nil) {
+        self.fileURL = fileURL ?? Self.defaultFileURL
+        userKits = Self.load(from: self.fileURL)
+    }
+
+    var availableKits: [NativKit] {
+        NativKit.builtIns + userKits.map { $0.resolved() }
+    }
+
+    func kit(id: String) -> NativKit? {
+        availableKits.first { $0.id == id }
+    }
+
+    func userKit(id: UUID) -> UserNativKit? {
+        userKits.first { $0.id == id }
+    }
+
+    func upsert(_ kit: UserNativKit) {
+        let kit = kit.normalized()
+        guard kit.isComplete else { return }
+        if let index = userKits.firstIndex(where: { $0.id == kit.id }) {
+            userKits[index] = kit
+        } else {
+            userKits.append(kit)
+        }
+        persist()
+    }
+
+    func delete(id: UUID) {
+        userKits.removeAll { $0.id == id }
+        persist()
+    }
+
+    func migrateLegacySettings(
+        mcpServers: [MCPServerConfig],
+        from settingsURL: URL? = nil
+    ) {
+        guard !FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        let settingsURL = settingsURL ?? Self.legacySettingsURL
+        guard let data = try? Data(contentsOf: settingsURL),
+              let payload = try? PropertyListDecoder().decode(LegacySettings.self, from: data),
+              let legacyKits = payload.userKits
+        else {
+            return
+        }
+
+        userKits = legacyKits.map { legacy in
+            var serverIDs = legacy.mcpServerIDs
+            let mcpTools = legacy.toolNames.compactMap { runtimeName -> NativKitMCPTool? in
+                guard let parsed = Self.parseLegacyMCPTool(runtimeName, servers: mcpServers) else {
+                    return nil
+                }
+                if !serverIDs.contains(parsed.serverID) { serverIDs.append(parsed.serverID) }
+                return parsed
+            }
+            return UserNativKit(
+                id: legacy.id,
+                name: legacy.name,
+                summary: legacy.summary,
+                mcpServerIDs: serverIDs,
+                mcpTools: mcpTools,
+                builtInToolNames: legacy.toolNames.filter { !$0.hasPrefix("mcp__") },
+                skillIDs: legacy.skillIDs,
+                extensionIDs: legacy.extensionIDs
+            ).normalized()
+        }
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(userKits) else { return }
+        try? FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    private static func load(from url: URL) -> [UserNativKit] {
+        guard let data = try? Data(contentsOf: url),
+              let kits = try? JSONDecoder().decode([UserNativKit].self, from: data)
+        else {
+            return []
+        }
+        return kits.map { $0.normalized() }
+    }
+
+    private static var defaultFileURL: URL {
+        let base = (try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? FileManager.default.homeDirectoryForCurrentUser
+        return base
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("Kits", isDirectory: true)
+            .appendingPathComponent("kits.json")
+    }
+
+    private static var legacySettingsURL: URL {
+        let base = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.homeDirectoryForCurrentUser
+        return base
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("Settings.plist")
+    }
+
+    private static func parseLegacyMCPTool(
+        _ runtimeName: String,
+        servers: [MCPServerConfig]
+    ) -> NativKitMCPTool? {
+        guard runtimeName.hasPrefix("mcp__") else { return nil }
+        let remainder = runtimeName.dropFirst("mcp__".count)
+        guard let separator = remainder.range(of: "__") else { return nil }
+        let runtimeSlug = String(remainder[..<separator.lowerBound])
+        let toolName = String(remainder[separator.upperBound...])
+        guard !toolName.isEmpty,
+              let server = servers.first(where: {
+                  let base = slug($0.name.isEmpty ? $0.command : $0.name)
+                  return runtimeSlug == base || runtimeSlug.hasPrefix("\(base)_")
+              })
+        else {
+            return nil
+        }
+        return NativKitMCPTool(serverID: server.id, name: toolName)
+    }
+
+    private static func slug(_ value: String) -> String {
+        let characters = value.unicodeScalars.map { scalar in
+            CharacterSet.alphanumerics.contains(scalar) ? Character(scalar) : "_"
+        }
+        let result = String(characters)
+        return result.isEmpty ? "server" : result
+    }
+
+    private struct LegacySettings: Decodable {
+        let userKits: [LegacyUserNativKit]?
+    }
+
+    private struct LegacyUserNativKit: Decodable {
+        let id: UUID
+        let name: String
+        let summary: String
+        let mcpServerIDs: [UUID]
+        let toolNames: [String]
+        let skillIDs: [UUID]
+        let extensionIDs: [String]
+
+        private enum CodingKeys: String, CodingKey {
+            case id, name, summary, mcpServerIDs, toolNames, skillIDs, extensionIDs
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+            name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            summary = try container.decodeIfPresent(String.self, forKey: .summary) ?? ""
+            mcpServerIDs = try container.decodeIfPresent([UUID].self, forKey: .mcpServerIDs) ?? []
+            toolNames = try container.decodeIfPresent([String].self, forKey: .toolNames) ?? []
+            skillIDs = try container.decodeIfPresent([UUID].self, forKey: .skillIDs) ?? []
+            extensionIDs = try container.decodeIfPresent([String].self, forKey: .extensionIDs) ?? []
+        }
+    }
+}

--- a/Sources/Nativ/Features/Extensions/ToolsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/ToolsSectionView.swift
@@ -124,7 +124,7 @@ struct ToolsSectionView: View {
         definitions += ChatServerStatsToolRegistry.definitions()
         definitions += ChatSwitchModelToolRegistry.definitions()
         definitions += ChatImageToolRegistry.definitions(canEdit: false)
-        return definitions.map {
+        var tools = definitions.map {
             ToolItem(
                 name: $0.function.name,
                 title: $0.function.name,
@@ -134,6 +134,14 @@ struct ToolsSectionView: View {
                 isBuiltIn: true
             )
         }
+        tools.append(ToolItem(
+            name: ChatUseKitToolRegistry.toolName,
+            title: ChatUseKitToolRegistry.toolName,
+            detail: "Makes a Kit's capabilities available after user confirmation.",
+            isRunnable: false,
+            isBuiltIn: true
+        ))
+        return tools
     }
 
     private var customTools: [ToolItem] {

--- a/Sources/Nativ/Features/MCP/MCPHostManager.swift
+++ b/Sources/Nativ/Features/MCP/MCPHostManager.swift
@@ -9,6 +9,15 @@ enum MCPServerConnectionState: Equatable {
     case failed(String)
 }
 
+struct MCPHostedTool: Identifiable {
+    let serverID: UUID
+    let name: String
+    let runtimeName: String
+    let definition: MLXChatToolDefinition
+
+    var id: String { "\(serverID.uuidString):\(name)" }
+}
+
 @MainActor
 final class MCPHostManager: ObservableObject {
     @Published private(set) var states: [UUID: MCPServerConnectionState] = [:]
@@ -40,10 +49,32 @@ final class MCPHostManager: ObservableObject {
     }
 
     func tools(forServer id: UUID) -> [(name: String, displayName: String)] {
-        guard let connection = connections[id] else { return [] }
-        return connection.tools.map {
-            (name: Self.toolName(slug: connection.slug, tool: $0.name), displayName: $0.name)
+        hostedTools(forServer: id).map {
+            (name: $0.runtimeName, displayName: $0.name)
         }
+    }
+
+    func hostedTools(forServer id: UUID) -> [MCPHostedTool] {
+        guard let connection = connections[id] else { return [] }
+        return connection.tools.map { tool in
+            let runtimeName = Self.toolName(slug: connection.slug, tool: tool.name)
+            return MCPHostedTool(
+                serverID: id,
+                name: tool.name,
+                runtimeName: runtimeName,
+                definition: MLXChatToolDefinition(
+                    function: MLXChatFunctionDefinition(
+                        name: runtimeName,
+                        description: tool.description,
+                        parameters: tool.parameters
+                    )
+                )
+            )
+        }
+    }
+
+    func hostedTool(serverID: UUID, name: String) -> MCPHostedTool? {
+        hostedTools(forServer: serverID).first { $0.name == name }
     }
 
     func handlesTool(named name: String) -> Bool {
@@ -61,6 +92,14 @@ final class MCPHostManager: ObservableObject {
         guard servers != appliedServers else { return }
         appliedServers = servers
         scheduleReload(servers: servers, debounce: true)
+    }
+
+    func ensureReloaded(servers: [MCPServerConfig]) async {
+        if servers != appliedServers {
+            appliedServers = servers
+            scheduleReload(servers: servers, debounce: false)
+        }
+        await reloadTask?.value
     }
 
     func reconnect(_ serverID: UUID) {

--- a/Sources/Nativ/Features/Routines/RoutineEditorView.swift
+++ b/Sources/Nativ/Features/Routines/RoutineEditorView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct RoutineEditor: View {
     let draft: RoutineDraft
     let availableModelIDs: [String]
+    @ObservedObject var kitStore: NativKitStore
     let onSave: (Routine) -> Void
     let onCancel: () -> Void
     var onDelete: (() -> Void)?
@@ -20,12 +21,14 @@ struct RoutineEditor: View {
     init(
         draft: RoutineDraft,
         availableModelIDs: [String],
+        kitStore: NativKitStore,
         onSave: @escaping (Routine) -> Void,
         onCancel: @escaping () -> Void,
         onDelete: (() -> Void)? = nil
     ) {
         self.draft = draft
         self.availableModelIDs = availableModelIDs
+        self.kitStore = kitStore
         self.onSave = onSave
         self.onCancel = onCancel
         self.onDelete = onDelete
@@ -48,6 +51,7 @@ struct RoutineEditor: View {
         !name.trimmingCharacters(in: .whitespaces).isEmpty
             && !modelID.isEmpty
             && !instructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && kitID.map { kitStore.kit(id: $0) != nil } != false
     }
 
     var body: some View {
@@ -96,15 +100,22 @@ struct RoutineEditor: View {
                         VStack(alignment: .leading, spacing: 10) {
                             Picker("Kit", selection: $kitID) {
                                 Text("None").tag(String?.none)
-                                ForEach(NativKit.all) { kit in
+                                if let kitID, kitStore.kit(id: kitID) == nil {
+                                    Text("Unavailable kit").tag(String?.some(kitID))
+                                }
+                                ForEach(kitStore.availableKits) { kit in
                                     Text(kit.name).tag(String?.some(kit.id))
                                 }
                             }
                             .labelsHidden()
-                            if let kitID, let kit = NativKit.all.first(where: { $0.id == kitID }) {
+                            if let kitID, let kit = kitStore.kit(id: kitID) {
                                 Text(kit.inventory)
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
+                            } else if kitID != nil {
+                                Text("This kit was removed. Choose another kit before the routine can run.")
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
                             }
                         }
                     }

--- a/Sources/Nativ/Features/Routines/RoutineKitResolver.swift
+++ b/Sources/Nativ/Features/Routines/RoutineKitResolver.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum RoutineKitError: LocalizedError, Equatable {
+    case unavailable(String)
+    case incomplete(String, [String])
+    case unsupportedBackgroundTool(String)
+    case invalidToolCall
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let name):
+            "The selected Kit “\(name)” is no longer available. Choose another Kit before running this routine."
+        case .incomplete(let name, let components):
+            "The Kit “\(name)” is not fully available: \(components.joined(separator: ", "))."
+        case .unsupportedBackgroundTool(let name):
+            "The tool “\(name)” requires an interactive chat and cannot run in a routine."
+        case .invalidToolCall:
+            "The model returned an invalid tool call."
+        }
+    }
+}
+
+enum RoutineKitResolver {
+    static func resolve(id: String, from kits: [NativKit]) throws -> NativKit {
+        guard let kit = kits.first(where: { $0.id == id }) else {
+            throw RoutineKitError.unavailable(id)
+        }
+        return kit
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
+++ b/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
@@ -104,6 +104,8 @@ enum RoutineLaunchAgent {
 enum RoutineHeadlessRun {
     private static var retainedRunner: RoutineRunner?
     private static var retainedModel: NativModel?
+    private static var retainedExtensionManager: NativExtensionManager?
+    private static var retainedMCPHost: MCPHostManager?
 
     static func execute(routineID: String) {
         MainActor.assumeIsolated {
@@ -116,19 +118,41 @@ enum RoutineHeadlessRun {
                 exit(EXIT_SUCCESS)
             }
             let model = NativModel()
+            let extensionManager = NativExtensionManager(
+                builtInExtensions: [VoiceDictationExtension()]
+            )
+            extensionManager.launch(
+                context: NativExtensionHostContext(
+                    transcriptionConfiguration: { nil },
+                    openSpeechModels: {},
+                    showMainWindow: {}
+                )
+            )
+            let mcpHost = MCPHostManager()
+            let kitStore = NativKitStore.shared
+            kitStore.migrateLegacySettings(mcpServers: model.settings.mcpServers)
             let runner = RoutineRunner(
                 model: model,
                 store: RoutineStore.shared,
-                sessionStore: ChatSessionStore()
+                sessionStore: ChatSessionStore(),
+                kitStore: kitStore,
+                extensionManager: extensionManager,
+                mcpHost: mcpHost
             )
             retainedModel = model
+            retainedExtensionManager = extensionManager
+            retainedMCPHost = mcpHost
             retainedRunner = runner
             runner.onRunCompleted = { _, _ in
                 model.stopServer()
+                mcpHost.shutdown()
+                extensionManager.shutdown()
                 exit(EXIT_SUCCESS)
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 600) {
                 MainActor.assumeIsolated { retainedModel?.stopServer() }
+                MainActor.assumeIsolated { retainedMCPHost?.shutdown() }
+                MainActor.assumeIsolated { retainedExtensionManager?.shutdown() }
                 exit(EXIT_SUCCESS)
             }
             runner.run(routine, source: .scheduled)

--- a/Sources/Nativ/Features/Routines/RoutineRunner.swift
+++ b/Sources/Nativ/Features/Routines/RoutineRunner.swift
@@ -3,19 +3,42 @@ import NativServerKit
 
 @MainActor
 final class RoutineRunner {
+    private struct CompletionResult {
+        let completion: MLXChatCompletion
+        let transcript: [ChatTranscriptMessage]
+    }
+
+    private struct ToolFailure: Encodable {
+        let ok = false
+        let error: String
+    }
+
     private let model: NativModel
     private let store: RoutineStore
     private let sessionStore: ChatSessionStore
+    private let kitStore: NativKitStore
+    private let extensionManager: NativExtensionManager
+    private let mcpHost: MCPHostManager
 
     var onRunCompleted: ((Routine, RoutineRun) -> Void)?
 
     private var queue: [(Routine, RoutineRunSource)] = []
     private var isExecuting = false
 
-    init(model: NativModel, store: RoutineStore, sessionStore: ChatSessionStore) {
+    init(
+        model: NativModel,
+        store: RoutineStore,
+        sessionStore: ChatSessionStore,
+        kitStore: NativKitStore,
+        extensionManager: NativExtensionManager,
+        mcpHost: MCPHostManager
+    ) {
         self.model = model
         self.store = store
         self.sessionStore = sessionStore
+        self.kitStore = kitStore
+        self.extensionManager = extensionManager
+        self.mcpHost = mcpHost
     }
 
     func run(_ routine: Routine, source: RoutineRunSource) {
@@ -24,9 +47,7 @@ final class RoutineRunner {
     }
 
     private func drain() {
-        guard !isExecuting, !queue.isEmpty else {
-            return
-        }
+        guard !isExecuting, !queue.isEmpty else { return }
         isExecuting = true
         let (routine, source) = queue.removeFirst()
         Task { @MainActor in
@@ -40,9 +61,15 @@ final class RoutineRunner {
         var run = RoutineRun(routineID: routine.id, source: source, status: .running)
         store.recordRun(run)
 
-        if !model.isRunning {
-            model.startServer()
+        let activation: NativKitActivationResult?
+        do {
+            activation = try await activateKit(for: routine)
+        } catch {
+            finish(&run, routine: routine, status: .failed, summary: error.localizedDescription)
+            return
         }
+
+        if !model.isRunning { model.startServer() }
         await waitForServer()
 
         guard let baseURL = model.activeServerBaseURL else {
@@ -52,53 +79,223 @@ final class RoutineRunner {
 
         let settings = model.settings.normalized()
         var messages: [MLXChatMessage] = []
-        if let systemPrompt = systemPrompt(for: routine) {
+        let systemPrompt = systemPrompt(settings: settings, activation: activation)
+        if !systemPrompt.isEmpty {
             messages.append(MLXChatMessage(role: "system", content: systemPrompt))
         }
         messages.append(MLXChatMessage(role: "user", content: routine.instructions))
 
-        let client = NativChatClient(baseURL: baseURL, apiKey: settings.serverAPIKey)
-        let request = MLXChatCompletionRequest(
-            model: routine.modelID,
-            messages: messages,
-            maxTokens: settings.maxTokens,
-            temperature: settings.temperature,
-            topK: settings.topK,
-            topP: settings.topP,
-            minP: settings.minP
-        )
-
         do {
-            let completion = try await client.completeChat(request)
-            let sessionID = appendRun(routine: routine, completion: completion)
+            let result = try await complete(
+                routine: routine,
+                messages: messages,
+                settings: settings,
+                baseURL: baseURL,
+                activation: activation
+            )
+            let sessionID = appendRun(routine: routine, transcript: result.transcript)
             NotificationCenter.default.post(name: .routineDidSaveChatSession, object: nil)
             run.sessionID = sessionID
-            finish(&run, routine: routine, status: .succeeded, summary: Self.summarize(completion.content))
+            finish(
+                &run,
+                routine: routine,
+                status: .succeeded,
+                summary: Self.summarize(result.completion.content)
+            )
         } catch {
             finish(&run, routine: routine, status: .failed, summary: error.localizedDescription)
         }
     }
 
-    private func appendRun(routine: Routine, completion: MLXChatCompletion) -> UUID {
-        let userMessage = ChatTranscriptMessage(
-            role: .user,
-            content: routine.instructions
+    private func activateKit(for routine: Routine) async throws -> NativKitActivationResult? {
+        guard let kitID = routine.kitID else { return nil }
+        let kit = try RoutineKitResolver.resolve(id: kitID, from: kitStore.availableKits)
+        let result = await NativKitActivationCoordinator(
+            model: model,
+            manager: extensionManager,
+            host: mcpHost
+        ).activate(kit)
+        guard result.unavailableComponents.isEmpty else {
+            throw RoutineKitError.incomplete(kit.name, result.unavailableComponents)
+        }
+        for name in result.builtInToolNames where !Self.backgroundToolNames.contains(name) {
+            throw RoutineKitError.unsupportedBackgroundTool(name)
+        }
+        if let scriptTool = result.customTools.first(where: { $0.kind == .script }) {
+            throw RoutineKitError.unsupportedBackgroundTool(scriptTool.name)
+        }
+        return result
+    }
+
+    private func complete(
+        routine: Routine,
+        messages initialMessages: [MLXChatMessage],
+        settings: NativSettings,
+        baseURL: URL,
+        activation: NativKitActivationResult?
+    ) async throws -> CompletionResult {
+        let client = NativChatClient(baseURL: baseURL, apiKey: settings.serverAPIKey)
+        var messages = initialMessages
+        var transcript = [ChatTranscriptMessage(role: .user, content: routine.instructions)]
+        var toolRound = 0
+
+        while true {
+            let advertisesTools = ChatToolRoundGate.advertisesTools(atRound: toolRound)
+            let tools = advertisesTools ? toolDefinitions(for: activation) : []
+            let request = MLXChatCompletionRequest(
+                model: routine.modelID,
+                messages: messages,
+                maxTokens: settings.maxTokens,
+                temperature: settings.temperature,
+                topK: settings.topK,
+                topP: settings.topP,
+                minP: settings.minP,
+                repetitionPenalty: settings.repetitionPenaltyEnabled ? settings.repetitionPenalty : nil,
+                enableThinking: settings.thinkingEnabled,
+                thinkingBudget: settings.thinkingEnabled
+                    && settings.thinkingBudgetEnabled
+                    && !settings.speculativeDecodingActive
+                    ? settings.thinkingBudget
+                    : nil,
+                thinkingStartToken: settings.thinkingEnabled ? settings.thinkingStartToken : nil,
+                thinkingEndToken: settings.thinkingEnabled ? settings.thinkingEndToken : nil,
+                tools: tools.isEmpty ? nil : tools,
+                toolChoice: tools.isEmpty ? nil : "auto"
+            )
+            let completion = try await client.completeChat(request)
+            let calls = normalizedToolCalls(completion.toolCalls)
+            messages.append(MLXChatMessage(
+                role: "assistant",
+                content: completion.content,
+                reasoningContent: completion.reasoningContent,
+                toolCalls: calls.isEmpty ? nil : calls
+            ))
+            transcript.append(ChatTranscriptMessage(
+                role: .assistant,
+                content: completion.content,
+                reasoningContent: completion.reasoningContent ?? "",
+                modelID: routine.modelID,
+                toolCalls: calls
+            ))
+
+            guard advertisesTools, !calls.isEmpty else {
+                return CompletionResult(completion: completion, transcript: transcript)
+            }
+
+            for call in calls {
+                let output: String
+                let status: ChatTranscriptMessage.ToolStatus
+                do {
+                    output = try await execute(
+                        call: call,
+                        settings: settings,
+                        baseURL: baseURL,
+                        activation: activation
+                    )
+                    status = .succeeded
+                } catch {
+                    output = Self.toolFailurePayload(error)
+                    status = .failed
+                }
+                let name = call.function?.name
+                messages.append(MLXChatMessage(
+                    role: "tool",
+                    content: output,
+                    toolCallID: call.id,
+                    name: name
+                ))
+                transcript.append(ChatTranscriptMessage(
+                    role: .tool,
+                    content: output,
+                    toolCallID: call.id,
+                    toolName: name,
+                    toolStatus: status,
+                    toolArguments: call.function?.arguments
+                ))
+            }
+            toolRound += 1
+        }
+    }
+
+    private func execute(
+        call: MLXChatToolCall,
+        settings: NativSettings,
+        baseURL: URL,
+        activation: NativKitActivationResult?
+    ) async throws -> String {
+        guard let name = call.function?.name else { throw RoutineKitError.invalidToolCall }
+        let allowedMCPNames = Set(activation?.mcpTools.map(\.runtimeName) ?? [])
+        if allowedMCPNames.contains(name) {
+            return try await mcpHost.callTool(named: name, argumentsJSON: call.function?.arguments)
+        }
+        if let customTool = activation?.customTools.first(where: { $0.toolName == name }) {
+            return try await CustomToolExecutor.execute(
+                customTool,
+                argumentsJSON: call.function?.arguments
+            )
+        }
+        guard activation?.builtInToolNames.contains(name) == true,
+              Self.backgroundToolNames.contains(name)
+        else {
+            throw RoutineKitError.invalidToolCall
+        }
+        let outcome = try await ChatToolDispatcher.execute(
+            call: call,
+            context: ChatToolExecutionContext(
+                imageGenerationModelID: settings.imageGenerationModelID,
+                baseURL: baseURL,
+                apiKey: settings.serverAPIKey,
+                imageReferences: [],
+                modelSearchPath: settings.expandedModelSearchPath,
+                additionalModelSearchPaths: settings.additionalModelSearchPaths
+            )
         )
-        let assistantMessage = ChatTranscriptMessage(
-            role: .assistant,
-            content: completion.content,
-            reasoningContent: completion.reasoningContent ?? "",
-            modelID: routine.modelID
-        )
+        return outcome.content
+    }
+
+    private func toolDefinitions(for activation: NativKitActivationResult?) -> [MLXChatToolDefinition] {
+        guard let activation else { return [] }
+        let builtInNames = Set(activation.builtInToolNames)
+        let builtIns = ChatToolRegistry.definitions(canEditImage: false).filter {
+            builtInNames.contains($0.function.name) && Self.backgroundToolNames.contains($0.function.name)
+        }
+        let customTools = activation.customTools.compactMap { try? $0.definition() }
+        return builtIns + customTools + activation.toolDefinitions
+    }
+
+    private func systemPrompt(
+        settings: NativSettings,
+        activation: NativKitActivationResult?
+    ) -> String {
+        var parts: [String] = []
+        if !settings.systemPrompt.isEmpty { parts.append(settings.systemPrompt) }
+        let tools = toolDefinitions(for: activation)
+        if !tools.isEmpty { parts.append(NativSkill.builtInToolGuide.instructions) }
+        parts.append(contentsOf: activation?.skills.map(\.instructions).filter { !$0.isEmpty } ?? [])
+        return parts.joined(separator: "\n\n")
+    }
+
+    private func appendRun(routine: Routine, transcript: [ChatTranscriptMessage]) -> UUID {
         if let sessionID = routine.sourceSessionID,
            var session = sessionStore.loadSession(id: sessionID) {
-            session.messages.append(userMessage)
-            session.messages.append(assistantMessage)
+            session.messages.append(contentsOf: transcript)
             session.updatedAt = Date()
             sessionStore.saveSession(session)
             return sessionID
         }
-        let session = makeSession(routine: routine, completion: completion)
+        let now = Date()
+        let session = ChatSession(
+            id: UUID(),
+            title: routine.name.isEmpty ? "Routine" : routine.name,
+            customTitle: nil,
+            createdAt: now,
+            updatedAt: now,
+            messages: transcript,
+            pinned: nil,
+            pinnedOrder: nil,
+            sessionOrder: nil,
+            folderID: nil
+        )
         sessionStore.saveSession(session)
         return session.id
     }
@@ -119,17 +316,13 @@ final class RoutineRunner {
     private func waitForServer(timeout: TimeInterval = 120) async {
         let deadline = Date().addingTimeInterval(timeout)
         while model.activeServerBaseURL == nil, Date() < deadline {
-            try? await Task.sleep(nanoseconds: 300_000_000)
+            try? await Task.sleep(for: .milliseconds(300))
         }
-        guard let baseURL = model.activeServerBaseURL else {
-            return
-        }
+        guard let baseURL = model.activeServerBaseURL else { return }
         let healthURL = baseURL.appendingPathComponent("v1/models")
         while Date() < deadline {
-            if await Self.isReachable(healthURL) {
-                return
-            }
-            try? await Task.sleep(nanoseconds: 500_000_000)
+            if await Self.isReachable(healthURL) { return }
+            try? await Task.sleep(for: .milliseconds(500))
         }
     }
 
@@ -144,43 +337,25 @@ final class RoutineRunner {
         }
     }
 
-    private func systemPrompt(for routine: Routine) -> String? {
-        guard let kitID = routine.kitID,
-              let kit = NativKit.all.first(where: { $0.id == kitID })
-        else {
-            return nil
+    private func normalizedToolCalls(_ calls: [MLXChatToolCall]) -> [MLXChatToolCall] {
+        calls.enumerated().map { index, call in
+            var call = call
+            if call.id?.isEmpty != false { call.id = "routine-tool-\(index)-\(UUID().uuidString)" }
+            return call
         }
-        let instructions = kit.skills
-            .filter(\.isEnabled)
-            .map(\.instructions)
-            .filter { !$0.isEmpty }
-        return instructions.isEmpty ? nil : instructions.joined(separator: "\n\n")
     }
 
-    private func makeSession(routine: Routine, completion: MLXChatCompletion) -> ChatSession {
-        let userMessage = ChatTranscriptMessage(
-            role: .user,
-            content: routine.instructions
-        )
-        let assistantMessage = ChatTranscriptMessage(
-            role: .assistant,
-            content: completion.content,
-            reasoningContent: completion.reasoningContent ?? "",
-            modelID: routine.modelID
-        )
-        let now = Date()
-        return ChatSession(
-            id: UUID(),
-            title: routine.name.isEmpty ? "Routine" : routine.name,
-            customTitle: nil,
-            createdAt: now,
-            updatedAt: now,
-            messages: [userMessage, assistantMessage],
-            pinned: nil,
-            pinnedOrder: nil,
-            sessionOrder: nil,
-            folderID: nil
-        )
+    private static let backgroundToolNames: Set<String> = [
+        ChatSystemMonitorToolRegistry.toolName,
+        ChatModelLibraryToolRegistry.toolName,
+        ChatServerStatsToolRegistry.toolName,
+    ]
+
+    private static func toolFailurePayload(_ error: Error) -> String {
+        guard let data = try? JSONEncoder().encode(ToolFailure(error: error.localizedDescription)) else {
+            return #"{"ok":false,"error":"Tool execution failed."}"#
+        }
+        return String(decoding: data, as: UTF8.self)
     }
 
     private static func summarize(_ content: String) -> String {

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -20,6 +20,8 @@ struct WelcomeGateView: View {
     @ObservedObject var navigation: ControlPanelNavigation
     @ObservedObject var runtime: SystemRuntimeMonitor
     @ObservedObject var extensionManager: NativExtensionManager
+    @ObservedObject var mcpHost: MCPHostManager
+    @ObservedObject var kitStore: NativKitStore
     let softwareUpdater: SoftwareUpdater
     let onComplete: (_ modelID: String?, _ serverAPIKey: String?) -> Void
 
@@ -31,6 +33,8 @@ struct WelcomeGateView: View {
                     navigation: navigation,
                     runtime: runtime,
                     extensionManager: extensionManager,
+                    mcpHost: mcpHost,
+                    kitStore: kitStore,
                     softwareUpdater: softwareUpdater
                 )
             } else {

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -98,6 +98,25 @@ final class ChatToolRegistryTests: XCTestCase {
         XCTAssertEqual(names.count, Set(names).count)
     }
 
+    func testUseKitDefinitionIncludesEveryAvailableKit() throws {
+        let kits = [
+            ChatKitDescriptor(id: "engineering", name: "Engineering", summary: "Build software."),
+            ChatKitDescriptor(id: "release", name: "Release", summary: "Prepare a release."),
+        ]
+        let definition = try XCTUnwrap(
+            ChatToolRegistry.definitions(canEditImage: false, kits: kits)
+                .first { $0.function.name == ChatUseKitToolRegistry.toolName }
+        )
+        let data = try JSONEncoder().encode(definition)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let function = try XCTUnwrap(object["function"] as? [String: Any])
+        let parameters = try XCTUnwrap(function["parameters"] as? [String: Any])
+        let properties = try XCTUnwrap(parameters["properties"] as? [String: Any])
+        let kitID = try XCTUnwrap(properties["kit_id"] as? [String: Any])
+
+        XCTAssertEqual(kitID["enum"] as? [String], ["engineering", "release"])
+    }
+
     func testImageToolSchemasAreGoldenPinned() throws {
         let golden = #"""
             [{"function":{"description":"Create one or more new images from a detailed text prompt. Image-model selection is handled by the app; do not ask for or provide a model identifier.","name":"generate_image","parameters":{"additionalProperties":false,"properties":{"count":{"maximum":4,"minimum":1,"type":"integer"},"height":{"maximum":2048,"minimum":256,"type":"integer"},"prompt":{"description":"A specific visual description or edit instruction.","type":"string"},"seed":{"type":["integer","null"]},"width":{"maximum":2048,"minimum":256,"type":"integer"}},"required":["prompt"],"type":"object"}},"type":"function"},{"function":{"description":"Edit the most recently attached or generated image using a text instruction. Image-model selection is handled by the app; do not ask for or provide a model identifier.","name":"edit_image","parameters":{"additionalProperties":false,"properties":{"count":{"maximum":4,"minimum":1,"type":"integer"},"height":{"maximum":2048,"minimum":256,"type":"integer"},"prompt":{"description":"A specific visual description or edit instruction.","type":"string"},"seed":{"type":["integer","null"]},"width":{"maximum":2048,"minimum":256,"type":"integer"}},"required":["prompt"],"type":"object"}},"type":"function"}]
@@ -670,6 +689,13 @@ final class ChatToolPresentationTests: XCTestCase {
                 .awaitingImageModelSelection: "Model switch",
                 .awaitingConsent: "Switch model?", .declined: "Model switch declined",
             ],
+            ChatUseKitToolRegistry.toolName: [
+                nil: "Kit tool", .preparing: "Making Kit available…",
+                .running: "Making Kit available…", .succeeded: "Kit available",
+                .failed: "Use Kit", .cancelled: "Use Kit",
+                .awaitingImageModelSelection: "Use Kit",
+                .awaitingConsent: "Use Kit?", .declined: "Kit activation declined",
+            ],
             "some_unknown_tool": [
                 nil: "some_unknown_tool", .preparing: "Running some_unknown_tool…",
                 .running: "Running some_unknown_tool…", .succeeded: "Ran some_unknown_tool",
@@ -700,6 +726,7 @@ final class ChatToolPresentationTests: XCTestCase {
             "generate_image", "edit_image",
             ChatSystemMonitorToolRegistry.toolName, ChatModelLibraryToolRegistry.toolName,
             ChatServerStatsToolRegistry.toolName, ChatSwitchModelToolRegistry.toolName,
+            ChatUseKitToolRegistry.toolName,
             "some_unknown_tool",
         ]
         let successLikeSymbol: [String: String] = [
@@ -709,6 +736,7 @@ final class ChatToolPresentationTests: XCTestCase {
             ChatModelLibraryToolRegistry.toolName: "shippingbox",
             ChatServerStatsToolRegistry.toolName: "chart.line.uptrend.xyaxis",
             ChatSwitchModelToolRegistry.toolName: "arrow.triangle.2.circlepath",
+            ChatUseKitToolRegistry.toolName: "shippingbox",
             "some_unknown_tool": "wrench.and.screwdriver",
         ]
 
@@ -840,6 +868,34 @@ final class ChatSwitchModelToolExecutorTests: XCTestCase {
     private func decode(_ json: String) throws -> [String: Any] {
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}
+
+final class ChatUseKitToolExecutorTests: XCTestCase {
+    func testSelectsKitByStableIdentifier() throws {
+        let kit = ChatKitDescriptor(id: "release", name: "Release", summary: "Prepare a release.")
+
+        let selected = try ChatUseKitToolExecutor().selectedKit(
+            call: makeCall(
+                name: ChatUseKitToolRegistry.toolName,
+                arguments: #"{"kit_id":"release"}"#
+            ),
+            kits: [kit]
+        )
+
+        XCTAssertEqual(selected, kit)
+    }
+
+    func testUnknownKitFailsInsteadOfActivatingFallback() {
+        XCTAssertThrowsError(try ChatUseKitToolExecutor().selectedKit(
+            call: makeCall(
+                name: ChatUseKitToolRegistry.toolName,
+                arguments: #"{"kit_id":"removed"}"#
+            ),
+            kits: []
+        )) { error in
+            XCTAssertEqual(error as? ChatUseKitToolError, .unknownKit("removed"))
+        }
     }
 }
 

--- a/Tests/NativTests/NativKitStoreTests.swift
+++ b/Tests/NativTests/NativKitStoreTests.swift
@@ -1,0 +1,117 @@
+import NativServerKit
+import XCTest
+
+@MainActor
+final class NativKitStoreTests: XCTestCase {
+    private var directory: URL!
+    private var fileURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NativKitStoreTests-\(UUID().uuidString)", isDirectory: true)
+        fileURL = directory.appendingPathComponent("kits.json")
+    }
+
+    override func tearDown() {
+        if let directory {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        super.tearDown()
+    }
+
+    func testToolSelectionAutomaticallyIncludesItsServer() throws {
+        let serverID = UUID()
+        let tool = NativKitMCPTool(serverID: serverID, name: "search")
+        let store = NativKitStore(fileURL: fileURL)
+
+        store.upsert(UserNativKit(name: "Research", mcpTools: [tool]))
+
+        let saved = try XCTUnwrap(store.userKits.first)
+        XCTAssertEqual(saved.mcpServerIDs, [serverID])
+        XCTAssertEqual(saved.mcpTools, [tool])
+    }
+
+    func testStableToolReferenceRoundTripsWithoutRuntimeSlug() throws {
+        let serverID = UUID()
+        let tool = NativKitMCPTool(serverID: serverID, name: "read_file")
+        let store = NativKitStore(fileURL: fileURL)
+        store.upsert(UserNativKit(name: "Files", mcpTools: [tool]))
+
+        let reloaded = NativKitStore(fileURL: fileURL)
+
+        XCTAssertEqual(reloaded.userKits.first?.mcpTools, [tool])
+        XCTAssertFalse(reloaded.userKits.first?.mcpTools.first?.name.contains("mcp__") ?? true)
+    }
+
+    func testDeletedKitIsNoLongerResolvable() throws {
+        let store = NativKitStore(fileURL: fileURL)
+        let kit = UserNativKit(name: "Temporary", builtInToolNames: ["list_models"])
+        store.upsert(kit)
+        XCTAssertNotNil(store.kit(id: kit.id.uuidString))
+
+        store.delete(id: kit.id)
+
+        XCTAssertNil(store.kit(id: kit.id.uuidString))
+    }
+
+    func testCustomToolReferencesUseStableIdentifiers() throws {
+        let toolID = UUID()
+        let store = NativKitStore(fileURL: fileURL)
+
+        store.upsert(UserNativKit(
+            name: "Deploy",
+            customToolIDs: [toolID, toolID]
+        ))
+
+        XCTAssertEqual(store.userKits.first?.customToolIDs, [toolID])
+    }
+
+    func testMigratesLegacyRuntimeToolNameToStableReference() throws {
+        struct LegacyKit: Encodable {
+            let id: UUID
+            let name: String
+            let summary: String
+            let mcpServerIDs: [UUID]
+            let toolNames: [String]
+            let skillIDs: [UUID]
+            let extensionIDs: [String]
+        }
+        struct LegacySettings: Encodable { let userKits: [LegacyKit] }
+
+        let server = MCPServerConfig(name: "My Files", command: "files")
+        let legacyURL = directory.appendingPathComponent("Settings.plist")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try PropertyListEncoder().encode(LegacySettings(userKits: [
+            LegacyKit(
+                id: UUID(),
+                name: "Files",
+                summary: "",
+                mcpServerIDs: [],
+                toolNames: ["mcp__My_Files__read_file"],
+                skillIDs: [],
+                extensionIDs: []
+            )
+        ]))
+        try data.write(to: legacyURL)
+        let store = NativKitStore(fileURL: fileURL)
+
+        store.migrateLegacySettings(mcpServers: [server], from: legacyURL)
+
+        XCTAssertEqual(
+            store.userKits.first?.mcpTools,
+            [NativKitMCPTool(serverID: server.id, name: "read_file")]
+        )
+        XCTAssertEqual(store.userKits.first?.mcpServerIDs, [server.id])
+    }
+
+    func testBuiltInCatalogHasOnlyCurrentKits() {
+        XCTAssertEqual(NativKit.builtIns.map(\.id), ["engineering", "research"])
+    }
+
+    func testRoutineResolutionFailsWhenSelectedKitWasRemoved() {
+        XCTAssertThrowsError(try RoutineKitResolver.resolve(id: "removed", from: [])) { error in
+            XCTAssertEqual(error as? RoutineKitError, .unavailable("removed"))
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -153,6 +153,9 @@ targets:
       - path: Sources/Nativ/NativSettings.swift
       - path: Sources/Nativ/Features/Extensions/NativSkill.swift
       - path: Sources/Nativ/Features/Extensions/CustomTool.swift
+      - path: Sources/Nativ/Features/Extensions/NativKit.swift
+      - path: Sources/Nativ/Features/Extensions/NativKitStore.swift
+      - path: Sources/Nativ/Features/Routines/RoutineKitResolver.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioInputDevicePreferences.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
       - path: Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -176,6 +179,7 @@ targets:
       - path: Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatServerStatsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatSwitchModelTool.swift
+      - path: Sources/Nativ/Features/Chat/Tools/ChatUseKitTool.swift
       - path: Sources/Nativ/Features/Artifacts/Artifact.swift
       - path: Sources/Nativ/Features/Chat/ChatSessionStore.swift
       - path: Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift


### PR DESCRIPTION
Supersedes #251.

## Summary

- Move user-created kits into a dedicated store with backward-compatible migration and stable typed component references.
- Add one shared activation path for chat and routines, including the consent-gated use_kit chat tool.
- Resolve routine kits at execution time, fail clearly when a kit or required component disappeared, and preserve routine tool traces in chat history.
- Make MCP tool selection include its server automatically and resolve runtime tool names from stable server ID plus raw tool name references.
- Support current custom endpoint tools in kits while rejecting interactive script tools in headless routines.
- Keep kit activation enable-only so one kit cannot disable components shared with another.

## Verification

- xcodegen generate
- Parsed every changed Swift source
- Type-checked the standalone kit domain, store, resolver, and activation layer with isolated dependencies
- Ran a persistence and deleted-kit resolution smoke test
- Added regression tests for kit storage, migration, MCP dependencies, deleted-kit resolution, and use_kit schemas
- App build and full Xcode test suite not run per request