### PR TITLE
Add server startup and model release controls

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -431,7 +431,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
         )
         refreshLocalModels()
         if WelcomePreferences.hasCompleted {
-            model.startServer()
+            model.startServerForConfiguredStartup()
         }
     }
 
@@ -496,6 +496,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
             return
         }
         requestLanguageModelSwitch(to: localModel)
+    }
+
+    @objc private func releaseModelFromMenu(_ sender: Any?) {
+        model.releaseLoadedModel()
     }
 
     @objc private func refreshModelsFromMenu(_ sender: Any?) {
@@ -671,6 +675,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
         var settings = model.settings
         settings.languageModelID = modelID
         settings.serverAPIKey = serverAPIKey
+        settings.serverStartupMode = .automatic
         model.settings = settings.normalized()
         WelcomePreferences.markCompleted()
 
@@ -1216,6 +1221,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
             submenu.addItem(.separator())
         }
 
+        if model.modelReleaseInProgress {
+            submenu.addItem(disabledMenuItem("Releasing Model…"))
+            submenu.addItem(.separator())
+        } else if model.loadedModelID != nil {
+            let releaseItem = NSMenuItem(
+                title: "Release Model",
+                action: #selector(releaseModelFromMenu(_:)),
+                keyEquivalent: ""
+            )
+            releaseItem.target = self
+            releaseItem.image = menuIcon(
+                "eject",
+                description: "Release model memory"
+            )
+            releaseItem.isEnabled = model.canReleaseLoadedModel
+            if !releaseItem.isEnabled {
+                releaseItem.toolTip = "Wait for active requests to finish before releasing the model."
+            }
+            submenu.addItem(releaseItem)
+            submenu.addItem(.separator())
+        }
+
         submenu.addItem(modelOptionMenuItem(title: "Load on demand", modelID: nil))
 
         let selectedModelID = model.settings.normalized().languageModelID
@@ -1692,9 +1719,9 @@ private struct SessionStatsContainerView: View {
                     section: section,
                     statusText: model.modelLoadFailure != nil
                         ? "Load failed"
-                        : model.settings.normalized().languageModelID == nil
-                        ? "Starting server…"
-                        : model.modelLoadingStatusText ?? "Loading model…",
+                        : model.isModelLoading
+                        ? model.modelLoadingStatusText ?? "Loading model…"
+                        : "Starting server…",
                     failure: model.modelLoadFailure
                 )
             }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -62,10 +62,12 @@ private final class ModelsNativState: ObservableObject {
     @Published private(set) var modelSwitchInProgress: Bool
     @Published private(set) var modelSwitchTargetID: String?
     @Published private(set) var modelLoadingProgress: Double?
-    @Published private(set) var metricsLoading: Bool
     @Published private(set) var modelLoadFailure: ModelLoadFailure?
+    @Published private(set) var modelReleaseInProgress: Bool
+    @Published private(set) var modelReleaseFailure: ModelReleaseFailure?
     @Published private(set) var systemHuggingFaceCredential: HuggingFaceCredential?
     @Published private(set) var loadedModelID: String?
+    @Published private(set) var activeRequestCount: Int
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -75,10 +77,12 @@ private final class ModelsNativState: ObservableObject {
         modelSwitchInProgress = model.modelSwitchInProgress
         modelSwitchTargetID = model.modelSwitchTargetID
         modelLoadingProgress = model.modelLoadingProgress
-        metricsLoading = model.metricsLoading
         modelLoadFailure = model.modelLoadFailure
+        modelReleaseInProgress = model.modelReleaseInProgress
+        modelReleaseFailure = model.modelReleaseFailure
         systemHuggingFaceCredential = model.systemHuggingFaceCredential
         loadedModelID = model.metrics?.server.loadedModel
+        activeRequestCount = model.metrics?.summary.inFlight ?? 0
 
         model.$settings
             .removeDuplicates()
@@ -100,13 +104,17 @@ private final class ModelsNativState: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] in self?.modelLoadingProgress = $0 }
             .store(in: &cancellables)
-        model.$metricsLoading
-            .removeDuplicates()
-            .sink { [weak self] in self?.metricsLoading = $0 }
-            .store(in: &cancellables)
         model.$modelLoadFailure
             .removeDuplicates()
             .sink { [weak self] in self?.modelLoadFailure = $0 }
+            .store(in: &cancellables)
+        model.$modelReleaseInProgress
+            .removeDuplicates()
+            .sink { [weak self] in self?.modelReleaseInProgress = $0 }
+            .store(in: &cancellables)
+        model.$modelReleaseFailure
+            .removeDuplicates()
+            .sink { [weak self] in self?.modelReleaseFailure = $0 }
             .store(in: &cancellables)
         model.$systemHuggingFaceCredential
             .removeDuplicates()
@@ -116,6 +124,11 @@ private final class ModelsNativState: ObservableObject {
             .map { $0?.server.loadedModel }
             .removeDuplicates()
             .sink { [weak self] in self?.loadedModelID = $0 }
+            .store(in: &cancellables)
+        model.$metrics
+            .map { $0?.summary.inFlight ?? 0 }
+            .removeDuplicates()
+            .sink { [weak self] in self?.activeRequestCount = $0 }
             .store(in: &cancellables)
     }
 
@@ -130,7 +143,7 @@ private final class ModelsNativState: ObservableObject {
         if modelSwitchInProgress {
             return modelSwitchTargetID
         }
-        guard metricsLoading || modelLoadingProgress != nil else {
+        guard modelLoadingProgress != nil else {
             return nil
         }
         return settings.normalized().languageModelID
@@ -412,6 +425,28 @@ struct ModelsView: View {
         let visibleModels = filteredLocalModels
         let normalizedSettings = modelState.settings.normalized()
 
+        ModelsRuntimeStatusRow(
+            isServerRunning: modelState.isRunning,
+            selectedModelID: normalizedSettings.languageModelID,
+            loadedModelID: modelState.loadedModelID,
+            loadingModelID: modelState.modelLoadingID,
+            activeRequestCount: modelState.activeRequestCount,
+            isReleasing: modelState.modelReleaseInProgress,
+            onRelease: model.releaseLoadedModel
+        )
+        .modelsListRow()
+
+        if let failure = modelState.modelReleaseFailure {
+            ModelsNotice(
+                title: "Couldn’t release model",
+                message: failure.message,
+                systemImage: "exclamationmark.triangle.fill",
+                color: .orange,
+                onDismiss: model.clearModelReleaseFailure
+            )
+            .modelsListRow()
+        }
+
         if let error = localLibrary.error {
             ModelsNotice(
                 title: "Couldn’t read the model cache",
@@ -469,6 +504,7 @@ struct ModelsView: View {
                     isSelectionDisabled: modelState.modelSwitchInProgress,
                     isModelLoading: modelState.modelLoadingID
                         == localModel.repoID,
+                    isLoaded: modelState.loadedModelID == localModel.repoID,
                     modelLoadingPercentage: modelState.modelLoadingPercentage,
                     isDeleting: localLibrary.deletingModelIDs.contains(
                         localModel.repoID),
@@ -1184,6 +1220,7 @@ private struct InstalledModelRow: View, Equatable {
     let preferredPreloadSlot: ModelPreloadSlot?
     let isSelectionDisabled: Bool
     let isModelLoading: Bool
+    let isLoaded: Bool
     let modelLoadingPercentage: Int?
     let isDeleting: Bool
     let canDelete: Bool
@@ -1200,6 +1237,7 @@ private struct InstalledModelRow: View, Equatable {
             && lhs.preferredPreloadSlot == rhs.preferredPreloadSlot
             && lhs.isSelectionDisabled == rhs.isSelectionDisabled
             && lhs.isModelLoading == rhs.isModelLoading
+            && lhs.isLoaded == rhs.isLoaded
             && lhs.modelLoadingPercentage == rhs.modelLoadingPercentage
             && lhs.isDeleting == rhs.isDeleting
             && lhs.canDelete == rhs.canDelete
@@ -1234,6 +1272,13 @@ private struct InstalledModelRow: View, Equatable {
                             Text(modelName(localModel.displayName))
                                 .font(.body.weight(.semibold))
                                 .lineLimit(1)
+                            if isLoaded {
+                                ModelPill(
+                                    title: "Loaded",
+                                    systemImage: "checkmark.circle.fill",
+                                    color: .green
+                                )
+                            }
                             if let sourceLabel = localModel.source.badgeLabel {
                                 ModelPill(
                                     title: sourceLabel,
@@ -1883,6 +1928,111 @@ private struct ModelProviderBadge: View {
         }
         .frame(width: 46, height: 46)
         .help(provider?.displayName ?? "Unknown provider")
+    }
+}
+
+private struct ModelsRuntimeStatusRow: View {
+    let isServerRunning: Bool
+    let selectedModelID: String?
+    let loadedModelID: String?
+    let loadingModelID: String?
+    let activeRequestCount: Int
+    let isReleasing: Bool
+    let onRelease: () -> Void
+
+    private var statusColor: Color {
+        if !isServerRunning {
+            return .secondary
+        }
+        if loadingModelID != nil {
+            return .orange
+        }
+        return loadedModelID == nil ? .orange : .green
+    }
+
+    private var title: String {
+        if !isServerRunning {
+            return "Server Off"
+        }
+        if loadingModelID != nil {
+            return "Loading Model"
+        }
+        return loadedModelID == nil ? "No Model Loaded" : "Model Loaded"
+    }
+
+    private var detail: String {
+        if let loadingModelID {
+            return loadingModelID
+        }
+        if let loadedModelID {
+            return loadedModelID
+        }
+        if isServerRunning {
+            if let selectedModelID {
+                return "\(selectedModelID) remains selected and will load when needed."
+            }
+            return "The server is ready and will load a selected model when needed."
+        }
+        return "Start the server to load a model."
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(
+                systemName: loadingModelID != nil
+                    ? "arrow.triangle.2.circlepath"
+                    : loadedModelID == nil ? "cube.transparent" : "cube.fill"
+            )
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(statusColor)
+                .frame(width: 34, height: 34)
+                .background(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .fill(statusColor.opacity(0.12))
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.callout.weight(.semibold))
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: 12)
+
+            if loadedModelID != nil, loadingModelID == nil {
+                Button(action: onRelease) {
+                    HStack(spacing: 6) {
+                        if isReleasing {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "eject")
+                        }
+                        Text(isReleasing ? "Releasing…" : "Release Model")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(isReleasing || activeRequestCount > 0)
+                .help(
+                    activeRequestCount > 0
+                        ? "Wait for active requests to finish before releasing the model."
+                        : "Release model memory without stopping the server."
+                )
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
     }
 }
 

--- a/Sources/Nativ/Features/Settings/SettingsView.swift
+++ b/Sources/Nativ/Features/Settings/SettingsView.swift
@@ -140,6 +140,25 @@ struct SettingsView: View {
                     .padding(.leading, 52)
 
                 settingsRow(
+                    title: "Server Startup",
+                    description: model.settings.serverStartupMode.description,
+                    systemImage: "power.circle"
+                ) {
+                    Picker("Server Startup", selection: serverStartupModeBinding) {
+                        ForEach(ServerStartupMode.allCases) { mode in
+                            Text(mode.displayName)
+                                .tag(mode)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(width: 220, alignment: .trailing)
+                }
+
+                Divider()
+                    .padding(.leading, 52)
+
+                settingsRow(
                     title: "Start at Login",
                     description: launchAtLogin.requiresApproval
                         ? "Approval is required in System Settings."
@@ -209,6 +228,17 @@ struct SettingsView: View {
                 .foregroundStyle(.secondary)
         }
         .frame(width: 220, alignment: .trailing)
+    }
+
+    private var serverStartupModeBinding: Binding<ServerStartupMode> {
+        Binding(
+            get: { model.settings.serverStartupMode },
+            set: { startupMode in
+                var settings = model.settings
+                settings.serverStartupMode = startupMode
+                model.settings = settings.normalized()
+            }
+        )
     }
 
     private var chatFontStepRange: ClosedRange<Double> {

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -32,6 +32,11 @@ struct ModelLoadFailure: Equatable, Identifiable, Sendable {
     }
 }
 
+struct ModelReleaseFailure: Equatable, Identifiable, Sendable {
+    let id = UUID()
+    let message: String
+}
+
 @MainActor
 final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     @Published private(set) var isRunning = false
@@ -45,6 +50,8 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     @Published private(set) var modelSwitchTargetID: String?
     @Published private(set) var modelLoadingProgress: Double?
     @Published private(set) var modelLoadFailure: ModelLoadFailure?
+    @Published private(set) var modelReleaseInProgress = false
+    @Published private(set) var modelReleaseFailure: ModelReleaseFailure?
     @Published private(set) var modelPreloadMemoryWarning: ModelPreloadMemoryWarning?
     @Published private(set) var metricsLoading = false
     @Published private(set) var systemHuggingFaceCredential =
@@ -74,6 +81,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     private var pendingModelPreloadSwitch: PendingModelPreloadSwitch?
     private var pendingServerRestartID: UUID?
     private var serverRestartTask: Task<Void, Never>?
+    private var modelReleaseTask: Task<Void, Never>?
     private var currentServerOutput = ""
 
     private let maxLogCharacters = 250_000
@@ -225,6 +233,18 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
         metrics?.server.displayLoadedModel ?? "None"
     }
 
+    var loadedModelID: String? {
+        metrics?.server.loadedModel
+    }
+
+    var canReleaseLoadedModel: Bool {
+        isRunning
+            && loadedModelID != nil
+            && metrics?.summary.inFlight == 0
+            && !modelReleaseInProgress
+            && !modelSwitchInProgress
+    }
+
     var isModelLoading: Bool {
         modelSwitchInProgress
             || (settings.normalized().languageModelID != nil
@@ -312,9 +332,18 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
         return settingsAppliedAtServerStart.serverBaseURL
     }
 
+    func startServerForConfiguredStartup() {
+        let startupMode = settings.normalized().serverStartupMode
+        guard startupMode.startsAutomatically else {
+            return
+        }
+        startServer()
+    }
+
     func startServer() {
         var shouldStartMetrics = false
         clearModelLoadFailure()
+        modelReleaseFailure = nil
         currentServerOutput = ""
         metricsClient = NativMetricsClient(baseURL: settings.serverBaseURL)
         modelLoadingProgress = settings.normalized().languageModelID == nil ? nil : 0
@@ -415,6 +444,9 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
     func stopServer(preserveSessionStats: Bool = false) {
         cancelPendingServerRestart()
+        modelReleaseTask?.cancel()
+        modelReleaseTask = nil
+        modelReleaseInProgress = false
         modelLoadingProgress = nil
         if preserveSessionStats {
             preserveCurrentSessionStats()
@@ -535,6 +567,48 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
     func switchLanguageModel(to modelID: String?) {
         switchPreloadedModel(to: modelID, for: .language)
+    }
+
+    func releaseLoadedModel() {
+        guard canReleaseLoadedModel, let loadedModelID else {
+            return
+        }
+
+        modelReleaseInProgress = true
+        modelReleaseFailure = nil
+        let baseURL = activeServerBaseURL ?? settings.serverBaseURL
+        let apiKey = settingsAppliedAtServerStart?.serverAPIKey
+        let client = NativModelManagementClient(baseURL: baseURL)
+
+        modelReleaseTask = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            defer {
+                self.modelReleaseTask = nil
+                self.modelReleaseInProgress = false
+                self.notifyMenuStateChanged()
+            }
+
+            do {
+                try await client.unloadModel(apiKey: apiKey)
+                try Task.checkCancellation()
+                self.appendLog("\nReleased \(loadedModelID) while keeping the server running.\n")
+                self.refreshMetricsIfRunning(force: true)
+            } catch is CancellationError {
+                return
+            } catch {
+                self.modelReleaseFailure = ModelReleaseFailure(
+                    message: error.localizedDescription
+                )
+                self.appendLog("\nFailed to release \(loadedModelID): \(error.localizedDescription)\n")
+            }
+        }
+        notifyMenuStateChanged()
+    }
+
+    func clearModelReleaseFailure() {
+        modelReleaseFailure = nil
     }
 
     @discardableResult
@@ -685,6 +759,8 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     }
 
     func applicationWillTerminate() {
+        modelReleaseTask?.cancel()
+        modelReleaseTask = nil
         stopMetricsPolling(clearSession: true)
         if server.isRunning {
             try? server.stop(timeout: 2)
@@ -786,6 +862,9 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
                     )
                 }
                 self.appendLog("\nmlx-vlm-server stopped with status \(status)\n")
+                self.modelReleaseTask?.cancel()
+                self.modelReleaseTask = nil
+                self.modelReleaseInProgress = false
                 self.isRunning = false
                 self.settingsAppliedAtServerStart = nil
                 self.huggingFaceTokenAppliedAtServerStart = nil

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -311,6 +311,51 @@ struct ModelConfigProfile: Codable, Equatable {
     }
 }
 
+enum ServerStartupMode: String, Codable, CaseIterable, Identifiable {
+    case manual
+    case automatic
+
+    var id: Self { self }
+
+    var startsAutomatically: Bool {
+        self == .automatic
+    }
+
+    var displayName: String {
+        switch self {
+        case .manual:
+            "Manual"
+        case .automatic:
+            "Automatic"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .manual:
+            "Start the server only when you choose to."
+        case .automatic:
+            "Start the server and restore selected models when Nativ opens."
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        switch value {
+        case Self.manual.rawValue:
+            self = .manual
+        case Self.automatic.rawValue, "serverOnly", "serverAndModels":
+            self = .automatic
+        default:
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unknown server startup mode: \(value)"
+            )
+        }
+    }
+}
+
 struct NativSettings: Codable, Equatable {
     /// Default hub cache location, resolved from the environment.
     /// See `HuggingFaceCache.defaultHubPath`.
@@ -337,6 +382,7 @@ struct NativSettings: Codable, Equatable {
     var huggingFaceToken: String?
     var serverHost: String
     var serverPort: Int
+    var serverStartupMode: ServerStartupMode
     var maxTokens: Int
     var maxKVSize: Int
     var systemPrompt: String
@@ -388,6 +434,7 @@ struct NativSettings: Codable, Equatable {
         huggingFaceToken: String? = nil,
         serverHost: String = Self.defaultServerHost,
         serverPort: Int = 8080,
+        serverStartupMode: ServerStartupMode = .automatic,
         maxTokens: Int = 2048,
         maxKVSize: Int = 0,
         systemPrompt: String = "",
@@ -438,6 +485,7 @@ struct NativSettings: Codable, Equatable {
         self.huggingFaceToken = huggingFaceToken
         self.serverHost = serverHost
         self.serverPort = serverPort
+        self.serverStartupMode = serverStartupMode
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
         self.systemPrompt = systemPrompt
@@ -490,6 +538,7 @@ struct NativSettings: Codable, Equatable {
         case huggingFaceToken
         case serverHost
         case serverPort
+        case serverStartupMode
         case selectedModelID
         case maxTokens
         case maxKVSize
@@ -547,6 +596,7 @@ struct NativSettings: Codable, Equatable {
         huggingFaceToken = try container.decodeIfPresent(String.self, forKey: .huggingFaceToken) ?? defaults.huggingFaceToken
         serverHost = try container.decodeIfPresent(String.self, forKey: .serverHost) ?? defaults.serverHost
         serverPort = try container.decodeIfPresent(Int.self, forKey: .serverPort) ?? defaults.serverPort
+        serverStartupMode = try container.decodeIfPresent(ServerStartupMode.self, forKey: .serverStartupMode) ?? defaults.serverStartupMode
         maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens) ?? defaults.maxTokens
         maxKVSize = try container.decodeIfPresent(Int.self, forKey: .maxKVSize) ?? defaults.maxKVSize
         systemPrompt = try container.decodeIfPresent(String.self, forKey: .systemPrompt) ?? defaults.systemPrompt
@@ -599,6 +649,7 @@ struct NativSettings: Codable, Equatable {
         try container.encodeIfPresent(huggingFaceToken, forKey: .huggingFaceToken)
         try container.encode(serverHost, forKey: .serverHost)
         try container.encode(serverPort, forKey: .serverPort)
+        try container.encode(serverStartupMode, forKey: .serverStartupMode)
         try container.encode(maxTokens, forKey: .maxTokens)
         try container.encode(maxKVSize, forKey: .maxKVSize)
         try container.encode(systemPrompt, forKey: .systemPrompt)

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -647,6 +647,57 @@ public final class NativMetricsClient {
     }
 }
 
+public enum NativModelManagementError: LocalizedError {
+    case invalidResponse
+    case httpStatus(Int, String?)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            "The Nativ server returned an invalid response."
+        case .httpStatus(let statusCode, let message):
+            message ?? "The Nativ server returned HTTP \(statusCode)."
+        }
+    }
+}
+
+public final class NativModelManagementClient {
+    private let baseURL: URL
+    private let session: URLSession
+
+    public init(
+        baseURL: URL,
+        configuration: URLSessionConfiguration = .ephemeral
+    ) {
+        self.baseURL = baseURL
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        session = URLSession(configuration: configuration)
+    }
+
+    deinit {
+        session.finishTasksAndInvalidate()
+    }
+
+    public func unloadModel(apiKey: String?) async throws {
+        var request = URLRequest(url: baseURL.appendingPathComponent("unload"))
+        request.httpMethod = "POST"
+        request.timeoutInterval = 300
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        NativServerAuthorization.authorize(&request, apiKey: apiKey)
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NativModelManagementError.invalidResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw NativModelManagementError.httpStatus(
+                httpResponse.statusCode,
+                NativServerErrorMessage.detail(from: String(decoding: data, as: UTF8.self))
+            )
+        }
+    }
+}
+
 public final class NativProcessController {
     public typealias OutputHandler = @Sendable (String) -> Void
     public typealias TerminationHandler = @Sendable (Int32) -> Void

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -55,6 +55,66 @@ final class NativSettingsTests: XCTestCase {
         }
     }
 
+    func testServerStartupModeRoundTripsWithoutChangingLaunchConfiguration() throws {
+        var settings = NativSettings(serverStartupMode: .manual)
+        let decoded = try JSONDecoder().decode(
+            NativSettings.self,
+            from: JSONEncoder().encode(settings)
+        )
+
+        XCTAssertEqual(decoded.serverStartupMode, .manual)
+
+        settings.serverStartupMode = .automatic
+        XCTAssertTrue(settings.hasSameLaunchConfiguration(as: decoded))
+    }
+
+    func testMissingServerStartupModePreservesAutomaticStartup() throws {
+        let settings = try JSONDecoder().decode(NativSettings.self, from: Data("{}".utf8))
+
+        XCTAssertEqual(settings.serverStartupMode, .automatic)
+    }
+
+    func testLegacyServerStartupModesMigrateToAutomatic() throws {
+        for legacyValue in ["serverOnly", "serverAndModels"] {
+            let data = Data("{\"serverStartupMode\":\"\(legacyValue)\"}".utf8)
+            let settings = try JSONDecoder().decode(NativSettings.self, from: data)
+
+            XCTAssertEqual(settings.serverStartupMode, .automatic)
+        }
+    }
+
+    func testModelManagementClientCallsAuthenticatedUnloadEndpoint() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ModelManagementURLProtocol.self]
+        var capturedRequest: URLRequest?
+        ModelManagementURLProtocol.handler = { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{}".utf8))
+        }
+        defer {
+            ModelManagementURLProtocol.handler = nil
+        }
+
+        let client = NativModelManagementClient(
+            baseURL: URL(string: "http://127.0.0.1:8080")!,
+            configuration: configuration
+        )
+        try await client.unloadModel(apiKey: "nativ_test")
+
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+        XCTAssertEqual(capturedRequest?.url?.path, "/unload")
+        XCTAssertEqual(
+            capturedRequest?.value(forHTTPHeaderField: "Authorization"),
+            "Bearer nativ_test"
+        )
+    }
+
     func testEmptyPreloadSelectionsAreOmitted() {
         let settings = NativSettings(
             languageModelID: " ",
@@ -590,6 +650,36 @@ final class NativSettingsTests: XCTestCase {
         )
         try data.write(to: url)
     }
+}
+
+private final class ModelManagementURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }
 
 private enum TestCredentialStoreError: Error {


### PR DESCRIPTION
So I've been facing issues where when I have multiple nativ version for dev open, opening each would automatically start the server, leading to OOM. I just think having this nozzle is necessary, because not even in this case, would be nice to not have nativ automatically load a large model when you start it, certainly think this might be causing #265.

This pr introduces a manual/automatic option in settings.

AppDelegate checks reference from user's selected option from settings, launching server through the `startServerForConfiguredStartup()`.

This pr still allows manual starting with `startServer()`

<img width="857" height="146" alt="Screenshot 2026-08-11 at 10 38 28 AM" src="https://github.com/user-attachments/assets/eeebee44-3bfe-4412-b8c8-46f8e03c431b" />


