### PR TITLE
Stabilize onboarding model metadata loading

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -421,7 +421,7 @@ private struct HuggingFaceHubClient: Sendable {
         }
     }
 
-    func model(id: String, token: String?) async throws -> HuggingFaceModel {
+    func modelData(id: String, token: String?) async throws -> Data {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "huggingface.co"
@@ -447,7 +447,7 @@ private struct HuggingFaceHubClient: Sendable {
             let message = (try? JSONDecoder().decode(HubErrorPayload.self, from: data))?.error ?? ""
             throw HuggingFaceHubError.requestFailed(httpResponse.statusCode, message)
         }
-        return try JSONDecoder().decode(HuggingFaceModel.self, from: data)
+        return data
     }
 
     func page(at url: URL, token: String?) async throws -> HuggingFaceModelPage {
@@ -492,6 +492,74 @@ private struct HuggingFaceHubClient: Sendable {
 private struct HuggingFaceModelPage: Sendable {
     let models: [HuggingFaceModel]
     let nextPageURL: URL?
+}
+
+struct HuggingFaceCuratedModelLoader: Sendable {
+    typealias FetchModelData = @Sendable (String) async -> Data?
+
+    private let maximumConcurrentRequests: Int
+    private let fetchModelData: FetchModelData
+
+    init(
+        maximumConcurrentRequests: Int = 4,
+        fetchModelData: @escaping FetchModelData
+    ) {
+        precondition(maximumConcurrentRequests > 0)
+        self.maximumConcurrentRequests = maximumConcurrentRequests
+        self.fetchModelData = fetchModelData
+    }
+
+    func load(ids: [String]) async -> [HuggingFaceModel] {
+        let payloads = await fetchPayloads(ids: ids)
+        guard !Task.isCancelled else {
+            return []
+        }
+
+        // Model decoding derives memory metadata and compiles model-name regexes.
+        // Keep it sequential while allowing the network requests to overlap.
+        let decoder = JSONDecoder()
+        return ids.compactMap { id in
+            guard let data = payloads[id] else {
+                return nil
+            }
+            return try? decoder.decode(HuggingFaceModel.self, from: data)
+        }
+    }
+
+    private func fetchPayloads(ids: [String]) async -> [String: Data] {
+        let fetchModelData = self.fetchModelData
+        return await withTaskGroup(
+            of: (String, Data?).self,
+            returning: [String: Data].self
+        ) { group in
+            var iterator = ids.makeIterator()
+            var payloads: [String: Data] = [:]
+            let initialRequestCount = min(maximumConcurrentRequests, ids.count)
+
+            for _ in 0..<initialRequestCount {
+                guard let id = iterator.next() else { break }
+                group.addTask {
+                    (id, await fetchModelData(id))
+                }
+            }
+
+            while let (id, data) = await group.next() {
+                if let data {
+                    payloads[id] = data
+                }
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    break
+                }
+                if let nextID = iterator.next() {
+                    group.addTask {
+                        (nextID, await fetchModelData(nextID))
+                    }
+                }
+            }
+            return payloads
+        }
+    }
 }
 
 enum HuggingFaceModelCatalog {
@@ -595,24 +663,12 @@ final class HuggingFaceModelLibrary: ObservableObject {
 
         searchTask = Task { [weak self] in
             guard let self else { return }
-            var fetched: [String: HuggingFaceModel] = [:]
-            await withTaskGroup(of: (String, HuggingFaceModel?).self) { group in
-                let client = self.client
-                for id in ids {
-                    group.addTask {
-                        do {
-                            return (id, try await client.model(id: id, token: token))
-                        } catch {
-                            return (id, nil)
-                        }
-                    }
-                }
-                for await (id, model) in group where model != nil {
-                    fetched[id] = model
-                }
+            let client = self.client
+            let loader = HuggingFaceCuratedModelLoader { id in
+                try? await client.modelData(id: id, token: token)
             }
+            let ordered = await loader.load(ids: ids)
             guard !Task.isCancelled else { return }
-            let ordered = ids.compactMap { fetched[$0] }
             self.buffer = ordered
             self.models = ordered
             self.error = ordered.isEmpty

--- a/Tests/NativTests/HuggingFaceCuratedModelLoaderTests.swift
+++ b/Tests/NativTests/HuggingFaceCuratedModelLoaderTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import XCTest
+
+final class HuggingFaceCuratedModelLoaderTests: XCTestCase {
+    func testBoundsFetchConcurrencyAndPreservesSuccessfulModelOrder() async throws {
+        let ids = (0..<12).map { "org/model-\($0)-9B-4bit" }
+        let missingID = ids[4]
+        let invalidID = ids[8]
+        var preparedPayloads = try Dictionary(
+            uniqueKeysWithValues: ids.map { ($0, try modelData(id: $0)) }
+        )
+        preparedPayloads[missingID] = nil
+        preparedPayloads[invalidID] = Data("not-json".utf8)
+        let payloads = preparedPayloads
+        let probe = CuratedFetchProbe(payloads: payloads)
+        let loader = HuggingFaceCuratedModelLoader(maximumConcurrentRequests: 3) { id in
+            await probe.fetch(id: id)
+        }
+
+        let models = await loader.load(ids: ids)
+        let maximumConcurrency = await probe.maximumConcurrency
+
+        XCTAssertEqual(
+            models.map(\.id),
+            ids.filter { $0 != missingID && $0 != invalidID }
+        )
+        XCTAssertEqual(maximumConcurrency, 3)
+    }
+
+    func testRepeatedCuratedModelDecodingIsStable() async throws {
+        let ids = (0..<12).map { "org/model-\($0)-9B-4bit" }
+        let payloads = try Dictionary(
+            uniqueKeysWithValues: ids.map { ($0, try modelData(id: $0)) }
+        )
+        let loader = HuggingFaceCuratedModelLoader { id in
+            payloads[id]
+        }
+
+        for _ in 0..<50 {
+            let models = await loader.load(ids: ids)
+            XCTAssertEqual(models.map(\.id), ids)
+        }
+    }
+
+    private func modelData(id: String) throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "id": id,
+            "downloads": 100,
+            "likes": 10,
+            "pipeline_tag": "text-generation",
+            "library_name": "mlx",
+            "tags": ["text-generation"],
+            "private": false,
+            "gated": false,
+            "safetensors": [
+                "parameters": ["F16": 2_000_000]
+            ]
+        ])
+    }
+}
+
+private actor CuratedFetchProbe {
+    private let payloads: [String: Data]
+    private var activeFetches = 0
+    private(set) var maximumConcurrency = 0
+
+    init(payloads: [String: Data]) {
+        self.payloads = payloads
+    }
+
+    func fetch(id: String) async -> Data? {
+        activeFetches += 1
+        maximumConcurrency = max(maximumConcurrency, activeFetches)
+        defer { activeFetches -= 1 }
+
+        let delayBucket = id.utf8.reduce(0) { $0 + Int($1) } % 4 + 1
+        let delay = UInt64(delayBucket) * 2_000_000
+        do {
+            try await Task.sleep(nanoseconds: delay)
+        } catch {
+            return nil
+        }
+        return payloads[id]
+    }
+}


### PR DESCRIPTION
see in #265, concurrent fetch requests, where for each model a worker is assigned, which led to crashes.

this pr introduces `HuggingFaceCuratedModelLoader` which fetches first, and return raw Data from Hugging Face instead of decoding inside each network task. This is followed by a bounded network concurrency, which only allows max of 4 requests, launched one after another. 

After all arrive a single `JSONDecoder` processes them, which all in all is an effort to not run more than one `HuggingFaceModel` decode concurrently.

Also, failed requests are skipped, along with invalid JSON.

Verification with main could only be that this pr doesn't crash when started from onboarding, unlike main