### PR TITLE
removing recurrent option for current chats

### DIFF
--- a/Docs/features/routines.md
+++ b/Docs/features/routines.md
@@ -18,8 +18,6 @@ an enabled flag — see [`Routine`](../../Sources/Nativ/Features/Routines/Routin
 
 - **New routine** from the sidebar creation menu opens the editor and, on save, creates the
   routine's chat.
-- **Make recurring** from an existing chat prefills a routine from that chat's last prompt, model,
-  and title.
 
 Removing a routine chat cancels its routine; editing a routine offers removal that keeps the chat.
 

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -1574,8 +1574,8 @@ struct ControlPanelView: View {
             onTogglePin: {
                 togglePinRecent(recent)
             },
-            onScheduleRoutine: {
-                scheduleRoutine(from: recent)
+            onEditRoutine: {
+                editRoutine(for: recent)
             },
             folders: chat.folders,
             onMoveToFolder: { folderID in
@@ -1606,34 +1606,16 @@ struct ControlPanelView: View {
         return routine.isEnabled ? .scheduled : .disabled
     }
 
-    private func scheduleRoutine(from recent: ControlPanelRecentSession) {
+    private func editRoutine(for recent: ControlPanelRecentSession) {
         guard case .chat(let sessionID) = recent.selection else {
             return
         }
         let settings = model.settings.normalized()
         routineModelLibrary.scan(searchPaths: settings.localModelSearchPaths)
-        if let existing = RoutineStore.shared.routine(forSession: sessionID) {
-            schedulingRoutineDraft = RoutineDraft(routine: existing)
+        guard let existing = RoutineStore.shared.routine(forSession: sessionID) else {
             return
         }
-        guard let session = ChatSessionStore().loadSession(id: sessionID) else {
-            return
-        }
-        let instructions = session.messages.last { $0.role == .user }?.content ?? ""
-        let modelID = session.messages
-            .last { $0.role == .assistant && !($0.modelID ?? "").isEmpty }?
-            .modelID
-            ?? settings.languageModelID
-            ?? ""
-        schedulingRoutineDraft = RoutineDraft(
-            routine: Routine(
-                name: recent.title,
-                instructions: instructions,
-                modelID: modelID,
-                triggerKind: .schedule,
-                sourceSessionID: sessionID
-            )
-        )
+        schedulingRoutineDraft = RoutineDraft(routine: existing)
     }
 
     private func presentNewRoutine() {
@@ -3857,7 +3839,7 @@ private struct ControlPanelRecentSessionRow: View {
     let onRename: (String) -> Void
     let onNewChat: () -> Void
     let onTogglePin: () -> Void
-    let onScheduleRoutine: () -> Void
+    let onEditRoutine: () -> Void
     let folders: [ChatFolder]
     let onMoveToFolder: (UUID?) -> Void
     let onCreateFolderForSession: () -> Void
@@ -4035,10 +4017,12 @@ private struct ControlPanelRecentSessionRow: View {
                 )
             }
 
-            Button {
-                onScheduleRoutine()
-            } label: {
-                Label(routineStatus == .none ? "Make recurring" : "Edit routine", systemImage: "bolt")
+            if routineStatus != .none {
+                Button {
+                    onEditRoutine()
+                } label: {
+                    Label("Edit routine", systemImage: "bolt")
+                }
             }
 
             Menu {


### PR DESCRIPTION
removing the ability to make existing chats or prev from becoming recurrent task. this should be a future feature and well thought out to handle the massive context model might digest while also allowing prev chats to have recurrency for automated tasks