### PR TITLE
Polish navigation, composers, Artifacts, and model download shutdown

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -372,6 +372,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
     private var modelScanError: String?
     private var lastScannedModelPath: String?
     private weak var highlightedMenuItem: NSMenuItem?
+    private var downloadShutdownTask: Task<Void, Never>?
+    private var didFinishDownloadShutdown = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         runtime.onUpdate = { [weak self] in
@@ -439,6 +441,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
         false
     }
 
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !didFinishDownloadShutdown else { return .terminateNow }
+        guard HuggingFaceDownloadManager.shared.activeCount > 0 else { return .terminateNow }
+
+        if downloadShutdownTask == nil {
+            downloadShutdownTask = Task { [weak self, weak sender] in
+                await HuggingFaceDownloadManager.shared.shutdownForTermination()
+                guard let self, let sender else { return }
+                didFinishDownloadShutdown = true
+                downloadShutdownTask = nil
+                sender.reply(toApplicationShouldTerminate: true)
+            }
+        }
+        return .terminateLater
+    }
+
     func applicationShouldHandleReopen(
         _ sender: NSApplication,
         hasVisibleWindows flag: Bool
@@ -449,7 +467,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUser
 
     func applicationWillTerminate(_ notification: Notification) {
         modelScanTask?.cancel()
-        HuggingFaceDownloadManager.shared.shutdown()
         extensionManager.shutdown()
         runtime.onUpdate = nil
         systemMenuBarPreferences.onChange = nil

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -3985,7 +3985,6 @@ private struct ControlPanelRecentSessionRow: View {
         .sidebarRowSelectionStyle(isSelected: isSelecting ? isChecked : isSelected)
         .opacity(isSelectionDisabled && !isCurrent && !isSelecting ? 0.55 : 1)
         .onHover { isHovering = $0 }
-        .animation(.easeInOut, value: isHovering)
         .contextMenu {
             rowMenuContents
         }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -1557,7 +1557,6 @@ struct ControlPanelView: View {
             routineStatus: routineStatus(for: recent),
             isSelected: sidebarSelection == recent.selection,
             isCurrent: isCurrentRecent(recent),
-            isActive: isRecentActive(recent),
             isSelectionDisabled: isRecentSelectionDisabled(recent),
             isDeleteDisabled: isRecentDeleteDisabled(recent),
             canExport: canExportRecent(recent),
@@ -2301,16 +2300,6 @@ struct ControlPanelView: View {
         case .imageGeneration(let sessionID):
             return sessionID == imageGeneration.currentSessionID
         case .tab, .extensionPage:
-            return false
-        }
-    }
-
-    /// True while this chat is the one generating a response — drives the title shimmer.
-    private func isRecentActive(_ recent: ControlPanelRecentSession) -> Bool {
-        switch recent.selection {
-        case .chat(let sessionID):
-            return sessionID == chat.activeRequestSessionID
-        case .imageGeneration, .tab, .extensionPage:
             return false
         }
     }
@@ -3841,7 +3830,6 @@ private struct ControlPanelRecentSessionRow: View {
     let routineStatus: RoutineRowStatus
     let isSelected: Bool
     let isCurrent: Bool
-    let isActive: Bool
     let isSelectionDisabled: Bool
     let isDeleteDisabled: Bool
     let canExport: Bool
@@ -3946,7 +3934,7 @@ private struct ControlPanelRecentSessionRow: View {
                                 .accessibilityLabel("Image session")
                         }
 
-                        TextShimmerWave(text: recent.title, active: isActive)
+                        Text(recent.title)
                             .lineLimit(1)
                             .truncationMode(.tail)
 

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -2407,7 +2407,8 @@ private struct ChatWorkspaceView: View {
                     model: model,
                     viewModel: imageGeneration,
                     workspaceMode: mode,
-                    onSelectWorkspaceMode: onSelectMode
+                    onSelectWorkspaceMode: onSelectMode,
+                    conversationWidthReduction: conversationWidthReduction
                 )
             }
         }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -517,6 +517,20 @@ struct ControlPanelView: View {
             Color.clear
                 .frame(height: ControlPanelLayout.titlebarHeight)
 
+            HStack(spacing: 6) {
+                Image(nsImage: NSApplication.shared.applicationIconImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(width: 24, height: 24)
+
+                Text("Nativ")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.primary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(height: 40)
+            .padding(.horizontal, 16)
+
             sidebarNavigation
                 .padding(.horizontal, 10)
                 .padding(.bottom, 5)

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -3874,7 +3874,7 @@ private struct ControlPanelRecentSessionRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 2) {
+        ZStack(alignment: .trailing) {
             if isRenaming {
                 HStack(spacing: 7) {
                     Circle()
@@ -3897,16 +3897,12 @@ private struct ControlPanelRecentSessionRow: View {
                             if !focused, isRenaming { commitRename() }
                         }
                 }
+                .padding(.trailing, 52)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .sidebarRowSelectionStyle(isSelected: isSelecting ? isChecked : isSelected)
             } else {
                 Button {
-                    if isSelecting {
-                        onToggleSelect()
-                    } else if isSelected, recent.isChat {
-                        beginRename()
-                    } else {
-                        onSelect()
-                    }
+                    activateRow()
                 } label: {
                     HStack(spacing: 7) {
                         if isSelecting {
@@ -3942,52 +3938,68 @@ private struct ControlPanelRecentSessionRow: View {
 
                         Spacer(minLength: 0)
                     }
+                    .padding(.trailing, 52)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .contentShape(.rect)
+                    .sidebarRowSelectionStyle(isSelected: isSelecting ? isChecked : isSelected)
                 }
                 .buttonStyle(.plain)
                 .disabled(isSelectionDisabled && !isSelecting)
                 .help(recent.title)
             }
 
-            Menu {
-                rowMenuContents
-            } label: {
-                Image(systemName: "ellipsis")
-                    .font(.caption)
-                    .frame(width: 24, height: 20)
-                    .contentShape(.rect)
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            .foregroundStyle(.secondary)
-            .help("Actions")
-            .opacity(isHovering && !isSelecting ? 1 : 0)
-            .allowsHitTesting(isHovering && !isSelecting)
+            HStack(spacing: 2) {
+                Menu {
+                    rowMenuContents
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.caption)
+                        .frame(width: 24, height: 20)
+                        .contentShape(.rect)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .foregroundStyle(.secondary)
+                .help("Actions")
+                .opacity(isHovering && !isSelecting ? 1 : 0)
+                .allowsHitTesting(isHovering && !isSelecting)
 
-            Button(role: .destructive, action: onDelete) {
-                Image(systemName: "trash")
-                    .font(.caption)
-                    .frame(width: 26, height: 20)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(isDeleteHovering ? Color.red.opacity(0.13) : Color.clear)
-                    )
+                Button(role: .destructive, action: onDelete) {
+                    Image(systemName: "trash")
+                        .font(.caption)
+                        .frame(width: 26, height: 20)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(isDeleteHovering ? Color.red.opacity(0.13) : Color.clear)
+                        )
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(isDeleteHovering ? Color.red : Color.secondary)
+                .disabled(isDeleteDisabled)
+                .help("Delete \(recent.title)")
+                .opacity(isHovering && !isSelecting && !isDeleteDisabled ? 1 : 0)
+                .allowsHitTesting(isHovering && !isSelecting && !isDeleteDisabled)
+                .onHover { isDeleteHovering = $0 }
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(isDeleteHovering ? Color.red : Color.secondary)
-            .disabled(isDeleteDisabled)
-            .help("Delete \(recent.title)")
-            .opacity(isHovering && !isSelecting && !isDeleteDisabled ? 1 : 0)
-            .allowsHitTesting(isHovering && !isSelecting && !isDeleteDisabled)
-            .onHover { isDeleteHovering = $0 }
+            .padding(.trailing, 7)
         }
-        .sidebarRowSelectionStyle(isSelected: isSelecting ? isChecked : isSelected)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 1)
         .opacity(isSelectionDisabled && !isCurrent && !isSelecting ? 0.55 : 1)
         .onHover { isHovering = $0 }
         .contextMenu {
             rowMenuContents
+        }
+    }
+
+    private func activateRow() {
+        if isSelecting {
+            onToggleSelect()
+        } else if isSelected, recent.isChat {
+            beginRename()
+        } else {
+            onSelect()
         }
     }
 

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -764,6 +764,7 @@ struct ControlPanelView: View {
             .sidebarRowSelectionStyle(isSelected: sidebarSelection == selection)
         }
         .buttonStyle(.plain)
+        .padding(.vertical, 1)
     }
 
     private func extensionSidebarButton(
@@ -780,6 +781,7 @@ struct ControlPanelView: View {
                 .sidebarRowSelectionStyle(isSelected: sidebarSelection == selection)
         }
         .buttonStyle(.plain)
+        .padding(.vertical, 1)
     }
 
     private var pinnedSection: some View {

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -761,8 +761,8 @@ struct ControlPanelView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(.rect)
+            .sidebarRowSelectionStyle(isSelected: sidebarSelection == selection)
         }
-        .sidebarRowSelectionStyle(isSelected: sidebarSelection == selection)
         .buttonStyle(.plain)
     }
 
@@ -777,8 +777,8 @@ struct ControlPanelView: View {
                 .labelStyle(SidebarNavigationLabelStyle())
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(.rect)
+                .sidebarRowSelectionStyle(isSelected: sidebarSelection == selection)
         }
-        .sidebarRowSelectionStyle(isSelected: sidebarSelection == selection)
         .buttonStyle(.plain)
     }
 

--- a/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
@@ -4,7 +4,7 @@ import PDFKit
 import SwiftUI
 import Vision
 
-enum ArtifactLayout {
+enum ArtifactLayout: Hashable {
     case grid
     case list
 }
@@ -115,6 +115,26 @@ struct ArtifactsView: View {
         smartSearchEnabled && (semanticSearch?.isModelInstalled == true)
     }
 
+    private var availableKinds: [ArtifactKind] {
+        ArtifactKind.allCases.filter { kind in
+            store.artifacts.contains { $0.kind == kind }
+        }
+    }
+
+    private var availableSources: [ArtifactSource] {
+        ArtifactSource.allCases.filter { source in
+            store.artifacts.contains { $0.source == source }
+        }
+    }
+
+    private var activeFilterCount: Int {
+        (kindFilter == nil ? 0 : 1)
+            + (sourceFilter == nil ? 0 : 1)
+            + (favoritesOnly ? 1 : 0)
+            + (dateFilter == .all ? 0 : 1)
+            + (groupByChat ? 1 : 0)
+    }
+
     private var filtered: [Artifact] {
         var result = store.artifacts
         if let kindFilter {
@@ -190,7 +210,7 @@ struct ArtifactsView: View {
                 }
                 .controlSize(.small)
             }
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 24)
             .padding(.vertical, 10)
             .background(Color(nsColor: .windowBackgroundColor))
             Divider()
@@ -420,7 +440,6 @@ struct ArtifactsView: View {
             semanticBanner
             filterBar
             Divider()
-            controlsBar
             if isSelecting {
                 selectionBar
             }
@@ -683,7 +702,7 @@ struct ArtifactsView: View {
                 semanticSettingsButton(config)
             }
         }
-        .padding(.horizontal, 22)
+        .padding(.horizontal, 24)
         .padding(.leading, titleLeadingInset)
         .padding(.top, 14)
         .padding(.bottom, 12)
@@ -736,110 +755,139 @@ struct ArtifactsView: View {
         .background(Color(nsColor: .controlBackgroundColor))
     }
 
-    private var controlsBar: some View {
-        HStack(spacing: 8) {
-            Button(isSelecting ? "Done" : "Select") {
-                isSelecting.toggle()
-                if !isSelecting {
-                    selection.removeAll()
-                }
-            }
-
-            Menu {
-                Toggle(isOn: $groupByChat) {
-                    Label("By Chat", systemImage: "bubble.left.and.bubble.right")
-                }
-                .disabled(isSearching)
-            } label: {
-                Label("Filter", systemImage: "line.3.horizontal.decrease")
-            }
-            .help(isSearching ? "Grouping is off while searching" : "Group artifacts by chat")
-            .fixedSize()
-
-            Menu {
-                Picker("Sort", selection: $sort) {
-                    ForEach(ArtifactSort.allCases) { option in
-                        Text(option.rawValue).tag(option)
-                    }
-                }
-                .pickerStyle(.inline)
-            } label: {
-                Label("Sort: \(sort.rawValue)", systemImage: "arrow.up.arrow.down")
-            }
-            .help("Sort artifacts")
-            .fixedSize()
-
-            if !showingByChat {
-                Picker("", selection: $layout) {
-                    Image(systemName: "square.grid.2x2").tag(ArtifactLayout.grid)
-                    Image(systemName: "list.bullet").tag(ArtifactLayout.list)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .frame(width: 84)
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 10)
-    }
-
     private var filterBar: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+        VStack(spacing: 7) {
             HStack(spacing: 8) {
-                filterChip(title: "All", isOn: kindFilter == nil && sourceFilter == nil) {
+                filterChip(title: "All", isOn: kindFilter == nil) {
                     kindFilter = nil
-                    sourceFilter = nil
                 }
 
-                ForEach(ArtifactKind.allCases) { kind in
+                ForEach(availableKinds) { kind in
                     let count = store.artifacts.filter { $0.kind == kind }.count
                     filterChip(title: "\(kind.pluralLabel) \(count)", systemImage: kind.systemImage, isOn: kindFilter == kind) {
                         kindFilter = kindFilter == kind ? nil : kind
                     }
                 }
 
-                Divider().frame(height: 16)
-
-                ForEach(ArtifactSource.allCases) { source in
-                    let count = store.artifacts.filter { $0.source == source }.count
-                    filterChip(title: "\(source.label) \(count)", systemImage: source.systemImage, isOn: sourceFilter == source) {
-                        sourceFilter = sourceFilter == source ? nil : source
-                    }
-                }
-
-                Divider().frame(height: 16)
-
-                filterChip(title: "Favorites", systemImage: favoritesOnly ? "star.fill" : "star", isOn: favoritesOnly) {
+                filterChip(
+                    title: "Favorites",
+                    systemImage: favoritesOnly ? "star.fill" : "star",
+                    isOn: favoritesOnly
+                ) {
                     favoritesOnly.toggle()
                 }
 
+                Spacer(minLength: 16)
+
+                Button(isSelecting ? "Done" : "Select") {
+                    isSelecting.toggle()
+                    if !isSelecting {
+                        selection.removeAll()
+                    }
+                }
+
                 Menu {
+                    Toggle(isOn: $groupByChat) {
+                        Label("Chat", systemImage: "bubble.left.and.bubble.right")
+                    }
+                    .disabled(isSearching)
+
+                    if !availableSources.isEmpty {
+                        Picker("Source", selection: $sourceFilter) {
+                            Text("All sources").tag(nil as ArtifactSource?)
+                            ForEach(availableSources) { source in
+                                Text(source.label).tag(source as ArtifactSource?)
+                            }
+                        }
+                        .pickerStyle(.inline)
+                    }
+
+                    Divider()
+
                     Picker("Date", selection: $dateFilter) {
                         ForEach(ArtifactDateFilter.allCases) { option in
                             Text(option.rawValue).tag(option)
                         }
                     }
+                    .pickerStyle(.inline)
                 } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "calendar")
-                        Text(dateFilter == .all ? "Date" : dateFilter.rawValue)
-                    }
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(dateFilter != .all ? Color.white : Color.primary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(dateFilter != .all ? Color.accentColor : Color(nsColor: .controlBackgroundColor), in: Capsule())
+                    Label(
+                        activeFilterCount == 0 ? "Group by" : "Group by \(activeFilterCount)",
+                        systemImage: "line.3.horizontal.decrease"
+                    )
                 }
-                .menuIndicator(.hidden)
+                .help(isSearching ? "Grouping by chat is off while searching" : "Group artifacts")
                 .fixedSize()
+
+                Menu {
+                    Picker("Sort", selection: $sort) {
+                        ForEach(ArtifactSort.allCases) { option in
+                            Text(option.rawValue).tag(option)
+                        }
+                    }
+                    .pickerStyle(.inline)
+                } label: {
+                    Label("Sort: \(sort.rawValue)", systemImage: "arrow.up.arrow.down")
+                }
+                .help("Sort artifacts")
+                .fixedSize()
+
+                if !showingByChat {
+                    layoutToggle
+                }
             }
-            .padding(.vertical, 2)
+            .frame(maxWidth: .infinity)
+
+            if activeFilterCount > 0 {
+                HStack {
+                    Text("\(activeFilterCount) \(activeFilterCount == 1 ? "filter" : "filters") applied")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Button("Clear all filters") {
+                        kindFilter = nil
+                        sourceFilter = nil
+                        favoritesOnly = false
+                        dateFilter = .all
+                        groupByChat = false
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Color.accentColor)
+                }
+            }
         }
+        .frame(maxWidth: .infinity)
         .padding(.horizontal, 24)
-        .padding(.top, 12)
-        .padding(.bottom, 12)
+        .padding(.vertical, 10)
+    }
+
+    private var layoutToggle: some View {
+        HStack(spacing: 0) {
+            layoutButton(.grid, systemImage: "square.grid.2x2", help: "Grid view")
+            layoutButton(.list, systemImage: "list.bullet", help: "List view")
+        }
+        .padding(2)
+        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    private func layoutButton(_ option: ArtifactLayout, systemImage: String, help: String) -> some View {
+        Button {
+            layout = option
+        } label: {
+            Image(systemName: systemImage)
+                .frame(width: 28, height: 24)
+                .foregroundStyle(layout == option ? Color.white : Color.primary)
+                .background(layout == option ? Color.accentColor : Color.clear, in: RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .help(help)
     }
 
     private var searchField: some View {

--- a/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
@@ -418,11 +418,12 @@ struct ArtifactsView: View {
         VStack(spacing: 0) {
             header
             semanticBanner
+            filterBar
+            Divider()
+            controlsBar
             if isSelecting {
                 selectionBar
             }
-            filterBar
-            Divider()
             contentView
         }
         .focusable()
@@ -666,43 +667,10 @@ struct ArtifactsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Spacer(minLength: 0)
+            Spacer(minLength: 24)
 
-            Button(isSelecting ? "Done" : "Select") {
-                isSelecting.toggle()
-                if !isSelecting {
-                    selection.removeAll()
-                }
-            }
-
-            Toggle(isOn: Binding(get: { showingByChat }, set: { groupByChat = $0 })) {
-                Label("By Chat", systemImage: "bubble.left.and.bubble.right")
-            }
-            .toggleStyle(.button)
-            .disabled(isSearching)
-            .help(isSearching ? "Grouping is off while searching" : "Group artifacts by chat")
-
-            if !showingByChat {
-                Menu {
-                    Picker("Sort", selection: $sort) {
-                        ForEach(ArtifactSort.allCases) { option in
-                            Text(option.rawValue).tag(option)
-                        }
-                    }
-                    .pickerStyle(.inline)
-                } label: {
-                    Text(sort.rawValue)
-                }
-                .fixedSize()
-
-                Picker("", selection: $layout) {
-                    Image(systemName: "square.grid.2x2").tag(ArtifactLayout.grid)
-                    Image(systemName: "list.bullet").tag(ArtifactLayout.list)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .frame(width: 84)
-            }
+            searchField
+                .frame(width: 280)
 
             Button(action: store.refresh) {
                 Image(systemName: "arrow.clockwise")
@@ -717,8 +685,8 @@ struct ArtifactsView: View {
         }
         .padding(.horizontal, 22)
         .padding(.leading, titleLeadingInset)
-        .padding(.top, 20)
-        .padding(.bottom, 16)
+        .padding(.top, 14)
+        .padding(.bottom, 12)
     }
 
     private var selectionBar: some View {
@@ -768,106 +736,142 @@ struct ArtifactsView: View {
         .background(Color(nsColor: .controlBackgroundColor))
     }
 
-    private var filterBar: some View {
+    private var controlsBar: some View {
         HStack(spacing: 8) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-            filterChip(title: "All", isOn: kindFilter == nil && sourceFilter == nil) {
-                kindFilter = nil
-                sourceFilter = nil
-            }
-
-            ForEach(ArtifactKind.allCases) { kind in
-                let count = store.artifacts.filter { $0.kind == kind }.count
-                filterChip(title: "\(kind.pluralLabel) \(count)", systemImage: kind.systemImage, isOn: kindFilter == kind) {
-                    kindFilter = kindFilter == kind ? nil : kind
+            Button(isSelecting ? "Done" : "Select") {
+                isSelecting.toggle()
+                if !isSelecting {
+                    selection.removeAll()
                 }
-            }
-
-            Divider().frame(height: 16)
-
-            ForEach(ArtifactSource.allCases) { source in
-                let count = store.artifacts.filter { $0.source == source }.count
-                filterChip(title: "\(source.label) \(count)", systemImage: source.systemImage, isOn: sourceFilter == source) {
-                    sourceFilter = sourceFilter == source ? nil : source
-                }
-            }
-
-            Divider().frame(height: 16)
-
-            filterChip(title: "Favorites", systemImage: favoritesOnly ? "star.fill" : "star", isOn: favoritesOnly) {
-                favoritesOnly.toggle()
             }
 
             Menu {
-                Picker("Date", selection: $dateFilter) {
-                    ForEach(ArtifactDateFilter.allCases) { option in
+                Toggle(isOn: $groupByChat) {
+                    Label("By Chat", systemImage: "bubble.left.and.bubble.right")
+                }
+                .disabled(isSearching)
+            } label: {
+                Label("Filter", systemImage: "line.3.horizontal.decrease")
+            }
+            .help(isSearching ? "Grouping is off while searching" : "Group artifacts by chat")
+            .fixedSize()
+
+            Menu {
+                Picker("Sort", selection: $sort) {
+                    ForEach(ArtifactSort.allCases) { option in
                         Text(option.rawValue).tag(option)
                     }
                 }
+                .pickerStyle(.inline)
             } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "calendar")
-                    Text(dateFilter == .all ? "Date" : dateFilter.rawValue)
-                }
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(dateFilter != .all ? Color.white : Color.primary)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 5)
-                .background(dateFilter != .all ? Color.accentColor : Color(nsColor: .controlBackgroundColor), in: Capsule())
+                Label("Sort: \(sort.rawValue)", systemImage: "arrow.up.arrow.down")
             }
-            .menuIndicator(.hidden)
+            .help("Sort artifacts")
             .fixedSize()
-                }
-                .padding(.vertical, 2)
-                .padding(.trailing, 24)
-            }
-            .mask(
-                LinearGradient(
-                    stops: [
-                        .init(color: .black, location: 0),
-                        .init(color: .black, location: 0.88),
-                        .init(color: .clear, location: 1)
-                    ],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-            )
 
-            HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                if smartSearchActive {
-                    Circle()
-                        .fill(Color.green.opacity(0.7))
-                        .frame(width: 7, height: 7)
-                        .help("Smart search is on")
+            if !showingByChat {
+                Picker("", selection: $layout) {
+                    Image(systemName: "square.grid.2x2").tag(ArtifactLayout.grid)
+                    Image(systemName: "list.bullet").tag(ArtifactLayout.list)
                 }
-                TextField("Search name or prompt", text: $search)
-                    .textFieldStyle(.plain)
-                    .focused($searchFocused)
-                    .frame(width: 200)
-                if !search.isEmpty {
-                    Button {
-                        search = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 84)
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 5)
-            .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-            )
-            .shadow(color: .black.opacity(0.12), radius: 6, x: -3, y: 0)
+
+            Spacer(minLength: 0)
         }
         .padding(.horizontal, 24)
+        .padding(.vertical, 10)
+    }
+
+    private var filterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                filterChip(title: "All", isOn: kindFilter == nil && sourceFilter == nil) {
+                    kindFilter = nil
+                    sourceFilter = nil
+                }
+
+                ForEach(ArtifactKind.allCases) { kind in
+                    let count = store.artifacts.filter { $0.kind == kind }.count
+                    filterChip(title: "\(kind.pluralLabel) \(count)", systemImage: kind.systemImage, isOn: kindFilter == kind) {
+                        kindFilter = kindFilter == kind ? nil : kind
+                    }
+                }
+
+                Divider().frame(height: 16)
+
+                ForEach(ArtifactSource.allCases) { source in
+                    let count = store.artifacts.filter { $0.source == source }.count
+                    filterChip(title: "\(source.label) \(count)", systemImage: source.systemImage, isOn: sourceFilter == source) {
+                        sourceFilter = sourceFilter == source ? nil : source
+                    }
+                }
+
+                Divider().frame(height: 16)
+
+                filterChip(title: "Favorites", systemImage: favoritesOnly ? "star.fill" : "star", isOn: favoritesOnly) {
+                    favoritesOnly.toggle()
+                }
+
+                Menu {
+                    Picker("Date", selection: $dateFilter) {
+                        ForEach(ArtifactDateFilter.allCases) { option in
+                            Text(option.rawValue).tag(option)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "calendar")
+                        Text(dateFilter == .all ? "Date" : dateFilter.rawValue)
+                    }
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(dateFilter != .all ? Color.white : Color.primary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(dateFilter != .all ? Color.accentColor : Color(nsColor: .controlBackgroundColor), in: Capsule())
+                }
+                .menuIndicator(.hidden)
+                .fixedSize()
+            }
+            .padding(.vertical, 2)
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 12)
         .padding(.bottom, 12)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            if smartSearchActive {
+                Circle()
+                    .fill(Color.green.opacity(0.7))
+                    .frame(width: 7, height: 7)
+                    .help("Smart search is on")
+            }
+            TextField("Search name or prompt", text: $search)
+                .textFieldStyle(.plain)
+                .focused($searchFocused)
+            if !search.isEmpty {
+                Button {
+                    search = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+        )
     }
 
     private func sectionHeader(_ title: String, count: Int) -> some View {

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -659,6 +659,7 @@ struct ComposerModelPicker: View {
                 selectedModelProvider: selectedModelProvider,
                 secondarySection: secondarySection,
                 isEnabled: !isDisabled,
+                usesSelectModelShortcut: shortcutLabel != nil,
                 statusLabel: statusLabel,
                 onSelectModel: onSelectModel,
                 onSwitchModel: onSwitchModel,
@@ -743,6 +744,7 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
     let selectedModelProvider: LocalModelProvider?
     let secondarySection: ComposerModelPickerSecondarySection?
     let isEnabled: Bool
+    let usesSelectModelShortcut: Bool
     let statusLabel: String
     let onSelectModel: (LocalModel) -> Void
     let onSwitchModel: (String) -> Void
@@ -760,6 +762,7 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
         button.focusRingType = .none
         button.target = context.coordinator
         button.action = #selector(Coordinator.showMenu(_:))
+        configureShortcut(for: button)
         button.setAccessibilityLabel("Model")
         return button
     }
@@ -767,7 +770,15 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
     func updateNSView(_ button: NSButton, context: Context) {
         context.coordinator.parent = self
         button.isEnabled = isEnabled
+        configureShortcut(for: button)
         context.coordinator.updateActionAvailability(isEnabled)
+    }
+
+    private func configureShortcut(for button: NSButton) {
+        button.keyEquivalent = usesSelectModelShortcut ? "m" : ""
+        button.keyEquivalentModifierMask = usesSelectModelShortcut
+            ? [.control, .shift]
+            : []
     }
 
     @MainActor

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -90,11 +90,13 @@ struct ChatComposer: View {
     let workspaceMode: ChatWorkspaceMode
     let onSelectWorkspaceMode: (ChatWorkspaceMode) -> Void
     let onSend: (Bool) -> Void
+    let onBackdropHeightChange: (CGFloat) -> Void
     @State private var editorContentHeight: CGFloat = 0
     @State private var didApplyInitialReasoningDefault = false
     private let textInset = EdgeInsets(top: 14, leading: 14, bottom: 10, trailing: 14)
     private let editorMinimumHeight: CGFloat = 64
     private let editorMaximumHeight: CGFloat = 120
+    private let composerVerticalPadding: CGFloat = 18
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -110,15 +112,17 @@ struct ChatComposer: View {
                 TimelineView(.periodic(from: .now, by: 1)) { context in
                     let elapsed = context.date.timeIntervalSince(sendingStartedAt)
                     Text(workingStatus(elapsed: elapsed))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
+                .padding(.leading, textInset.leading + 4)
             } else if let unavailableReason {
                 Text(unavailableReason)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    .padding(.leading, textInset.leading + 4)
             }
 
             if !viewModel.currentSessionQueuedPrompts.isEmpty {
@@ -235,8 +239,13 @@ struct ChatComposer: View {
                     .stroke(Color(nsColor: .separatorColor), lineWidth: 0.75)
             }
             .shadow(color: .black.opacity(0.08), radius: 12, x: 0, y: 4)
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { height in
+                onBackdropHeightChange(height + (composerVerticalPadding * 2))
+            }
         }
-        .padding(.vertical, 18)
+        .padding(.vertical, composerVerticalPadding)
         .task(id: modelScanKey) {
             localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
         }

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -93,7 +93,7 @@ struct ChatComposer: View {
     let onBackdropHeightChange: (CGFloat) -> Void
     @State private var editorContentHeight: CGFloat = 0
     @State private var didApplyInitialReasoningDefault = false
-    private let textInset = EdgeInsets(top: 14, leading: 14, bottom: 10, trailing: 14)
+    private let textInset = EdgeInsets(top: 12, leading: 14, bottom: 12, trailing: 14)
     private let editorMinimumHeight: CGFloat = 64
     private let editorMaximumHeight: CGFloat = 120
     private let composerVerticalPadding: CGFloat = 18
@@ -546,6 +546,7 @@ struct ChatComposer: View {
     }
 
     private func send() {
+        guard canSend else { return }
         onSend(selectedLocalModel?.capabilities.contains(.tools) == true)
     }
 

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -99,7 +99,6 @@ private enum ChatTranscriptLayout {
     static let conversationMaxWidth: CGFloat = 680
     static let horizontalPadding: CGFloat = 32
     static let messageHorizontalInset: CGFloat = 32
-    static let composerHorizontalInset: CGFloat = 12
     static let composerClearance: CGFloat = 48
     static let composerFadeExtension: CGFloat = 40
 }
@@ -331,14 +330,9 @@ private struct ChatComposerContainer: View {
         .frame(
             maxWidth: ChatTranscriptLayout.conversationMaxWidth
                 - conversationWidthReduction
-                - (ChatTranscriptLayout.composerHorizontalInset * 2)
         )
         .frame(maxWidth: .infinity)
-        .padding(
-            .horizontal,
-            ChatTranscriptLayout.horizontalPadding
-                + ChatTranscriptLayout.composerHorizontalInset
-        )
+        .padding(.horizontal, ChatTranscriptLayout.horizontalPadding)
         .onGeometryChange(for: CGFloat.self) { proxy in
             proxy.size.height
         } action: { height in

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -3581,7 +3581,7 @@ private struct ChatSelectablePromptText: NSViewRepresentable {
 private extension Color {
     static let nativMark = Color(nsColor: NSColor(name: nil) { appearance in
         let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-        return isDark ? NSColor.black : NSColor(white: 0.86, alpha: 1)
+        return isDark ? NSColor(white: 0.5, alpha: 1) : NSColor(white: 0.25, alpha: 1)
     })
 }
 

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -310,8 +310,7 @@ private struct ChatComposerContainer: View {
             unavailableReason: model.modelLoadingStatusText
                 ?? chat.unavailableReason(isRunning: model.isRunning, selectedModelID: selectedModelID)
                 ?? model.settings.structuredOutputValidationError,
-            canCompose: model.isRunning
-                && !model.isModelLoading
+            canCompose: (model.isRunning || model.isModelLoading)
                 && selectedModelID?.isEmpty == false
                 && model.settings.structuredOutputValidationError == nil,
             canSend: !model.isModelLoading

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -114,6 +114,7 @@ private struct ChatTranscriptView: View {
     let onExploreImageModels: (ChatImageOperation) -> Void
     @State private var transcriptScrollPosition = ScrollPosition(edge: .bottom)
     @State private var composerHeight: CGFloat = 0
+    @State private var composerBackdropHeight: CGFloat = 0
     @State private var followsLatestMessage = true
     @State private var isUserScrollingTranscript = false
 
@@ -194,6 +195,9 @@ private struct ChatTranscriptView: View {
                                 transcriptScrollPosition.scrollTo(edge: .bottom)
                             }
                         }
+                    },
+                    onBackdropHeightChange: { height in
+                        composerBackdropHeight = height
                     }
                 )
             }
@@ -256,7 +260,7 @@ private struct ChatTranscriptView: View {
             .frame(height: ChatTranscriptLayout.composerFadeExtension)
 
             Color.nativMainContentBackground
-                .frame(height: max(72, composerHeight))
+                .frame(height: max(72, composerBackdropHeight))
         }
         .allowsHitTesting(false)
         .accessibilityHidden(true)
@@ -294,6 +298,7 @@ private struct ChatComposerContainer: View {
     let onSelectWorkspaceMode: (ChatWorkspaceMode) -> Void
     let conversationWidthReduction: CGFloat
     let onHeightChange: (CGFloat) -> Void
+    let onBackdropHeightChange: (CGFloat) -> Void
 
     private var selectedModelID: String? {
         model.settings.normalized().languageModelID
@@ -320,7 +325,8 @@ private struct ChatComposerContainer: View {
                     using: model,
                     languageModelSupportsTools: languageModelSupportsTools
                 )
-            }
+            },
+            onBackdropHeightChange: onBackdropHeightChange
         )
         .frame(
             maxWidth: ChatTranscriptLayout.conversationMaxWidth

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -95,11 +95,16 @@ struct ChatView: View {
     }
 }
 
+private enum ChatTranscriptLayout {
+    static let conversationMaxWidth: CGFloat = 680
+    static let horizontalPadding: CGFloat = 32
+    static let messageHorizontalInset: CGFloat = 32
+    static let composerHorizontalInset: CGFloat = 12
+    static let composerClearance: CGFloat = 48
+    static let composerFadeExtension: CGFloat = 40
+}
+
 private struct ChatTranscriptView: View {
-    private enum Layout {
-        static let conversationMaxWidth: CGFloat = 680
-        static let horizontalPadding: CGFloat = 32
-    }
 
     @ObservedObject var model: NativModel
     @ObservedObject var chat: ChatViewModel
@@ -152,31 +157,46 @@ private struct ChatTranscriptView: View {
                     }
                 }
             }
-            .frame(maxWidth: Layout.conversationMaxWidth - conversationWidthReduction)
+            .frame(
+                maxWidth: ChatTranscriptLayout.conversationMaxWidth
+                    - conversationWidthReduction
+                    - (ChatTranscriptLayout.messageHorizontalInset * 2)
+            )
             .frame(maxWidth: .infinity)
-            .padding(.horizontal, Layout.horizontalPadding)
+            .padding(
+                .horizontal,
+                ChatTranscriptLayout.horizontalPadding
+                    + ChatTranscriptLayout.messageHorizontalInset
+            )
             .padding(.top, 18)
-            .padding(.bottom, max(18, composerHeight))
+            .padding(
+                .bottom,
+                max(18, composerHeight + ChatTranscriptLayout.composerClearance)
+            )
         }
         .scrollPosition($transcriptScrollPosition)
         .overlay(alignment: .bottom) {
-            ChatComposerContainer(
-                model: model,
-                chat: chat,
-                workspaceMode: workspaceMode,
-                onSelectWorkspaceMode: onSelectWorkspaceMode,
-                conversationWidthReduction: conversationWidthReduction,
-                onHeightChange: { height in
-                    let isInitialMeasurement = composerHeight == 0
-                    composerHeight = height
-                    if isInitialMeasurement {
-                        Task { @MainActor in
-                            try? await Task.sleep(for: .milliseconds(50))
-                            transcriptScrollPosition.scrollTo(edge: .bottom)
+            ZStack(alignment: .bottom) {
+                composerBackdrop
+
+                ChatComposerContainer(
+                    model: model,
+                    chat: chat,
+                    workspaceMode: workspaceMode,
+                    onSelectWorkspaceMode: onSelectWorkspaceMode,
+                    conversationWidthReduction: conversationWidthReduction,
+                    onHeightChange: { height in
+                        let isInitialMeasurement = composerHeight == 0
+                        composerHeight = height
+                        if isInitialMeasurement {
+                            Task { @MainActor in
+                                try? await Task.sleep(for: .milliseconds(50))
+                                transcriptScrollPosition.scrollTo(edge: .bottom)
+                            }
                         }
                     }
-                }
-            )
+                )
+            }
         }
         .onScrollPhaseChange { _, newPhase, context in
             switch newPhase {
@@ -220,6 +240,26 @@ private struct ChatTranscriptView: View {
 
     private func isAtTranscriptBottom(_ geometry: ScrollGeometry) -> Bool {
         geometry.visibleRect.maxY >= geometry.contentSize.height - 8
+    }
+
+    private var composerBackdrop: some View {
+        VStack(spacing: 0) {
+            LinearGradient(
+                colors: [
+                    Color.nativMainContentBackground.opacity(0),
+                    Color.nativMainContentBackground.opacity(0.84),
+                    Color.nativMainContentBackground,
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: ChatTranscriptLayout.composerFadeExtension)
+
+            Color.nativMainContentBackground
+                .frame(height: max(72, composerHeight))
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
     }
 
     private func userPromptEditingUnavailableReason(
@@ -282,9 +322,17 @@ private struct ChatComposerContainer: View {
                 )
             }
         )
-        .frame(maxWidth: 680 - conversationWidthReduction)
+        .frame(
+            maxWidth: ChatTranscriptLayout.conversationMaxWidth
+                - conversationWidthReduction
+                - (ChatTranscriptLayout.composerHorizontalInset * 2)
+        )
         .frame(maxWidth: .infinity)
-        .padding(.horizontal, 32)
+        .padding(
+            .horizontal,
+            ChatTranscriptLayout.horizontalPadding
+                + ChatTranscriptLayout.composerHorizontalInset
+        )
         .onGeometryChange(for: CGFloat.self) { proxy in
             proxy.size.height
         } action: { height in

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
@@ -13,6 +13,7 @@ struct ImageGenerationView: View {
     @ObservedObject var viewModel: ImageGenerationViewModel
     let workspaceMode: ChatWorkspaceMode
     let onSelectWorkspaceMode: (ChatWorkspaceMode) -> Void
+    let conversationWidthReduction: CGFloat
     @State private var transcriptScrollPosition = ScrollPosition(edge: .bottom)
     @State private var composerHeight: CGFloat = 0
     @State private var followsLatestTurn = true
@@ -26,7 +27,10 @@ struct ImageGenerationView: View {
                     workspaceMode: workspaceMode,
                     onSelectWorkspaceMode: onSelectWorkspaceMode
                 )
-                    .frame(maxWidth: Layout.composerMaxWidth)
+                    .frame(
+                        maxWidth: Layout.composerMaxWidth
+                            - conversationWidthReduction
+                    )
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal, Layout.horizontalPadding)
                     .onGeometryChange(for: CGFloat.self) { proxy in

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
@@ -301,7 +301,7 @@ private struct ImageGenerationComposer: View {
             statusLabel: localModelStatusLabel,
             helpText: modelPickerHelp,
             accessibilityValue: modelLabel,
-            shortcutLabel: nil,
+            shortcutLabel: "⌃⇧M",
             onSelectModel: selectImageModel,
             onSwitchModel: selectImageModel
         )

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -1106,15 +1106,30 @@ final class HuggingFaceDownloadManager: ObservableObject {
         }
     }
 
-    func shutdown() {
+    /// Stops downloader subprocesses before the app exits while preserving the
+    /// Hugging Face cache, including resumable `.incomplete` files.
+    func shutdownForTermination(timeout: Duration = .seconds(2)) async {
         let activeContexts = Array(contexts.values)
-        activeContexts.forEach {
-            $0.operation?.cancel()
-            $0.task?.cancel()
+        let waiters = activeContexts.flatMap { $0.waiters.values }
+        let operations = activeContexts.compactMap(\.operation)
+
+        activeContexts.forEach { context in
+            context.task?.cancel()
+            context.operation?.cancel()
         }
+
         contexts.removeAll()
         downloads.removeAll()
         progressUpdateTimes.removeAll()
+        waiters.forEach { $0.resume(throwing: CancellationError()) }
+
+        await withTaskGroup(of: Void.self) { group in
+            for operation in operations {
+                group.addTask {
+                    await operation.waitForExit(timeout: timeout)
+                }
+            }
+        }
     }
 
     private func enqueue(
@@ -1543,12 +1558,14 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         from tqdm.auto import tqdm
         from huggingface_hub import snapshot_download
 
-        parent_pid = os.getppid()
-        def exit_if_parent_stops():
+        parent_pid = int(sys.argv[3])
+
+        def exit_if_parent_terminates():
             while os.getppid() == parent_pid:
-                time.sleep(1)
-            os._exit(143)
-        threading.Thread(target=exit_if_parent_stops, daemon=True).start()
+                time.sleep(0.25)
+            os._exit(0)
+
+        threading.Thread(target=exit_if_parent_terminates, daemon=True).start()
 
         ignored_patterns = \(HuggingFaceDownloadFilePolicy.pythonListLiteral)
         expected_bytes = 0
@@ -1619,7 +1636,13 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         }
 
         self.executableURL = pythonURL
-        self.arguments = ["-c", script, repoID, cachePath]
+        self.arguments = [
+            "-c",
+            script,
+            repoID,
+            cachePath,
+            String(ProcessInfo.processInfo.processIdentifier)
+        ]
         self.environment = environment
         self.repoID = repoID
         self.cachePath = cachePath
@@ -1799,6 +1822,22 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         }
     }
 
+    func waitForExit(timeout: Duration) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while currentProcess?.isRunning == true, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+
+        guard let process = currentProcess, process.isRunning else { return }
+        Darwin.kill(process.processIdentifier, SIGKILL)
+
+        let forcedExitDeadline = clock.now.advanced(by: .seconds(1))
+        while process.isRunning, clock.now < forcedExitDeadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     func pause() {
         lock.lock()
         isPaused = true
@@ -1830,6 +1869,12 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return wasCancelled
+    }
+
+    private var currentProcess: Process? {
+        lock.lock()
+        defer { lock.unlock() }
+        return process
     }
 
     private func clearProcess(_ process: Process) {


### PR DESCRIPTION
## Summary

This PR now contains a broader UI and lifecycle polish pass across Nativ:

- **Sidebar and sessions**
  - Add full-color Nativ branding above the main navigation.
  - Add consistent 2 px vertical separation between navigation and session rows.
  - Expand navigation and chat-session hit targets so the whole visible row responds to clicks.
  - Keep the actions and delete controls inside each chat row and make them immediately available on hover.
  - Remove the trailing chat-row hover animation so highlights do not linger while moving through the list.

- **Chat and image composers**
  - Match the chat and image composer widths.
  - Inset transcript content and reserve enough bottom clearance so messages are not obscured by the composer.
  - Add a stable, height-aware fade above the composer without stacking a second translucent backdrop.
  - Align loading and unavailable status text with the composer content.
  - Add **Control–Shift–M** as the model-picker shortcut in both workspaces.
  - Improve the Nativ mark contrast in the chat window.

- **Artifacts**
  - Move search into the header and simplify the filtering controls.
  - Only show artifact-kind and source options that are present in the library.
  - Keep Favorites directly accessible.
  - Consolidate chat grouping, source, and date under **Group by**.
  - Keep sorting and grid/list layout as distinct controls.
  - Show the active filter count and provide a single clear-all action.
  - Correct toolbar alignment, spacing, and menu duplication.

- **Model download lifecycle**
  - Defer normal app termination asynchronously while active Hugging Face downloader subprocesses are stopped.
  - Bound graceful shutdown and force-kill a downloader only if it does not exit within the timeout.
  - Add a parent-process watchdog so Force Quit cannot leave an orphaned Python downloader or open network connection.
  - Preserve Hugging Face `.incomplete` files so interrupted downloads remain resumable.

## Why

Several controls looked larger than their real clickable areas, chat hover state animated after the pointer had already left, and the composer could cover transcript content because its backdrop and clearance were based on separate fixed assumptions. The Artifacts controls also duplicated concepts across multiple rows and menus.

Model downloads run in a Python subprocess. Previously, abruptly terminating Nativ could reparent that process to launchd, allowing the transfer and network connection to continue after the app was gone.

## User impact

Navigation and session selection now feel immediate and predictable, composer content remains readable at the bottom of long chats, Artifacts controls are easier to scan, and closing Nativ reliably stops active model network transfers without discarding resumable download data.

## Screenshots

### Sidebar branding, navigation, and session list

![Sidebar branding, navigation, and session list](https://raw.githubusercontent.com/Blaizzy/nativ/pc/pr-276-assets/pr-276/sidebar-chat.jpeg)

### Chat composer spacing, width, and transcript clearance

![Chat composer](https://raw.githubusercontent.com/Blaizzy/nativ/pc/pr-276-assets/pr-276/chat-composer.jpeg)

### Matching image composer

![Image composer](https://raw.githubusercontent.com/Blaizzy/nativ/pc/pr-276-assets/pr-276/image-composer.jpeg)

### Artifacts header, filters, sorting, and layout controls

![Artifacts toolbar](https://raw.githubusercontent.com/Blaizzy/nativ/pc/pr-276-assets/pr-276/artifacts.jpeg)

> The download-shutdown change has no static UI. It was verified with live downloader processes as described below.

## Validation

- `make xcode-run`
- Debug app built successfully, signed with the configured Apple Development identity, and opened.
- `codesign --verify --deep --strict`
- `git diff --check`
- Verified navigation and chat-session full-row click targets in the rebuilt app.
- Verified chat/image composer sizing and Artifacts layout in the rebuilt app.
- **Normal Quit during a live download:** Nativ and its downloader were both gone on the first 250 ms process check.
- **Force Close during a live download:** the parent watchdog removed the downloader in about 100 ms.
- Confirmed partial Hugging Face `.incomplete` files remained on disk for resume after both shutdown paths.
