### PR TITLE
rerouting user if image model is now downloaded

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -12,7 +12,6 @@ struct ChatToolExecutionContext {
     let imageReferences: [ChatImageAttachment]
     let modelSearchPath: String
     let additionalModelSearchPaths: [String]
-    var huggingFaceToken: String? = nil
     var analyticsDatabaseURL: URL? = nil
     var imageToolDependencies = ChatImageToolDependencies.live
     var imageModelSelection: ChatImageModelSelectionHandler? = nil
@@ -131,9 +130,7 @@ enum ChatToolDispatcher {
         let availableModels = try await context.imageToolDependencies.discoverModels(
             imageRequest.operation,
             context.modelSearchPath,
-            context.additionalModelSearchPaths,
-            context.huggingFaceToken,
-            context.imageGenerationModelID
+            context.additionalModelSearchPaths
         )
         let imageModelID: String
         switch ChatImageModelSelection.resolve(

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -362,10 +362,9 @@ final class ChatViewModel: ObservableObject {
         let attachments: [ChatImageAttachment]
     }
 
-    private struct ImageModelPreparationContext {
+    private struct ImageModelDiscoveryContext {
         let modelSearchPath: String
         let additionalModelSearchPaths: [String]
-        let huggingFaceToken: String?
     }
 
     @Published private(set) var sessions: [ChatSessionSummary] = []
@@ -402,8 +401,7 @@ final class ChatViewModel: ObservableObject {
     private weak var appModel: NativModel?
     private let toolConsentGate = ChatToolConsentGate()
     private let imageModelSelectionGate = ChatImageModelSelectionGate()
-    private var imageModelPreparationTasks: [UUID: Task<Void, Never>] = [:]
-    private var imageModelPreparationContexts: [UUID: ImageModelPreparationContext] = [:]
+    private var imageModelDiscoveryContexts: [UUID: ImageModelDiscoveryContext] = [:]
     private var imageModelRefreshTask: Task<Void, Never>?
     private var composerSnapshot: ComposerSnapshot?
 
@@ -957,73 +955,20 @@ final class ChatViewModel: ObservableObject {
 
     func selectImageModel(_ toolMessageID: UUID, _ modelID: String) {
         guard let request = imageModelSelectionRequests[toolMessageID],
-              let selectedModel = ChatImageModelSelection.selectedModel(
+              ChatImageModelSelection.selectedModel(
                   withID: modelID,
                   from: request
-              )
+              ) != nil
         else {
             return
         }
-
-        guard !selectedModel.isInstalled else {
-            imageModelSelectionGate.select(modelID: modelID, for: toolMessageID)
-            return
-        }
-        guard let preparationContext = imageModelPreparationContexts[toolMessageID] else {
-            return
-        }
-
-        imageModelPreparationTasks[toolMessageID]?.cancel()
-        imageModelPreparationTasks[toolMessageID] = Task { @MainActor [weak self] in
-            defer {
-                self?.imageModelPreparationTasks.removeValue(forKey: toolMessageID)
-            }
-            do {
-                try await HuggingFaceDownloadManager.shared.downloadIfNeeded(
-                    repoID: selectedModel.modelID,
-                    sizeBytes: selectedModel.downloadSizeBytes,
-                    cachePath: preparationContext.modelSearchPath,
-                    token: preparationContext.huggingFaceToken
-                )
-                try Task.checkCancellation()
-                let installedModels = try await ChatImageModelSelection.installedOptions(
-                    modelSearchPath: preparationContext.modelSearchPath,
-                    additionalModelSearchPaths: preparationContext.additionalModelSearchPaths
-                )
-                guard ChatImageModelSelection.isPrepared(
-                    modelID: selectedModel.modelID,
-                    for: request.operation,
-                    installedModels: installedModels
-                ) else {
-                    HuggingFaceDownloadManager.shared.reportError(
-                        "The downloaded model is not compatible with \(request.operation.capabilityName).",
-                        for: selectedModel.modelID
-                    )
-                    return
-                }
-                guard self?.imageModelSelectionRequests[toolMessageID] != nil else {
-                    return
-                }
-                self?.imageModelSelectionGate.select(
-                    modelID: selectedModel.modelID,
-                    for: toolMessageID
-                )
-            } catch is CancellationError {
-                return
-            } catch {
-                HuggingFaceDownloadManager.shared.reportError(
-                    error.localizedDescription,
-                    for: selectedModel.modelID
-                )
-            }
-        }
+        imageModelSelectionGate.select(modelID: modelID, for: toolMessageID)
     }
 
     func cancelImageModelSelection(_ toolMessageID: UUID) {
         guard imageModelSelectionRequests[toolMessageID] != nil else {
             return
         }
-        imageModelPreparationTasks.removeValue(forKey: toolMessageID)?.cancel()
         imageModelSelectionGate.cancel(toolMessageID)
     }
 
@@ -1033,7 +978,7 @@ final class ChatViewModel: ObservableObject {
         }
 
         let pendingRequests = imageModelSelectionRequests.compactMap { id, request in
-            imageModelPreparationContexts[id].map { (id, request.operation, $0) }
+            imageModelDiscoveryContexts[id].map { (id, request.operation, $0) }
         }
         imageModelRefreshTask?.cancel()
         imageModelRefreshTask = Task { @MainActor [weak self] in
@@ -1042,8 +987,7 @@ final class ChatViewModel: ObservableObject {
                     let models = try await ChatImageModelSelection.availableOptions(
                         for: operation,
                         modelSearchPath: context.modelSearchPath,
-                        additionalModelSearchPaths: context.additionalModelSearchPaths,
-                        huggingFaceToken: context.huggingFaceToken
+                        additionalModelSearchPaths: context.additionalModelSearchPaths
                     )
                     try Task.checkCancellation()
                     guard self?.imageModelSelectionRequests[toolMessageID]?.operation
@@ -1059,8 +1003,7 @@ final class ChatViewModel: ObservableObject {
                 } catch is CancellationError {
                     return
                 } catch {
-                    // Keep the last known choices if the local cache cannot be
-                    // scanned. Hub failures are already handled as offline mode.
+                    // Keep the last known choices if the local cache cannot be scanned.
                 }
             }
         }
@@ -1454,10 +1397,9 @@ final class ChatViewModel: ObservableObject {
                         beforeOrAt: toolMessageID,
                         in: queuedRequest.sessionID
                     )
-                    let imageModelPreparationContext = ImageModelPreparationContext(
+                    let imageModelDiscoveryContext = ImageModelDiscoveryContext(
                         modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
-                        additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
-                        huggingFaceToken: appModel?.effectiveHuggingFaceToken
+                        additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths
                     )
                     let context = ChatToolExecutionContext(
                         imageGenerationModelID: activeImageModelID,
@@ -1466,19 +1408,15 @@ final class ChatViewModel: ObservableObject {
                         imageReferences: references,
                         modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
                         additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
-                        huggingFaceToken: imageModelPreparationContext.huggingFaceToken,
                         imageModelSelection: { [weak self] request in
                             guard let self else {
                                 throw CancellationError()
                             }
                             defer {
-                                self.imageModelPreparationTasks
-                                    .removeValue(forKey: toolMessageID)?
-                                    .cancel()
                                 self.imageModelSelectionRequests.removeValue(
                                     forKey: toolMessageID
                                 )
-                                self.imageModelPreparationContexts.removeValue(
+                                self.imageModelDiscoveryContexts.removeValue(
                                     forKey: toolMessageID
                                 )
                             }
@@ -1486,8 +1424,8 @@ final class ChatViewModel: ObservableObject {
                             let selectedModelID = await self.imageModelSelectionGate
                                 .awaitSelection(for: toolMessageID) {
                                     self.imageModelSelectionRequests[toolMessageID] = request
-                                    self.imageModelPreparationContexts[toolMessageID] =
-                                        imageModelPreparationContext
+                                    self.imageModelDiscoveryContexts[toolMessageID] =
+                                        imageModelDiscoveryContext
                                     self.setToolMessageStatus(
                                         toolMessageID,
                                         in: queuedRequest.sessionID,
@@ -1772,7 +1710,7 @@ final class ChatViewModel: ObservableObject {
         }
         if status != .awaitingImageModelSelection {
             imageModelSelectionRequests.removeValue(forKey: id)
-            imageModelPreparationContexts.removeValue(forKey: id)
+            imageModelDiscoveryContexts.removeValue(forKey: id)
         }
         persistSession(sessionID, updateTimestamp: true)
         if currentSessionID == sessionID {
@@ -1790,7 +1728,7 @@ final class ChatViewModel: ObservableObject {
         }
         if status != .awaitingImageModelSelection {
             imageModelSelectionRequests.removeValue(forKey: id)
-            imageModelPreparationContexts.removeValue(forKey: id)
+            imageModelDiscoveryContexts.removeValue(forKey: id)
         }
         persistSession(sessionID, updateTimestamp: true)
         if currentSessionID == sessionID {
@@ -1888,7 +1826,7 @@ final class ChatViewModel: ObservableObject {
             message.toolStatus = .running
         }
         imageModelSelectionRequests.removeValue(forKey: toolMessageID)
-        imageModelPreparationContexts.removeValue(forKey: toolMessageID)
+        imageModelDiscoveryContexts.removeValue(forKey: toolMessageID)
         persistSession(sessionID, updateTimestamp: true)
         if currentSessionID == sessionID {
             bumpScroll()
@@ -2743,57 +2681,51 @@ private struct ChatAgentStepCell: View {
     @ViewBuilder
     private var imageModelSelectionPrompt: some View {
         if let request = imageModelSelectionRequest {
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Choose the model to use for \(request.operation.capabilityName).")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-
-                if request.models.isEmpty {
-                    Text("No compatible downloaded models are available.")
+            if request.requiresInstallation {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("No compatible \(request.operation.capabilityName) model is installed. Download one in Models, then return here to continue.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
-                }
+                        .fixedSize(horizontal: false, vertical: true)
 
-                if !request.installedModels.isEmpty {
-                    imageModelSection(
-                        title: "Downloaded",
-                        models: request.installedModels
-                    )
-                }
+                    HStack(spacing: 8) {
+                        cancelImageModelSelectionButton
 
-                if !request.downloadableModels.isEmpty {
-                    imageModelSection(
-                        title: "Available to download",
-                        models: request.downloadableModels
-                    )
-                }
-
-                HStack(spacing: 8) {
-                    Button("Cancel") {
-                        onCancelImageModelSelection(message.id)
+                        Button("Open Models") {
+                            onExploreImageModels(request.operation)
+                        }
+                        .buttonStyle(.borderedProminent)
                     }
-                    .buttonStyle(.bordered)
-
-                    Button("Explore models") {
-                        onExploreImageModels(request.operation)
-                    }
-                    .buttonStyle(.bordered)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 7)
+            } else {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Choose the model to use for \(request.operation.capabilityName).")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    imageModelSection(models: request.models)
+
+                    cancelImageModelSelectionButton
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 7)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 7)
         }
     }
 
+    private var cancelImageModelSelectionButton: some View {
+        Button("Cancel") {
+            onCancelImageModelSelection(message.id)
+        }
+        .buttonStyle(.bordered)
+    }
+
     private func imageModelSection(
-        title: String,
         models: [ChatImageModelOption]
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.secondary)
-
             ForEach(models) { model in
                 ChatImageModelOptionRow(model: model) {
                     onSelectImageModel(message.id, model.modelID)
@@ -2913,37 +2845,29 @@ private struct ChatAgentStepCell: View {
 }
 
 private struct ChatImageModelOptionRow: View {
-    private static let downloadButtonLabelWidth: CGFloat = 180
-
-    @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
-
     let model: ChatImageModelOption
     let onChoose: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 10) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(model.displayName)
-                        .font(.callout.weight(.medium))
-                        .foregroundStyle(.primary)
-                    Text(model.modelID)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-
-                Spacer(minLength: 12)
-                trailingControl
-            }
-
-            if let error = downloadManager.errorByModelID[model.modelID] {
-                Label(error, systemImage: "exclamationmark.triangle.fill")
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.displayName)
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.primary)
+                Text(model.modelID)
                     .font(.caption)
-                    .foregroundStyle(.orange)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
+
+            Spacer(minLength: 12)
+            Button(action: onChoose) {
+                Label("Use", systemImage: "chevron.right")
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Use \(model.displayName)")
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
@@ -2955,46 +2879,6 @@ private struct ChatImageModelOptionRow: View {
             RoundedRectangle(cornerRadius: 7)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         }
-    }
-
-    @ViewBuilder
-    private var trailingControl: some View {
-        if model.isInstalled {
-            Button(action: onChoose) {
-                Label("Use", systemImage: "chevron.right")
-                    .labelStyle(.titleAndIcon)
-            }
-            .buttonStyle(.bordered)
-            .accessibilityLabel("Use \(model.displayName)")
-        } else if downloadManager.isDownloading(model.modelID) {
-            ModelDownloadProgressControl(
-                progress: downloadManager.progress(for: model.modelID),
-                isPaused: downloadManager.isPaused(for: model.modelID),
-                onPauseResume: {
-                    if downloadManager.isPaused(for: model.modelID) {
-                        downloadManager.resumeDownload(model.modelID)
-                    } else {
-                        downloadManager.pauseDownload(model.modelID)
-                    }
-                },
-                onRemove: { downloadManager.removeDownload(model.modelID) }
-            )
-        } else {
-            Button(action: onChoose) {
-                Label(downloadTitle, systemImage: "arrow.down.circle")
-                    .frame(width: Self.downloadButtonLabelWidth)
-            }
-            .buttonStyle(.borderedProminent)
-            .accessibilityLabel("Download and use \(model.displayName)")
-        }
-    }
-
-    private var downloadTitle: String {
-        guard let sizeBytes = model.downloadSizeBytes else {
-            return "Download"
-        }
-        let size = ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
-        return "Download · \(size)"
     }
 }
 

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NativServerKit
 
 enum ChatImageOperation: String, Equatable, Sendable {
     case generate
@@ -32,66 +31,31 @@ enum ChatImageOperation: String, Equatable, Sendable {
 }
 
 struct ChatImageModelOption: Identifiable, Equatable, Sendable {
-    enum Availability: Equatable, Sendable {
-        case installed
-        case downloadable(sizeBytes: Int64?)
-    }
-
     var id: String { modelID }
 
     let displayName: String
     let modelID: String
     let capabilities: Set<LocalModelCapability>
-    let availability: Availability
-
-    var isInstalled: Bool {
-        availability == .installed
-    }
-
-    var downloadSizeBytes: Int64? {
-        guard case .downloadable(let sizeBytes) = availability else {
-            return nil
-        }
-        return sizeBytes
-    }
 
     init(model: LocalModel) {
         let repositoryName = model.repoID.split(separator: "/").last.map(String.init)
         displayName = repositoryName ?? model.displayName
         modelID = model.repoID
         capabilities = model.capabilities
-        availability = .installed
-    }
-
-    init(
-        downloadableModel model: HuggingFaceModel,
-        capabilities: Set<LocalModelCapability>,
-        sizeBytes: Int64
-    ) {
-        displayName = Self.repositoryName(from: model.id)
-        modelID = model.id
-        self.capabilities = capabilities
-        availability = .downloadable(sizeBytes: sizeBytes)
     }
 
     init(
         displayName: String,
         modelID: String,
-        capabilities: Set<LocalModelCapability>,
-        availability: Availability = .installed
+        capabilities: Set<LocalModelCapability>
     ) {
         self.displayName = displayName
         self.modelID = modelID
         self.capabilities = capabilities
-        self.availability = availability
     }
 
     func supports(_ operation: ChatImageOperation) -> Bool {
         capabilities.contains(operation.requiredCapability)
-    }
-
-    private static func repositoryName(from modelID: String) -> String {
-        modelID.split(separator: "/").last.map(String.init) ?? modelID
     }
 }
 
@@ -99,12 +63,8 @@ struct ChatImageModelSelectionRequest: Equatable, Sendable {
     let operation: ChatImageOperation
     let models: [ChatImageModelOption]
 
-    var installedModels: [ChatImageModelOption] {
-        models.filter(\.isInstalled)
-    }
-
-    var downloadableModels: [ChatImageModelOption] {
-        models.filter { !$0.isInstalled }
+    var requiresInstallation: Bool {
+        models.isEmpty
     }
 }
 
@@ -114,76 +74,17 @@ enum ChatImageModelResolution: Equatable, Sendable {
 }
 
 enum ChatImageModelSelection {
-    typealias RecommendationLoader = @Sendable (
-        LocalModelCapability,
-        String?
-    ) async throws -> [HuggingFaceModel]
-
-    static let recommendedModelCount = 3
-    private static let supportedDownloadableModelFamilies =
-        (try? Nativ.imageGenerationModelTypes()) ?? []
-
     static func availableOptions(
         for operation: ChatImageOperation,
         modelSearchPath: String,
-        additionalModelSearchPaths: [String],
-        huggingFaceToken: String?,
-        preferredInstalledModelID: String? = nil,
-        recommendationLoader: RecommendationLoader = { capability, token in
-            try await HuggingFaceModelCatalog.popularModels(
-                with: capability,
-                token: token
-            )
-        }
+        additionalModelSearchPaths: [String]
     ) async throws -> [ChatImageModelOption] {
-        let installedModels = try await installedOptions(
-            modelSearchPath: modelSearchPath,
-            additionalModelSearchPaths: additionalModelSearchPaths
-        )
-        let compatibleInstalledModels = compatibleModels(
+        compatibleModels(
             for: operation,
-            in: installedModels
-        )
-
-        guard needsRecommendations(
-            preferredInstalledModelID: preferredInstalledModelID,
-            installedModels: compatibleInstalledModels
-        ) else {
-            return compatibleInstalledModels
-        }
-
-        let downloadableModels: [ChatImageModelOption]
-        do {
-            let installedModelIDs = Set(compatibleInstalledModels.map(\.modelID))
-            let candidates = try await recommendationLoader(
-                operation.requiredCapability,
-                huggingFaceToken
+            in: try await installedOptions(
+                modelSearchPath: modelSearchPath,
+                additionalModelSearchPaths: additionalModelSearchPaths
             )
-            .filter { !$0.isPrivate && !$0.isGated }
-            .compactMap { model -> (HuggingFaceModel, Set<LocalModelCapability>)? in
-                let capabilities = downloadableCapabilities(
-                    modelID: model.id,
-                    tags: model.tags
-                )
-                guard capabilities.contains(operation.requiredCapability) else {
-                    return nil
-                }
-                return (model, capabilities)
-            }
-            .filter { !installedModelIDs.contains($0.0.id) }
-            downloadableModels = await resolvedDownloadOptions(
-                Array(candidates.prefix(recommendedModelCount))
-            )
-        } catch {
-            // Hub access is optional. When the device is offline, the picker
-            // remains useful and shows only models already on the device.
-            downloadableModels = []
-        }
-
-        return displayOptions(
-            for: operation,
-            installedModels: compatibleInstalledModels,
-            downloadableModels: downloadableModels
         )
     }
 
@@ -217,7 +118,7 @@ enum ChatImageModelSelection {
         let compatibleModels = compatibleModels(for: operation, in: availableModels)
         if let selectedModelID = normalized(selectedModelID),
            let selectedModel = compatibleModels.first(where: {
-               $0.modelID == selectedModelID && $0.isInstalled
+               $0.modelID == selectedModelID
            }) {
             return .selected(selectedModel)
         }
@@ -235,117 +136,11 @@ enum ChatImageModelSelection {
         models.filter { $0.supports(operation) }
     }
 
-    static func downloadableCapabilities(
-        modelID: String,
-        tags: [String]
-    ) -> Set<LocalModelCapability> {
-        let descriptors = ([modelID] + tags).joined(separator: " ").lowercased()
-        guard !["gguf", "lora", "adapter", "controlnet"].contains(where: {
-            descriptors.contains($0)
-        }) else {
-            return []
-        }
-        let name = modelID.split(separator: "/").last.map(String.init)?
-            .lowercased()
-            .replacingOccurrences(of: "-", with: "_") ?? ""
-        let family: String? = if name.contains("flux2") || name.contains("flux_2") {
-            "flux2"
-        } else if name.contains("bonsai") {
-            "bonsai"
-        } else if name.contains("ideogram_4") || name.contains("ideogram4") {
-            "ideogram4"
-        } else if name.contains("mage_flow") {
-            "mage_flow"
-        } else {
-            nil
-        }
-        guard let family, supportedDownloadableModelFamilies.contains(family) else {
-            return []
-        }
-        if family == "flux2" {
-            return [.imageGeneration, .imageEditing]
-        }
-        if family == "mage_flow", MLXImageModelResolver.isKnownImageEditOnlyModelID(modelID) {
-            return [.imageEditing]
-        }
-        return [.imageGeneration]
-    }
-
-    private static func resolvedDownloadOptions(
-        _ candidates: [(HuggingFaceModel, Set<LocalModelCapability>)]
-    ) async -> [ChatImageModelOption] {
-        await withTaskGroup(of: (Int, ChatImageModelOption?).self) { group in
-            for (index, candidate) in candidates.enumerated() {
-                group.addTask {
-                    let size: Int64?
-                    if let estimate = candidate.0.estimatedDownloadBytes {
-                        size = estimate
-                    } else {
-                        size = await HubModelSizeResolver.shared.resolveSize(for: candidate.0.id)
-                    }
-                    guard let size else { return (index, nil) }
-                    return (index, ChatImageModelOption(
-                        downloadableModel: candidate.0,
-                        capabilities: candidate.1,
-                        sizeBytes: size
-                    ))
-                }
-            }
-            return await group.reduce(into: []) { $0.append($1) }
-                .sorted { $0.0 < $1.0 }
-                .compactMap(\.1)
-        }
-    }
-
-    static func displayOptions(
-        for operation: ChatImageOperation,
-        installedModels: [ChatImageModelOption],
-        downloadableModels: [ChatImageModelOption]
-    ) -> [ChatImageModelOption] {
-        let installed = compatibleModels(for: operation, in: installedModels)
-            .sorted(by: modelOrder)
-
-        var includedModelIDs = Set(installed.map(\.modelID))
-        var recommendations: [ChatImageModelOption] = []
-        for option in compatibleModels(for: operation, in: downloadableModels) {
-            guard !option.isInstalled,
-                  includedModelIDs.insert(option.modelID).inserted
-            else {
-                continue
-            }
-            recommendations.append(option)
-            if recommendations.count == recommendedModelCount {
-                break
-            }
-        }
-
-        return installed + recommendations
-    }
-
-    static func needsRecommendations(
-        preferredInstalledModelID: String?,
-        installedModels: [ChatImageModelOption]
-    ) -> Bool {
-        if let preferredInstalledModelID = normalized(preferredInstalledModelID),
-           installedModels.contains(where: { $0.modelID == preferredInstalledModelID }) {
-            return false
-        }
-        return true
-    }
-
     static func selectedModel(
         withID modelID: String,
         from request: ChatImageModelSelectionRequest
     ) -> ChatImageModelOption? {
         request.models.first { $0.modelID == modelID }
-    }
-
-    static func isPrepared(
-        modelID: String,
-        for operation: ChatImageOperation,
-        installedModels: [ChatImageModelOption]
-    ) -> Bool {
-        installedModels.contains { $0.modelID == modelID && $0.supports(operation) }
     }
 
     private static func normalized(_ value: String?) -> String? {

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
@@ -140,9 +140,7 @@ struct ChatImageToolDependencies: Sendable {
     typealias ModelDiscovery = @Sendable (
         ChatImageOperation,
         String,
-        [String],
-        String?,
-        String?
+        [String]
     ) async throws -> [ChatImageModelOption]
     typealias Execution = @Sendable (
         ChatImageToolRequest,
@@ -156,13 +154,11 @@ struct ChatImageToolDependencies: Sendable {
     let execute: Execution
 
     static let live = Self(
-        discoverModels: { operation, path, additionalPaths, token, preferredModelID in
+        discoverModels: { operation, path, additionalPaths in
             try await ChatImageModelSelection.availableOptions(
                 for: operation,
                 modelSearchPath: path,
-                additionalModelSearchPaths: additionalPaths,
-                huggingFaceToken: token,
-                preferredInstalledModelID: preferredModelID
+                additionalModelSearchPaths: additionalPaths
             )
         },
         execute: { request, modelID, baseURL, apiKey, references in

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -161,6 +161,8 @@ final class ChatToolRegistryTests: XCTestCase {
         }
         XCTAssertEqual(request.operation, .generate)
         XCTAssertEqual(request.models.map(\.modelID), ["org/generator", "org/both"])
+        XCTAssertEqual(request.models.map(\.displayName), ["generator", "both"])
+        XCTAssertFalse(request.requiresInstallation)
     }
 
     func testSingleCompatibleModelStillRequiresExplicitSelection() {
@@ -221,7 +223,7 @@ final class ChatToolRegistryTests: XCTestCase {
         XCTAssertEqual(request.models.map(\.modelID), ["org/editor", "org/both"])
     }
 
-    func testNoInstalledImageModelStillPresentsExploreFlow() {
+    func testNoInstalledImageModelRequiresInstallationRecovery() {
         let resolution = ChatImageModelSelection.resolve(
             operation: .generate,
             selectedModelID: nil,
@@ -233,175 +235,25 @@ final class ChatToolRegistryTests: XCTestCase {
         }
         XCTAssertEqual(request.operation, .generate)
         XCTAssertTrue(request.models.isEmpty)
+        XCTAssertTrue(request.requiresInstallation)
     }
 
-    func testPickerShowsAllDownloadedModelsAndThreeHubRecommendations() {
-        let installed = [
-            imageModelOption("org/local-b"),
-            imageModelOption("org/local-a"),
-        ]
-        let downloadable = (1...5).map {
-            imageModelOption(
-                "org/remote-\($0)",
-                availability: .downloadable(sizeBytes: Int64($0) * 1_000)
-            )
-        }
-
-        let options = ChatImageModelSelection.displayOptions(
-            for: .generate,
-            installedModels: installed,
-            downloadableModels: downloadable
-        )
-
-        XCTAssertEqual(options.count, 5)
-        XCTAssertEqual(Array(options.prefix(2).map(\.modelID)), ["org/local-a", "org/local-b"])
-        XCTAssertEqual(options.filter { !$0.isInstalled }.count, 3)
-    }
-
-    func testPickerAlwaysShowsEveryDownloadedModel() {
-        let installed = (1...7).map { imageModelOption("org/local-\($0)") }
-        let downloadable = (1...5).map {
-            imageModelOption(
-                "org/remote-\($0)",
-                availability: .downloadable(sizeBytes: Int64($0) * 1_000)
-            )
-        }
-
-        let options = ChatImageModelSelection.displayOptions(
-            for: .generate,
-            installedModels: installed,
-            downloadableModels: downloadable
-        )
-
-        XCTAssertEqual(options.count, 10)
-        XCTAssertEqual(options.filter(\.isInstalled).count, 7)
-        XCTAssertEqual(options.filter { !$0.isInstalled }.count, 3)
-    }
-
-    func testOfflinePickerShowsOnlyDownloadedModels() {
-        let installed = [imageModelOption("org/local")]
-
-        let options = ChatImageModelSelection.displayOptions(
-            for: .generate,
-            installedModels: installed,
-            downloadableModels: []
-        )
-
-        XCTAssertEqual(options, installed)
-    }
-
-    func testOfflineRecommendationFailureReturnsAnEmptyPicker() async throws {
+    func testMissingModelCacheReturnsNoOptions() async throws {
         let missingPath = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .path
         let options = try await ChatImageModelSelection.availableOptions(
             for: .generate,
             modelSearchPath: missingPath,
-            additionalModelSearchPaths: [],
-            huggingFaceToken: nil,
-            recommendationLoader: { _, _ in
-                throw URLError(.notConnectedToInternet)
-            }
+            additionalModelSearchPaths: []
         )
 
         XCTAssertTrue(options.isEmpty)
     }
 
-    func testRecommendationsOnlyAcceptSupportedMLXImageFamilies() {
-        XCTAssertEqual(
-            ChatImageModelSelection.downloadableCapabilities(
-                modelID: "mlx-community/flux2-klein-4b-8bit",
-                tags: ["mlx"]
-            ),
-            [.imageGeneration, .imageEditing]
-        )
-        XCTAssertEqual(
-            ChatImageModelSelection.downloadableCapabilities(
-                modelID: "mlx-community/stable-diffusion-xl",
-                tags: ["mlx"]
-            ),
-            []
-        )
-        XCTAssertEqual(
-            ChatImageModelSelection.downloadableCapabilities(
-                modelID: "MLXBits/ideogram-4-mlx-q4",
-                tags: ["gguf"]
-            ),
-            []
-        )
-    }
-
-    func testDownloadedModelIsValidatedBeforeToolExecution() {
-        let model = imageModelOption("org/generator")
-
-        XCTAssertTrue(ChatImageModelSelection.isPrepared(
-            modelID: model.modelID,
-            for: .generate,
-            installedModels: [model]
-        ))
-        XCTAssertFalse(ChatImageModelSelection.isPrepared(
-            modelID: model.modelID,
-            for: .edit,
-            installedModels: [model]
-        ))
-    }
-
     func testExploreModelsUsesTheRequestedImageCapability() {
         XCTAssertEqual(ChatImageOperation.generate.requiredCapability, .imageGeneration)
         XCTAssertEqual(ChatImageOperation.edit.requiredCapability, .imageEditing)
-    }
-
-    func testPickerDoesNotRecommendAnAlreadyDownloadedModel() {
-        let installed = [imageModelOption("org/shared")]
-        let downloadable = [
-            imageModelOption(
-                "org/shared",
-                availability: .downloadable(sizeBytes: nil)
-            ),
-            imageModelOption(
-                "org/remote",
-                availability: .downloadable(sizeBytes: nil)
-            ),
-        ]
-
-        let options = ChatImageModelSelection.displayOptions(
-            for: .generate,
-            installedModels: installed,
-            downloadableModels: downloadable
-        )
-
-        XCTAssertEqual(options.map(\.modelID), ["org/shared", "org/remote"])
-    }
-
-    func testSavedDownloadableModelStillRequiresUserSelection() {
-        let downloadable = imageModelOption(
-            "org/remote",
-            availability: .downloadable(sizeBytes: nil)
-        )
-
-        let resolution = ChatImageModelSelection.resolve(
-            operation: .generate,
-            selectedModelID: downloadable.modelID,
-            availableModels: [downloadable]
-        )
-
-        guard case .selectionRequired(let request) = resolution else {
-            return XCTFail("a remote recommendation must not download without consent")
-        }
-        XCTAssertEqual(request.models, [downloadable])
-    }
-
-    func testPreselectedDownloadedModelSkipsHubRecommendations() {
-        let installed = [imageModelOption("org/local")]
-
-        XCTAssertFalse(ChatImageModelSelection.needsRecommendations(
-            preferredInstalledModelID: "org/local",
-            installedModels: installed
-        ))
-        XCTAssertTrue(ChatImageModelSelection.needsRecommendations(
-            preferredInstalledModelID: "org/missing",
-            installedModels: installed
-        ))
     }
 
     func testNativeSelectionRejectsAnIdentifierOutsideItsRequest() throws {
@@ -443,7 +295,7 @@ final class ChatToolRegistryTests: XCTestCase {
         var didStartExecution = false
         var imageContext = makeContext(modelSearchPath: missingPath)
         imageContext.imageToolDependencies = ChatImageToolDependencies(
-            discoverModels: { _, path, additionalPaths, _, _ in
+            discoverModels: { _, path, additionalPaths in
                 try await ChatImageModelSelection.installedOptions(
                     modelSearchPath: path,
                     additionalModelSearchPaths: additionalPaths
@@ -476,6 +328,84 @@ final class ChatToolRegistryTests: XCTestCase {
     }
 
     @MainActor
+    func testNoInstalledModelPresentsRecoveryWithoutStartingGeneration() async throws {
+        var presentedRequest: ChatImageModelSelectionRequest?
+        var didStartExecution = false
+        var context = makeContext()
+        context.imageToolDependencies = ChatImageToolDependencies(
+            discoverModels: { _, _, _ in [] },
+            execute: { _, _, _, _, _ in
+                throw FakeToolError()
+            }
+        )
+        context.imageModelSelection = { request in
+            presentedRequest = request
+            return "org/not-offered"
+        }
+        context.imageExecutionWillStart = { _ in
+            didStartExecution = true
+        }
+
+        do {
+            _ = try await ChatToolDispatcher.execute(
+                call: makeCall(
+                    name: ChatImageToolRegistry.generateToolName,
+                    arguments: #"{"prompt":"A lake"}"#
+                ),
+                context: context
+            )
+            XCTFail("generation must wait for an installed model")
+        } catch let error as ChatImageToolError {
+            guard case .modelSelectionUnavailable(.generate) = error else {
+                return XCTFail("expected modelSelectionUnavailable(.generate), got \(error)")
+            }
+        }
+
+        XCTAssertEqual(presentedRequest?.operation, .generate)
+        XCTAssertEqual(presentedRequest?.models, [])
+        XCTAssertEqual(presentedRequest?.requiresInstallation, true)
+        XCTAssertFalse(didStartExecution)
+    }
+
+    @MainActor
+    func testPreselectedModelPropagatesExactIDWithoutPresentingSelection() async throws {
+        let selectedModel = ChatImageModelOption(
+            displayName: "Image Model",
+            modelID: "org/preselected-image-model",
+            capabilities: [.imageGeneration]
+        )
+        let recorder = ImageToolExecutionRecorder()
+        var sessionModelID: String?
+        var context = makeContext(imageModelID: selectedModel.modelID)
+        context.imageToolDependencies = ChatImageToolDependencies(
+            discoverModels: { _, _, _ in [selectedModel] },
+            execute: { _, modelID, _, _, _ in
+                await recorder.record(modelID: modelID)
+                return ChatImageToolExecution(content: #"{"ok":true}"#, attachments: [])
+            }
+        )
+        context.imageModelSelection = { _ in
+            XCTFail("a valid preselection must not present the model picker")
+            return "org/unexpected"
+        }
+        context.imageExecutionWillStart = { modelID in
+            sessionModelID = modelID
+        }
+
+        _ = try await ChatToolDispatcher.execute(
+            call: makeCall(
+                name: ChatImageToolRegistry.generateToolName,
+                arguments: #"{"prompt":"A lake"}"#
+            ),
+            context: context
+        )
+
+        XCTAssertEqual(sessionModelID, selectedModel.modelID)
+        let executedModelID = await recorder.recordedModelID()
+        XCTAssertEqual(executedModelID, selectedModel.modelID)
+    }
+
+    @MainActor
     func testNativeSelectionPropagatesExactModelIDToExecutionAndSessionCallback() async throws {
         let selectedModel = ChatImageModelOption(
             displayName: "Image Model",
@@ -491,7 +421,7 @@ final class ChatToolRegistryTests: XCTestCase {
         var sessionModelID: String?
         var context = makeContext()
         context.imageToolDependencies = ChatImageToolDependencies(
-            discoverModels: { _, _, _, _, _ in [selectedModel, languageModel] },
+            discoverModels: { _, _, _ in [selectedModel, languageModel] },
             execute: { _, modelID, _, _, _ in
                 await recorder.record(modelID: modelID)
                 return ChatImageToolExecution(content: #"{"ok":true}"#, attachments: [])
@@ -646,17 +576,6 @@ final class ChatToolRegistryTests: XCTestCase {
         ]
     }
 
-    private func imageModelOption(
-        _ modelID: String,
-        availability: ChatImageModelOption.Availability = .installed
-    ) -> ChatImageModelOption {
-        ChatImageModelOption(
-            displayName: modelID.split(separator: "/").last.map(String.init) ?? modelID,
-            modelID: modelID,
-            capabilities: [.imageGeneration],
-            availability: availability
-        )
-    }
 }
 
 @MainActor


### PR DESCRIPTION
finishes the tasks from #131, now routes user when chat model is trying to tool-call a image model, when none is present:


<img width="833" height="493" alt="Screenshot 2026-08-13 at 9 26 55 AM" src="https://github.com/user-attachments/assets/55017062-e528-4529-9a3d-cfee28ac35fa" />


