### PR TITLE
Adopt MCP tools via a consent-gating adapter

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		32E3DD03D61C201E783539AF /* ChatServerStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */; };
 		33ADC132B82225C5E233F440 /* ChatSwitchModelTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */; };
 		351B2202E8690FC608A32AEF /* IntegrationServicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */; };
+		3583BC09DCAFC37BBB94749D /* MCPHostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5D77458EF56DD1B8F4AE17 /* MCPHostManager.swift */; };
 		359208BE69EFF7BF033D4BA6 /* LICENSES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8614BD975152DDCEAC4EF777 /* LICENSES.txt */; };
 		361D948B1B76F41B63A0B832 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
 		36405D7EB30E430CF06956EB /* ShellEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */; };
@@ -159,6 +160,7 @@
 		BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */; };
 		BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5919AB4E9488642C73886266 /* ShellEnvironment.swift */; };
 		BEA11D430947F6C01177EDE8 /* ChatToolRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */; };
+		BF5A1AD007F259A2F926AF57 /* ChatWorkspacePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */; };
 		C03E948D1C7E27B27838C4C6 /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7F610FC8739BA80227DB26 /* NativKit.swift */; };
 		C5CE4EBDB988CF611FB2D6DA /* SystemMenuBarPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE1E26171E964D9769E65CB /* SystemMenuBarPreferences.swift */; };
 		C84FA1A269F12B130EAEB57B /* ModelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EB7572F271F7D68DC3F97D /* ModelsView.swift */; };
@@ -309,6 +311,7 @@
 		35C1220F03EC60874920E0CE /* RoutineScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineScheduler.swift; sourceTree = "<group>"; };
 		37408935D4EAA2CA89CC0A4C /* VoiceDictationExtensionRuntime.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = VoiceDictationExtensionRuntime.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		38E6FD97A66F91B3B667B3FE /* NativChatClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativChatClient.swift; sourceTree = "<group>"; };
+		39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatWorkspacePicker.swift; sourceTree = "<group>"; };
 		3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironmentTests.swift; sourceTree = "<group>"; };
 		3B1B970F41F1B5612B791ABE /* KitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KitsSectionView.swift; sourceTree = "<group>"; };
 		3B965B701714787B0A85AE6B /* AudioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTests.swift; sourceTree = "<group>"; };
@@ -868,6 +871,7 @@
 				530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */,
 				31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */,
 				F553434CA19B929108FF740F /* ChatView.swift */,
+				39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */,
 				967B3678137E2B152FAC9838 /* Tools */,
 			);
 			path = Chat;
@@ -1164,6 +1168,7 @@
 				444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */,
 				B47F34B1273BEEAA4D5DD314 /* ChatView.swift in Sources */,
 				8AD4D0675D4C4F456ACEA352 /* ChatWebSearchTool.swift in Sources */,
+				BF5A1AD007F259A2F926AF57 /* ChatWorkspacePicker.swift in Sources */,
 				FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */,
 				45BD4C408B9739ABC051A9E7 /* ControlPanelView.swift in Sources */,
 				086BC5B6FF02F0305536333B /* CustomTool.swift in Sources */,
@@ -1277,6 +1282,7 @@
 				4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */,
 				4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */,
 				9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */,
+				3583BC09DCAFC37BBB94749D /* MCPHostManager.swift in Sources */,
 				B2B154008527C6291C17AC93 /* MLXImageModelResolver.swift in Sources */,
 				EF3678F684519D8ADC625B20 /* MLXImageModelResolverTests.swift in Sources */,
 				F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -17,6 +17,7 @@ struct ChatToolExecutionContext {
     var imageToolDependencies = ChatImageToolDependencies.live
     var imageModelSelection: ChatImageModelSelectionHandler? = nil
     var imageExecutionWillStart: (@MainActor @Sendable (String) -> Void)? = nil
+    var mcpHost: MCPHostManager? = nil
 }
 
 struct ChatToolExecutionOutcome {
@@ -49,16 +50,19 @@ struct ChatNativeToolDescriptor {
 }
 
 enum ChatToolRegistry {
-    static func definitions(canEditImage: Bool) -> [MLXChatToolDefinition] {
-        descriptors(canEditImage: canEditImage).map(\.definition)
+    @MainActor
+    static func definitions(context: ChatToolExecutionContext? = nil, canEditImage: Bool) -> [MLXChatToolDefinition] {
+        descriptors(context: context, canEditImage: canEditImage).map(\.definition)
     }
 
-    static func descriptors(canEditImage: Bool) -> [ChatNativeToolDescriptor] {
+    @MainActor
+    static func descriptors(context: ChatToolExecutionContext? = nil, canEditImage: Bool) -> [ChatNativeToolDescriptor] {
         var definitions = ChatImageToolRegistry.definitions(canEdit: canEditImage)
         definitions += ChatSystemMonitorToolRegistry.definitions()
         definitions += ChatModelLibraryToolRegistry.definitions()
         definitions += ChatServerStatsToolRegistry.definitions()
         definitions += ChatSwitchModelToolRegistry.definitions()
+        definitions += context?.mcpHost?.toolDefinitions() ?? []
         var tools = definitions.map {
             ChatNativeToolDescriptor(definition: $0, configuration: nil)
         }
@@ -68,6 +72,59 @@ enum ChatToolRegistry {
         ))
         return tools
     }
+}
+
+enum MCPToolNaming {
+    static let qualifiedPrefix = "mcp__"
+}
+
+/// Adapts `MCPHostManager` into the shape the chat tool loop needs —
+/// dispatch and, unconditionally, consent-gating.
+struct ChatMCPHostBridge {
+    let host: MCPHostManager
+
+    @MainActor
+    func canHandle(_ name: String) -> Bool {
+        host.handlesTool(named: name)
+    }
+
+    @MainActor
+    func requiresConsent(_ name: String) -> Bool {
+        canHandle(name)
+    }
+
+    @MainActor
+    func execute(call: MLXChatToolCall) async throws -> ChatToolExecutionOutcome {
+        guard let name = call.function?.name else {
+            throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
+        }
+        let result = try await host.callTool(named: name, argumentsJSON: call.function?.arguments)
+        return ChatToolExecutionOutcome(content: result, attachments: [])
+    }
+
+    static func declinedPayload(toolName: String) -> String {
+        let payload = ChatMCPToolResultPayload(ok: false, declined: true, error: "The user declined this action.")
+        return (try? encodedPayload(payload))
+            ?? #"{"ok":false,"declined":true,"error":"The user declined this action."}"#
+    }
+
+    static func failurePayload(toolName: String, error: Error) -> String {
+        let payload = ChatMCPToolResultPayload(ok: false, declined: false, error: error.localizedDescription)
+        return (try? encodedPayload(payload))
+            ?? #"{"ok":false,"declined":false,"error":"MCP tool failed."}"#
+    }
+
+    private static func encodedPayload(_ payload: ChatMCPToolResultPayload) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return String(decoding: try encoder.encode(payload), as: UTF8.self)
+    }
+}
+
+private struct ChatMCPToolResultPayload: Encodable {
+    let ok: Bool
+    let declined: Bool
+    let error: String?
 }
 
 enum ChatToolDispatcher {
@@ -114,10 +171,16 @@ enum ChatToolDispatcher {
     }
 
     static func failurePayload(toolName: String?, error: Error) -> String {
-        guard let toolName, let handler = failureHandlers[toolName] else {
-            return ChatImageToolExecutor().failurePayload(operation: toolName ?? "tool", error: error)
+        guard let toolName else {
+            return ChatImageToolExecutor().failurePayload(operation: "tool", error: error)
         }
-        return handler(toolName, error)
+        if let handler = failureHandlers[toolName] {
+            return handler(toolName, error)
+        }
+        if toolName.hasPrefix(MCPToolNaming.qualifiedPrefix) {
+            return ChatMCPHostBridge.failurePayload(toolName: toolName, error: error)
+        }
+        return ChatImageToolExecutor().failurePayload(operation: toolName, error: error)
     }
 
     private static func executeImageTool(
@@ -273,6 +336,8 @@ enum ChatToolPresentation {
             return switchModelTitle(status: status)
         case ChatWebSearchToolRegistry.toolName:
             return webSearchTitle(status: status)
+        case let name? where name.hasPrefix(MCPToolNaming.qualifiedPrefix):
+            return mcpTitle(toolName: name, status: status)
         default:
             return genericTitle(toolName: toolName, status: status)
         }
@@ -305,6 +370,8 @@ enum ChatToolPresentation {
                 return "arrow.triangle.2.circlepath"
             case ChatWebSearchToolRegistry.toolName:
                 return "globe"
+            case let name? where name.hasPrefix(MCPToolNaming.qualifiedPrefix):
+                return "puzzlepiece.extension"
             default:
                 return "wrench.and.screwdriver"
             }
@@ -397,6 +464,39 @@ enum ChatToolPresentation {
         case nil:
             return "Web search"
         }
+    }
+
+    private static func mcpTitle(toolName: String, status: ChatTranscriptMessage.ToolStatus?) -> String {
+        let name = mcpDisplayName(for: toolName) ?? toolName
+        switch status {
+        case .awaitingConsent:
+            return "Run \(name)?"
+        case .preparing, .running:
+            return "Running \(name)…"
+        case .succeeded:
+            return "Ran \(name)"
+        case .declined:
+            return "\(name) declined"
+        case .failed, .cancelled, .awaitingImageModelSelection, nil:
+            return name
+        }
+    }
+
+    private static func mcpDisplayName(for qualifiedName: String) -> String? {
+        guard qualifiedName.hasPrefix(MCPToolNaming.qualifiedPrefix) else { return nil }
+        let remainder = qualifiedName.dropFirst(MCPToolNaming.qualifiedPrefix.count)
+        guard let separatorRange = remainder.range(of: "__") else { return nil }
+        let server = remainder[..<separatorRange.lowerBound]
+        let tool = remainder[separatorRange.upperBound...]
+        guard !server.isEmpty, !tool.isEmpty else { return nil }
+        return "\(tool) (\(server))"
+    }
+
+    static func mcpConsentDescription(toolName: String?) -> String {
+        guard let toolName, let display = mcpDisplayName(for: toolName) else {
+            return "The model wants to run this tool."
+        }
+        return "The model wants to run \(display)."
     }
 
     private static func genericTitle(toolName: String?, status: ChatTranscriptMessage.ToolStatus?) -> String {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1402,6 +1402,85 @@ final class ChatViewModel: ObservableObject {
                     continue
                 }
 
+                // MCPHostManager.callTool has no consent concept of its own,
+                // so every MCP call needs this gate unconditionally.
+                if let host = mcpHost, host.handlesTool(named: toolCall.function?.name ?? "") {
+                    updateToolMessage(
+                        toolMessageID,
+                        in: queuedRequest.sessionID,
+                        status: .awaitingConsent,
+                        content: "",
+                        attachments: []
+                    )
+                    let approved = await awaitToolConsent(for: toolMessageID)
+                    switch ChatToolConsentRouter.outcome(approved: approved, isCancelled: Task.isCancelled) {
+                    case .cancelled:
+                        cancelToolMessages(
+                            currentID: toolMessageID,
+                            currentCall: toolCall,
+                            remainingCalls: Array(toolCalls.dropFirst(index + 1)),
+                            after: insertionAnchor,
+                            in: queuedRequest.sessionID
+                        )
+                        throw CancellationError()
+                    case .declined:
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .declined,
+                            content: ChatMCPHostBridge.declinedPayload(toolName: toolCall.function?.name ?? "tool"),
+                            attachments: []
+                        )
+                        continue
+                    case .approved:
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .running,
+                            content: "",
+                            attachments: []
+                        )
+                    }
+                    do {
+                        let outcome = try await ChatMCPHostBridge(host: host).execute(call: toolCall)
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .succeeded,
+                            content: outcome.content,
+                            attachments: outcome.attachments
+                        )
+                        appModel?.refreshMetricsIfRunning(force: true)
+                    } catch is CancellationError {
+                        cancelToolMessages(
+                            currentID: toolMessageID,
+                            currentCall: toolCall,
+                            remainingCalls: Array(toolCalls.dropFirst(index + 1)),
+                            after: insertionAnchor,
+                            in: queuedRequest.sessionID
+                        )
+                        throw CancellationError()
+                    } catch let error as URLError where error.code == .cancelled {
+                        cancelToolMessages(
+                            currentID: toolMessageID,
+                            currentCall: toolCall,
+                            remainingCalls: Array(toolCalls.dropFirst(index + 1)),
+                            after: insertionAnchor,
+                            in: queuedRequest.sessionID
+                        )
+                        throw CancellationError()
+                    } catch {
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .failed,
+                            content: ChatMCPHostBridge.failurePayload(toolName: toolCall.function?.name ?? "tool", error: error),
+                            attachments: []
+                        )
+                    }
+                    continue
+                }
+
                 do {
                     let references = latestImageReferences(
                         beforeOrAt: toolMessageID,
@@ -1459,7 +1538,8 @@ final class ChatViewModel: ObservableObject {
                                 modelID: selectedModelID,
                                 in: queuedRequest.sessionID
                             )
-                        }
+                        },
+                        mcpHost: mcpHost
                     )
                     let outcome: ChatToolExecutionOutcome
                     if let customTool {
@@ -1468,12 +1548,8 @@ final class ChatViewModel: ObservableObject {
                             argumentsJSON: toolCall.function?.arguments
                         )
                         outcome = ChatToolExecutionOutcome(content: result, attachments: [])
-                    } else if let host = mcpHost,
-                              let toolName = toolCall.function?.name,
-                              host.handlesTool(named: toolName) {
-                        let result = try await host.callTool(named: toolName, argumentsJSON: toolCall.function?.arguments)
-                        outcome = ChatToolExecutionOutcome(content: result, attachments: [])
                     } else {
+                        // MCP calls never reach here — consent-gated above already.
                         outcome = try await ChatToolDispatcher.execute(call: toolCall, context: context)
                     }
                     updateToolMessage(
@@ -1549,12 +1625,23 @@ final class ChatViewModel: ObservableObject {
         let advertisesToolsForModel = advertisesTools && queuedRequest.languageModelSupportsTools
         var toolDefinitions: [MLXChatToolDefinition] = advertisesToolsForModel
             ? ChatToolRegistry.definitions(
+                context: ChatToolExecutionContext(
+                    imageGenerationModelID: nil,
+                    baseURL: settings.serverBaseURL,
+                    apiKey: settings.serverAPIKey,
+                    imageReferences: [],
+                    modelSearchPath: settings.expandedModelSearchPath,
+                    additionalModelSearchPaths: settings.additionalModelSearchPaths,
+                    mcpHost: mcpHost
+                ),
                 canEditImage: precedingMessages.contains { !$0.imageAttachments.isEmpty }
             )
             : []
         if advertisesToolsForModel {
+            // mcpHost's own tool definitions already flow in via
+            // ChatToolRegistry.definitions(context:) above -- appending them
+            // again here would double-register every MCP tool.
             toolDefinitions += settings.customTools.compactMap { try? $0.definition() }
-            toolDefinitions += mcpHost?.toolDefinitions() ?? []
             let webSearchIsConfigured = ChatWebSearchToolRegistry.isConfigured()
             toolDefinitions.removeAll {
                 settings.disabledToolNames.contains($0.function.name)
@@ -2689,6 +2776,9 @@ private struct ChatAgentStepCell: View {
             return Text("The model wants to switch to ")
                 + Text(verbatim: requestedModelID).bold()
                 + Text(". The server restarts briefly; your session is kept.")
+        }
+        if let toolName = message.toolName, toolName.hasPrefix(MCPToolNaming.qualifiedPrefix) {
+            return Text(ChatToolPresentation.mcpConsentDescription(toolName: toolName))
         }
         return Text("The model wants to run this script tool on your Mac. Confirm to allow its code to run.")
     }

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -49,7 +49,8 @@ private final class FakeModelSwitchingSurface: ChatModelSwitchingSurface {
 
 private func makeContext(
     imageModelID: String? = nil,
-    modelSearchPath: String = ""
+    modelSearchPath: String = "",
+    mcpHost: MCPHostManager? = nil
 ) -> ChatToolExecutionContext {
     ChatToolExecutionContext(
         imageGenerationModelID: imageModelID,
@@ -60,7 +61,8 @@ private func makeContext(
         additionalModelSearchPaths: [],
         analyticsDatabaseURL: FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
-            .appendingPathComponent("Analytics.sqlite3")
+            .appendingPathComponent("Analytics.sqlite3"),
+        mcpHost: mcpHost
     )
 }
 
@@ -68,6 +70,7 @@ private func makeCall(name: String, arguments: String = "{}") -> MLXChatToolCall
     MLXChatToolCall(id: "1", function: MLXChatFunctionCall(name: name, arguments: arguments))
 }
 
+@MainActor
 final class ChatToolRegistryTests: XCTestCase {
     func testDefinitionsAlwaysAdvertiseWebSearch() {
         let names = ChatToolRegistry.definitions(canEditImage: false)
@@ -86,7 +89,7 @@ final class ChatToolRegistryTests: XCTestCase {
     }
 
     func testDefinitionsAdvertiseGenerationAndGuidanceWithNoImageModelConfigured() {
-        let names = ChatToolRegistry.definitions(canEditImage: false)
+        let names = ChatToolRegistry.definitions(context: makeContext(), canEditImage: false)
             .map(\.function.name)
 
         XCTAssertTrue(names.contains(ChatImageToolRegistry.generateToolName))
@@ -97,18 +100,18 @@ final class ChatToolRegistryTests: XCTestCase {
     }
 
     func testDefinitionsOfferEditOnlyWhenAnImageIsAvailable() {
-        let withoutEdit = ChatToolRegistry.definitions(canEditImage: false)
+        let withoutEdit = ChatToolRegistry.definitions(context: makeContext(), canEditImage: false)
             .map(\.function.name)
         XCTAssertTrue(withoutEdit.contains(ChatImageToolRegistry.generateToolName))
         XCTAssertFalse(withoutEdit.contains(ChatImageToolRegistry.editToolName))
 
-        let withEdit = ChatToolRegistry.definitions(canEditImage: true)
+        let withEdit = ChatToolRegistry.definitions(context: makeContext(), canEditImage: true)
             .map(\.function.name)
         XCTAssertTrue(withEdit.contains(ChatImageToolRegistry.editToolName))
     }
 
     func testDefinitionsNeverAdvertiseDuplicateToolNames() {
-        let names = ChatToolRegistry.definitions(canEditImage: true)
+        let names = ChatToolRegistry.definitions(context: makeContext(), canEditImage: true)
             .map(\.function.name)
 
         XCTAssertEqual(names.count, Set(names).count)
@@ -887,6 +890,13 @@ final class ChatToolPresentationTests: XCTestCase {
                 .awaitingImageModelSelection: "some_unknown_tool",
                 .awaitingConsent: "some_unknown_tool", .declined: "some_unknown_tool",
             ],
+            "mcp__websearch__search": [
+                nil: "search (websearch)", .preparing: "Running search (websearch)…",
+                .running: "Running search (websearch)…", .succeeded: "Ran search (websearch)",
+                .failed: "search (websearch)", .cancelled: "search (websearch)",
+                .awaitingImageModelSelection: "search (websearch)",
+                .awaitingConsent: "Run search (websearch)?", .declined: "search (websearch) declined",
+            ],
         ]
 
         for (toolName, byStatus) in expected {
@@ -910,6 +920,7 @@ final class ChatToolPresentationTests: XCTestCase {
             "generate_image", "edit_image",
             ChatSystemMonitorToolRegistry.toolName, ChatModelLibraryToolRegistry.toolName,
             ChatServerStatsToolRegistry.toolName, ChatSwitchModelToolRegistry.toolName,
+            "mcp__websearch__search",
             "some_unknown_tool",
         ]
         let successLikeSymbol: [String: String] = [
@@ -919,6 +930,7 @@ final class ChatToolPresentationTests: XCTestCase {
             ChatModelLibraryToolRegistry.toolName: "shippingbox",
             ChatServerStatsToolRegistry.toolName: "chart.line.uptrend.xyaxis",
             ChatSwitchModelToolRegistry.toolName: "arrow.triangle.2.circlepath",
+            "mcp__websearch__search": "puzzlepiece.extension",
             "some_unknown_tool": "wrench.and.screwdriver",
         ]
 
@@ -936,6 +948,24 @@ final class ChatToolPresentationTests: XCTestCase {
             XCTAssertEqual(ChatToolPresentation.symbolName(toolName: toolName, status: .running), successLikeSymbol[toolName])
             XCTAssertEqual(ChatToolPresentation.symbolName(toolName: toolName, status: nil), successLikeSymbol[toolName])
         }
+    }
+
+    func testMCPConsentDescriptionNamesTheActualToolAndServer() {
+        XCTAssertEqual(
+            ChatToolPresentation.mcpConsentDescription(toolName: "mcp__websearch__search"),
+            "The model wants to run search (websearch)."
+        )
+    }
+
+    func testMCPConsentDescriptionFallsBackForANonMCPOrMissingToolName() {
+        XCTAssertEqual(
+            ChatToolPresentation.mcpConsentDescription(toolName: nil),
+            "The model wants to run this tool."
+        )
+        XCTAssertEqual(
+            ChatToolPresentation.mcpConsentDescription(toolName: "not_mcp_shaped"),
+            "The model wants to run this tool."
+        )
     }
 }
 
@@ -1187,5 +1217,28 @@ final class ChatTranscriptMessageCodableTests: XCTestCase {
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(ChatTranscriptMessage.self, from: data)
         XCTAssertEqual(decoded, original)
+    }
+}
+
+final class ChatMCPHostBridgeTests: XCTestCase {
+    func testDeclinedPayloadShape() throws {
+        let payload = ChatMCPHostBridge.declinedPayload(toolName: "mcp__websearch__search")
+        let object = try decode(payload)
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["declined"] as? Bool, true)
+        XCTAssertEqual(object["error"] as? String, "The user declined this action.")
+    }
+
+    func testFailurePayloadShape() throws {
+        let payload = ChatMCPHostBridge.failurePayload(toolName: "mcp__websearch__search", error: FakeToolError())
+        let object = try decode(payload)
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["declined"] as? Bool, false)
+        XCTAssertEqual(object["error"] as? String, "fake failure")
+    }
+
+    private func decode(_ json: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -170,6 +170,7 @@ targets:
       - path: Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
       - path: Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift
+      - path: Sources/Nativ/Features/MCP/MCPHostManager.swift
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift


### PR DESCRIPTION
## Summary

Adds MCP tool support to the coordinator's own chat loop via `MCPHostManager`, gated behind the same consent-card UI as `switch_model`. `MCPHostManager.callTool` itself has no consent concept at all — without this, any MCP call the model requests would run the instant it's requested, no approval step.

## How it works

- `ChatMCPHostBridge` adapts `MCPHostManager` into the shape the chat loop's dispatch/consent code needs.
- MCP tool calls are detected (`host.handlesTool(named:)`) and routed through the same approve/deny consent-card flow `switch_model` already uses — mirrors that existing shape directly rather than introducing a shared abstraction, so it doesn't touch that already-proven code path.
- Declining shows a clean declined payload back to the model (`ChatMCPHostBridge.declinedPayload`) rather than silently dropping the call.

This is a prerequisite for the separate `spawn_agent` PR, whose sub-agents reuse the same consent-gating primitives introduced here for their own MCP calls — but it stands on its own: any chat turn, not just a sub-agent, can now use MCP tools with consent.

## Test plan

- [x] Full test suite green
- [x] Manual verification: an MCP tool call shows a consent card naming the actual tool/server, requires approval before running
- [x] Manual verification: declining an MCP call surfaces a clean declined result, not a silent drop

