### PR TITLE
Add model README details panel

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
 		04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */; };
+		060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */; };
 		086BC5B6FF02F0305536333B /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
 		088297CDFEFECD2787806AD7 /* VoiceCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */; };
 		0935A0AC0D6A6298D551EEAE /* ArtifactSemanticSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */; };
@@ -168,6 +169,7 @@
 		C89558DC65CAAEC956198688 /* ExtensionsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5BCE1A4769FE7823B5C79D /* ExtensionsHubView.swift */; };
 		C8B10834D4DF407907FCCF6C /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5919AB4E9488642C73886266 /* ShellEnvironment.swift */; };
 		C904E51D66BFED1808E18FE5 /* ChatScreenCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */; };
+		C92083D5C6AF4F5FE29A39E9 /* HuggingFaceModelReadme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */; };
 		CEE42CCB57866B76CE85E588 /* MCPServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A7ACB288953FD476C47E8 /* MCPServerConfig.swift */; };
 		D4F073244DE11FD98AD708E2 /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */; };
 		D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EF3E0B4A9EEC293EFD5F8A /* ChatImageTool.swift */; };
@@ -184,6 +186,7 @@
 		E180E254213BCD770141B872 /* VoiceAnimationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632EB67BFAC2BCBE082A3E2B /* VoiceAnimationPreferences.swift */; };
 		E1A4AA0C4AA32599FF2D54E7 /* ChatFontScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */; };
 		E30FD12D491FF35A89A52754 /* WebSearchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295CCB27C6CBD1025E62D11 /* WebSearchSettingsView.swift */; };
+		E36D43D088EF55D617BCDDBB /* HuggingFaceModelReadme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */; };
 		E407C7F9CE883C978DE7D716 /* PersistentMenuActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */; };
 		E4D299AADEA8470C37256DDE /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
 		E5DF6B83A09106489F564CED /* HuggingFaceCuratedModelLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */; };
@@ -308,6 +311,7 @@
 		27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionStateStore.swift; sourceTree = "<group>"; };
 		2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPrimaryTaskResolverTests.swift; sourceTree = "<group>"; };
 		2CF9F903E2609C4A522C19CF /* ChatConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatConfigurationView.swift; sourceTree = "<group>"; };
+		2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelReadmeTests.swift; sourceTree = "<group>"; };
 		30D9C81870FB504D03D2A1D5 /* MCPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPClient.swift; sourceTree = "<group>"; };
 		30E2A903D604A57696674510 /* NativSystemPermissionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativSystemPermissionController.swift; sourceTree = "<group>"; };
 		31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolRegistry.swift; sourceTree = "<group>"; };
@@ -439,6 +443,7 @@
 		F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPromptRevision.swift; sourceTree = "<group>"; };
 		F553434CA19B929108FF740F /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		F84C7B764CE1B6F63746E3BB /* Perplexity.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Perplexity.png; sourceTree = "<group>"; };
+		FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelReadme.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -780,6 +785,7 @@
 				1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */,
 				E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */,
 				7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */,
+				FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */,
 				EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */,
 				F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */,
 				61126D4235AFF77D82F1F80B /* MLXImageModelResolver.swift */,
@@ -902,6 +908,7 @@
 				DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */,
 				A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */,
 				908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */,
+				2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */,
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
 				8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */,
@@ -1193,6 +1200,7 @@
 				F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */,
 				7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */,
 				B55A6BE5C7B03181E2CD03D6 /* HuggingFaceHub.swift in Sources */,
+				E36D43D088EF55D617BCDDBB /* HuggingFaceModelReadme.swift in Sources */,
 				575DCB7EC96DAB35B415434C /* ImageGenerationView.swift in Sources */,
 				BC0753B567DC8935199FCDFB /* ImageGenerationViewModel.swift in Sources */,
 				2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */,
@@ -1286,6 +1294,8 @@
 				0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */,
 				E5DF6B83A09106489F564CED /* HuggingFaceCuratedModelLoaderTests.swift in Sources */,
 				D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */,
+				C92083D5C6AF4F5FE29A39E9 /* HuggingFaceModelReadme.swift in Sources */,
+				060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */,
 				237BB8D2F99FFE536CF0421B /* ImageGenerationViewModel.swift in Sources */,
 				41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */,
 				351B2202E8690FC608A32AEF /* IntegrationServicesTests.swift in Sources */,

--- a/Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
@@ -240,6 +240,10 @@ enum HuggingFaceModelReadmeFormatting {
 
     private static func normalizeHTMLFragment(_ markdown: String) -> String {
         var output = markdown
+        output = replacingMatches(in: output, pattern: "<table\\b[^>]*>(.*?)</table\\s*>") {
+            match, source in
+            markdownTable(from: capture(1, from: match, source: source))
+        }
         output = replacingMatches(in: output, pattern: "<!--.*?-->") { _, _ in "" }
         output = replacingMatches(in: output, pattern: "<(script|style|svg)\\b[^>]*>.*?</\\1\\s*>") {
             _, _ in ""
@@ -312,6 +316,103 @@ enum HuggingFaceModelReadmeFormatting {
         return output
             .replacingOccurrences(of: "[ \\t]+\\n", with: "\n", options: .regularExpression)
             .replacingOccurrences(of: "\\n(?:[ \\t]*\\n){2,}", with: "\n\n", options: .regularExpression)
+    }
+
+    private struct HTMLTableCell {
+        let text: String
+        let isHeader: Bool
+    }
+
+    /// Foundation parses GitHub-style Markdown tables but not raw HTML tables.
+    /// Translate complete rows before the general HTML cleanup so model-card
+    /// comparisons retain their columns and can scroll horizontally.
+    private static func markdownTable(from html: String) -> String {
+        guard let rowExpression = try? NSRegularExpression(
+            pattern: "<tr\\b[^>]*>(.*?)</tr\\s*>",
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ),
+        let cellExpression = try? NSRegularExpression(
+            pattern: "<(th|td)\\b([^>]*)>(.*?)</\\1\\s*>",
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return ""
+        }
+
+        let source = html as NSString
+        let rowMatches = rowExpression.matches(
+            in: html,
+            range: NSRange(location: 0, length: source.length)
+        )
+        var rows: [[HTMLTableCell]] = []
+        var columnCount = 0
+
+        for rowMatch in rowMatches {
+            let rowHTML = capture(1, from: rowMatch, source: source)
+            let rowSource = rowHTML as NSString
+            let cellMatches = cellExpression.matches(
+                in: rowHTML,
+                range: NSRange(location: 0, length: rowSource.length)
+            )
+            var cells: [HTMLTableCell] = []
+
+            for cellMatch in cellMatches {
+                let tagName = capture(1, from: cellMatch, source: rowSource).lowercased()
+                let attributes = capture(2, from: cellMatch, source: rowSource)
+                let cellHTML = capture(3, from: cellMatch, source: rowSource)
+                let colspan = max(Int(htmlAttribute("colspan", in: attributes) ?? "") ?? 1, 1)
+                cells.append(
+                    HTMLTableCell(
+                        text: normalizedHTMLTableCell(cellHTML),
+                        isHeader: tagName == "th"
+                    )
+                )
+                cells.append(
+                    contentsOf: repeatElement(
+                        HTMLTableCell(text: "", isHeader: false),
+                        count: colspan - 1
+                    )
+                )
+            }
+
+            guard !cells.isEmpty else { continue }
+            columnCount = max(columnCount, cells.count)
+            rows.append(cells)
+        }
+
+        guard !rows.isEmpty, columnCount > 0 else { return "" }
+        let emptyCell = HTMLTableCell(text: "", isHeader: false)
+        rows = rows.map { row in
+            row + Array(repeating: emptyCell, count: columnCount - row.count)
+        }
+
+        func markdownRow(_ row: [HTMLTableCell], isFirstRow: Bool = false) -> String {
+            let values = row.map { cell -> String in
+                guard !isFirstRow, cell.isHeader, !cell.text.isEmpty else {
+                    return cell.text
+                }
+                return "**\(cell.text)**"
+            }
+            return "| \(values.joined(separator: " | ")) |"
+        }
+
+        var markdownRows = [markdownRow(rows[0], isFirstRow: true)]
+        markdownRows.append(
+            "| \(Array(repeating: "---", count: columnCount).joined(separator: " | ")) |"
+        )
+        markdownRows.append(contentsOf: rows.dropFirst().map { markdownRow($0) })
+        return "\n\n\(markdownRows.joined(separator: "\n"))\n\n"
+    }
+
+    private static func normalizedHTMLTableCell(_ html: String) -> String {
+        normalizeHTMLFragment(html)
+            .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(
+                of: "(?<!\\\\)\\|",
+                with: "\\\\|",
+                options: .regularExpression
+            )
     }
 
     private static func replacingMatches(

--- a/Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
@@ -314,6 +314,14 @@ enum HuggingFaceModelReadmeFormatting {
 
         output = decodeHTMLEntities(output)
         return output
+            // HTML model cards commonly indent links inside centered paragraphs.
+            // Once converted to Markdown, four leading spaces turn those links
+            // into code blocks instead of interactive links.
+            .replacingOccurrences(
+                of: "(?m)^[ \\t]+(?=(?:!?\\[|\\*\\*|#{1,6}[ \\t]))",
+                with: "",
+                options: .regularExpression
+            )
             .replacingOccurrences(of: "[ \\t]+\\n", with: "\n", options: .regularExpression)
             .replacingOccurrences(of: "\\n(?:[ \\t]*\\n){2,}", with: "\n\n", options: .regularExpression)
     }

--- a/Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
@@ -1,0 +1,394 @@
+import Foundation
+
+@MainActor
+final class HuggingFaceModelReadmeStore: ObservableObject {
+    @Published private(set) var modelID: String?
+    @Published private(set) var markdown: String?
+    @Published private(set) var isLoading = false
+    @Published private(set) var error: String?
+
+    private let client = HuggingFaceModelReadmeClient()
+    private var cache: [String: String] = [:]
+
+    func load(repoID: String, localSnapshotURL: URL?, token: String?) async {
+        modelID = repoID
+        error = nil
+
+        if let cached = cache[repoID] {
+            markdown = cached
+            isLoading = false
+            return
+        }
+
+        markdown = nil
+        isLoading = true
+        do {
+            let markdown = try await client.readme(
+                repoID: repoID,
+                localSnapshotURL: localSnapshotURL,
+                token: token
+            )
+            try Task.checkCancellation()
+            guard modelID == repoID else { return }
+            cache[repoID] = markdown
+            self.markdown = markdown
+            error = nil
+        } catch is CancellationError {
+            return
+        } catch {
+            guard modelID == repoID else { return }
+            markdown = nil
+            self.error = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
+        }
+        guard modelID == repoID else { return }
+        isLoading = false
+    }
+
+    func clearSelection() {
+        modelID = nil
+        markdown = nil
+        isLoading = false
+        error = nil
+    }
+}
+
+enum HuggingFaceModelReadmeError: LocalizedError, Equatable {
+    case invalidRepositoryID
+    case notFound
+    case authenticationRequired
+    case invalidResponse
+    case requestFailed(Int)
+    case empty
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRepositoryID:
+            "This model doesn’t have a Hugging Face repository."
+        case .notFound:
+            "This model doesn’t include a README."
+        case .authenticationRequired:
+            "Sign in to Hugging Face to view this model’s README."
+        case .invalidResponse:
+            "Hugging Face returned an invalid README response."
+        case .requestFailed(let statusCode):
+            "The model README couldn’t be loaded (HTTP \(statusCode))."
+        case .empty:
+            "This model’s README is empty."
+        }
+    }
+}
+
+struct HuggingFaceModelReadmeClient: Sendable {
+    func readme(
+        repoID: String,
+        localSnapshotURL: URL?,
+        token: String?
+    ) async throws -> String {
+        if let localSnapshotURL,
+           let localReadme = try await localReadme(in: localSnapshotURL)
+        {
+            return try preparedMarkdown(from: localReadme)
+        }
+
+        let pathComponents = repoID.split(separator: "/", omittingEmptySubsequences: true)
+        guard pathComponents.count == 2 else {
+            throw HuggingFaceModelReadmeError.invalidRepositoryID
+        }
+
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/\(repoID)/raw/main/README.md"
+        guard let url = components.url else {
+            throw HuggingFaceModelReadmeError.invalidRepositoryID
+        }
+
+        var request = URLRequest(url: url, timeoutInterval: 20)
+        request.setValue("text/markdown, text/plain", forHTTPHeaderField: "Accept")
+        request.setValue("Nativ/1.0", forHTTPHeaderField: "User-Agent")
+        HuggingFaceAuthentication.authorize(&request, token: token)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try Task.checkCancellation()
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HuggingFaceModelReadmeError.invalidResponse
+        }
+        switch httpResponse.statusCode {
+        case 200..<300:
+            return try preparedMarkdown(from: String(decoding: data, as: UTF8.self))
+        case 401, 403:
+            throw HuggingFaceModelReadmeError.authenticationRequired
+        case 404:
+            throw HuggingFaceModelReadmeError.notFound
+        default:
+            throw HuggingFaceModelReadmeError.requestFailed(httpResponse.statusCode)
+        }
+    }
+
+    private func localReadme(in snapshotURL: URL) async throws -> String? {
+        let candidates = ["README.md", "README.MD", "readme.md"]
+            .map { snapshotURL.appendingPathComponent($0, isDirectory: false) }
+        guard let readmeURL = candidates.first(where: {
+            FileManager.default.fileExists(atPath: $0.path)
+        }) else {
+            return nil
+        }
+
+        return try await Task.detached(priority: .utility) {
+            try String(contentsOf: readmeURL, encoding: .utf8)
+        }.value
+    }
+
+    private func preparedMarkdown(from markdown: String) throws -> String {
+        let prepared = HuggingFaceModelReadmeFormatting.displayMarkdown(markdown)
+        guard !prepared.isEmpty else {
+            throw HuggingFaceModelReadmeError.empty
+        }
+        return prepared
+    }
+}
+
+enum HuggingFaceModelReadmeFormatting {
+    static func displayMarkdown(_ markdown: String) -> String {
+        let normalized = markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        var lines = normalized.split(separator: "\n", omittingEmptySubsequences: false)
+
+        if lines.first?.trimmingCharacters(in: .whitespaces) == "---",
+           let closingIndex = lines.dropFirst().firstIndex(where: {
+               let line = $0.trimmingCharacters(in: .whitespaces)
+               return line == "---" || line == "..."
+           })
+        {
+            lines.removeSubrange(lines.startIndex...closingIndex)
+        }
+
+        return normalizeHTMLOutsideCodeFences(lines.joined(separator: "\n"))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func removingDuplicateLeadingTitle(_ markdown: String, modelTitle: String) -> String {
+        var lines = markdown.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let headingIndex = lines.firstIndex(where: {
+            !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) else {
+            return markdown
+        }
+
+        let candidate = lines[headingIndex].trimmingCharacters(in: .whitespaces)
+        guard candidate.hasPrefix("#") else { return markdown }
+        let heading = candidate.drop(while: { $0 == "#" || $0.isWhitespace })
+        guard normalizedTitle(String(heading)) == normalizedTitle(modelTitle) else {
+            return markdown
+        }
+
+        lines.remove(at: headingIndex)
+        while headingIndex < lines.endIndex,
+              lines[headingIndex].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            lines.remove(at: headingIndex)
+        }
+        return lines.joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func normalizedTitle(_ title: String) -> String {
+        title.lowercased().unicodeScalars.compactMap { scalar -> Character? in
+            CharacterSet.alphanumerics.contains(scalar) ? Character(String(scalar)) : nil
+        }.map(String.init).joined()
+    }
+
+    /// Hugging Face model cards frequently use small HTML fragments for centered banners,
+    /// navigation links, and inline emphasis. Textual intentionally renders Markdown rather
+    /// than arbitrary HTML, so translate the safe presentation subset instead of exposing tags.
+    private static func normalizeHTMLOutsideCodeFences(_ markdown: String) -> String {
+        var result = ""
+        var prose = ""
+        var fence: String?
+
+        func flushProse() {
+            guard !prose.isEmpty else { return }
+            result += normalizeHTMLFragment(prose)
+            prose = ""
+        }
+
+        for line in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+            let text = String(line)
+            let trimmed = text.trimmingCharacters(in: .whitespaces)
+            let delimiter: String? = trimmed.hasPrefix("```") ? "```"
+                : (trimmed.hasPrefix("~~~") ? "~~~" : nil)
+
+            if let delimiter {
+                if fence == nil {
+                    flushProse()
+                    fence = delimiter
+                } else if fence == delimiter {
+                    fence = nil
+                }
+                result += text + "\n"
+            } else if fence == nil {
+                prose += text + "\n"
+            } else {
+                result += text + "\n"
+            }
+        }
+        flushProse()
+        return result
+    }
+
+    private static func normalizeHTMLFragment(_ markdown: String) -> String {
+        var output = markdown
+        output = replacingMatches(in: output, pattern: "<!--.*?-->") { _, _ in "" }
+        output = replacingMatches(in: output, pattern: "<(script|style|svg)\\b[^>]*>.*?</\\1\\s*>") {
+            _, _ in ""
+        }
+        output = replacingMatches(in: output, pattern: "<img\\b[^>]*>") { match, source in
+            let tag = source.substring(with: match.range)
+            guard let sourceURL = htmlAttribute("src", in: tag), !sourceURL.isEmpty else {
+                return ""
+            }
+            let alt = htmlAttribute("alt", in: tag) ?? ""
+            return "![\(decodeHTMLEntities(alt))](\(decodeHTMLEntities(sourceURL)))"
+        }
+        output = replacingMatches(in: output, pattern: "<a\\b([^>]*)>(.*?)</a\\s*>") {
+            match, source in
+            let attributes = capture(1, from: match, source: source)
+            let label = capture(2, from: match, source: source)
+                .replacingOccurrences(
+                    of: "</?(span|font|b|strong|i|em)\\b[^>]*>",
+                    with: "",
+                    options: [.regularExpression, .caseInsensitive]
+                )
+                .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let url = htmlAttribute("href", in: attributes), !url.isEmpty else {
+                return label
+            }
+            return "[\(decodeHTMLEntities(label))](\(decodeHTMLEntities(url)))"
+        }
+
+        for level in 1...6 {
+            output = replacingMatches(
+                in: output,
+                pattern: "<h\(level)\\b[^>]*>(.*?)</h\(level)\\s*>"
+            ) { match, source in
+                let title = capture(1, from: match, source: source)
+                    .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return "\n\n\(String(repeating: "#", count: level)) \(title)\n\n"
+            }
+        }
+
+        let literalReplacements: [(String, String)] = [
+            ("<br\\s*/?>", "  \n"),
+            ("<hr\\s*/?>", "\n\n---\n\n"),
+            ("<(b|strong)\\b[^>]*>", "**"),
+            ("</(b|strong)\\s*>", "**"),
+            ("<(i|em)\\b[^>]*>", "*"),
+            ("</(i|em)\\s*>", "*"),
+            ("<code\\b[^>]*>", "`"),
+            ("</code\\s*>", "`"),
+            ("<li\\b[^>]*>", "\n- "),
+            ("</li\\s*>", ""),
+            ("<summary\\b[^>]*>", "\n\n### "),
+            ("</summary\\s*>", "\n\n"),
+            ("<(div|p|center|section|figure|figcaption|details|ul|ol|table|thead|tbody|tr|blockquote)\\b[^>]*>", "\n\n"),
+            ("</(div|p|center|section|figure|figcaption|details|ul|ol|table|thead|tbody|tr|blockquote)\\s*>", "\n\n"),
+            ("<(td|th)\\b[^>]*>", " | "),
+            ("</(td|th)\\s*>", " | "),
+            ("</?(span|font|picture|source|sup|sub|kbd|u)\\b[^>]*>", ""),
+        ]
+        for (pattern, replacement) in literalReplacements {
+            output = output.replacingOccurrences(
+                of: pattern,
+                with: replacement,
+                options: [.regularExpression, .caseInsensitive]
+            )
+        }
+
+        output = decodeHTMLEntities(output)
+        return output
+            .replacingOccurrences(of: "[ \\t]+\\n", with: "\n", options: .regularExpression)
+            .replacingOccurrences(of: "\\n(?:[ \\t]*\\n){2,}", with: "\n\n", options: .regularExpression)
+    }
+
+    private static func replacingMatches(
+        in input: String,
+        pattern: String,
+        transform: (NSTextCheckingResult, NSString) -> String
+    ) -> String {
+        guard let expression = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return input
+        }
+        let source = input as NSString
+        let matches = expression.matches(
+            in: input,
+            range: NSRange(location: 0, length: source.length)
+        )
+        var output = input
+        for match in matches.reversed() {
+            guard let range = Range(match.range, in: output) else { continue }
+            output.replaceSubrange(range, with: transform(match, source))
+        }
+        return output
+    }
+
+    private static func capture(
+        _ index: Int,
+        from match: NSTextCheckingResult,
+        source: NSString
+    ) -> String {
+        guard index < match.numberOfRanges, match.range(at: index).location != NSNotFound else {
+            return ""
+        }
+        return source.substring(with: match.range(at: index))
+    }
+
+    private static func htmlAttribute(_ name: String, in tag: String) -> String? {
+        let escapedName = NSRegularExpression.escapedPattern(for: name)
+        guard let expression = try? NSRegularExpression(
+            pattern: "\\b\(escapedName)\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)'|([^\\s>]+))",
+            options: .caseInsensitive
+        ) else {
+            return nil
+        }
+        let source = tag as NSString
+        guard let match = expression.firstMatch(
+            in: tag,
+            range: NSRange(location: 0, length: source.length)
+        ) else {
+            return nil
+        }
+        for index in 1..<match.numberOfRanges where match.range(at: index).location != NSNotFound {
+            return source.substring(with: match.range(at: index))
+        }
+        return nil
+    }
+
+    private static func decodeHTMLEntities(_ text: String) -> String {
+        var output = text
+        let named = [
+            "&nbsp;": " ", "&amp;": "&", "&lt;": "<", "&gt;": ">",
+            "&quot;": "\"", "&apos;": "'", "&#39;": "'",
+        ]
+        for (entity, value) in named {
+            output = output.replacingOccurrences(of: entity, with: value)
+        }
+        return replacingMatches(in: output, pattern: "&#(x?[0-9a-f]+);") { match, source in
+            let value = capture(1, from: match, source: source)
+            let radix = value.lowercased().hasPrefix("x") ? 16 : 10
+            let digits = radix == 16 ? String(value.dropFirst()) : value
+            guard let scalarValue = UInt32(digits, radix: radix),
+                  let scalar = UnicodeScalar(scalarValue)
+            else {
+                return source.substring(with: match.range)
+            }
+            return String(Character(scalar))
+        }
+    }
+}

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import SwiftUI
+import Textual
 
 private enum ModelsPageSection: String, CaseIterable, Identifiable {
     case installed = "Installed"
@@ -51,6 +52,12 @@ private struct HubSearchTaskID: Hashable {
     let capabilities: Set<LocalModelCapability>
     let access: HubAccessFilter
     let authenticationToken: String?
+}
+
+private struct ModelReadmeSelection: Equatable {
+    let repoID: String
+    let provider: LocalModelProvider?
+    let localSnapshotURL: URL?
 }
 
 /// Filters the app-wide model publisher down to values that can actually
@@ -186,6 +193,7 @@ struct ModelsView: View {
     @StateObject private var modelState: ModelsNativState
     @StateObject private var localLibrary = LocalModelLibrary()
     @StateObject private var hubLibrary = HuggingFaceModelLibrary()
+    @StateObject private var readmeStore = HuggingFaceModelReadmeStore()
     // Keep download progress observation in the banner and individual rows.
     // Observing the manager here invalidates the entire Models view for every
     // progress tick, which makes Discover scroll janky during downloads.
@@ -202,6 +210,7 @@ struct ModelsView: View {
     @State private var handledSpeechModelDiscoveryRequest = 0
     @State private var handledImageModelDiscoveryRequest = 0
     @State private var lastStartedHubSearchTaskID: HubSearchTaskID?
+    @State private var readmeSelection: ModelReadmeSelection?
 
     init(
         model: NativModel,
@@ -280,6 +289,17 @@ struct ModelsView: View {
                 token: modelState.effectiveHuggingFaceToken
             )
         }
+        .task(id: readmeSelection?.repoID) {
+            guard let readmeSelection else {
+                readmeStore.clearSelection()
+                return
+            }
+            await readmeStore.load(
+                repoID: readmeSelection.repoID,
+                localSnapshotURL: readmeSelection.localSnapshotURL,
+                token: modelState.effectiveHuggingFaceToken
+            )
+        }
         .onDisappear {
             localLibrary.cancel()
             hubLibrary.cancel()
@@ -350,7 +370,38 @@ struct ModelsView: View {
                 .padding(.horizontal, 22)
                 .padding(.vertical, 14)
 
-            sectionScroller
+            sectionResults
+        }
+    }
+
+    @ViewBuilder
+    private var sectionResults: some View {
+        if let readmeSelection, section == renderedSection {
+            VStack(spacing: 0) {
+                switch renderedSection {
+                case .installed:
+                    installedResultsHeader
+                        .modelsListRow(top: 0)
+                case .discover:
+                    discoverResultsHeader
+                        .modelsListRow(top: 0)
+                }
+
+                HStack(spacing: 0) {
+                    sectionScroller(showsResultsHeader: false)
+
+                    Divider()
+                    ModelReadmePanel(
+                        selection: readmeSelection,
+                        store: readmeStore,
+                        onClose: { self.readmeSelection = nil }
+                    )
+                    .frame(width: 340)
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
+            }
+        } else {
+            sectionScroller(showsResultsHeader: true)
         }
     }
 
@@ -383,7 +434,7 @@ struct ModelsView: View {
     }
 
     @ViewBuilder
-    private var sectionScroller: some View {
+    private func sectionScroller(showsResultsHeader: Bool) -> some View {
         if section != renderedSection {
             ScrollView {
                 Text("Opening \(section.rawValue)…")
@@ -397,7 +448,7 @@ struct ModelsView: View {
             case .installed:
                 ScrollView {
                     LazyVStack(spacing: 0) {
-                        installedRows
+                        installedRows(showsResultsHeader: showsResultsHeader)
 
                         Color.clear
                             .frame(height: 12)
@@ -405,13 +456,13 @@ struct ModelsView: View {
                     }
                 }
             case .discover:
-                discoverScroller
+                discoverScroller(showsResultsHeader: showsResultsHeader)
             }
         }
     }
 
     @ViewBuilder
-    private var installedRows: some View {
+    private func installedRows(showsResultsHeader: Bool) -> some View {
         let visibleModels = filteredLocalModels
         let normalizedSettings = modelState.settings.normalized()
 
@@ -442,18 +493,10 @@ struct ModelsView: View {
             )
             .modelsListRow()
         } else {
-            HStack {
-                Text(
-                    "\(visibleModels.count) \(visibleModels.count == 1 ? "model" : "models")"
-                )
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
-                Spacer()
-                if localLibrary.isScanning {
-                    ProgressView().controlSize(.small)
-                }
+            if showsResultsHeader {
+                installedResultsHeader
+                    .modelsListRow(top: 0)
             }
-            .modelsListRow(top: 0)
 
             ForEach(visibleModels) { localModel in
                 let preloadSlots = preloadSlots(for: localModel)
@@ -473,6 +516,7 @@ struct ModelsView: View {
                     isModelLoading: modelState.modelLoadingID
                         == localModel.repoID,
                     modelLoadingPercentage: modelState.modelLoadingPercentage,
+                    isReadmeSelected: readmeSelection?.repoID == localModel.repoID,
                     isDeleting: localLibrary.deletingModelIDs.contains(
                         localModel.repoID),
                     canDelete: localModel.isDeletable && !modelState.modelSwitchInProgress
@@ -488,10 +532,30 @@ struct ModelsView: View {
                             model.switchPreloadedModel(to: nil, for: slot)
                         }
                     },
+                    onShowReadme: {
+                        showReadme(
+                            repoID: localModel.repoID,
+                            provider: localModel.provider,
+                            localSnapshotURL: localModel.snapshotURL
+                        )
+                    },
                     onDelete: { deleteInstalledModel(localModel) }
                 )
                 .equatable()
                 .modelsListRow()
+            }
+        }
+    }
+
+    private var installedResultsHeader: some View {
+        let visibleModels = filteredLocalModels
+        return HStack {
+            Text("\(visibleModels.count) \(visibleModels.count == 1 ? "model" : "models")")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+            Spacer()
+            if localLibrary.isScanning {
+                ProgressView().controlSize(.small)
             }
         }
     }
@@ -519,7 +583,7 @@ struct ModelsView: View {
     }
 
     @ViewBuilder
-    private var discoverScroller: some View {
+    private func discoverScroller(showsResultsHeader: Bool) -> some View {
         if let error = hubLibrary.error {
             ScrollView {
                 ModelsNotice(
@@ -568,13 +632,23 @@ struct ModelsView: View {
             // every scroll pass is noticeably more expensive than Installed.
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    discoverResultsHeader
-                        .modelsListRow(top: 0)
+                    if showsResultsHeader {
+                        discoverResultsHeader
+                            .modelsListRow(top: 0)
+                    }
 
                     ForEach(models) { hubModel in
                         HubModelRowContainer(
                             model: hubModel,
                             isInstalled: installedIDs.contains(hubModel.id),
+                            isReadmeSelected: readmeSelection?.repoID == hubModel.id,
+                            onShowReadme: {
+                                showReadme(
+                                    repoID: hubModel.id,
+                                    provider: hubModel.provider,
+                                    localSnapshotURL: nil
+                                )
+                            },
                             onDownload: { downloadSizeBytes in
                                 downloadManager.download(
                                     repoID: hubModel.id,
@@ -649,6 +723,26 @@ struct ModelsView: View {
             modelState.loadedModelID,
         ]
         return configuredModelIDs.contains(repoID)
+    }
+
+    private func showReadme(
+        repoID: String,
+        provider: LocalModelProvider?,
+        localSnapshotURL: URL?
+    ) {
+        let selection = ModelReadmeSelection(
+            repoID: repoID,
+            provider: provider,
+            localSnapshotURL: localSnapshotURL
+        )
+        if readmeSelection == selection {
+            return
+        }
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            readmeSelection = selection
+        }
     }
 
     private func preloadSlots(for localModel: LocalModel) -> [ModelPreloadSlot] {
@@ -1189,6 +1283,113 @@ private struct DebouncedModelsSearchField: NSViewRepresentable {
     }
 }
 
+private struct ModelReadmePanel: View {
+    let selection: ModelReadmeSelection
+    @ObservedObject var store: HuggingFaceModelReadmeStore
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .background(Color.nativMainContentBackground)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Model README")
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            ModelProviderBadge(provider: selection.provider)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(modelName(selection.repoID))
+                    .font(.headline)
+                    .lineLimit(1)
+                Text(selection.repoID)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.semibold))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.borderless)
+            .help("Close model details")
+            .accessibilityLabel("Close model details")
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.modelID != selection.repoID || store.isLoading {
+            VStack(spacing: 10) {
+                ProgressView()
+                Text("Loading README…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let markdown = store.markdown {
+            ScrollView {
+                StructuredText(
+                    markdown: NativMarkdownFormatting.normalizedMathDelimiters(
+                        in: HuggingFaceModelReadmeFormatting.removingDuplicateLeadingTitle(
+                            markdown,
+                            modelTitle: modelName(selection.repoID)
+                        )
+                    ),
+                    baseURL: readmeAssetBaseURL,
+                    syntaxExtensions: [.math]
+                )
+                .textual.structuredTextStyle(.gitHub)
+                .textual.imageAttachmentLoader(.image(relativeTo: readmeAssetBaseURL))
+                .textual.overflowMode(.wrap)
+                .textual.textSelection(.enabled)
+                .font(.callout)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(18)
+            }
+        } else {
+            ContentUnavailableView {
+                Label("README unavailable", systemImage: "doc.text.magnifyingglass")
+            } description: {
+                Text(store.error ?? "This model doesn’t include a README.")
+            } actions: {
+                if let hubURL {
+                    Link("Open on Hugging Face", destination: hubURL)
+                }
+            }
+        }
+    }
+
+    private var hubURL: URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/\(selection.repoID)"
+        return components.url
+    }
+
+    private var readmeAssetBaseURL: URL {
+        if let localSnapshotURL = selection.localSnapshotURL {
+            return localSnapshotURL.appendingPathComponent("", isDirectory: true)
+        }
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/\(selection.repoID)/resolve/main/"
+        return components.url ?? URL(string: "https://huggingface.co/")!
+    }
+}
+
 private struct InstalledModelRow: View, Equatable {
     let localModel: LocalModel
     let preloadSlots: [ModelPreloadSlot]
@@ -1197,9 +1398,11 @@ private struct InstalledModelRow: View, Equatable {
     let isSelectionDisabled: Bool
     let isModelLoading: Bool
     let modelLoadingPercentage: Int?
+    let isReadmeSelected: Bool
     let isDeleting: Bool
     let canDelete: Bool
     let onSetPreload: (ModelPreloadSlot, Bool) -> Void
+    let onShowReadme: () -> Void
     let onDelete: () -> Void
 
     @State private var showsDeleteConfirmation = false
@@ -1213,6 +1416,7 @@ private struct InstalledModelRow: View, Equatable {
             && lhs.isSelectionDisabled == rhs.isSelectionDisabled
             && lhs.isModelLoading == rhs.isModelLoading
             && lhs.modelLoadingPercentage == rhs.modelLoadingPercentage
+            && lhs.isReadmeSelected == rhs.isReadmeSelected
             && lhs.isDeleting == rhs.isDeleting
             && lhs.canDelete == rhs.canDelete
     }
@@ -1227,17 +1431,7 @@ private struct InstalledModelRow: View, Equatable {
 
     var body: some View {
         HStack(spacing: 10) {
-            Button {
-                guard let preferredPreloadSlot else {
-                    showsUnsupportedModelInformation = true
-                    return
-                }
-                guard !isSelectionDisabled else { return }
-                onSetPreload(
-                    preferredPreloadSlot,
-                    !selectedPreloadSlots.contains(preferredPreloadSlot)
-                )
-            } label: {
+            Button(action: onShowReadme) {
                 HStack(spacing: 14) {
                     ModelProviderBadge(provider: localModel.provider, isHighlighted: isSelected)
 
@@ -1332,8 +1526,10 @@ private struct InstalledModelRow: View, Equatable {
             }
             .buttonStyle(.plain)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .help(rowHelp)
-            .accessibilityLabel(rowHelp)
+            .help("Show README for \(localModel.repoID)")
+            .accessibilityLabel("Show details for \(localModel.repoID)")
+
+            loadButton
 
             if isDeleting {
                 ProgressView()
@@ -1365,7 +1561,7 @@ private struct InstalledModelRow: View, Equatable {
         }
         .padding(14)
         .contentShape(RoundedRectangle(cornerRadius: 12))
-        .modelRowBackground(isHighlighted: isSelected)
+        .modelRowBackground(isHighlighted: isReadmeSelected || isSelected)
         .alert("Model isn’t supported", isPresented: $showsUnsupportedModelInformation) {
             Button("OK", role: .cancel) {}
                 .keyboardShortcut(.defaultAction)
@@ -1380,6 +1576,57 @@ private struct InstalledModelRow: View, Equatable {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This permanently removes \(localModel.repoID) from the local Hugging Face cache.")
+        }
+    }
+
+    @ViewBuilder
+    private var loadButton: some View {
+        if let preferredPreloadSlot {
+            let isLoaded = selectedPreloadSlots.contains(preferredPreloadSlot)
+            Button {
+                guard !isSelectionDisabled else { return }
+                onSetPreload(preferredPreloadSlot, !isLoaded)
+            } label: {
+                Label(
+                    isLoaded ? "Unload" : "Load",
+                    systemImage: isLoaded ? "stop.fill" : "play.fill"
+                )
+                .font(.callout.weight(.medium))
+                .foregroundStyle(isLoaded ? Color.primary : Color.white)
+                .padding(.horizontal, 11)
+                .frame(height: 30)
+                .background(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(
+                            isLoaded
+                                ? Color.secondary.opacity(0.12)
+                                : Color.accentColor
+                        )
+                )
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(isSelectionDisabled)
+            .help(rowHelp)
+            .accessibilityLabel(rowHelp)
+            .fixedSize()
+        } else {
+            Button {
+                showsUnsupportedModelInformation = true
+            } label: {
+                Label("Unavailable", systemImage: "exclamationmark.triangle")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .frame(height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(Color.secondary.opacity(0.10))
+                    )
+            }
+            .buttonStyle(.plain)
+            .help(rowHelp)
+            .fixedSize()
         }
     }
 
@@ -1504,10 +1751,12 @@ private struct HubModelRow: View, Equatable {
     let model: HuggingFaceModel
     let downloadSizeBytes: Int64?
     let isInstalled: Bool
+    let isReadmeSelected: Bool
     let isDownloading: Bool
     let downloadProgress: Double
     let isDownloadPaused: Bool
     let downloadError: String?
+    let onShowReadme: () -> Void
     let onDownload: () -> Void
     let onPauseResume: () -> Void
     let onRemoveDownload: () -> Void
@@ -1518,6 +1767,7 @@ private struct HubModelRow: View, Equatable {
         lhs.model == rhs.model
             && lhs.downloadSizeBytes == rhs.downloadSizeBytes
             && lhs.isInstalled == rhs.isInstalled
+            && lhs.isReadmeSelected == rhs.isReadmeSelected
             && lhs.isDownloading == rhs.isDownloading
             && lhs.downloadProgress == rhs.downloadProgress
             && lhs.isDownloadPaused == rhs.isDownloadPaused
@@ -1558,60 +1808,73 @@ private struct HubModelRow: View, Equatable {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 14) {
-                ModelProviderBadge(provider: model.provider)
+                Button(action: onShowReadme) {
+                    HStack(spacing: 14) {
+                        ModelProviderBadge(provider: model.provider)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 7) {
-                        Text(modelName(model.id))
-                            .font(.body.weight(.semibold))
-                            .lineLimit(1)
-                        if model.isGated {
-                            ModelPill(title: "Gated", systemImage: "lock")
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 7) {
+                                Text(modelName(model.id))
+                                    .font(.body.weight(.semibold))
+                                    .lineLimit(1)
+                                if model.isGated {
+                                    ModelPill(title: "Gated", systemImage: "lock")
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .clipped()
+
+                            Text(model.id)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+
+                            HStack(spacing: 6) {
+                                ModelPill(
+                                    title: compactCount(model.downloads),
+                                    systemImage: "arrow.down.circle"
+                                )
+                                ModelPill(title: compactCount(model.likes), systemImage: "heart")
+                                if let sizeBytes = downloadSizeBytes {
+                                    ModelPill(
+                                        title: ByteCountFormatter.string(
+                                            fromByteCount: sizeBytes, countStyle: .file),
+                                        systemImage: "internaldrive"
+                                    )
+                                }
+                                if let memoryFitWarning {
+                                    HubModelMemoryWarningBadge(warning: memoryFitWarning)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .clipped()
+
+                            HStack(spacing: 6) {
+                                ForEach(
+                                    LocalModelCapability.visibleModelTags.filter(
+                                        model.capabilities.contains
+                                    ),
+                                    id: \.self
+                                ) { capability in
+                                    CapabilityPill(capability: capability)
+                                }
+                            }
+                            // Keep Discover rows the same height so the mounted page has
+                            // stable geometry when capability pills are absent.
+                            .frame(maxWidth: .infinity, minHeight: 19, alignment: .leading)
+                            .clipped()
                         }
+                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+
+                        Spacer(minLength: 12)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .clipped()
-
-                    Text(model.id)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-
-                    HStack(spacing: 6) {
-                        ModelPill(
-                            title: compactCount(model.downloads), systemImage: "arrow.down.circle")
-                        ModelPill(title: compactCount(model.likes), systemImage: "heart")
-                        if let sizeBytes = downloadSizeBytes {
-                            ModelPill(
-                                title: ByteCountFormatter.string(
-                                    fromByteCount: sizeBytes, countStyle: .file),
-                                systemImage: "internaldrive"
-                            )
-                        }
-                        if let memoryFitWarning {
-                            HubModelMemoryWarningBadge(warning: memoryFitWarning)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .clipped()
-
-                    HStack(spacing: 6) {
-                        ForEach(
-                            LocalModelCapability.visibleModelTags.filter(
-                                model.capabilities.contains
-                            ),
-                            id: \.self
-                        ) { capability in
-                            CapabilityPill(capability: capability)
-                        }
-                    }
-                    // Keep Discover rows the same height so the mounted page has
-                    // stable geometry when capability pills are absent.
-                    .frame(maxWidth: .infinity, minHeight: 19, alignment: .leading)
-                    .clipped()
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+                .help("Show README for \(model.id)")
+                .accessibilityLabel("Show details for \(model.id)")
 
                 if isInstalled {
                     Label("Installed", systemImage: "checkmark.circle.fill")
@@ -1642,7 +1905,7 @@ private struct HubModelRow: View, Equatable {
             }
         }
         .padding(14)
-        .modelRowBackground(isHighlighted: false)
+        .modelRowBackground(isHighlighted: isReadmeSelected)
     }
 
     private var downloadHelp: String {
@@ -1780,6 +2043,8 @@ private struct HubModelRowContainer: View, Equatable {
 
     let model: HuggingFaceModel
     let isInstalled: Bool
+    let isReadmeSelected: Bool
+    let onShowReadme: () -> Void
     let onDownload: (Int64?) -> Void
     let onPauseResume: () -> Void
     let onRemoveDownload: () -> Void
@@ -1787,12 +2052,16 @@ private struct HubModelRowContainer: View, Equatable {
     init(
         model: HuggingFaceModel,
         isInstalled: Bool,
+        isReadmeSelected: Bool,
+        onShowReadme: @escaping () -> Void,
         onDownload: @escaping (Int64?) -> Void,
         onPauseResume: @escaping () -> Void,
         onRemoveDownload: @escaping () -> Void
     ) {
         self.model = model
         self.isInstalled = isInstalled
+        self.isReadmeSelected = isReadmeSelected
+        self.onShowReadme = onShowReadme
         self.onDownload = onDownload
         self.onPauseResume = onPauseResume
         self.onRemoveDownload = onRemoveDownload
@@ -1804,6 +2073,7 @@ private struct HubModelRowContainer: View, Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.model == rhs.model
             && lhs.isInstalled == rhs.isInstalled
+            && lhs.isReadmeSelected == rhs.isReadmeSelected
     }
 
     var body: some View {
@@ -1812,10 +2082,12 @@ private struct HubModelRowContainer: View, Equatable {
             model: model,
             downloadSizeBytes: downloadSizeBytes,
             isInstalled: isInstalled,
+            isReadmeSelected: isReadmeSelected,
             isDownloading: downloadSnapshot.isDownloading,
             downloadProgress: downloadSnapshot.progress,
             isDownloadPaused: downloadSnapshot.isPaused,
             downloadError: downloadSnapshot.error,
+            onShowReadme: onShowReadme,
             onDownload: {
                 onDownload(downloadSizeBytes)
             },

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -387,17 +387,19 @@ struct ModelsView: View {
                         .modelsListRow(top: 0)
                 }
 
-                HStack(spacing: 0) {
-                    sectionScroller(showsResultsHeader: false)
+                GeometryReader { geometry in
+                    HStack(spacing: 0) {
+                        sectionScroller(showsResultsHeader: false)
 
-                    Divider()
-                    ModelReadmePanel(
-                        selection: readmeSelection,
-                        store: readmeStore,
-                        onClose: { self.readmeSelection = nil }
-                    )
-                    .frame(width: 340)
-                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                        Divider()
+                        ModelReadmePanel(
+                            selection: readmeSelection,
+                            store: readmeStore,
+                            onClose: { self.readmeSelection = nil }
+                        )
+                        .frame(width: geometry.size.width * 0.4)
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                    }
                 }
             }
         } else {
@@ -1353,7 +1355,7 @@ private struct ModelReadmePanel: View {
                 .textual.imageAttachmentLoader(.image(relativeTo: readmeAssetBaseURL))
                 .textual.overflowMode(.wrap)
                 .textual.textSelection(.enabled)
-                .font(.callout)
+                .font(.system(size: 15))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(18)
             }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -376,21 +376,24 @@ struct ModelsView: View {
 
     @ViewBuilder
     private var sectionResults: some View {
-        if let readmeSelection, section == renderedSection {
-            VStack(spacing: 0) {
-                switch renderedSection {
-                case .installed:
-                    installedResultsHeader
-                        .modelsListRow(top: 0)
-                case .discover:
-                    discoverResultsHeader
-                        .modelsListRow(top: 0)
-                }
+        // Keep the results hierarchy mounted when details open. Replacing the
+        // whole scroller here made a card click wait for the visible rows to
+        // be rebuilt before SwiftUI could present the README loading state.
+        VStack(spacing: 0) {
+            switch renderedSection {
+            case .installed:
+                installedResultsHeader
+                    .modelsListRow(top: 0)
+            case .discover:
+                discoverResultsHeader
+                    .modelsListRow(top: 0)
+            }
 
-                GeometryReader { geometry in
-                    HStack(spacing: 0) {
-                        sectionScroller(showsResultsHeader: false)
+            GeometryReader { geometry in
+                HStack(spacing: 0) {
+                    sectionScroller(showsResultsHeader: false)
 
+                    if let readmeSelection, section == renderedSection {
                         Divider()
                         ModelReadmePanel(
                             selection: readmeSelection,
@@ -402,8 +405,6 @@ struct ModelsView: View {
                     }
                 }
             }
-        } else {
-            sectionScroller(showsResultsHeader: true)
         }
     }
 
@@ -1352,8 +1353,9 @@ private struct ModelReadmePanel: View {
                     syntaxExtensions: [.math]
                 )
                 .textual.structuredTextStyle(.gitHub)
+                .textual.tableStyle(.overflow(relativeWidth: 4))
                 .textual.imageAttachmentLoader(.image(relativeTo: readmeAssetBaseURL))
-                .textual.overflowMode(.wrap)
+                .textual.overflowMode(.scroll)
                 .textual.textSelection(.enabled)
                 .font(.system(size: 15))
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -272,8 +272,15 @@ struct ModelsView: View {
                 transaction.disablesAnimations = true
                 withTransaction(transaction) {
                     renderedSection = newSection
+                    selectFirstReadme(in: newSection)
                 }
             }
+        }
+        .onChange(of: localLibrary.models.map(\.repoID)) { _, _ in
+            selectFirstVisibleReadmeIfNeeded(in: .installed)
+        }
+        .onChange(of: hubLibrary.models.map(\.id)) { _, _ in
+            selectFirstVisibleReadmeIfNeeded(in: .discover)
         }
         .task(id: hubSearchTaskID) {
             guard renderedSection == .discover else { return }
@@ -745,6 +752,45 @@ struct ModelsView: View {
         transaction.disablesAnimations = true
         withTransaction(transaction) {
             readmeSelection = selection
+        }
+    }
+
+    private func selectFirstVisibleReadmeIfNeeded(in targetSection: ModelsPageSection) {
+        guard renderedSection == targetSection else { return }
+        let visibleIDs: [String] = switch targetSection {
+        case .installed:
+            filteredLocalModels.map(\.repoID)
+        case .discover:
+            filteredHubModels.map(\.id)
+        }
+        guard readmeSelection == nil || !visibleIDs.contains(readmeSelection?.repoID ?? "") else {
+            return
+        }
+        selectFirstReadme(in: targetSection)
+    }
+
+    private func selectFirstReadme(in targetSection: ModelsPageSection) {
+        switch targetSection {
+        case .installed:
+            guard let model = filteredLocalModels.first else {
+                readmeSelection = nil
+                return
+            }
+            showReadme(
+                repoID: model.repoID,
+                provider: model.provider,
+                localSnapshotURL: model.snapshotURL
+            )
+        case .discover:
+            guard let model = filteredHubModels.first else {
+                readmeSelection = nil
+                return
+            }
+            showReadme(
+                repoID: model.id,
+                provider: model.provider,
+                localSnapshotURL: nil
+            )
         }
     }
 

--- a/Tests/NativTests/HuggingFaceModelReadmeTests.swift
+++ b/Tests/NativTests/HuggingFaceModelReadmeTests.swift
@@ -45,6 +45,8 @@ final class HuggingFaceModelReadmeTests: XCTestCase {
         XCTAssertTrue(output.contains("[Hugging Face](https://huggingface.co/google/gemma-4)"))
         XCTAssertTrue(output.contains("[GitHub](https://github.com/google-deepmind/gemma)"))
         XCTAssertTrue(output.contains("**License:** Apache 2.0"))
+        XCTAssertFalse(output.contains("    [Hugging Face]"))
+        XCTAssertFalse(output.contains("    [GitHub]"))
         XCTAssertFalse(output.contains("<div"))
         XCTAssertFalse(output.contains("<a "))
     }

--- a/Tests/NativTests/HuggingFaceModelReadmeTests.swift
+++ b/Tests/NativTests/HuggingFaceModelReadmeTests.swift
@@ -62,6 +62,30 @@ final class HuggingFaceModelReadmeTests: XCTestCase {
         )
     }
 
+    func testDisplayMarkdownConvertsHTMLTableIntoCompleteMarkdownRows() {
+        let markdown = """
+        <table>
+          <thead><tr><th>Benchmark</th><th>Model A</th><th>Model B</th></tr></thead>
+          <tbody>
+            <tr><th>Coding Agent</th><td>88.8</td><td>84.6</td></tr>
+            <tr><th colspan="3">Repository tasks</th></tr>
+            <tr><td>NL2Repo</td><td>69.4</td><td>47.2</td></tr>
+          </tbody>
+        </table>
+        """
+
+        XCTAssertEqual(
+            HuggingFaceModelReadmeFormatting.displayMarkdown(markdown),
+            """
+            | Benchmark | Model A | Model B |
+            | --- | --- | --- |
+            | **Coding Agent** | 88.8 | 84.6 |
+            | **Repository tasks** |  |  |
+            | NL2Repo | 69.4 | 47.2 |
+            """
+        )
+    }
+
     func testRemovingDuplicateLeadingTitleMatchesRepositoryName() {
         let markdown = """
         # North Micro Vision Instruct

--- a/Tests/NativTests/HuggingFaceModelReadmeTests.swift
+++ b/Tests/NativTests/HuggingFaceModelReadmeTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+final class HuggingFaceModelReadmeTests: XCTestCase {
+    func testDisplayMarkdownRemovesModelCardFrontMatter() {
+        let markdown = """
+        ---
+        license: apache-2.0
+        tags:
+          - mlx
+        ---
+        # Model title
+
+        Model details.
+        """
+
+        XCTAssertEqual(
+            HuggingFaceModelReadmeFormatting.displayMarkdown(markdown),
+            "# Model title\n\nModel details."
+        )
+    }
+
+    func testDisplayMarkdownPreservesMarkdownWithoutFrontMatter() {
+        let markdown = "\n# Model title\r\n\r\nModel details.\n"
+
+        XCTAssertEqual(
+            HuggingFaceModelReadmeFormatting.displayMarkdown(markdown),
+            "# Model title\n\nModel details."
+        )
+    }
+
+    func testDisplayMarkdownConvertsCommonModelCardHTML() {
+        let markdown = """
+        <div align="center">
+          <img src=https://ai.google.dev/gemma/images/gemma4_banner.png>
+        </div>
+        <p align="center">
+          <a href="https://huggingface.co/google/gemma-4">Hugging Face</a> |
+          <a href="https://github.com/google-deepmind/gemma">GitHub</a><br>
+          <b>License:</b> Apache 2.0
+        </p>
+        """
+
+        let output = HuggingFaceModelReadmeFormatting.displayMarkdown(markdown)
+        XCTAssertTrue(output.contains("![](https://ai.google.dev/gemma/images/gemma4_banner.png)"))
+        XCTAssertTrue(output.contains("[Hugging Face](https://huggingface.co/google/gemma-4)"))
+        XCTAssertTrue(output.contains("[GitHub](https://github.com/google-deepmind/gemma)"))
+        XCTAssertTrue(output.contains("**License:** Apache 2.0"))
+        XCTAssertFalse(output.contains("<div"))
+        XCTAssertFalse(output.contains("<a "))
+    }
+
+    func testDisplayMarkdownDoesNotRewriteHTMLInsideCodeFence() {
+        let markdown = """
+        ```html
+        <div>Example</div>
+        ```
+        """
+
+        XCTAssertEqual(
+            HuggingFaceModelReadmeFormatting.displayMarkdown(markdown),
+            markdown
+        )
+    }
+
+    func testRemovingDuplicateLeadingTitleMatchesRepositoryName() {
+        let markdown = """
+        # North Micro Vision Instruct
+
+        ![](banner.png)
+
+        Model details.
+        """
+
+        XCTAssertEqual(
+            HuggingFaceModelReadmeFormatting.removingDuplicateLeadingTitle(
+                markdown,
+                modelTitle: "North-Micro-Vision-Instruct"
+            ),
+            "![](banner.png)\n\nModel details."
+        )
+    }
+
+    func testRemovingDuplicateLeadingTitlePreservesDifferentHeading() {
+        let markdown = "# Usage\n\nRun the model."
+
+        XCTAssertEqual(
+            HuggingFaceModelReadmeFormatting.removingDuplicateLeadingTitle(
+                markdown,
+                modelTitle: "North-Micro-Vision-Instruct"
+            ),
+            markdown
+        )
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -191,6 +191,7 @@ targets:
       - path: Sources/Nativ/Utilities/Formatting.swift
       - path: Sources/Nativ/Utilities/MarkdownFormatting.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceHub.swift
+      - path: Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
       - path: Sources/Nativ/Features/Chat/ChatScreenCapture.swift
     dependencies:
       - target: NativServerKit


### PR DESCRIPTION
## Summary

- add a right-side Hugging Face README panel when an installed or Discover model card is selected
- keep the Models header, search, filters, and result count full-width; begin the split panel alongside the first model card
- replace installed-card click-to-load behavior with explicit Load and Unload controls
- render model-card Markdown, common embedded HTML, relative images, links, tables, and code cleanly
- load READMEs from an installed snapshot first, then Hugging Face, with authentication, cancellation, and caching
- avoid repeating a repository title already shown in the panel header

## Why

Model cards previously offered no in-app context, while clicking an installed card could unexpectedly change the loaded model. This makes model details discoverable without leaving Nativ and makes loading an explicit action.

## Validation

- `HuggingFaceModelReadmeTests`: 6 passed
- macOS Debug build succeeded
- signed development build verified and opened