### PR TITLE
Recover from a frozen chat instead of locking the UI

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -2301,8 +2301,11 @@ struct ControlPanelView: View {
 
     private func isRecentDeleteDisabled(_ recent: ControlPanelRecentSession) -> Bool {
         switch recent.selection {
-        case .chat(let sessionID):
-            return chat.isSessionBusy(sessionID)
+        case .chat:
+            // Deleting a chat now cancels its in-flight request first, so a busy
+            // session is safe to remove. Disabling this button left a chat whose
+            // stream never finished permanently undeletable.
+            return false
         case .imageGeneration:
             return imageGeneration.isGenerating
         case .tab, .extensionPage:

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1068,6 +1068,10 @@ final class ChatViewModel: ObservableObject {
         activeTask = nil
     }
 
+    private func ownsActiveRequest(_ requestID: UUID) -> Bool {
+        activeRequestID == requestID
+    }
+
     func prioritizeQueuedRequest(_ requestID: UUID) {
         guard let index = requestQueue.firstIndex(where: { $0.id == requestID }), index > 0 else {
             return
@@ -1225,21 +1229,31 @@ final class ChatViewModel: ObservableObject {
                 // the session marked busy forever, which is what made a frozen
                 // chat impossible to delete, stop, or switch away from.
                 defer {
+                    let ownedRequest = ownsActiveRequest(queuedRequest.id)
                     releaseActiveRequestSlot(matching: queuedRequest.id)
-                    if currentSessionID == queuedRequest.sessionID {
-                        bumpScroll()
+                    if ownedRequest {
+                        if currentSessionID == queuedRequest.sessionID {
+                            bumpScroll()
+                        }
+                        startNextRequestIfNeeded()
                     }
-                    startNextRequestIfNeeded()
                 }
 
                 do {
                     try await runChatLoop(queuedRequest)
                     appModel?.refreshMetricsIfRunning(force: true)
                 } catch is CancellationError {
-                    finishActiveAssistantAsCancelled(in: queuedRequest.sessionID)
+                    if ownsActiveRequest(queuedRequest.id) {
+                        finishActiveAssistantAsCancelled(in: queuedRequest.sessionID)
+                    }
                 } catch let error as URLError where error.code == .cancelled {
-                    finishActiveAssistantAsCancelled(in: queuedRequest.sessionID)
+                    if ownsActiveRequest(queuedRequest.id) {
+                        finishActiveAssistantAsCancelled(in: queuedRequest.sessionID)
+                    }
                 } catch {
+                    guard ownsActiveRequest(queuedRequest.id) else {
+                        return
+                    }
                     appModel?.reportModelLoadFailure(
                         modelID: queuedRequest.settings.languageModelID,
                         error: error
@@ -1557,6 +1571,9 @@ final class ChatViewModel: ObservableObject {
             }
 
             toolRounds += 1
+            guard ownsActiveRequest(queuedRequest.id) else {
+                throw CancellationError()
+            }
             assistantMessageID = UUID()
             activeAssistantMessageID = assistantMessageID
             guard insertAssistantMessage(

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -737,8 +737,10 @@ final class ChatViewModel: ObservableObject {
     }
 
     func deleteSession(_ sessionID: UUID) {
-        guard !isSessionBusy(sessionID) else {
-            return
+        // A busy session used to be undeletable, so a chat whose stream never
+        // finished could not be removed at all. Cancel its work and delete it.
+        if isSessionBusy(sessionID) {
+            cancelRequests(for: sessionID)
         }
 
         storedSessions.removeAll { $0.id == sessionID }
@@ -1025,6 +1027,45 @@ final class ChatViewModel: ObservableObject {
 
     func cancel() {
         activeTask?.cancel()
+        // Do not wait for the task to unwind: a stalled stream may stay parked in
+        // URLSession until its idle timeout fires, and the composer must become
+        // usable the moment the user asks to stop.
+        if let sessionID = activeRequestSessionID {
+            finishActiveAssistantAsCancelled(in: sessionID)
+        }
+        releaseActiveRequestSlot(matching: nil)
+        startNextRequestIfNeeded()
+    }
+
+    /// Cancels in-flight and queued work for one session, leaving other sessions
+    /// untouched.
+    private func cancelRequests(for sessionID: UUID) {
+        requestQueue.removeAll { $0.sessionID == sessionID }
+        guard activeRequestSessionID == sessionID else {
+            return
+        }
+        activeTask?.cancel()
+        finishActiveAssistantAsCancelled(in: sessionID)
+        releaseActiveRequestSlot(matching: nil)
+        startNextRequestIfNeeded()
+    }
+
+    /// Frees the single in-flight request slot.
+    ///
+    /// Pass the owning request's id to release it only if that request still owns
+    /// the slot, or `nil` to force-release whatever is active (user-driven
+    /// recovery). `activeTask` is always cleared together with the rest of the
+    /// slot so `startNextRequestIfNeeded()` can never be blocked by a handle that
+    /// outlived its request.
+    private func releaseActiveRequestSlot(matching requestID: UUID?) {
+        if let requestID, activeRequestID != requestID {
+            return
+        }
+        activeRequestID = nil
+        activeAssistantMessageID = nil
+        activeRequestSessionID = nil
+        sendingStartedAt = nil
+        activeTask = nil
     }
 
     func prioritizeQueuedRequest(_ requestID: UUID) {
@@ -1179,6 +1220,18 @@ final class ChatViewModel: ObservableObject {
                     return
                 }
 
+                // Release the in-flight slot on every exit path. Clearing it only
+                // after the request returned normally meant a stalled stream left
+                // the session marked busy forever, which is what made a frozen
+                // chat impossible to delete, stop, or switch away from.
+                defer {
+                    releaseActiveRequestSlot(matching: queuedRequest.id)
+                    if currentSessionID == queuedRequest.sessionID {
+                        bumpScroll()
+                    }
+                    startNextRequestIfNeeded()
+                }
+
                 do {
                     try await runChatLoop(queuedRequest)
                     appModel?.refreshMetricsIfRunning(force: true)
@@ -1200,19 +1253,6 @@ final class ChatViewModel: ObservableObject {
                     }
                     appModel?.refreshMetricsIfRunning(force: true)
                 }
-
-                guard activeRequestID == queuedRequest.id else {
-                    return
-                }
-                activeRequestID = nil
-                activeAssistantMessageID = nil
-                activeRequestSessionID = nil
-                sendingStartedAt = nil
-                activeTask = nil
-                if currentSessionID == queuedRequest.sessionID {
-                    bumpScroll()
-                }
-                startNextRequestIfNeeded()
             }
             return
         }

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -638,7 +638,7 @@ final class AudioCaptureLibrary: ObservableObject {
         let client = NativChatClient(
             baseURL: configuration.serverBaseURL,
             apiKey: configuration.serverAPIKey,
-            timeout: 1_800
+            resourceTimeout: 1_800
         )
         let chunks = Self.transcriptChunks(transcript, maximumCharacters: 14_000)
         var partialSummaries: [String] = []

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -46,6 +46,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
     @Published private(set) var modelSwitchInProgress = false
     @Published private(set) var modelSwitchTargetID: String?
+    private var modelSwitchWatchdog: Task<Void, Never>?
     @Published private(set) var modelLoadingProgress: Double?
     @Published private(set) var modelLoadFailure: ModelLoadFailure?
     @Published private(set) var modelPreloadMemoryWarning: ModelPreloadMemoryWarning?
@@ -1022,16 +1023,23 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     /// `modelSwitchInProgress` normally clears once metrics confirm the newly
     /// started server. When that server comes up but never serves metrics, the
     /// flag used to stay set forever, disabling the model picker and the
-    /// start/stop buttons with no way to recover short of relaunching. The
-    /// watchdog re-checks the flag and target before acting, so a stale one that
-    /// fires after a successful switch is a no-op.
+    /// start/stop buttons with no way to recover short of relaunching.
+    ///
+    /// Each switch replaces the previous watchdog, so only the newest one can
+    /// fire. Comparing the target alone is not enough: switching away from a
+    /// model and back again would otherwise let the first watchdog time out the
+    /// second switch early.
     private func armModelSwitchWatchdog(
         timeout: TimeInterval = NativModel.modelSwitchTimeout
     ) {
+        modelSwitchWatchdog?.cancel()
         let targetID = modelSwitchTargetID
-        Task { @MainActor [weak self] in
+        modelSwitchWatchdog = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(timeout))
-            guard let self,
+            // `try?` swallows the cancellation error, so check explicitly rather
+            // than acting on a watchdog that has already been replaced.
+            guard !Task.isCancelled,
+                  let self,
                   self.modelSwitchInProgress,
                   self.modelSwitchTargetID == targetID
             else {

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -41,6 +41,9 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     @Published private(set) var lastMetricsFetchAt: Date?
     @Published private(set) var allTimeStats = NativAllTimeStats()
     @Published private(set) var sessionTokenActivity: [SessionTokenActivitySample] = []
+    /// How long a model switch may stay unconfirmed before the controls unlock.
+    static let modelSwitchTimeout: TimeInterval = 180
+
     @Published private(set) var modelSwitchInProgress = false
     @Published private(set) var modelSwitchTargetID: String?
     @Published private(set) var modelLoadingProgress: Double?
@@ -611,6 +614,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
         settings = nextSettings
         modelSwitchInProgress = true
         modelSwitchTargetID = normalizedModelID
+        armModelSwitchWatchdog()
         notifyMenuStateChanged()
 
         Task { @MainActor [weak self] in
@@ -1011,5 +1015,36 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
     private func notifyMenuStateChanged() {
         onMenuStateChanged?()
+    }
+
+    /// Unlocks the model controls if a switch never reports back.
+    ///
+    /// `modelSwitchInProgress` normally clears once metrics confirm the newly
+    /// started server. When that server comes up but never serves metrics, the
+    /// flag used to stay set forever, disabling the model picker and the
+    /// start/stop buttons with no way to recover short of relaunching. The
+    /// watchdog re-checks the flag and target before acting, so a stale one that
+    /// fires after a successful switch is a no-op.
+    private func armModelSwitchWatchdog(
+        timeout: TimeInterval = NativModel.modelSwitchTimeout
+    ) {
+        let targetID = modelSwitchTargetID
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(timeout))
+            guard let self,
+                  self.modelSwitchInProgress,
+                  self.modelSwitchTargetID == targetID
+            else {
+                return
+            }
+            self.appendLog(
+                "\nModel switch did not confirm within \(Int(timeout))s; "
+                    + "unlocking model controls.\n"
+            )
+            self.modelSwitchInProgress = false
+            self.modelSwitchTargetID = nil
+            self.clearPreservedSessionStats()
+            self.notifyMenuStateChanged()
+        }
     }
 }

--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -542,18 +542,30 @@ public final class NativChatClient {
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
 
+    /// How long a streaming response may go without delivering any bytes before
+    /// the request fails. `timeoutIntervalForRequest` is an inactivity timer that
+    /// URLSession resets whenever new data arrives, so this bounds a stalled
+    /// stream without limiting a healthy one.
+    public static let defaultIdleTimeout: TimeInterval = 120
+
+    /// Total budget for one request. Long generations legitimately run for many
+    /// minutes, so this only exists to stop a connection leaking forever; stalls
+    /// are caught by `idleTimeout`, not here.
+    public static let defaultResourceTimeout: TimeInterval = 3_600
+
     public init(
         baseURL: URL = URL(string: "http://127.0.0.1:8080")!,
         apiKey: String? = nil,
-        timeout: TimeInterval = 600
+        idleTimeout: TimeInterval = NativChatClient.defaultIdleTimeout,
+        resourceTimeout: TimeInterval = NativChatClient.defaultResourceTimeout
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
-        self.timeout = timeout
+        self.timeout = idleTimeout
 
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = timeout
-        configuration.timeoutIntervalForResource = timeout
+        configuration.timeoutIntervalForRequest = idleTimeout
+        configuration.timeoutIntervalForResource = resourceTimeout
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         self.session = URLSession(configuration: configuration)
     }

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -719,13 +719,29 @@ public final class NativProcessController {
             return process
         }
 
+        // uvicorn treats SIGTERM and SIGINT as graceful shutdowns and waits for
+        // in-flight requests, so a wedged generation survives both and the app is
+        // left reporting a server it cannot stop. Escalate to SIGKILL rather than
+        // giving up, while keeping the overall wait inside `timeout` so this does
+        // not block its caller for any longer than before.
         process.terminate()
+        waitForExit(process, timeout: timeout * 0.6)
+
+        if process.isRunning {
+            process.interrupt()
+            waitForExit(process, timeout: timeout * 0.2)
+        }
+
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+            waitForExit(process, timeout: timeout * 0.2)
+        }
+    }
+
+    private func waitForExit(_ process: Process, timeout: TimeInterval) {
         let deadline = Date().addingTimeInterval(timeout)
         while process.isRunning && Date() < deadline {
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
-        }
-        if process.isRunning {
-            process.interrupt()
         }
     }
 


### PR DESCRIPTION
polishing how frozen chat is handled, had a case where if it freezes:

1. can't delete the chat b/c it's now still "loading"
2. can't start another chat
3. can't pause the model

to recreate, start server and ask model for long response, as it writes, end the server, any text written from then on freezes the entire app, only option is to quit it.

The in-flight request slot is now released on every exit path instead of only the happy one, so a stream that stalls can no longer leave a chat permanently "generating."
