### PR TITLE
improving markdown rendering in chat

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		D76DC0072E523E6409DF1176 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 730B64747E8A780CD14AF88F /* Textual */; };
 		D8838254D03112C2EABE37AC /* ModelPrimaryTaskResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */; };
 		D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
+		D94A6B329A8D7D3285147914 /* MarkdownFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */; };
 		DC1ED6C1A11081FB70F1F019 /* NativImageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */; };
 		DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677360D86DDAFAB194A995E7 /* Main.swift */; };
 		DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */; };
@@ -189,6 +190,7 @@
 		E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */; };
 		E77359B5F8F6AF656F2008C6 /* Exa.png in Resources */ = {isa = PBXBuildFile; fileRef = 995095FAF89C9D1DEC4158FB /* Exa.png */; };
 		E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41417C210BF817681A8C6D87 /* IntegrationsView.swift */; };
+		E9ED405A9BC0BC4AA8884860 /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */; };
 		EB19103900BE04518CBFF993 /* WebSearchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295CCB27C6CBD1025E62D11 /* WebSearchSettingsView.swift */; };
 		ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
 		ED6BDF238125ABAB48A4227D /* RoutineSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90012E8ECF43A5A55BFD8787 /* RoutineSupport.swift */; };
@@ -379,6 +381,7 @@
 		A118DF27AE0EF852DC458BB7 /* AudioInputVolumeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputVolumeController.swift; sourceTree = "<group>"; };
 		A1389B0FCBFE26464CD80041 /* Brave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Brave.png; sourceTree = "<group>"; };
 		A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationServicesTests.swift; sourceTree = "<group>"; };
+		A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormattingTests.swift; sourceTree = "<group>"; };
 		A55A33BE26A6AF77B69C0430 /* ArtifactSearchIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSearchIndex.swift; sourceTree = "<group>"; };
 		A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceCacheTests.swift; sourceTree = "<group>"; };
 		A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSystemStatsTool.swift; sourceTree = "<group>"; };
@@ -902,6 +905,7 @@
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
 				8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */,
+				A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */,
 				3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */,
 				2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */,
 				E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */,
@@ -1293,6 +1297,8 @@
 				2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */,
 				B2B154008527C6291C17AC93 /* MLXImageModelResolver.swift in Sources */,
 				EF3678F684519D8ADC625B20 /* MLXImageModelResolverTests.swift in Sources */,
+				E9ED405A9BC0BC4AA8884860 /* MarkdownFormatting.swift in Sources */,
+				D94A6B329A8D7D3285147914 /* MarkdownFormattingTests.swift in Sources */,
 				F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */,
 				D8838254D03112C2EABE37AC /* ModelPrimaryTaskResolverTests.swift in Sources */,
 				252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -3434,32 +3434,26 @@ private struct ChatMessageText: View {
                 content: content,
                 fontScale: chatFontScale
             )
-        } else if rendersMarkdown && !isStreaming {
+        } else if rendersMarkdown {
             StructuredText(
-                markdown: NativMarkdownFormatting.normalizedMathDelimiters(in: content),
+                markdown: NativMarkdownFormatting.normalizedMathDelimiters(in: renderableMarkdown),
                 syntaxExtensions: [.math]
             )
             .textual.structuredTextStyle(.gitHub)
             .textual.textSelection(.enabled)
             .font(ChatFontMetrics.bodyFont(scale: chatFontScale))
         } else {
-            renderedText
+            Text(content)
                 .textSelection(.enabled)
                 .font(ChatFontMetrics.bodyFont(scale: chatFontScale))
         }
     }
 
-    private var renderedText: Text {
-        guard rendersMarkdown,
-              let attributed = try? AttributedString(
-                markdown: content,
-                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-              )
-        else {
-            return Text(content)
+    private var renderableMarkdown: String {
+        guard isStreaming else {
+            return content
         }
-
-        return Text(attributed)
+        return NativMarkdownFormatting.streamingMarkdown(of: content)
     }
 }
 

--- a/Sources/Nativ/Utilities/MarkdownFormatting.swift
+++ b/Sources/Nativ/Utilities/MarkdownFormatting.swift
@@ -36,6 +36,42 @@ enum NativMarkdownFormatting {
         return normalizedLines.joined(separator: "\n")
     }
 
+    static func streamingMarkdown(of markdown: String) -> String {
+        guard !markdown.isEmpty else {
+            return markdown
+        }
+
+        let lines = markdown.components(separatedBy: "\n")
+        var activeFence: CodeFence?
+        var fenceOpenedAtLine: Int?
+
+        for (offset, line) in lines.enumerated() {
+            if let fence = activeFence {
+                if isClosingFence(line, for: fence) {
+                    activeFence = nil
+                    fenceOpenedAtLine = nil
+                }
+                continue
+            }
+            if let openingFence = codeFence(in: line) {
+                activeFence = openingFence
+                fenceOpenedAtLine = offset
+            }
+        }
+
+        guard let fence = activeFence, let openedAt = fenceOpenedAtLine else {
+            return markdown
+        }
+
+        let bodyLines = lines[lines.index(after: openedAt)...]
+        guard bodyLines.contains(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+        else {
+            return lines.prefix(openedAt).joined(separator: "\n")
+        }
+
+        return markdown + "\n" + String(repeating: String(fence.marker), count: fence.length)
+    }
+
     private struct CodeFence {
         let marker: Character
         let length: Int

--- a/Tests/NativTests/MarkdownFormattingTests.swift
+++ b/Tests/NativTests/MarkdownFormattingTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import XCTest
+
+final class MarkdownStreamingTests: XCTestCase {
+    private func streaming(_ markdown: String) -> String {
+        NativMarkdownFormatting.streamingMarkdown(of: markdown)
+    }
+
+    private func openFenceCount(in markdown: String) -> Int {
+        var open = 0
+        var marker: Character?
+        var length = 0
+        for line in markdown.components(separatedBy: "\n") {
+            let trimmed = line.drop(while: { $0 == " " })
+            guard let first = trimmed.first, first == "`" || first == "~" else { continue }
+            let run = trimmed.prefix(while: { $0 == first }).count
+            guard run >= 3 else { continue }
+            if let active = marker {
+                guard first == active, run >= length else { continue }
+                guard trimmed.dropFirst(run).allSatisfy({ $0 == " " || $0 == "\t" }) else {
+                    continue
+                }
+                marker = nil
+                open -= 1
+            } else {
+                marker = first
+                length = run
+                open += 1
+            }
+        }
+        return open
+    }
+
+    func testEmptyInputIsUnchanged() {
+        XCTAssertEqual(streaming(""), "")
+    }
+
+    func testTextWithoutFencesIsUnchanged() {
+        let source = "# Title\n\nA partially written paragr"
+        XCTAssertEqual(streaming(source), source)
+    }
+
+    func testBalancedFencesAreUnchanged() {
+        let source = "Intro\n\n```swift\nlet a = 1\n```\n\nOutro"
+        XCTAssertEqual(streaming(source), source)
+    }
+
+    func testOpenFenceIsClosedSoCodeRendersWhileStreaming() {
+        XCTAssertEqual(
+            streaming("Here:\n\n```swift\nlet a = 1\nlet b = 2"),
+            "Here:\n\n```swift\nlet a = 1\nlet b = 2\n```"
+        )
+    }
+
+    func testFenceOpenerWithoutBodyIsWithheld() {
+        XCTAssertEqual(streaming("Intro\n\n```swift"), "Intro\n")
+        XCTAssertEqual(streaming("Intro\n\n```swift\n"), "Intro\n")
+        XCTAssertEqual(streaming("```"), "")
+    }
+
+    func testClosingFenceMatchesTheOpeningMarkerAndLength() {
+        XCTAssertEqual(streaming("~~~\nx = 1"), "~~~\nx = 1\n~~~")
+        XCTAssertEqual(streaming("````\nnested ``` here"), "````\nnested ``` here\n````")
+    }
+
+    func testOnlyTheLastUnclosedFenceIsClosed() {
+        XCTAssertEqual(
+            streaming("```\nfirst\n```\n\n```py\nsecond"),
+            "```\nfirst\n```\n\n```py\nsecond\n```"
+        )
+    }
+
+    func testBlankLinesInsideAFenceStayInsideIt() {
+        XCTAssertEqual(streaming("```\nfirst\n\nsecond"), "```\nfirst\n\nsecond\n```")
+    }
+
+    func testEveryStreamPrefixRendersWithBalancedFences() {
+        let corpus = [
+            "# Report\n\nIntro line.\n\n```swift\nlet x = 1\n```\n\n- one\n- two\n\nDone.",
+            "no fences at all, just prose",
+            "~~~\nraw\n~~~\n\nmore text\n\n> a quote",
+            "````\nouter\n```\ninner\n```\n````\ntail",
+            "text\n\n   ```js\n   indented()\n   ```\n\nend"
+        ]
+        for text in corpus {
+            for length in 1...text.count {
+                let source = String(text.prefix(length))
+                XCTAssertEqual(
+                    openFenceCount(in: streaming(source)),
+                    0,
+                    "unbalanced fence at length \(length) of \(text.debugDescription)"
+                )
+            }
+        }
+    }
+
+    func testEveryStreamPrefixOnlyAddsAClosingFenceOrTrimsAnEmptyOpener() {
+        let text = "Intro\n\n```swift\nlet x = 1\n```\n\nOutro\n\n~~~\ntail"
+        for length in 1...text.count {
+            let source = String(text.prefix(length))
+            let result = streaming(source)
+            let addedClosing = result.hasPrefix(source)
+            let trimmedOpener = source.hasPrefix(result)
+            XCTAssertTrue(
+                addedClosing || trimmedOpener,
+                "result diverged from the source at length \(length)"
+            )
+        }
+    }
+
+    func testCompletedMarkdownIsNeverAltered() {
+        let text = "# Report\n\nIntro line.\n\n```swift\nlet x = 1\n```\n\n- one\n- two\n"
+        XCTAssertEqual(streaming(text), text)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -189,6 +189,7 @@ targets:
       - path: Sources/Nativ/Features/Dashboard/NativAnalyticsStore.swift
       - path: Sources/Nativ/NativModel.swift
       - path: Sources/Nativ/Utilities/Formatting.swift
+      - path: Sources/Nativ/Utilities/MarkdownFormatting.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceHub.swift
       - path: Sources/Nativ/Features/Chat/ChatScreenCapture.swift
     dependencies:


### PR DESCRIPTION
Assistant replies streamed as raw text (visible `##`, `-`, and ```) and only snapped into styled markdown once the response finished. Now the streaming buffer goes through the same renderer, with an unterminated code fence closed virtually so code blocks render styled as they arrive.