### PR TITLE
Set up global model folder access

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -1404,9 +1404,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     }
 
     private var modelScanKey: String {
-        let settings = model.settings.normalized()
-        return ([settings.expandedModelSearchPath] + settings.additionalModelSearchPaths)
-            .joined(separator: "\u{0}")
+        model.settings.localModelSearchPaths.cacheKey
     }
 
     private func refreshLocalModelsIfNeeded() {
@@ -1418,9 +1416,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
     private func refreshLocalModels() {
         modelScanTask?.cancel()
-        let settings = model.settings.normalized()
-        let searchPath = settings.expandedModelSearchPath
-        let additionalPaths = settings.additionalModelSearchPaths
+        let searchPaths = model.settings.localModelSearchPaths
         let scanKey = modelScanKey
         modelScanInProgress = true
         modelScanError = nil
@@ -1432,7 +1428,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
             }
 
             do {
-                let models = try await LocalModelDiscovery.scan(path: searchPath, additionalPaths: additionalPaths)
+                let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
                 guard !Task.isCancelled else {
                     return
                 }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -310,10 +310,7 @@ struct ControlPanelView: View {
                         repoID: modelID,
                         searchPath: settings.modelSearchPath
                     )
-                    embeddingLibrary.scan(
-                        path: settings.modelSearchPath,
-                        additionalPaths: settings.additionalModelSearchPaths
-                    )
+                    embeddingLibrary.scan(searchPaths: settings.localModelSearchPaths)
                     NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
                 }
                 navigation.open(.models)
@@ -324,10 +321,7 @@ struct ControlPanelView: View {
                         repoID: modelID,
                         path: settings.modelSearchPath
                     )
-                    embeddingLibrary.scan(
-                        path: settings.modelSearchPath,
-                        additionalPaths: settings.additionalModelSearchPaths
-                    )
+                    embeddingLibrary.scan(searchPaths: settings.localModelSearchPaths)
                     NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
                 }
             },
@@ -441,10 +435,7 @@ struct ControlPanelView: View {
         .onAppear {
             applySidebarSelection(navigation.requestedTab.map(ControlPanelSidebarSelection.tab) ?? sidebarSelection)
             handleNewChatRequest()
-            embeddingLibrary.scan(
-                path: model.settings.modelSearchPath,
-                additionalPaths: model.settings.normalized().additionalModelSearchPaths
-            )
+            embeddingLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
             artifacts.onDeleteArtifact = { artifact in
                 switch artifact.source {
                 case .uploaded:
@@ -1620,10 +1611,7 @@ struct ControlPanelView: View {
             return
         }
         let settings = model.settings.normalized()
-        routineModelLibrary.scan(
-            path: settings.modelSearchPath,
-            additionalPaths: settings.additionalModelSearchPaths
-        )
+        routineModelLibrary.scan(searchPaths: settings.localModelSearchPaths)
         if let existing = RoutineStore.shared.routine(forSession: sessionID) {
             schedulingRoutineDraft = RoutineDraft(routine: existing)
             return
@@ -1650,10 +1638,7 @@ struct ControlPanelView: View {
 
     private func presentNewRoutine() {
         let settings = model.settings.normalized()
-        routineModelLibrary.scan(
-            path: settings.modelSearchPath,
-            additionalPaths: settings.additionalModelSearchPaths
-        )
+        routineModelLibrary.scan(searchPaths: settings.localModelSearchPaths)
         schedulingRoutineDraft = RoutineDraft(
             routine: Routine(modelID: settings.languageModelID ?? "")
         )

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -238,16 +238,10 @@ struct ChatComposer: View {
         }
         .padding(.vertical, 18)
         .task(id: modelScanKey) {
-            localLibrary.scan(
-                path: model.settings.modelSearchPath,
-                additionalPaths: model.settings.normalized().additionalModelSearchPaths
-            )
+            localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
         }
         .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
-            localLibrary.scan(
-                path: model.settings.modelSearchPath,
-                additionalPaths: model.settings.normalized().additionalModelSearchPaths
-            )
+            localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
         }
         .onChange(of: localLibrary.models) { _, models in
             disableThinkingIfUnsupported(modelID: selectedModelID, models: models)
@@ -268,9 +262,7 @@ struct ChatComposer: View {
     }
 
     private var modelScanKey: String {
-        let settings = model.settings.normalized()
-        return ([settings.expandedModelSearchPath] + settings.additionalModelSearchPaths)
-            .joined(separator: "\u{0}")
+        model.settings.localModelSearchPaths.cacheKey
     }
 
     private var modelPicker: some View {

--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -150,22 +150,17 @@ struct ModelConfigurationView: View {
     }
 
     private var draftModelScanKey: String {
-        let normalizedSettings = settings.normalized()
-        return ([
-            String(normalizedSettings.speculativeDecodingEnabled),
-            normalizedSettings.modelSearchPath
-        ] + normalizedSettings.additionalModelSearchPaths)
-            .joined(separator: "\u{0}")
+        [
+            String(settings.speculativeDecodingEnabled),
+            settings.localModelSearchPaths.cacheKey
+        ].joined(separator: "\u{0}")
     }
 
     private func scanDraftModelLibraryIfNeeded() {
         guard settings.speculativeDecodingEnabled else {
             return
         }
-        draftModelLibrary.scan(
-            path: settings.modelSearchPath,
-            additionalPaths: settings.normalized().additionalModelSearchPaths
-        )
+        draftModelLibrary.scan(searchPaths: settings.localModelSearchPaths)
     }
 
     private var header: some View {

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
@@ -194,8 +194,10 @@ enum ChatImageModelSelection {
         let models: [LocalModel]
         do {
             models = try await LocalModelDiscovery.scan(
-                path: modelSearchPath,
-                additionalPaths: additionalModelSearchPaths
+                searchPaths: LocalModelSearchPaths(
+                    primary: modelSearchPath,
+                    additional: additionalModelSearchPaths
+                )
             )
         } catch LocalModelDiscoveryError.pathNotFound {
             // A fresh install may not have a model cache directory yet.

--- a/Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
@@ -46,8 +46,10 @@ struct ChatModelLibraryToolExecutor {
         }
 
         let models = try await LocalModelDiscovery.scan(
-            path: context.modelSearchPath,
-            additionalPaths: context.additionalModelSearchPaths
+            searchPaths: LocalModelSearchPaths(
+                primary: context.modelSearchPath,
+                additional: context.additionalModelSearchPaths
+            )
         )
         let payload = ChatModelLibraryToolResultPayload(
             ok: true,

--- a/Sources/Nativ/Features/Dashboard/DashboardViewModel.swift
+++ b/Sources/Nativ/Features/Dashboard/DashboardViewModel.swift
@@ -213,13 +213,13 @@ final class DashboardViewModel: ObservableObject {
         applyPreferredSelectionIfPossible()
     }
 
-    func scanModels(at path: String, additionalPaths: [String] = []) {
+    func scanModels(searchPaths: LocalModelSearchPaths) {
         modelScanTask?.cancel()
         localModelError = nil
 
-        modelScanTask = Task { [path] in
+        modelScanTask = Task {
             do {
-                let models = try await LocalModelDiscovery.scan(path: path, additionalPaths: additionalPaths)
+                let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
                 guard !Task.isCancelled else {
                     return
                 }

--- a/Sources/Nativ/Features/Dashboard/StatsView.swift
+++ b/Sources/Nativ/Features/Dashboard/StatsView.swift
@@ -83,8 +83,7 @@ struct StatsView: View {
 
 private struct DashboardModelState: Equatable {
     let isRunning: Bool
-    let modelSearchPath: String
-    let additionalModelSearchPaths: [String]
+    let modelSearchPaths: LocalModelSearchPaths
     let analyticsDatabaseURL: URL
     let loadedModelID: String?
     let historicalMetricsRevision: DashboardMetricsRevision?
@@ -92,8 +91,7 @@ private struct DashboardModelState: Equatable {
     @MainActor
     init(model: NativModel) {
         isRunning = model.isRunning
-        modelSearchPath = model.settings.modelSearchPath
-        additionalModelSearchPaths = model.settings.normalized().additionalModelSearchPaths
+        modelSearchPaths = model.settings.localModelSearchPaths
         analyticsDatabaseURL = model.analyticsDatabaseURL
         loadedModelID = model.metrics?.server.loadedModel
         historicalMetricsRevision = model.metrics.map {
@@ -158,7 +156,7 @@ private struct DashboardContentView: View, Equatable {
         .onAppear {
             syncDashboardState(scanModels: true, reloadHistory: true)
         }
-        .onChange(of: modelState.modelSearchPath) { _, _ in
+        .onChange(of: modelState.modelSearchPaths) { _, _ in
             syncDashboardState(scanModels: true, reloadHistory: false)
         }
         .onChange(of: modelState.analyticsDatabaseURL) { _, _ in
@@ -445,10 +443,7 @@ private struct DashboardContentView: View, Equatable {
         dashboard.updateAnalyticsDatabaseURL(modelState.analyticsDatabaseURL)
         dashboard.updatePreferredModelID(modelState.loadedModelID)
         if scanModels {
-            dashboard.scanModels(
-                at: modelState.modelSearchPath,
-                additionalPaths: modelState.additionalModelSearchPaths
-            )
+            dashboard.scanModels(searchPaths: modelState.modelSearchPaths)
         }
         if reloadHistory {
             dashboard.reloadHistorical()

--- a/Sources/Nativ/Features/Extensions/NativExtensionHostBroker.swift
+++ b/Sources/Nativ/Features/Extensions/NativExtensionHostBroker.swift
@@ -116,8 +116,10 @@ final class NativExtensionHostBroker:
         case .listModels:
             let configuration = try configuration()
             let models = try await LocalModelDiscovery.scan(
-                path: configuration.modelSearchPath,
-                additionalPaths: configuration.additionalModelSearchPaths
+                searchPaths: LocalModelSearchPaths(
+                    primary: configuration.modelSearchPath,
+                    additional: configuration.additionalModelSearchPaths
+                )
             )
             let descriptors = models.map {
                 NativExtensionModelDescriptor(
@@ -145,8 +147,10 @@ final class NativExtensionHostBroker:
                 modelID = requestedModelID
             } else {
                 let models = try await LocalModelDiscovery.scan(
-                    path: configuration.modelSearchPath,
-                    additionalPaths: configuration.additionalModelSearchPaths
+                    searchPaths: LocalModelSearchPaths(
+                        primary: configuration.modelSearchPath,
+                        additional: configuration.additionalModelSearchPaths
+                    )
                 )
                 guard let resolvedModelID = LocalModelDiscovery.speechToTextModelID(
                     in: models,

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
@@ -201,16 +201,10 @@ private struct ImageGenerationComposer: View {
         }
         .padding(.vertical, 18)
         .task(id: modelScanKey) {
-            localLibrary.scan(
-                path: model.settings.modelSearchPath,
-                additionalPaths: model.settings.normalized().additionalModelSearchPaths
-            )
+            localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
         }
         .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
-            localLibrary.scan(
-                path: model.settings.modelSearchPath,
-                additionalPaths: model.settings.normalized().additionalModelSearchPaths
-            )
+            localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
         }
         .onChange(of: localLibrary.models) { _, models in
             let generationModels = models.filter {
@@ -367,9 +361,7 @@ private struct ImageGenerationComposer: View {
     }
 
     private var modelScanKey: String {
-        let settings = model.settings.normalized()
-        return ([settings.expandedModelSearchPath] + settings.additionalModelSearchPaths)
-            .joined(separator: "\u{0}")
+        model.settings.localModelSearchPaths.cacheKey
     }
 
     private var actionButtonColor: Color {

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -66,6 +66,10 @@ final class IntegrationsViewModel: ObservableObject {
         profiles.openAIBaseURL
     }
 
+    var modelSearchPaths: LocalModelSearchPaths {
+        serverModel.settings.localModelSearchPaths
+    }
+
     private var integrationServerBaseURL: URL {
         serverModel.activeServerBaseURL ?? serverModel.settings.serverBaseURL
     }
@@ -82,12 +86,11 @@ final class IntegrationsViewModel: ObservableObject {
     }
 
     func appear() {
-        library.scan(path: serverModel.settings.modelSearchPath)
         refreshStatuses()
     }
 
     func modelsDidChange() {
-        library.scan(path: serverModel.settings.modelSearchPath)
+        scanModels()
     }
 
     func select(_ tool: IntegrationTool) {
@@ -237,6 +240,10 @@ final class IntegrationsViewModel: ObservableObject {
         NSPasteboard.general.setString(command, forType: .string)
     }
 
+    private func scanModels() {
+        library.scan(searchPaths: serverModel.settings.localModelSearchPaths)
+    }
+
     private func configureProfile(tool: IntegrationTool, selectedModelID: String) throws {
         try profiles.configure(
             tool: tool,
@@ -380,6 +387,9 @@ struct IntegrationsView: View {
         }
         .background(Color.nativMainContentBackground)
         .onAppear(perform: viewModel.appear)
+        .task(id: viewModel.modelSearchPaths) {
+            viewModel.modelsDidChange()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
             viewModel.modelsDidChange()
         }
@@ -654,7 +664,7 @@ private struct IntegrationDetailView: View {
                     Text("Scanning installed models…").foregroundStyle(.secondary)
                 }
             } else if viewModel.eligibleModels.isEmpty {
-                Text("No installed chat models were found. Download one from the Models page first.")
+                Text("No installed chat models were found. Add a model folder or download one from Models.")
                     .foregroundStyle(.secondary)
             } else {
                 Picker("Model", selection: $viewModel.selectedModelID) {

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -4,6 +4,27 @@ extension Notification.Name {
     static let localModelLibraryDidChange = Notification.Name("LocalModelLibraryDidChange")
 }
 
+struct LocalModelSearchPaths: Hashable, Sendable {
+    let primary: String
+    let additional: [String]
+
+    init(primary: String, additional: [String] = []) {
+        let expandedPrimary = LocalModelDiscovery.expandedPath(primary)
+        self.primary = expandedPrimary
+
+        var seen = Set([expandedPrimary])
+        self.additional = additional
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map(LocalModelDiscovery.expandedPath)
+            .filter { seen.insert($0).inserted }
+    }
+
+    var all: [String] { [primary] + additional }
+
+    var cacheKey: String { all.joined(separator: "\u{0}") }
+}
+
 enum LocalModelCapability: String, CaseIterable, Hashable, Sendable {
     case text
     case vision
@@ -303,11 +324,12 @@ enum LocalModelDiscovery {
 
     private static let scanCache = ScanCache()
 
-    static func scan(path: String, additionalPaths: [String] = []) async throws -> [LocalModel] {
-        let expandedPath = Self.expandedPath(path)
-        let expandedAdditionalPaths = additionalPaths.map(Self.expandedPath)
+    static func scan(searchPaths: LocalModelSearchPaths) async throws -> [LocalModel] {
         return try await scanCache.scan(
-            key: ScanCache.Key(path: expandedPath, additionalPaths: expandedAdditionalPaths)
+            key: ScanCache.Key(
+                path: searchPaths.primary,
+                additionalPaths: searchPaths.additional
+            )
         )
     }
 
@@ -1608,14 +1630,14 @@ final class LocalModelLibrary: ObservableObject {
         scanTask?.cancel()
     }
 
-    func scan(path: String, additionalPaths: [String] = []) {
+    func scan(searchPaths: LocalModelSearchPaths) {
         scanTask?.cancel()
         isScanning = true
         error = nil
 
         scanTask = Task { [weak self] in
             do {
-                let models = try await LocalModelDiscovery.scan(path: path, additionalPaths: additionalPaths)
+                let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
                 guard !Task.isCancelled else {
                     return
                 }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -959,9 +959,7 @@ struct ModelsView: View {
     }
 
     private var modelScanPath: String {
-        let settings = modelState.settings.normalized()
-        return ([settings.expandedModelSearchPath] + settings.additionalModelSearchPaths)
-            .joined(separator: "\u{0}")
+        modelState.settings.localModelSearchPaths.cacheKey
     }
 
     private var sourcesMenu: some View {
@@ -992,10 +990,7 @@ struct ModelsView: View {
     }
 
     private func rescanLocalModels() {
-        localLibrary.scan(
-            path: modelState.settings.modelSearchPath,
-            additionalPaths: modelState.settings.normalized().additionalModelSearchPaths
-        )
+        localLibrary.scan(searchPaths: modelState.settings.localModelSearchPaths)
     }
 
     private func addModelSourceFolder() {

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -592,8 +592,10 @@ final class AudioCaptureLibrary: ObservableObject {
             throw AudioCaptureLibraryError.serverNotRunning
         }
         let installedModels = try await LocalModelDiscovery.scan(
-            path: configuration.modelSearchPath,
-            additionalPaths: configuration.additionalModelSearchPaths
+            searchPaths: LocalModelSearchPaths(
+                primary: configuration.modelSearchPath,
+                additional: configuration.additionalModelSearchPaths
+            )
         )
         guard let modelID = LocalModelDiscovery.speechToTextModelID(
             in: installedModels,
@@ -620,8 +622,10 @@ final class AudioCaptureLibrary: ObservableObject {
             throw AudioCaptureLibraryError.serverNotRunning
         }
         let installedModels = try await LocalModelDiscovery.scan(
-            path: configuration.modelSearchPath,
-            additionalPaths: configuration.additionalModelSearchPaths
+            searchPaths: LocalModelSearchPaths(
+                primary: configuration.modelSearchPath,
+                additional: configuration.additionalModelSearchPaths
+            )
         )
         let languageModels = installedModels.filter(\.isEligibleForLanguageModelPicker)
         let modelID = configuration.languageModelID.flatMap { selectedID in

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -105,10 +105,7 @@ struct AudioView: View {
         .onAppear {
             handleViewAppear()
         }
-        .onChange(of: model.settings.modelSearchPath) { _, _ in
-            refreshLocalModels()
-        }
-        .onChange(of: model.settings.additionalModelSearchPaths) { _, _ in
+        .onChange(of: model.settings.localModelSearchPaths) { _, _ in
             refreshLocalModels()
         }
         .onChange(of: inputDevices.selectedDeviceID) { _, _ in
@@ -2180,11 +2177,7 @@ struct AudioView: View {
     }
 
     private func refreshLocalModels() {
-        let settings = model.settings.normalized()
-        localLibrary.scan(
-            path: settings.modelSearchPath,
-            additionalPaths: settings.additionalModelSearchPaths
-        )
+        localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
     }
 
     private func startInputMonitoringIfNeeded() {

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -274,8 +274,10 @@ final class VoiceCaptureCoordinator {
             let installedModels: [LocalModel]
             do {
                 installedModels = try await LocalModelDiscovery.scan(
-                    path: configuration.modelSearchPath,
-                    additionalPaths: configuration.additionalModelSearchPaths
+                    searchPaths: LocalModelSearchPaths(
+                        primary: configuration.modelSearchPath,
+                        additional: configuration.additionalModelSearchPaths
+                    )
                 )
             } catch {
                 guard !Task.isCancelled else {

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -1003,22 +1003,18 @@ struct NativSettings: Codable, Equatable {
         NSString(string: modelSearchPath).expandingTildeInPath
     }
 
+    var localModelSearchPaths: LocalModelSearchPaths {
+        LocalModelSearchPaths(
+            primary: modelSearchPath,
+            additional: additionalModelSearchPaths
+        )
+    }
+
     /// All directories to search for a locally-available model: the primary model
     /// folder, any user-added folders, and the Hugging Face hub cache. Consolidated
     /// here so callers don't each re-derive the roots (and each miss custom folders).
     var modelSearchRoots: [String] {
-        var roots: [String] = []
-        let primary = expandedModelSearchPath.trimmingCharacters(in: .whitespaces)
-        if !primary.isEmpty {
-            roots.append(primary)
-        }
-        for path in additionalModelSearchPaths {
-            let expanded = NSString(string: path).expandingTildeInPath
-                .trimmingCharacters(in: .whitespaces)
-            if !expanded.isEmpty {
-                roots.append(expanded)
-            }
-        }
+        var roots = localModelSearchPaths.all
         if let hubCache = ProcessInfo.processInfo.environment["HF_HUB_CACHE"], !hubCache.isEmpty {
             roots.append(hubCache)
         }

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -176,8 +176,8 @@ private struct WelcomeView: View {
             .padding(.vertical, 32)
         }
         .frame(minWidth: 900, minHeight: 760)
-        .task(id: modelSearchPath) {
-            modelLibrary.scan(path: model.settings.modelSearchPath)
+        .task(id: model.settings.localModelSearchPaths) {
+            modelLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
         }
         .task(id: step) {
             guard step == .permissions else { return }
@@ -766,7 +766,7 @@ private struct WelcomeView: View {
     }
 
     private func refreshModelChoices() {
-        modelLibrary.scan(path: model.settings.modelSearchPath)
+        modelLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
         requestRecommendedModels()
     }
 
@@ -790,7 +790,7 @@ private struct WelcomeView: View {
             cachePath: model.settings.modelSearchPath,
             token: model.effectiveHuggingFaceToken
         ) {
-            modelLibrary.scan(path: model.settings.modelSearchPath)
+            modelLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
             if selectedModelID == nil {
                 selectedModelID = hubModel.id
             }

--- a/Tests/NativTests/LocalModelDiscoveryTests.swift
+++ b/Tests/NativTests/LocalModelDiscoveryTests.swift
@@ -4,6 +4,10 @@ import XCTest
 final class LocalModelDiscoveryTests: XCTestCase {
     private var temporaryCache: URL!
 
+    private var searchPaths: LocalModelSearchPaths {
+        LocalModelSearchPaths(primary: temporaryCache.path)
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         temporaryCache = FileManager.default.temporaryDirectory
@@ -23,9 +27,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
     func testDiscoversMageFlowComponentLayoutAsImageGenerationModel() async throws {
         try makeMageFlowSnapshot(repoID: "microsoft/Mage-Flow-Turbo")
 
-        let models = try await LocalModelDiscovery.scan(
-            path: temporaryCache.path
-        )
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
 
         let model = try XCTUnwrap(models.first)
         XCTAssertEqual(models.count, 1)
@@ -38,9 +40,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
     func testDiscoversMageFlowEditComponentLayoutAsImageEditingModel() async throws {
         try makeMageFlowSnapshot(repoID: "microsoft/Mage-Flow-Edit-Turbo")
 
-        let models = try await LocalModelDiscovery.scan(
-            path: temporaryCache.path
-        )
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
 
         let model = try XCTUnwrap(models.first)
         XCTAssertEqual(models.count, 1)
@@ -48,6 +48,29 @@ final class LocalModelDiscoveryTests: XCTestCase {
         XCTAssertEqual(model.provider, .microsoft)
         XCTAssertTrue(model.capabilities.contains(.imageEditing))
         XCTAssertFalse(model.capabilities.contains(.imageGeneration))
+    }
+
+    func testDiscoversModelFromAdditionalSearchFolder() async throws {
+        let externalModel = temporaryCache.appendingPathComponent(
+            "external/owner/model",
+            isDirectory: true
+        )
+        try writeJSON(
+            ["model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]],
+            to: externalModel.appendingPathComponent("config.json")
+        )
+        try write("weights", to: externalModel.appendingPathComponent("model.safetensors"))
+
+        let models = try await LocalModelDiscovery.scan(
+            searchPaths: LocalModelSearchPaths(
+                primary: temporaryCache.path,
+                additional: [externalModel.path]
+            )
+        )
+
+        let model = try XCTUnwrap(models.first { $0.repoID == externalModel.standardizedFileURL.path })
+        XCTAssertEqual(model.source, .external)
+        XCTAssertTrue(model.capabilities.contains(.text))
     }
 
     func testClassifiesEncoderWithPoolingAsEmbeddingModel() async throws {
@@ -58,7 +81,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
             sentenceTransformer: true
         )
 
-        let models = try await LocalModelDiscovery.scan(path: temporaryCache.path)
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
         let model = try XCTUnwrap(models.first)
         XCTAssertTrue(model.capabilities.contains(.embeddings))
     }
@@ -71,7 +94,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
             sentenceTransformer: false
         )
 
-        let models = try await LocalModelDiscovery.scan(path: temporaryCache.path)
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
         let model = try XCTUnwrap(models.first)
         XCTAssertFalse(model.capabilities.contains(.embeddings))
         XCTAssertTrue(model.capabilities.contains(.text))
@@ -85,7 +108,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
             sentenceTransformer: true
         )
 
-        let models = try await LocalModelDiscovery.scan(path: temporaryCache.path)
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
         let model = try XCTUnwrap(models.first)
         XCTAssertTrue(model.capabilities.contains(.embeddings))
     }
@@ -99,7 +122,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
             stamp: ["kind": "embedding", "modality": "text"]
         )
 
-        let models = try await LocalModelDiscovery.scan(path: temporaryCache.path)
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
         let model = try XCTUnwrap(models.first)
         XCTAssertTrue(model.capabilities.contains(.embeddings))
     }
@@ -125,7 +148,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
             ]
         )
 
-        let models = try await LocalModelDiscovery.scan(path: temporaryCache.path)
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
 
         XCTAssertFalse(models.contains { $0.repoID == "org/incomplete-sharded-model" })
         XCTAssertTrue(models.contains { $0.repoID == "org/complete-sharded-model" })
@@ -155,7 +178,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
                 .appendingPathComponent("model.safetensors.index.json")
         )
 
-        let models = try await LocalModelDiscovery.scan(path: temporaryCache.path)
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
 
         XCTAssertFalse(models.contains { $0.repoID == "org/malformed-index" })
         XCTAssertFalse(models.contains { $0.repoID == "org/empty-index" })
@@ -181,7 +204,7 @@ final class LocalModelDiscoveryTests: XCTestCase {
             withDestinationURL: blobURL
         )
 
-        let models = try await LocalModelDiscovery.scan(path: temporaryCache.path)
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
 
         XCTAssertTrue(models.contains { $0.repoID == repoID })
     }

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -2,6 +2,21 @@ import XCTest
 @testable import NativServerKit
 
 final class NativSettingsTests: XCTestCase {
+    func testLocalModelSearchPathsIncludeNormalizedAdditionalFolders() {
+        let settings = NativSettings(
+            modelSearchPath: "~/managed-models",
+            additionalModelSearchPaths: [" ~/external-models ", "~/external-models", " "]
+        )
+
+        XCTAssertEqual(
+            settings.localModelSearchPaths,
+            LocalModelSearchPaths(
+                primary: "~/managed-models",
+                additional: ["~/external-models"]
+            )
+        )
+    }
+
     func testLaunchArgumentsRouteEachPreloadedModelToItsOwnFlag() {
         let settings = NativSettings(
             languageModelID: "org/language",


### PR DESCRIPTION
Centralizes model discovery so folders added in Models are available across Nativ’s tools, actions, utilities, and integrations, addressing [#260](https://github.com/Blaizzy/nativ/issues/260).

I'd say prior to this, this was poorly designed. Additional folders alongside main one should be available across all components of Nativ that might need model folders, done so by defining a `LocalModelSearchPaths(primary: modelSearchPath, additional: additionalModelSearchPaths)` 

