### PR TITLE
Fix microphone permission request flow

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */; };
 		060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */; };
+		07E17841B388FBBD8C8A28EF /* NativSystemPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E2A903D604A57696674510 /* NativSystemPermissionController.swift */; };
 		086BC5B6FF02F0305536333B /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
 		088297CDFEFECD2787806AD7 /* VoiceCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */; };
 		0935A0AC0D6A6298D551EEAE /* ArtifactSemanticSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */; };
@@ -1318,6 +1319,7 @@
 				90EE7AA87400E84D947CBBF3 /* NativSettings.swift in Sources */,
 				DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */,
 				ACBA3EAEE7677FCAD4977850 /* NativSkill.swift in Sources */,
+				07E17841B388FBBD8C8A28EF /* NativSystemPermissionController.swift in Sources */,
 				BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */,
 				36405D7EB30E430CF06956EB /* ShellEnvironmentTests.swift in Sources */,
 				293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */,

--- a/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
+++ b/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
@@ -398,7 +398,8 @@ final class NativExtensionManager: ObservableObject {
             markPermissionRequested(permission)
             switch AVCaptureDevice.authorizationStatus(for: .audio) {
             case .notDetermined:
-                NativSystemPermissionController.requestMicrophone { [weak self] _ in
+                Task { [weak self] in
+                    _ = await NativSystemPermissionController.requestMicrophone()
                     self?.refreshPermissionStatuses()
                 }
             case .denied, .restricted:

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -90,7 +90,7 @@ final class AudioCaptureLibrary: ObservableObject {
     @Published private(set) var activeIncludesSystemAudio = false
     @Published private(set) var processingRecordIDs = Set<String>()
     @Published var lastErrorMessage: String?
-    @Published private(set) var shouldOfferScreenCaptureSettings = false
+    @Published private(set) var permissionRequiringSettings: NativPermission?
     @Published private(set) var playingRecordID: String?
     @Published private(set) var isPlaybackPaused = false
 
@@ -217,7 +217,7 @@ final class AudioCaptureLibrary: ObservableObject {
         meterState.update(0)
         lastMeterPublishAt = .distantPast
 
-        guard Self.hasMicrophoneAccess() else {
+        guard await NativSystemPermissionController.requestMicrophone() else {
             fail(AudioCaptureLibraryError.microphonePermissionRequired)
             return
         }
@@ -279,7 +279,15 @@ final class AudioCaptureLibrary: ObservableObject {
 
     func clearLastError() {
         lastErrorMessage = nil
-        shouldOfferScreenCaptureSettings = false
+        permissionRequiringSettings = nil
+    }
+
+    func openPermissionSettings() {
+        guard let permissionRequiringSettings else {
+            return
+        }
+        clearLastError()
+        NativSystemPermissionController.openSettings(for: permissionRequiringSettings)
     }
 
     func stop() async {
@@ -712,12 +720,16 @@ final class AudioCaptureLibrary: ObservableObject {
 
     private func fail(_ error: Error) {
         lastErrorMessage = error.localizedDescription
-        if let captureError = error as? AudioCaptureLibraryError,
-           case .screenCapturePermissionRequired = captureError
-        {
-            shouldOfferScreenCaptureSettings = true
-        } else {
-            shouldOfferScreenCaptureSettings = false
+        permissionRequiringSettings = nil
+        if let captureError = error as? AudioCaptureLibraryError {
+            switch captureError {
+            case .microphonePermissionRequired:
+                permissionRequiringSettings = .microphone
+            case .screenCapturePermissionRequired:
+                permissionRequiringSettings = .screenRecording
+            default:
+                break
+            }
         }
         resetCaptureState()
     }
@@ -810,10 +822,6 @@ final class AudioCaptureLibrary: ObservableObject {
         meterState.update(level)
         self.elapsed = elapsed
         updateRecordingOverlay(level: level, elapsed: elapsed)
-    }
-
-    private static func hasMicrophoneAccess() -> Bool {
-        AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
     }
 
     private static func makeOutputURL(

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -153,10 +153,9 @@ struct AudioView: View {
                 }
             )
         ) {
-            if captureLibrary.shouldOfferScreenCaptureSettings {
+            if captureLibrary.permissionRequiringSettings != nil {
                 Button("Open System Settings") {
-                    captureLibrary.clearLastError()
-                    NativSystemPermissionController.openScreenCaptureSettings()
+                    captureLibrary.openPermissionSettings()
                 }
                 Button("Not Now", role: .cancel) {
                     captureLibrary.clearLastError()

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -1,5 +1,4 @@
 import AppKit
-import AVFoundation
 import NativServerKit
 
 struct VoiceTranscriptionConfiguration {
@@ -121,24 +120,13 @@ final class VoiceCaptureCoordinator {
             guard let self else {
                 return
             }
-            let status = AVCaptureDevice.authorizationStatus(for: .audio)
-            let granted: Bool
-            switch status {
-            case .authorized:
-                granted = true
-            case .notDetermined:
-                granted = await AVCaptureDevice.requestAccess(for: .audio)
-            default:
-                granted = false
-            }
+            let granted = await NativSystemPermissionController.requestMicrophone()
             guard !Task.isCancelled, self.isShortcutHeld else {
                 return
             }
             guard granted else {
                 self.overlay.showFailure()
-                if status == .denied || status == .restricted {
-                    self.presentMicrophonePermissionAlert()
-                }
+                self.presentMicrophonePermissionAlert()
                 return
             }
 

--- a/Sources/Nativ/Utilities/NativSystemPermissionController.swift
+++ b/Sources/Nativ/Utilities/NativSystemPermissionController.swift
@@ -4,14 +4,30 @@ import AVFoundation
 
 enum NativSystemPermissionController {
     @MainActor
-    static func requestMicrophone(
-        completion: @escaping @MainActor (Bool) -> Void
-    ) {
-        NSApplication.shared.activate(ignoringOtherApps: true)
-        AVCaptureDevice.requestAccess(for: .audio) { granted in
-            Task { @MainActor in
-                completion(granted)
-            }
+    static func requestMicrophone() async -> Bool {
+        let status = AVCaptureDevice.authorizationStatus(for: .audio)
+        if status == .notDetermined {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+        }
+        return await resolveMicrophoneAccess(status: status) {
+            await AVCaptureDevice.requestAccess(for: .audio)
+        }
+    }
+
+    @MainActor
+    static func resolveMicrophoneAccess(
+        status: AVAuthorizationStatus,
+        requestAccess: @MainActor () async -> Bool
+    ) async -> Bool {
+        switch status {
+        case .authorized:
+            return true
+        case .notDetermined:
+            return await requestAccess()
+        case .denied, .restricted:
+            return false
+        @unknown default:
+            return false
         }
     }
 
@@ -72,6 +88,18 @@ enum NativSystemPermissionController {
     @MainActor
     static func openScreenCaptureSettings() {
         openPrivacyPane("Privacy_ScreenCapture")
+    }
+
+    @MainActor
+    static func openSettings(for permission: NativPermission) {
+        switch permission {
+        case .microphone:
+            openMicrophoneSettings()
+        case .accessibility:
+            openAccessibilitySettings()
+        case .screenRecording:
+            openScreenCaptureSettings()
+        }
     }
 
     @MainActor
@@ -191,14 +219,7 @@ final class NativPermissionStore: ObservableObject {
     }
 
     func openSettings(for permission: NativPermission) {
-        switch permission {
-        case .microphone:
-            NativSystemPermissionController.openMicrophoneSettings()
-        case .accessibility:
-            NativSystemPermissionController.openAccessibilitySettings()
-        case .screenRecording:
-            NativSystemPermissionController.openScreenCaptureSettings()
-        }
+        NativSystemPermissionController.openSettings(for: permission)
     }
 
     private func resolvedStatus(for permission: NativPermission) -> NativPermissionStatus {
@@ -232,7 +253,8 @@ final class NativPermissionStore: ObservableObject {
         switch permission {
         case .microphone:
             pendingPermission = permission
-            NativSystemPermissionController.requestMicrophone { [weak self] _ in
+            Task { [weak self] in
+                _ = await NativSystemPermissionController.requestMicrophone()
                 self?.pendingPermission = nil
                 self?.refresh()
             }

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -1,6 +1,65 @@
+import AVFoundation
 import Foundation
 import XCTest
 @testable import NativServerKit
+
+@MainActor
+final class NativSystemPermissionControllerTests: XCTestCase {
+    func testAuthorizedMicrophoneAccessDoesNotRequestAgain() async {
+        var requestCount = 0
+
+        let granted = await NativSystemPermissionController.resolveMicrophoneAccess(
+            status: .authorized
+        ) {
+            requestCount += 1
+            return false
+        }
+
+        XCTAssertTrue(granted)
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testUndeterminedMicrophoneAccessRequestsAndReturnsGrant() async {
+        var requestCount = 0
+
+        let granted = await NativSystemPermissionController.resolveMicrophoneAccess(
+            status: .notDetermined
+        ) {
+            requestCount += 1
+            return true
+        }
+
+        XCTAssertTrue(granted)
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testUndeterminedMicrophoneAccessReturnsDenial() async {
+        let granted = await NativSystemPermissionController.resolveMicrophoneAccess(
+            status: .notDetermined
+        ) {
+            false
+        }
+
+        XCTAssertFalse(granted)
+    }
+
+    func testDeniedOrRestrictedMicrophoneAccessDoesNotRequestAgain() async {
+        var requestCount = 0
+
+        for status in [AVAuthorizationStatus.denied, .restricted] {
+            let granted = await NativSystemPermissionController.resolveMicrophoneAccess(
+                status: status
+            ) {
+                requestCount += 1
+                return true
+            }
+
+            XCTAssertFalse(granted)
+        }
+
+        XCTAssertEqual(requestCount, 0)
+    }
+}
 
 @MainActor
 final class AudioAnalyticsStoreTests: XCTestCase {

--- a/project.yml
+++ b/project.yml
@@ -168,6 +168,7 @@ targets:
       - path: Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
       - path: Sources/Nativ/Features/VoiceCapture/VoiceAnimationPreferences.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
+      - path: Sources/Nativ/Utilities/NativSystemPermissionController.swift
       - path: Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
       - path: Sources/Nativ/Features/MCP/MCPServerCatalog.swift
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift


### PR DESCRIPTION
Closes #291

- request microphone access when its status is not determined
- centralize microphone authorization across Audio capture and dictation
- offer the appropriate System Settings recovery action after denial
- add regression coverage for all microphone authorization states

The first screenshot shows the UI state when the status is `.notDetermined`, the second screenshot shows the UI state when the status is `.denied`. In both cases, you can grant access, either directly from the app or from system settings.

<img width="1728" height="1117" alt="Screenshot 2026-08-13 at 1 08 08 AM" src="https://github.com/user-attachments/assets/65085557-ee2b-46c0-bc40-30c545c370df" />
<img width="1728" height="1117" alt="Screenshot 2026-08-13 at 1 10 05 AM" src="https://github.com/user-attachments/assets/0f12d625-2f08-4d16-bb91-9e56a35680b4" />
