### PR TITLE
UI changes for the MCP page

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -24,4 +24,4 @@ For running Nativ, building from source, and the project layout, see the
 |---|---|
 | [Extensions](extending/extensions.md) | The extension package format, manifest, lifecycle, permissions, and adding a first-party extension. |
 | [Kits](extending/kits.md) | Authoring a Kit — a curated bundle of MCP servers, skills, and extensions. |
-| [MCP catalog](extending/mcp-catalog.md) | Contributing an MCP server to the built-in Browse catalog. |
+| [MCP catalog](extending/mcp-catalog.md) | Contributing a server to the built-in MCP list. |

--- a/Docs/extending/mcp-catalog.md
+++ b/Docs/extending/mcp-catalog.md
@@ -1,7 +1,7 @@
 # Contributing an MCP server to the catalog
 
-The **Browse catalog** grid in Nativ's MCP section is the list of community MCP
-servers we've reviewed and shipped. Every server in it is one entry in
+The **Built in** section on Nativ's MCP page lists the community MCP servers
+we've reviewed and shipped. Every server in it is one entry in
 [`Sources/Nativ/Resources/MCPCatalog.json`](../../Sources/Nativ/Resources/MCPCatalog.json),
 and every entry has to pass CI before it can merge — the
 [`Verify MCP Catalog`](../../.github/workflows/verify-mcp-catalog.yml) workflow

--- a/Docs/features/integrations.md
+++ b/Docs/features/integrations.md
@@ -21,7 +21,7 @@ tools become available to a tool-calling model in [Chat](chat.md).
 - Configured servers persist in settings and are (re)started by the host
   ([`MCPHostManager`](../../Sources/Nativ/Features/MCP/MCPHostManager.swift)).
 - Each MCP tool call passes through the same consent gate as built-in chat tools before it runs.
-- The **Browse catalog** grid lists reviewed community servers; a [Kit](../extending/kits.md)
+- The **Built in** list exposes reviewed community servers directly; a [Kit](../extending/kits.md)
   can bundle several servers, skills, and extensions and enable them together.
 
 Authoring: add a server to the catalog via [MCP catalog](../extending/mcp-catalog.md); bundle

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		2BF78B0A20ED752102326A38 /* ChatImageModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */; };
 		2BF94914481EEA1A493F5926 /* VoiceDictationExtensionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1573A2D88784C9D404156D25 /* VoiceDictationExtensionRuntime.swift */; };
 		2C9930764FCB1AF6B4C66363 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
+		2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */; };
 		2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		31D67AFE2E2CD864C37D6CFA /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		326C969CB7D0F41F38467DFE /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
@@ -64,6 +65,7 @@
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */; };
 		44F8A17BDE2610C6E90CE53F /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
+		4572BDBE09CB7D688B8838CA /* MCPServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */; };
 		45BD4C408B9739ABC051A9E7 /* ControlPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C7712D68B2782589312766 /* ControlPanelView.swift */; };
 		463870509178CCD59287E1BE /* VoiceTranscriptInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23155DB5E733D8887D83AFD0 /* VoiceTranscriptInserter.swift */; };
 		482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */; };
@@ -159,6 +161,7 @@
 		BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */; };
 		BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5919AB4E9488642C73886266 /* ShellEnvironment.swift */; };
 		BEA11D430947F6C01177EDE8 /* ChatToolRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */; };
+		BF5A1AD007F259A2F926AF57 /* ChatWorkspacePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */; };
 		C03E948D1C7E27B27838C4C6 /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7F610FC8739BA80227DB26 /* NativKit.swift */; };
 		C5CE4EBDB988CF611FB2D6DA /* SystemMenuBarPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE1E26171E964D9769E65CB /* SystemMenuBarPreferences.swift */; };
 		C84FA1A269F12B130EAEB57B /* ModelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EB7572F271F7D68DC3F97D /* ModelsView.swift */; };
@@ -182,6 +185,7 @@
 		E30FD12D491FF35A89A52754 /* WebSearchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295CCB27C6CBD1025E62D11 /* WebSearchSettingsView.swift */; };
 		E407C7F9CE883C978DE7D716 /* PersistentMenuActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */; };
 		E4D299AADEA8470C37256DDE /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
+		E5DF6B83A09106489F564CED /* HuggingFaceCuratedModelLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */; };
 		E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */; };
 		E77359B5F8F6AF656F2008C6 /* Exa.png in Resources */ = {isa = PBXBuildFile; fileRef = 995095FAF89C9D1DEC4158FB /* Exa.png */; };
 		E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41417C210BF817681A8C6D87 /* IntegrationsView.swift */; };
@@ -309,6 +313,7 @@
 		35C1220F03EC60874920E0CE /* RoutineScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineScheduler.swift; sourceTree = "<group>"; };
 		37408935D4EAA2CA89CC0A4C /* VoiceDictationExtensionRuntime.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = VoiceDictationExtensionRuntime.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		38E6FD97A66F91B3B667B3FE /* NativChatClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativChatClient.swift; sourceTree = "<group>"; };
+		39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatWorkspacePicker.swift; sourceTree = "<group>"; };
 		3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironmentTests.swift; sourceTree = "<group>"; };
 		3B1B970F41F1B5612B791ABE /* KitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KitsSectionView.swift; sourceTree = "<group>"; };
 		3B965B701714787B0A85AE6B /* AudioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTests.swift; sourceTree = "<group>"; };
@@ -362,6 +367,7 @@
 		8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureCoordinator.swift; sourceTree = "<group>"; };
 		8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProviderTests.swift; sourceTree = "<group>"; };
 		90012E8ECF43A5A55BFD8787 /* RoutineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineSupport.swift; sourceTree = "<group>"; };
+		908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceCuratedModelLoaderTests.swift; sourceTree = "<group>"; };
 		96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativEmbeddingsClient.swift; sourceTree = "<group>"; };
 		995095FAF89C9D1DEC4158FB /* Exa.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Exa.png; sourceTree = "<group>"; };
 		9A7A7ACB288953FD476C47E8 /* MCPServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerConfig.swift; sourceTree = "<group>"; };
@@ -383,6 +389,7 @@
 		ADEC2FFE7F1CFAC59170AC63 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		AFA5142DB692E378ADE8DFA0 /* ChatWebSearchToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatWebSearchToolTests.swift; sourceTree = "<group>"; };
 		B0E2EE61C1652C49ECC69658 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerCatalog.swift; sourceTree = "<group>"; };
 		B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListModelsTool.swift; sourceTree = "<group>"; };
 		B5C2AB90FC12D1B83D6691F4 /* ArtifactStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactStore.swift; sourceTree = "<group>"; };
 		B7C7712D68B2782589312766 /* ControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelView.swift; sourceTree = "<group>"; };
@@ -652,6 +659,7 @@
 			isa = PBXGroup;
 			children = (
 				8C5D77458EF56DD1B8F4AE17 /* MCPHostManager.swift */,
+				B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */,
 			);
 			path = MCP;
 			sourceTree = "<group>";
@@ -868,6 +876,7 @@
 				530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */,
 				31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */,
 				F553434CA19B929108FF740F /* ChatView.swift */,
+				39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */,
 				967B3678137E2B152FAC9838 /* Tools */,
 			);
 			path = Chat;
@@ -889,6 +898,7 @@
 				AFA5142DB692E378ADE8DFA0 /* ChatWebSearchToolTests.swift */,
 				DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */,
 				A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */,
+				908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */,
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
 				8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */,
@@ -1054,11 +1064,11 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				ED4CB78AB93E015D0BE21F7B /* NativExtensionSDK */,
 				1622B274F4DF5A85C2FDB081 /* NativServerKit */,
-				51AD42FA29E71F2450386688 /* NativTests */,
+				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				7082E254E8272A5E8D13E6F0 /* VoiceDictationExtensionRuntime */,
+				51AD42FA29E71F2450386688 /* NativTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1164,6 +1174,7 @@
 				444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */,
 				B47F34B1273BEEAA4D5DD314 /* ChatView.swift in Sources */,
 				8AD4D0675D4C4F456ACEA352 /* ChatWebSearchTool.swift in Sources */,
+				BF5A1AD007F259A2F926AF57 /* ChatWorkspacePicker.swift in Sources */,
 				FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */,
 				45BD4C408B9739ABC051A9E7 /* ControlPanelView.swift in Sources */,
 				086BC5B6FF02F0305536333B /* CustomTool.swift in Sources */,
@@ -1190,6 +1201,7 @@
 				482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */,
 				2452C5D7B24CA5FF6FAA36E2 /* MCPHostManager.swift in Sources */,
 				6C872B0124611E3D0297E2FD /* MCPSectionView.swift in Sources */,
+				4572BDBE09CB7D688B8838CA /* MCPServerCatalog.swift in Sources */,
 				A1492AA9B1D71B4E57310EF6 /* MLXImageModelResolver.swift in Sources */,
 				DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */,
 				052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */,
@@ -1268,6 +1280,7 @@
 				9E5AB6D42F995E0A78C4EA79 /* HubModelSizeResolver.swift in Sources */,
 				A2DF29E907CC0CEF6EF86FBD /* HuggingFaceCache.swift in Sources */,
 				0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */,
+				E5DF6B83A09106489F564CED /* HuggingFaceCuratedModelLoaderTests.swift in Sources */,
 				D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */,
 				237BB8D2F99FFE536CF0421B /* ImageGenerationViewModel.swift in Sources */,
 				41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */,
@@ -1277,6 +1290,7 @@
 				4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */,
 				4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */,
 				9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */,
+				2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */,
 				B2B154008527C6291C17AC93 /* MLXImageModelResolver.swift in Sources */,
 				EF3678F684519D8ADC625B20 /* MLXImageModelResolverTests.swift in Sources */,
 				F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */,

--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -182,7 +182,7 @@ private struct KitDetailView: View {
             ForEach(kit.mcpEntries) { entry in
                 KitPartRow(
                     symbol: entry.symbol,
-                    tint: entry.tint,
+                    tint: .nativTint(entry.tintName),
                     logoAssetName: entry.logoAssetName,
                     title: entry.name,
                     subtitle: entry.summary,
@@ -225,19 +225,13 @@ private struct KitDetailView: View {
     // MARK: Bindings
 
     private func mcpBinding(_ entry: MCPCatalogEntry) -> Binding<Bool> {
-        // Match by launch identity (command + arguments), not name, so the
-        // toggle never targets an unrelated server that shares a name.
-        func matches(_ server: MCPServerConfig) -> Bool {
-            server.command == entry.command && server.arguments == entry.arguments
-        }
+        let catalog = MCPServerCatalog.bundled
         return Binding(
-            get: { model.settings.mcpServers.first(where: matches)?.isEnabled ?? false },
+            get: { catalog.isEnabled(entry, in: model.settings.mcpServers) },
             set: { newValue in
-                if let index = model.settings.mcpServers.firstIndex(where: matches) {
-                    model.settings.mcpServers[index].isEnabled = newValue
-                } else if newValue {
-                    model.settings.mcpServers.append(entry.makeConfig())
-                }
+                var servers = model.settings.mcpServers
+                catalog.setEnabled(newValue, for: entry, in: &servers)
+                model.settings.mcpServers = servers
             }
         )
     }

--- a/Sources/Nativ/Features/Extensions/MCPSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/MCPSectionView.swift
@@ -5,44 +5,49 @@ struct MCPSectionView: View {
     @ObservedObject var host: MCPHostManager
     @ObservedObject var model: NativModel
     @State private var editing: MCPServerConfig?
-    @State private var showingCatalog = false
     @State private var pendingDelete: MCPServerConfig?
+
+    private let catalog = MCPServerCatalog.bundled
 
     var body: some View {
         HubSectionScaffold(
             title: "MCP",
             subtitle: "Connect Model Context Protocol servers so tool-capable models can use their tools."
         ) {
-            HStack(spacing: 8) {
-                Button {
-                    showingCatalog = true
-                } label: {
-                    Label("Browse catalog", systemImage: "square.grid.2x2")
-                }
-                Button {
-                    editing = MCPServerConfig(name: "", isEnabled: true)
-                } label: {
-                    Label("Add your own", systemImage: "plus")
-                }
+            Button {
+                editing = MCPServerConfig(name: "", isEnabled: true)
+            } label: {
+                Label("Add your own", systemImage: "plus")
             }
         } content: {
-            if visibleServers.isEmpty {
+            if catalog.entries.isEmpty && customServers.isEmpty {
                 HubEmptyHint(
                     icon: "server.rack",
-                    text: "No servers yet. Add your own, or browse the community catalog of approved servers."
+                    text: "No built-in servers are available. You can still add your own MCP server."
                 )
             } else {
-                VStack(spacing: 0) {
-                    ForEach(Array(visibleServers.enumerated()), id: \.element.id) { index, server in
-                        if index > 0 { Divider() }
-                        MCPServerRow(
-                            server: server,
-                            state: host.states[server.id],
-                            onToggle: { toggle(server) },
-                            onReconnect: { host.reconnect(server.id) },
-                            onEdit: { editing = server },
-                            onDelete: { pendingDelete = server }
-                        )
+                VStack(alignment: .leading, spacing: 22) {
+                    if !catalog.entries.isEmpty {
+                        serverGroup(title: "Built in") {
+                            ForEach(Array(catalog.entries.enumerated()), id: \.element.id) { index, entry in
+                                if index > 0 { Divider() }
+                                builtInServerRow(entry)
+                            }
+                        }
+                    }
+
+                    serverGroup(title: "Custom") {
+                        if customServers.isEmpty {
+                            Text("No custom servers added.")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                                .padding(.vertical, 11)
+                        } else {
+                            ForEach(Array(customServers.enumerated()), id: \.element.id) { index, server in
+                                if index > 0 { Divider() }
+                                configuredServerRow(server)
+                            }
+                        }
                     }
                 }
             }
@@ -53,13 +58,6 @@ struct MCPSectionView: View {
                 editing = nil
             } onCancel: {
                 editing = nil
-            }
-        }
-        .sheet(isPresented: $showingCatalog) {
-            MCPCatalogView(
-                installedNames: Set(model.settings.mcpServers.map(\.name))
-            ) { entry in
-                save(entry.makeConfig())
             }
         }
         .alert(
@@ -83,12 +81,62 @@ struct MCPSectionView: View {
         }
     }
 
-    /// Servers with an actual command — a command-less entry can't launch, so
-    /// it's not shown as an option (it does nothing).
-    private var visibleServers: [MCPServerConfig] {
-        model.settings.mcpServers.filter {
+    private var customServers: [MCPServerConfig] {
+        catalog.customServers(in: model.settings.mcpServers).filter {
             !$0.command.trimmingCharacters(in: .whitespaces).isEmpty
         }
+    }
+
+    @ViewBuilder
+    private func serverGroup<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 6)
+            content()
+        }
+    }
+
+    private func builtInServerRow(_ entry: MCPCatalogEntry) -> some View {
+        let configured = catalog.configuredServer(
+            for: entry,
+            in: model.settings.mcpServers
+        )
+        let presentation = configured ?? entry.makeConfiguration(isEnabled: false)
+
+        return MCPServerRow(
+            server: presentation,
+            state: configured.flatMap { host.states[$0.id] } ?? .disabled,
+            onToggle: { toggle(entry) },
+            onReconnect: configured.map { server in { host.reconnect(server.id) } },
+            onEdit: { editing = presentation },
+            onDelete: configured.map { server in { pendingDelete = server } }
+        )
+    }
+
+    private func configuredServerRow(_ server: MCPServerConfig) -> some View {
+        MCPServerRow(
+            server: server,
+            state: host.states[server.id],
+            onToggle: { toggle(server) },
+            onReconnect: { host.reconnect(server.id) },
+            onEdit: { editing = server },
+            onDelete: { pendingDelete = server }
+        )
+    }
+
+    private func toggle(_ entry: MCPCatalogEntry) {
+        var servers = model.settings.mcpServers
+        catalog.setEnabled(
+            !catalog.isEnabled(entry, in: servers),
+            for: entry,
+            in: &servers
+        )
+        model.settings.mcpServers = servers
     }
 
     private func toggle(_ server: MCPServerConfig) {
@@ -115,9 +163,9 @@ private struct MCPServerRow: View {
     let server: MCPServerConfig
     let state: MCPServerConnectionState?
     let onToggle: () -> Void
-    let onReconnect: () -> Void
+    let onReconnect: (() -> Void)?
     let onEdit: () -> Void
-    let onDelete: () -> Void
+    let onDelete: (() -> Void)?
 
     var body: some View {
         HStack(spacing: 12) {
@@ -130,7 +178,7 @@ private struct MCPServerRow: View {
                     .foregroundStyle(.secondary)
             }
             Spacer(minLength: 12)
-            if server.isEnabled {
+            if server.isEnabled, let onReconnect {
                 Button(action: onReconnect) {
                     Image(systemName: "arrow.clockwise")
                 }
@@ -144,16 +192,18 @@ private struct MCPServerRow: View {
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
             .help("Edit")
-            Menu {
-                Button(role: .destructive, action: onDelete) {
-                    Label("Delete", systemImage: "trash")
+            if let onDelete {
+                Menu {
+                    Button(role: .destructive, action: onDelete) {
+                        Label("Delete", systemImage: "trash")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
                 }
-            } label: {
-                Image(systemName: "ellipsis")
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 22)
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .frame(width: 22)
             Toggle("", isOn: Binding(get: { server.isEnabled }, set: { _ in onToggle() }))
                 .labelsHidden()
                 .toggleStyle(.switch)
@@ -389,150 +439,5 @@ private struct MCPServerEditor: View {
         } catch {
             jsonError = "Invalid JSON: \(error.localizedDescription)"
         }
-    }
-}
-
-// MARK: - Community catalog
-//
-// A catalog entry is contributed to `Resources/MCPCatalog.json`, plus an
-// optional logo image (dropped into Assets.xcassets as `MCPLogo-<name>`).
-// Every entry must pass the `verify-mcp-catalog` CI check — the server is
-// launched over stdio and has to complete an MCP handshake and list at least
-// one tool — before it can merge. Until a logo asset exists we render a tinted
-// glyph tile so the grid always looks complete. See Docs/mcp-catalog.md.
-
-struct MCPCatalogEntry: Identifiable, Decodable {
-    let id: String
-    let name: String
-    let summary: String
-    let command: String
-    let arguments: [String]
-    let symbol: String
-    let tint: Color
-    var logoAssetName: String { "MCPLogo-\(name)" }
-
-    private enum CodingKeys: String, CodingKey {
-        case id, name, summary, command
-        case arguments = "args"
-        case symbol, tint
-    }
-
-    init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        id = try c.decode(String.self, forKey: .id)
-        name = try c.decode(String.self, forKey: .name)
-        summary = try c.decode(String.self, forKey: .summary)
-        command = try c.decode(String.self, forKey: .command)
-        arguments = try c.decodeIfPresent([String].self, forKey: .arguments) ?? []
-        symbol = try c.decodeIfPresent(String.self, forKey: .symbol) ?? "server.rack"
-        let tintName = try c.decodeIfPresent(String.self, forKey: .tint) ?? "accent"
-        tint = .nativTint(tintName)
-    }
-
-    func makeConfig() -> MCPServerConfig {
-        MCPServerConfig(name: name, command: command, arguments: arguments, isEnabled: true)
-    }
-
-    /// The community catalog, decoded once from the bundled `MCPCatalog.json`.
-    static let catalog: [MCPCatalogEntry] = {
-        guard let url = Bundle.main.url(forResource: "MCPCatalog", withExtension: "json"),
-              let data = try? Data(contentsOf: url),
-              let entries = try? JSONDecoder().decode([MCPCatalogEntry].self, from: data)
-        else { return [] }
-        return entries
-    }()
-}
-
-private let mcpCatalog = MCPCatalogEntry.catalog
-
-private struct MCPCatalogView: View {
-    let installedNames: Set<String>
-    let onAdd: (MCPCatalogEntry) -> Void
-    @Environment(\.dismiss) private var dismiss
-
-    private let columns = [GridItem(.adaptive(minimum: 220, maximum: 300), spacing: 14)]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("Community catalog")
-                        .font(.system(size: 17, weight: .semibold))
-                    Text("Native-sponsored servers, approved and merged into Nativ. Adding one launches it locally the first time you connect.")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer(minLength: 16)
-                NativHoverCloseButton { dismiss() }
-            }
-            .padding(24)
-
-            ScrollView {
-                LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
-                    ForEach(mcpCatalog) { entry in
-                        MCPCatalogCard(
-                            entry: entry,
-                            isAdded: installedNames.contains(entry.name),
-                            onAdd: { onAdd(entry) }
-                        )
-                    }
-                }
-                .padding(.horizontal, 24)
-                .padding(.bottom, 24)
-            }
-        }
-        .frame(width: 720, height: 560)
-    }
-}
-
-private struct MCPCatalogCard: View {
-    let entry: MCPCatalogEntry
-    let isAdded: Bool
-    let onAdd: () -> Void
-    @State private var hovering = false
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 6) {
-                NativTintedIconTile(symbol: entry.symbol, tint: entry.tint, logoAssetName: entry.logoAssetName)
-                Spacer(minLength: 0)
-                Image(systemName: "checkmark.seal.fill")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.tint)
-                    .help("Native-sponsored")
-            }
-            VStack(alignment: .leading, spacing: 3) {
-                Text(entry.name)
-                    .font(.system(size: 14, weight: .semibold))
-                Text(entry.summary)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 4)
-            if isAdded {
-                Label("Added", systemImage: "checkmark")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
-            } else {
-                Button(action: onAdd) {
-                    Label("Add", systemImage: "plus")
-                        .font(.system(size: 12, weight: .medium))
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
-        }
-        .padding(14)
-        .frame(height: 168, alignment: .topLeading)
-        .background(Color.primary.opacity(hovering ? 0.05 : 0.025), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        )
-        .onHover { hovering = $0 }
     }
 }

--- a/Sources/Nativ/Features/Extensions/MCPSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/MCPSectionView.swift
@@ -93,8 +93,8 @@ struct MCPSectionView: View {
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(title.uppercased())
-                .font(.system(size: 10, weight: .semibold))
+            Text(title)
+                .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .padding(.bottom, 6)
             content()

--- a/Sources/Nativ/Features/Extensions/NativKit.swift
+++ b/Sources/Nativ/Features/Extensions/NativKit.swift
@@ -1,4 +1,3 @@
-import NativServerKit
 import SwiftUI
 
 // A Kit is a ready-made setup: a curated bundle of MCP servers, their tools,
@@ -17,7 +16,7 @@ struct NativKit: Identifiable {
 
     /// Catalog MCP entries this kit references, in listed order.
     var mcpEntries: [MCPCatalogEntry] {
-        mcpServerIDs.compactMap { id in MCPCatalogEntry.catalog.first { $0.id == id } }
+        mcpServerIDs.compactMap { MCPServerCatalog.bundled.entry(id: $0) }
     }
 
     /// A one-line inventory of what the kit turns on.
@@ -124,13 +123,12 @@ enum NativKitActivation {
         model: NativModel,
         manager: NativExtensionManager
     ) {
+        let catalog = MCPServerCatalog.bundled
+        var servers = model.settings.mcpServers
         for entry in kit.mcpEntries {
-            if let index = matchingServerIndex(for: entry, in: model.settings.mcpServers) {
-                model.settings.mcpServers[index].isEnabled = enabled
-            } else if enabled {
-                model.settings.mcpServers.append(entry.makeConfig())
-            }
+            catalog.setEnabled(enabled, for: entry, in: &servers)
         }
+        model.settings.mcpServers = servers
 
         for skill in kit.skills {
             if let index = model.settings.skills.firstIndex(where: { $0.id == skill.id }) {
@@ -175,18 +173,7 @@ enum NativKitActivation {
         return names
     }
 
-    /// Matches a catalog entry to a configured server by launch identity
-    /// (command + arguments), so a kit never toggles an unrelated server that
-    /// merely shares a name.
-    private static func matchingServerIndex(
-        for entry: MCPCatalogEntry,
-        in servers: [MCPServerConfig]
-    ) -> Int? {
-        servers.firstIndex { $0.command == entry.command && $0.arguments == entry.arguments }
-    }
-
     private static func isServerEnabled(_ entry: MCPCatalogEntry, in model: NativModel) -> Bool {
-        guard let index = matchingServerIndex(for: entry, in: model.settings.mcpServers) else { return false }
-        return model.settings.mcpServers[index].isEnabled
+        MCPServerCatalog.bundled.isEnabled(entry, in: model.settings.mcpServers)
     }
 }

--- a/Sources/Nativ/Features/MCP/MCPServerCatalog.swift
+++ b/Sources/Nativ/Features/MCP/MCPServerCatalog.swift
@@ -1,0 +1,224 @@
+import Foundation
+import NativServerKit
+
+struct MCPCatalogEntry: Decodable, Equatable, Identifiable, Sendable {
+    let id: String
+    let name: String
+    let summary: String
+    let command: String
+    let arguments: [String]
+    let symbol: String
+    let tintName: String
+    let requiredEnvironment: [String]
+    let sourceURL: String?
+
+    var logoAssetName: String { "MCPLogo-\(name)" }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, summary, command, symbol, sourceURL
+        case arguments = "args"
+        case tintName = "tint"
+        case requiredEnvironment = "requiredEnv"
+    }
+
+    init(
+        id: String,
+        name: String,
+        summary: String,
+        command: String,
+        arguments: [String] = [],
+        symbol: String = "server.rack",
+        tintName: String = "accent",
+        requiredEnvironment: [String] = [],
+        sourceURL: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.summary = summary
+        self.command = command
+        self.arguments = arguments
+        self.symbol = symbol
+        self.tintName = tintName
+        self.requiredEnvironment = requiredEnvironment
+        self.sourceURL = sourceURL
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        summary = try container.decode(String.self, forKey: .summary)
+        command = try container.decode(String.self, forKey: .command)
+        arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
+        symbol = try container.decodeIfPresent(String.self, forKey: .symbol) ?? "server.rack"
+        tintName = try container.decodeIfPresent(String.self, forKey: .tintName) ?? "accent"
+        requiredEnvironment = try container.decodeIfPresent(
+            [String].self,
+            forKey: .requiredEnvironment
+        ) ?? []
+        sourceURL = try container.decodeIfPresent(String.self, forKey: .sourceURL)
+    }
+
+    func makeConfiguration(isEnabled: Bool = true) -> MCPServerConfig {
+        MCPServerConfig(
+            catalogID: id,
+            name: name,
+            command: command,
+            arguments: arguments,
+            isEnabled: isEnabled
+        )
+    }
+}
+
+enum MCPServerCatalogError: Error, Equatable {
+    case duplicateIdentifier(String)
+    case duplicateLaunchConfiguration(String)
+}
+
+/// Immutable index of the MCP servers supplied with Nativ.
+///
+/// Catalog identifiers are the durable identity. Launch configuration matching
+/// exists only to adopt settings created before `MCPServerConfig.catalogID` was
+/// introduced.
+struct MCPServerCatalog: Sendable {
+    static let bundled: MCPServerCatalog = {
+        guard let url = Bundle.main.url(forResource: "MCPCatalog", withExtension: "json") else {
+            assertionFailure("MCPCatalog.json is missing from the application bundle")
+            return .empty
+        }
+
+        do {
+            let entries = try JSONDecoder().decode(
+                [MCPCatalogEntry].self,
+                from: Data(contentsOf: url)
+            )
+            return try MCPServerCatalog(entries: entries)
+        } catch {
+            assertionFailure("Could not load MCPCatalog.json: \(error)")
+            return .empty
+        }
+    }()
+
+    static let empty = MCPServerCatalog(
+        entries: [],
+        entriesByID: [:],
+        entryIDsByLaunchConfiguration: [:]
+    )
+
+    let entries: [MCPCatalogEntry]
+
+    private let entriesByID: [String: MCPCatalogEntry]
+    private let entryIDsByLaunchConfiguration: [LaunchConfiguration: String]
+
+    init(entries: [MCPCatalogEntry]) throws {
+        var entriesByID: [String: MCPCatalogEntry] = [:]
+        var entryIDsByLaunchConfiguration: [LaunchConfiguration: String] = [:]
+
+        for entry in entries {
+            guard entriesByID.updateValue(entry, forKey: entry.id) == nil else {
+                throw MCPServerCatalogError.duplicateIdentifier(entry.id)
+            }
+
+            let launchConfiguration = LaunchConfiguration(entry: entry)
+            guard entryIDsByLaunchConfiguration.updateValue(
+                entry.id,
+                forKey: launchConfiguration
+            ) == nil else {
+                throw MCPServerCatalogError.duplicateLaunchConfiguration(entry.command)
+            }
+        }
+
+        self.init(
+            entries: entries,
+            entriesByID: entriesByID,
+            entryIDsByLaunchConfiguration: entryIDsByLaunchConfiguration
+        )
+    }
+
+    func entry(id: String) -> MCPCatalogEntry? {
+        entriesByID[id]
+    }
+
+    func entry(matching server: MCPServerConfig) -> MCPCatalogEntry? {
+        if let catalogID = server.catalogID {
+            return entriesByID[catalogID]
+        }
+
+        let launchConfiguration = LaunchConfiguration(server: server)
+        guard let entryID = entryIDsByLaunchConfiguration[launchConfiguration] else {
+            return nil
+        }
+        return entriesByID[entryID]
+    }
+
+    func configuredServer(
+        for entry: MCPCatalogEntry,
+        in servers: [MCPServerConfig]
+    ) -> MCPServerConfig? {
+        configurationIndex(for: entry, in: servers).map { servers[$0] }
+    }
+
+    func isEnabled(_ entry: MCPCatalogEntry, in servers: [MCPServerConfig]) -> Bool {
+        configuredServer(for: entry, in: servers)?.isEnabled == true
+    }
+
+    /// Enables or disables a built-in server without duplicating legacy settings.
+    /// Disabling an unconfigured server is a no-op; enabling it installs the
+    /// catalog defaults and records its stable catalog identity.
+    func setEnabled(
+        _ enabled: Bool,
+        for entry: MCPCatalogEntry,
+        in servers: inout [MCPServerConfig]
+    ) {
+        if let index = configurationIndex(for: entry, in: servers) {
+            servers[index].catalogID = entry.id
+            servers[index].isEnabled = enabled
+        } else if enabled {
+            servers.append(entry.makeConfiguration())
+        }
+    }
+
+    func customServers(in servers: [MCPServerConfig]) -> [MCPServerConfig] {
+        servers.filter { entry(matching: $0) == nil }
+    }
+
+    private init(
+        entries: [MCPCatalogEntry],
+        entriesByID: [String: MCPCatalogEntry],
+        entryIDsByLaunchConfiguration: [LaunchConfiguration: String]
+    ) {
+        self.entries = entries
+        self.entriesByID = entriesByID
+        self.entryIDsByLaunchConfiguration = entryIDsByLaunchConfiguration
+    }
+
+    private func configurationIndex(
+        for entry: MCPCatalogEntry,
+        in servers: [MCPServerConfig]
+    ) -> Int? {
+        if let index = servers.firstIndex(where: { $0.catalogID == entry.id }) {
+            return index
+        }
+
+        let expectedLaunchConfiguration = LaunchConfiguration(entry: entry)
+        return servers.firstIndex {
+            $0.catalogID == nil
+                && LaunchConfiguration(server: $0) == expectedLaunchConfiguration
+        }
+    }
+
+    private struct LaunchConfiguration: Hashable, Sendable {
+        let command: String
+        let arguments: [String]
+
+        init(entry: MCPCatalogEntry) {
+            command = entry.command
+            arguments = entry.arguments
+        }
+
+        init(server: MCPServerConfig) {
+            command = server.command
+            arguments = server.arguments
+        }
+    }
+}

--- a/Sources/NativServerKit/MCPServerConfig.swift
+++ b/Sources/NativServerKit/MCPServerConfig.swift
@@ -2,6 +2,9 @@ import Foundation
 
 public struct MCPServerConfig: Codable, Equatable, Identifiable, Sendable {
     public var id: UUID
+    /// Stable identifier for configurations supplied by Nativ's built-in catalog.
+    /// Custom configurations leave this nil.
+    public var catalogID: String?
     public var name: String
     public var command: String
     public var arguments: [String]
@@ -10,6 +13,7 @@ public struct MCPServerConfig: Codable, Equatable, Identifiable, Sendable {
 
     public init(
         id: UUID = UUID(),
+        catalogID: String? = nil,
         name: String = "",
         command: String = "",
         arguments: [String] = [],
@@ -17,6 +21,7 @@ public struct MCPServerConfig: Codable, Equatable, Identifiable, Sendable {
         isEnabled: Bool = true
     ) {
         self.id = id
+        self.catalogID = catalogID
         self.name = name
         self.command = command
         self.arguments = arguments

--- a/project.yml
+++ b/project.yml
@@ -169,6 +169,7 @@ targets:
       - path: Sources/Nativ/Features/VoiceCapture/VoiceAnimationPreferences.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
       - path: Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
+      - path: Sources/Nativ/Features/MCP/MCPServerCatalog.swift
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift


### PR DESCRIPTION
- remove the extra MCP catalog modal
- display built-in MCP servers directly on the MCP page
- separate built-in and custom server configurations

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/17364a40-1178-4875-83d1-2a7f90d6d662" />
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/ecacb8c6-8671-42df-a2fd-fb59997bb5ac" />
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/a5b602d1-a636-48a1-bbfc-490f85d222b0" />
