### PR TITLE
Polish sidebar and model controls

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -135,6 +135,7 @@ private enum ControlPanelLayout {
     static let sidebarMaximumWidth: CGFloat = 320
     static let detailMinimumWidth: CGFloat = 720
     static let titlebarHeight: CGFloat = 52
+    static let sidebarBrandTopClearance: CGFloat = 28
     static let collapsedSidebarTitleClearance: CGFloat = 108
     static let sidebarButtonLeadingPadding: CGFloat = 88
     static let modelConfigurationButtonTrailingPadding: CGFloat = 12
@@ -515,7 +516,7 @@ struct ControlPanelView: View {
     private var sidebar: some View {
         VStack(spacing: 0) {
             Color.clear
-                .frame(height: ControlPanelLayout.titlebarHeight)
+                .frame(height: ControlPanelLayout.sidebarBrandTopClearance)
 
             HStack(spacing: 6) {
                 Image(nsImage: NSApplication.shared.applicationIconImage)

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -135,7 +135,7 @@ private enum ControlPanelLayout {
     static let sidebarMaximumWidth: CGFloat = 320
     static let detailMinimumWidth: CGFloat = 720
     static let titlebarHeight: CGFloat = 52
-    static let sidebarBrandTopClearance: CGFloat = 36
+    static let sidebarBrandTopClearance: CGFloat = 46
     static let sidebarBrandBottomClearance: CGFloat = 8
     static let collapsedSidebarTitleClearance: CGFloat = 108
     static let sidebarButtonLeadingPadding: CGFloat = 88

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -135,7 +135,8 @@ private enum ControlPanelLayout {
     static let sidebarMaximumWidth: CGFloat = 320
     static let detailMinimumWidth: CGFloat = 720
     static let titlebarHeight: CGFloat = 52
-    static let sidebarBrandTopClearance: CGFloat = 28
+    static let sidebarBrandTopClearance: CGFloat = 36
+    static let sidebarBrandBottomClearance: CGFloat = 8
     static let collapsedSidebarTitleClearance: CGFloat = 108
     static let sidebarButtonLeadingPadding: CGFloat = 88
     static let modelConfigurationButtonTrailingPadding: CGFloat = 12
@@ -531,6 +532,7 @@ struct ControlPanelView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .frame(height: 40)
             .padding(.horizontal, 16)
+            .padding(.bottom, ControlPanelLayout.sidebarBrandBottomClearance)
 
             sidebarNavigation
                 .padding(.horizontal, 10)

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -1072,7 +1072,7 @@ private struct ComposerModelPickerLabel: View {
                 .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(.secondary)
         }
-        .font(.caption.weight(.medium))
+        .font(.system(size: 12, weight: .medium))
         .foregroundStyle(Color.primary)
         .padding(.leading, 10)
         .padding(.trailing, 8)

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -629,6 +629,7 @@ struct ComposerModelPickerSecondarySection {
 }
 
 struct ComposerModelPicker: View {
+    @Environment(\.colorScheme) private var colorScheme
     @State private var isPickerHovered = false
     @State private var isMenuOpen = false
 
@@ -725,11 +726,9 @@ struct ComposerModelPicker: View {
     }
 
     private var pickerHighlightColor: Color {
-        let background = NSColor.controlBackgroundColor
-        return Color(
-            nsColor: background.blended(withFraction: 0.24, of: NSColor.labelColor)
-                ?? background
-        )
+        colorScheme == .light
+            ? Color.black.opacity(0.08)
+            : Color.white.opacity(0.14)
     }
 
     private var pickerRestingColor: Color {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1581,33 +1581,7 @@ private struct InstalledModelRow: View, Equatable {
 
             loadButton
 
-            if isDeleting {
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(width: 30, height: 30)
-                    .help("Deleting model")
-            } else if let snapshotURL = localModel.snapshotURL {
-                Button {
-                    NSWorkspace.shared.activateFileViewerSelecting([snapshotURL])
-                } label: {
-                    Image(systemName: "arrow.up.forward.square")
-                        .frame(width: 20, height: 20)
-                }
-                .buttonStyle(.borderless)
-                .help("Show in Finder")
-                .accessibilityLabel("Show \(localModel.repoID) in Finder")
-            }
-
-            ModelDownloadActionButton(
-                title: canDelete
-                    ? "Delete installed model"
-                    : "Stop the server before deleting this model",
-                systemImage: "trash",
-                tint: .red,
-                isDisabled: !canDelete || isDeleting
-            ) {
-                showsDeleteConfirmation = true
-            }
+            modelActionsMenu
         }
         .padding(14)
         .contentShape(RoundedRectangle(cornerRadius: 12))
@@ -1626,6 +1600,49 @@ private struct InstalledModelRow: View, Equatable {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This permanently removes \(localModel.repoID) from the local Hugging Face cache.")
+        }
+    }
+
+    @ViewBuilder
+    private var modelActionsMenu: some View {
+        if isDeleting {
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 30, height: 30)
+                .help("Deleting model")
+        } else {
+            Menu {
+                if let snapshotURL = localModel.snapshotURL {
+                    Button {
+                        NSWorkspace.shared.activateFileViewerSelecting([snapshotURL])
+                    } label: {
+                        Label("Show in Finder", systemImage: "arrow.up.forward.square")
+                    }
+
+                    Divider()
+                }
+
+                Button(role: .destructive) {
+                    showsDeleteConfirmation = true
+                } label: {
+                    Label("Delete Model…", systemImage: "trash")
+                }
+                .disabled(!canDelete)
+            } label: {
+                Image(systemName: "ellipsis")
+                    .rotationEffect(.degrees(90))
+                    .frame(width: 30, height: 30)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help(
+                canDelete
+                    ? "Model actions"
+                    : "Model actions — stop the server before deleting this model"
+            )
+            .accessibilityLabel("Actions for \(localModel.repoID)")
         }
     }
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1483,7 +1483,7 @@ private struct InstalledModelRow: View, Equatable {
         HStack(spacing: 10) {
             Button(action: onShowReadme) {
                 HStack(spacing: 14) {
-                    ModelProviderBadge(provider: localModel.provider, isHighlighted: isSelected)
+                    ModelProviderBadge(provider: localModel.provider)
 
                     VStack(alignment: .leading, spacing: 6) {
                         HStack(spacing: 7) {
@@ -1585,7 +1585,7 @@ private struct InstalledModelRow: View, Equatable {
         }
         .padding(14)
         .contentShape(RoundedRectangle(cornerRadius: 12))
-        .modelRowBackground(isHighlighted: isReadmeSelected || isSelected)
+        .modelRowBackground(isHighlighted: isReadmeSelected)
         .alert("Model isn’t supported", isPresented: $showsUnsupportedModelInformation) {
             Button("OK", role: .cancel) {}
                 .keyboardShortcut(.defaultAction)
@@ -1654,21 +1654,13 @@ private struct InstalledModelRow: View, Equatable {
                 guard !isSelectionDisabled else { return }
                 onSetPreload(preferredPreloadSlot, !isLoaded)
             } label: {
-                Label(
-                    isLoaded ? "Unload" : "Load",
-                    systemImage: isLoaded ? "stop.fill" : "play.fill"
-                )
-                .font(.callout.weight(.medium))
-                .foregroundStyle(isLoaded ? Color.primary : Color.white)
-                .padding(.horizontal, 11)
-                .frame(height: 30)
+                Image(systemName: isLoaded ? "stop.fill" : "play.fill")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 36, height: 30)
                 .background(
                     RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .fill(
-                            isLoaded
-                                ? Color.secondary.opacity(0.12)
-                                : Color.accentColor
-                        )
+                        .fill(isLoaded ? Color.red : Color.accentColor)
                 )
                 .contentShape(Rectangle())
             }
@@ -2462,9 +2454,6 @@ private struct ModelRowBackground: ViewModifier {
     }
 
     private var backgroundColor: Color {
-        if isHighlighted {
-            return Color.accentColor.opacity(0.38)
-        }
         if isHovered {
             return Color.accentColor.opacity(0.08)
         }


### PR DESCRIPTION
## Summary

- align the Nativ brand row more naturally between the macOS titlebar controls and sidebar navigation
- use appearance-aware model-picker highlighting so light mode no longer turns the selected model control almost black
- consolidate installed-model Finder and delete actions into a compact vertical-ellipsis menu

## Why

These controls had three related UI polish issues: the sidebar brand sat too low, the chat model picker resolved an AppKit dynamic color against the wrong appearance, and installed model cards exposed too many separate secondary actions.

## User impact

The sidebar hierarchy is better balanced, model selection stays readable in both light and dark modes, and installed model cards have a cleaner primary-action layout without removing Finder or deletion access.

## Validation

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make xcode-run`
- Debug app built successfully, signed with the configured Apple Development identity, verified, and opened
