### PR TITLE
Add Parallel Search to the MCP catalog

### DIFF
--- a/Sources/Nativ/Resources/MCPCatalog.json
+++ b/Sources/Nativ/Resources/MCPCatalog.json
@@ -59,5 +59,14 @@
     "symbol": "cylinder.split.1x2",
     "tint": "green",
     "sourceURL": "https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite"
+  },
+  {
+    "id": "parallel-search",
+    "name": "Parallel Search",
+    "summary": "Search the live web and fetch clean content from URLs.",
+    "command": "npx",
+    "args": ["-y", "mcp-remote@0.1.38", "https://search.parallel.ai/mcp", "--transport", "http-only"],
+    "symbol": "globe",
+    "tint": "indigo"
   }
 ]


### PR DESCRIPTION
Nativ's MCP catalog gives local models access to additional tools without changing the app's defaults. This adds Parallel Search as an optional entry for live web search and clean URL fetching through its free remote MCP endpoint.

## What changed

- Added a `parallel-search` catalog entry using the existing `npx` launcher pattern.
- Pinned `mcp-remote` to `0.1.38` and selected its Streamable HTTP transport.
- Kept the entry credential-free and left the existing Fetch server and native web-search providers unchanged.

## Validation

- Parsed `MCPCatalog.json` successfully.
- Passed `git diff --check` and confirmed the patch only appends the approved catalog record.
- Passed `python scripts/verify_mcp_catalog.py --only parallel-search` with two tools.
- Confirmed the endpoint lists `web_search` and `web_fetch` in a credential-free temporary environment.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.