### PR TITLE
Gate integration discovery behind an explicit action

### DIFF
--- a/Docs/features/integrations.md
+++ b/Docs/features/integrations.md
@@ -4,6 +4,11 @@ Nativ serves local models over standard APIs, so external agents and editors tha
 Anthropic can point straight at it. The **Integrations** page writes each tool's configuration
 automatically; the per-tool sections below document what each one needs for manual setup.
 
+The **Integrations** page does not start model or tool discovery when opened. Choose **Check
+integrations** to scan the configured model folders, run the login shell, read known tool
+configuration files, and execute installed tools with `--version`. The check does not start an
+interactive agent session or choose a project folder; **Refresh** repeats it explicitly.
+
 ## Connection details
 
 - OpenAI-compatible base URL: `http://127.0.0.1:8080/v1`

--- a/Sources/Nativ/Features/Integrations/IntegrationTypes.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationTypes.swift
@@ -213,6 +213,45 @@ struct IntegrationToolStatus: Equatable, Sendable {
     static let unavailable = IntegrationToolStatus(executableURL: nil, version: nil, isConfigured: false)
 }
 
+enum IntegrationDiscoveryPhase: Equatable, Sendable {
+    case notChecked
+    case checking
+    case checked
+}
+
+enum IntegrationDiscoveryTrigger: Sendable {
+    case viewAppeared
+    case userRequested
+    case modelLibraryChanged
+}
+
+struct IntegrationDiscoveryRequest: Equatable, Sendable {
+    let scansModels: Bool
+    let probesTools: Bool
+}
+
+struct IntegrationDiscoveryCoordinator: Sendable {
+    private(set) var phase: IntegrationDiscoveryPhase = .notChecked
+
+    mutating func request(for trigger: IntegrationDiscoveryTrigger) -> IntegrationDiscoveryRequest? {
+        switch trigger {
+        case .viewAppeared, .modelLibraryChanged:
+            // Lifecycle events never authorize local discovery. The user must
+            // explicitly start every scan from the Integrations page.
+            return nil
+        case .userRequested:
+            guard phase != .checking else { return nil }
+            phase = .checking
+            return IntegrationDiscoveryRequest(scansModels: true, probesTools: true)
+        }
+    }
+
+    mutating func complete() {
+        guard phase == .checking else { return }
+        phase = .checked
+    }
+}
+
 enum IntegrationServiceError: LocalizedError {
     case missingExecutable(IntegrationTool)
     case invalidConfiguration(URL)

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -23,6 +23,7 @@ final class IntegrationsViewModel: ObservableObject {
     @Published private(set) var statuses = Dictionary(
         uniqueKeysWithValues: IntegrationTool.allCases.map { ($0, IntegrationToolStatus.unavailable) }
     )
+    @Published private(set) var discoveryPhase = IntegrationDiscoveryPhase.notChecked
     @Published private(set) var isRefreshingStatuses = false
     @Published private(set) var activeOperation: IntegrationTool?
     @Published var errorMessage: String?
@@ -30,6 +31,7 @@ final class IntegrationsViewModel: ObservableObject {
     let library = LocalModelLibrary()
     private let serverModel: NativModel
     private let defaults = UserDefaults.standard
+    private var discoveryCoordinator = IntegrationDiscoveryCoordinator()
     private var libraryObservation: AnyCancellable?
 
     init(serverModel: NativModel) {
@@ -62,12 +64,12 @@ final class IntegrationsViewModel: ObservableObject {
 
     var isBusy: Bool { activeOperation != nil }
 
-    var integrationEndpoint: String {
-        profiles.openAIBaseURL
+    var isDiscovering: Bool {
+        discoveryPhase == .checking || isRefreshingStatuses || library.isScanning
     }
 
-    var modelSearchPaths: LocalModelSearchPaths {
-        serverModel.settings.localModelSearchPaths
+    var integrationEndpoint: String {
+        profiles.openAIBaseURL
     }
 
     private var integrationServerBaseURL: URL {
@@ -86,11 +88,15 @@ final class IntegrationsViewModel: ObservableObject {
     }
 
     func appear() {
-        refreshStatuses()
+        handleDiscovery(.viewAppeared)
     }
 
     func modelsDidChange() {
-        scanModels()
+        handleDiscovery(.modelLibraryChanged)
+    }
+
+    func requestDiscovery() {
+        handleDiscovery(.userRequested)
     }
 
     func select(_ tool: IntegrationTool) {
@@ -113,7 +119,18 @@ final class IntegrationsViewModel: ObservableObject {
         }
     }
 
-    func refreshStatuses() {
+    private func handleDiscovery(_ trigger: IntegrationDiscoveryTrigger) {
+        guard let request = discoveryCoordinator.request(for: trigger) else { return }
+        discoveryPhase = discoveryCoordinator.phase
+        if request.scansModels {
+            library.scan(searchPaths: serverModel.settings.localModelSearchPaths)
+        }
+        if request.probesTools {
+            refreshStatuses()
+        }
+    }
+
+    private func refreshStatuses() {
         guard !isRefreshingStatuses else { return }
         isRefreshingStatuses = true
         let baseURL = integrationServerBaseURL
@@ -141,6 +158,8 @@ final class IntegrationsViewModel: ObservableObject {
             }
             statuses = refreshed
             isRefreshingStatuses = false
+            discoveryCoordinator.complete()
+            discoveryPhase = discoveryCoordinator.phase
         }
     }
 
@@ -238,10 +257,6 @@ final class IntegrationsViewModel: ObservableObject {
         guard let command = launchCommand(for: tool, workingDirectory: workingDirectory) else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(command, forType: .string)
-    }
-
-    private func scanModels() {
-        library.scan(searchPaths: serverModel.settings.localModelSearchPaths)
     }
 
     private func configureProfile(tool: IntegrationTool, selectedModelID: String) throws {
@@ -387,9 +402,6 @@ struct IntegrationsView: View {
         }
         .background(Color.nativMainContentBackground)
         .onAppear(perform: viewModel.appear)
-        .task(id: viewModel.modelSearchPaths) {
-            viewModel.modelsDidChange()
-        }
         .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
             viewModel.modelsDidChange()
         }
@@ -426,17 +438,23 @@ private struct IntegrationCatalogView: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                Button {
-                    viewModel.refreshStatuses()
-                } label: {
-                    if viewModel.isRefreshingStatuses {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Label("Refresh", systemImage: "arrow.clockwise")
+                if viewModel.discoveryPhase != .notChecked {
+                    Button {
+                        viewModel.requestDiscovery()
+                    } label: {
+                        if viewModel.isDiscovering {
+                            HStack(spacing: 8) {
+                                ProgressView().controlSize(.small)
+                                Text("Checking…")
+                            }
+                        } else {
+                            Label("Refresh", systemImage: "arrow.clockwise")
+                        }
                     }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.isDiscovering)
+                    .help("Scan the configured model folders and check installed integrations")
                 }
-                .buttonStyle(.bordered)
-                .disabled(viewModel.isRefreshingStatuses)
             }
             .padding(.horizontal, 22)
             .padding(.leading, titleLeadingInset)
@@ -445,19 +463,38 @@ private struct IntegrationCatalogView: View {
 
             Divider()
 
-            ScrollView {
-                LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
-                    ForEach(IntegrationTool.allCases) { tool in
-                        IntegrationCard(
-                            tool: tool,
-                            status: viewModel.statuses[tool] ?? .unavailable,
-                            isLoading: viewModel.isRefreshingStatuses
-                        ) {
-                            viewModel.select(tool)
+            if viewModel.discoveryPhase == .notChecked {
+                ContentUnavailableView {
+                    Label("Check installed models and tools", systemImage: "hand.raised.fill")
+                } description: {
+                    Text(
+                        "Nativ will scan your configured model folders, run your login shell, read known integration configuration files, and execute installed tools with --version. It will not start an interactive agent session or choose a project folder."
+                    )
+                } actions: {
+                    Button("Check integrations") {
+                        viewModel.requestDiscovery()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityHint("Starts the disclosed local model and integration checks")
+                }
+                .frame(maxWidth: 620, maxHeight: .infinity)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(32)
+            } else {
+                ScrollView {
+                    LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
+                        ForEach(IntegrationTool.allCases) { tool in
+                            IntegrationCard(
+                                tool: tool,
+                                status: viewModel.statuses[tool] ?? .unavailable,
+                                isLoading: viewModel.isDiscovering
+                            ) {
+                                viewModel.select(tool)
+                            }
                         }
                     }
+                    .padding(24)
                 }
-                .padding(24)
             }
         }
     }
@@ -525,8 +562,18 @@ private struct IntegrationCard: View {
             .contentShape(RoundedRectangle(cornerRadius: 16))
         }
         .buttonStyle(.plain)
+        .disabled(isLoading)
         .onHover { isHovering = $0 }
-        .accessibilityLabel("Configure \(tool.displayName)")
+        .accessibilityLabel("\(tool.displayName), \(accessibilityStatus)")
+        .accessibilityHint(isLoading ? "Wait for the integration check to finish" : "Opens integration setup")
+    }
+
+    private var accessibilityStatus: String {
+        if isLoading { return "checking" }
+        if tool.isGuidedSetup { return "guided setup" }
+        if status.executableURL == nil { return "not installed" }
+        if status.isConfigured { return "configured" }
+        return "ready to configure"
     }
 }
 
@@ -570,7 +617,9 @@ private struct IntegrationDetailView: View {
                     if tool.isGuidedSetup {
                         guidedSetupPanel
                         modelPanel
-                    } else if status.executableURL == nil, !viewModel.isRefreshingStatuses {
+                    } else if viewModel.isDiscovering {
+                        discoveryProgressPanel
+                    } else if status.executableURL == nil {
                         missingToolPanel
                     } else {
                         modelPanel
@@ -588,6 +637,16 @@ private struct IntegrationDetailView: View {
         .onAppear {
             workingDirectory = viewModel.workingDirectory(for: tool)
                 ?? FileManager.default.homeDirectoryForCurrentUser
+        }
+    }
+
+    private var discoveryProgressPanel: some View {
+        IntegrationPanel(title: "Checking integrations", systemImage: "magnifyingglass") {
+            HStack(spacing: 10) {
+                ProgressView().controlSize(.small)
+                Text("Checking installed models and tools…")
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 
@@ -648,8 +707,8 @@ private struct IntegrationDetailView: View {
                     NSWorkspace.shared.open(tool.installURL)
                 }
                 .buttonStyle(.borderedProminent)
-                Button("Check again") {
-                    viewModel.refreshStatuses()
+                Button("Refresh integrations") {
+                    viewModel.requestDiscovery()
                 }
                 .buttonStyle(.bordered)
             }

--- a/Tests/NativTests/IntegrationServicesTests.swift
+++ b/Tests/NativTests/IntegrationServicesTests.swift
@@ -72,6 +72,59 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertEqual(Set(IntegrationTool.allCases), Self.coveredTools)
     }
 
+    func testViewAppearanceDoesNotRequestIntegrationDiscovery() {
+        var discovery = IntegrationDiscoveryCoordinator()
+
+        XCTAssertNil(discovery.request(for: .viewAppeared))
+        XCTAssertEqual(discovery.phase, .notChecked)
+    }
+
+    func testModelChangeDoesNotRequestDiscoveryBeforeUserApproval() {
+        var discovery = IntegrationDiscoveryCoordinator()
+
+        XCTAssertNil(discovery.request(for: .modelLibraryChanged))
+        XCTAssertEqual(discovery.phase, .notChecked)
+    }
+
+    func testExplicitUserCheckRequestsModelAndToolDiscovery() {
+        var discovery = IntegrationDiscoveryCoordinator()
+
+        XCTAssertEqual(
+            discovery.request(for: .userRequested),
+            IntegrationDiscoveryRequest(scansModels: true, probesTools: true)
+        )
+        XCTAssertEqual(discovery.phase, .checking)
+    }
+
+    func testDuplicateUserCheckIsIgnoredWhileDiscoveryIsRunning() {
+        var discovery = IntegrationDiscoveryCoordinator()
+        _ = discovery.request(for: .userRequested)
+
+        XCTAssertNil(discovery.request(for: .userRequested))
+        XCTAssertEqual(discovery.phase, .checking)
+    }
+
+    func testModelChangeDoesNotRequestDiscoveryAfterUserApproval() {
+        var discovery = IntegrationDiscoveryCoordinator()
+        _ = discovery.request(for: .userRequested)
+        discovery.complete()
+
+        XCTAssertNil(discovery.request(for: .modelLibraryChanged))
+        XCTAssertEqual(discovery.phase, .checked)
+    }
+
+    func testExplicitRefreshRepeatsModelAndToolDiscovery() {
+        var discovery = IntegrationDiscoveryCoordinator()
+        _ = discovery.request(for: .userRequested)
+        discovery.complete()
+
+        XCTAssertEqual(
+            discovery.request(for: .userRequested),
+            IntegrationDiscoveryRequest(scansModels: true, probesTools: true)
+        )
+        XCTAssertEqual(discovery.phase, .checking)
+    }
+
     func testConfiguredServerAPIKeyIsUsedByProfilesAndLaunchEnvironment() throws {
         manager = IntegrationProfileManager(
             serverBaseURL: serverBaseURL,


### PR DESCRIPTION
## Summary

- Stop the Integrations page from scanning configured model folders or probing installed tools on page appearance and model-library notifications.
- Add an explicit **Check integrations** action, with **Refresh** as the repeat action.
- Disclose the local operations performed by discovery and add accurate progress, disabled, and accessibility states.
- Preserve the global model search paths introduced in #266 and cover passive lifecycle events with regression tests.

## Why

Opening **Dev → Integrations** currently starts local discovery without a direct user action. Discovery can scan configured model folders, run the login shell, read known integration configuration files, and execute installed tools with `--version`.

This change makes those operations visible and user initiated. It is intentionally scoped to discovery initiated by the Integrations page: it does not start an interactive agent session, choose or change a project folder, alter app-wide model scanning elsewhere, or sandbox external tools.

## Checks

- `git diff --check upstream/main...HEAD`
- Focused `IntegrationServicesTests` and `LocalModelDiscoveryTests`: 40 passed, 0 failed
- Nativ macOS app build passed using a temporary XcodeGen project generated from `project.yml`; only the unrelated downloadable `mlx-vlm-server` resource packaging phase was omitted