### PR TITLE
Fix unknown-tool error mislabeling in the tool dispatcher

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -193,6 +193,22 @@ enum ChatToolRegistry {
     }
 }
 
+enum ChatUnknownToolError: LocalizedError {
+    case unknownTool(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownTool(let name):
+            return "Unknown tool: \(name)"
+        }
+    }
+}
+
+private struct ChatUnknownToolResultPayload: Encodable {
+    let ok: Bool
+    let error: String?
+}
+
 enum ChatToolDispatcher {
     private typealias Handler =
         @Sendable (
@@ -281,17 +297,27 @@ enum ChatToolDispatcher {
         context: ChatToolExecutionContext
     ) async throws -> ChatToolExecutionOutcome {
         guard let name = call.function?.name, let handler = handlers[name] else {
-            throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
+            throw ChatUnknownToolError.unknownTool(call.function?.name ?? "unknown")
         }
         return try await handler(call, context)
     }
 
     static func failurePayload(toolName: String?, error: Error) -> String {
         guard let toolName, let handler = failureHandlers[toolName] else {
-            return ChatImageToolExecutor().failurePayload(
-                operation: toolName ?? "tool", error: error)
+            return unknownToolFailurePayload(error: error)
         }
         return handler(toolName, error)
+    }
+
+    private static func unknownToolFailurePayload(error: Error) -> String {
+        let payload = ChatUnknownToolResultPayload(ok: false, error: error.localizedDescription)
+        return (try? encodedPayload(payload)) ?? #"{"ok":false,"error":"Unknown tool."}"#
+    }
+
+    private static func encodedPayload(_ payload: ChatUnknownToolResultPayload) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return String(decoding: try encoder.encode(payload), as: UTF8.self)
     }
 
     private static func executeImageTool(

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -769,6 +769,28 @@ final class ChatToolRegistryTests: XCTestCase {
             availability: availability
         )
     }
+
+    func testUnknownToolNameGetsAGenericFailurePayloadNotAnImageOne() throws {
+        let payload = ChatToolDispatcher.failurePayload(
+            toolName: "websearch",
+            error: ChatUnknownToolError.unknownTool("websearch")
+        )
+        let object = try decode(payload)
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["error"] as? String, "Unknown tool: websearch")
+        XCTAssertNil(object["operation"], "must not fall through to the image-tool shape")
+    }
+
+    func testDispatcherExecuteThrowsUnknownToolErrorForAnUnrecognizedName() async {
+        do {
+            _ = try await ChatToolDispatcher.execute(call: makeCall(name: "websearch"), context: makeContext())
+            XCTFail("an unrecognized tool name must not execute")
+        } catch let error as ChatUnknownToolError {
+            XCTAssertEqual(error.errorDescription, "Unknown tool: websearch")
+        } catch {
+            XCTFail("expected ChatUnknownToolError, got \(error)")
+        }
+    }
 }
 
 @MainActor


### PR DESCRIPTION
An unrecognized tool call (hallucinated name, or a typo) was mislabeled as an image-tool failure instead of a clear "unknown tool" error, since `ChatToolDispatcher` had no dedicated case for it and fell through to `ChatImageToolError.unsupportedTool`.

Adds `ChatUnknownToolError`/`ChatUnknownToolResultPayload` (neutral `ok`/`error` shape, no `operation` field) so an unrecognized name now surfaces as `"Unknown tool: <name>"` instead of impersonating an image-tool error.

2 files, +51/-2. 525/526 tests pass; the one failure (`testBuiltInToolsUseThePresentationOrder`) is a pre-existing, unrelated tool-order drift on current `main`, not touched here.
