### PR TITLE
Fix image model empty state and discovery flow

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -2416,7 +2416,8 @@ private struct ChatWorkspaceView: View {
                     viewModel: imageGeneration,
                     workspaceMode: mode,
                     onSelectWorkspaceMode: onSelectMode,
-                    conversationWidthReduction: conversationWidthReduction
+                    conversationWidthReduction: conversationWidthReduction,
+                    onExploreImageModels: { onExploreImageModels(.generate) }
                 )
             }
         }

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -291,6 +291,8 @@ struct ChatComposer: View {
             helpText: modelPickerHelp,
             accessibilityValue: modelPickerAccessibilityValue,
             shortcutLabel: "⌃⇧M",
+            emptyStateActionTitle: nil,
+            onEmptyStateAction: nil,
             onSelectModel: select,
             onSwitchModel: { model.switchLanguageModel(to: $0) }
         )
@@ -646,6 +648,8 @@ struct ComposerModelPicker: View {
     let helpText: String
     let accessibilityValue: String
     let shortcutLabel: String?
+    let emptyStateActionTitle: String?
+    let onEmptyStateAction: (() -> Void)?
     let onSelectModel: (LocalModel) -> Void
     let onSwitchModel: (String) -> Void
 
@@ -663,6 +667,8 @@ struct ComposerModelPicker: View {
                 isEnabled: !isDisabled,
                 usesSelectModelShortcut: shortcutLabel != nil,
                 statusLabel: statusLabel,
+                emptyStateActionTitle: emptyStateActionTitle,
+                onEmptyStateAction: onEmptyStateAction,
                 onSelectModel: onSelectModel,
                 onSwitchModel: onSwitchModel,
                 onTrackingChanged: { isTracking in
@@ -746,6 +752,8 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
     let isEnabled: Bool
     let usesSelectModelShortcut: Bool
     let statusLabel: String
+    let emptyStateActionTitle: String?
+    let onEmptyStateAction: (() -> Void)?
     let onSelectModel: (LocalModel) -> Void
     let onSwitchModel: (String) -> Void
     let onTrackingChanged: (Bool) -> Void
@@ -876,9 +884,26 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
                 let item = NSMenuItem(title: parent.statusLabel, action: nil, keyEquivalent: "")
                 item.isEnabled = false
                 menu.addItem(item)
+
+                if let actionTitle = parent.emptyStateActionTitle,
+                   parent.onEmptyStateAction != nil {
+                    menu.addItem(.separator())
+                    let actionItem = NSMenuItem(
+                        title: actionTitle,
+                        action: #selector(performEmptyStateAction),
+                        keyEquivalent: ""
+                    )
+                    actionItem.target = self
+                    actionItem.isEnabled = true
+                    menu.addItem(actionItem)
+                }
             }
 
             return menu
+        }
+
+        @objc private func performEmptyStateAction() {
+            parent.onEmptyStateAction?()
         }
 
         private func makeSecondaryMenu(

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
@@ -14,6 +14,8 @@ struct ImageGenerationView: View {
     let workspaceMode: ChatWorkspaceMode
     let onSelectWorkspaceMode: (ChatWorkspaceMode) -> Void
     let conversationWidthReduction: CGFloat
+    let onExploreImageModels: () -> Void
+    @StateObject private var localLibrary = LocalModelLibrary()
     @State private var transcriptScrollPosition = ScrollPosition(edge: .bottom)
     @State private var composerHeight: CGFloat = 0
     @State private var followsLatestTurn = true
@@ -24,8 +26,12 @@ struct ImageGenerationView: View {
                 ImageGenerationComposer(
                     model: model,
                     viewModel: viewModel,
+                    localModels: localLibrary.models,
+                    isScanningForModels: localLibrary.isScanning,
+                    modelScanError: localLibrary.error,
                     workspaceMode: workspaceMode,
-                    onSelectWorkspaceMode: onSelectWorkspaceMode
+                    onSelectWorkspaceMode: onSelectWorkspaceMode,
+                    onExploreImageModels: onExploreImageModels
                 )
                     .frame(
                         maxWidth: Layout.composerMaxWidth
@@ -47,21 +53,59 @@ struct ImageGenerationView: View {
                     }
             }
             .background(Color.nativMainContentBackground)
+            .task(id: modelScanKey) {
+                localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
+                localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
+            }
+            .onChange(of: imageModels.map(\.repoID)) { _, modelIDs in
+                viewModel.applyDefaultModel(
+                    model.settings.normalized().imageGenerationModelID,
+                    installedImageModelIDs: modelIDs
+                )
+            }
             .onAppear {
                 viewModel.applyDefaultModel(model.settings.normalized().imageGenerationModelID)
                 followsLatestTurn = true
                 transcriptScrollPosition.scrollTo(edge: .bottom)
             }
             .onDisappear {
+                localLibrary.cancel()
                 viewModel.persistDraftState()
             }
+    }
+
+    private var imageModels: [LocalModel] {
+        localLibrary.models.filter {
+            !$0.capabilities.isDisjoint(
+                with: [.imageGeneration, .imageEditing]
+            )
+        }
+    }
+
+    private var selectedModelID: String? {
+        imageModels.contains { $0.repoID == viewModel.modelID }
+            ? viewModel.modelID
+            : nil
+    }
+
+    private var modelScanKey: String {
+        model.settings.localModelSearchPaths.cacheKey
     }
 
     private var transcript: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 22) {
                 if viewModel.turns.isEmpty {
-                    ImageGenerationEmptyView(isRunning: model.isRunning)
+                    ImageGenerationEmptyView(
+                        isRunning: model.isRunning,
+                        selectedModelID: selectedModelID,
+                        modelLoadingProgress: model.isModelLoading
+                            && model.modelLoadingID == selectedModelID
+                            ? model.modelLoadingProgress
+                            : nil
+                    )
                         .frame(maxWidth: .infinity)
                         .padding(.top, 120)
                 } else {
@@ -106,9 +150,12 @@ struct ImageGenerationView: View {
 private struct ImageGenerationComposer: View {
     @ObservedObject var model: NativModel
     @ObservedObject var viewModel: ImageGenerationViewModel
+    let localModels: [LocalModel]
+    let isScanningForModels: Bool
+    let modelScanError: String?
     let workspaceMode: ChatWorkspaceMode
     let onSelectWorkspaceMode: (ChatWorkspaceMode) -> Void
-    @StateObject private var localLibrary = LocalModelLibrary()
+    let onExploreImageModels: () -> Void
     @State private var editorContentHeight: CGFloat = 0
     @State private var showsSettings = false
     @State private var isDropTargeted = false
@@ -119,6 +166,14 @@ private struct ImageGenerationComposer: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
+            if let unavailableReason {
+                Text(unavailableReason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .padding(.leading, textInset.leading + 4)
+            }
+
             VStack(alignment: .leading, spacing: 0) {
                 ZStack(alignment: .topLeading) {
                     ChatComposerTextEditor(
@@ -204,29 +259,6 @@ private struct ImageGenerationComposer: View {
             )
         }
         .padding(.vertical, 18)
-        .task(id: modelScanKey) {
-            localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
-            localLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
-        }
-        .onChange(of: localLibrary.models) { _, models in
-            let generationModels = models.filter {
-                $0.capabilities.contains(.imageGeneration)
-            }
-            let editOnlyModels = models.filter {
-                $0.capabilities.contains(.imageEditing)
-                    && !$0.capabilities.contains(.imageGeneration)
-            }
-            viewModel.applyDefaultModel(
-                model.settings.normalized().imageGenerationModelID,
-                installedImageModelIDs: (generationModels + editOnlyModels)
-                    .map(\.repoID)
-            )
-        }
-        .onDisappear {
-            localLibrary.cancel()
-        }
     }
 
     @ViewBuilder
@@ -260,11 +292,14 @@ private struct ImageGenerationComposer: View {
     }
 
     private var canCompose: Bool {
-        model.isRunning && !viewModel.isGenerating
+        model.isRunning
+            && selectedModelID != nil
+            && !viewModel.isGenerating
     }
 
     private var canSubmit: Bool {
-        viewModel.canSubmit(isRunning: model.isRunning)
+        selectedModelID != nil
+            && viewModel.canSubmit(isRunning: model.isRunning)
             && (!selectedModelIsEditOnly || viewModel.nextRequestIsEdit)
     }
 
@@ -282,13 +317,17 @@ private struct ImageGenerationComposer: View {
     }
 
     private var modelLabel: String {
-        viewModel.modelID.split(separator: "/").last.map(String.init) ?? viewModel.modelID
+        guard let selectedModelID else {
+            return "Choose model"
+        }
+        return selectedModelID.split(separator: "/").last.map(String.init)
+            ?? selectedModelID
     }
 
     private var modelPicker: some View {
         ComposerModelPicker(
             models: imageModels,
-            selectedModelID: viewModel.modelID,
+            selectedModelID: selectedModelID,
             selectedModelLabel: modelLabel,
             selectedModelProvider: selectedModelProvider,
             selectedModelDetail: nil,
@@ -302,42 +341,42 @@ private struct ImageGenerationComposer: View {
             helpText: modelPickerHelp,
             accessibilityValue: modelLabel,
             shortcutLabel: "⌃⇧M",
+            emptyStateActionTitle: "Browse Image Models…",
+            onEmptyStateAction: onExploreImageModels,
             onSelectModel: selectImageModel,
             onSwitchModel: selectImageModel
         )
     }
 
     private var imageModels: [LocalModel] {
-        localLibrary.models.filter {
+        localModels.filter {
             !$0.capabilities.isDisjoint(
                 with: [.imageGeneration, .imageEditing]
             )
         }
     }
 
+    private var selectedModelID: String? {
+        imageModels.contains { $0.repoID == viewModel.modelID }
+            ? viewModel.modelID
+            : nil
+    }
+
     private var selectedModelIsEditOnly: Bool {
-        if let selectedModel = imageModels.first(where: {
-            $0.repoID == viewModel.modelID
-        }) {
-            return selectedModel.capabilities.contains(.imageEditing)
-                && !selectedModel.capabilities.contains(.imageGeneration)
-        }
-        return MLXImageModelResolver.isKnownImageEditOnlyModelID(
-            viewModel.modelID
-        )
+        guard let selectedModelID,
+              let selectedModel = imageModels.first(where: {
+                  $0.repoID == selectedModelID
+              })
+        else { return false }
+        return selectedModel.capabilities.contains(.imageEditing)
+            && !selectedModel.capabilities.contains(.imageGeneration)
     }
 
     private var selectedModelProvider: LocalModelProvider? {
-        if let provider = imageModels.first(where: {
-            $0.repoID == viewModel.modelID
-        })?.provider {
-            return provider
-        }
-        return LocalModelProviderResolver.resolve(
-            repoID: viewModel.modelID,
-            modelType: nil,
-            architectures: []
-        )
+        guard let selectedModelID else { return nil }
+        return imageModels.first(where: {
+            $0.repoID == selectedModelID
+        })?.provider
     }
 
     private var isSelectedModelLoading: Bool {
@@ -345,10 +384,10 @@ private struct ImageGenerationComposer: View {
     }
 
     private var localModelStatusLabel: String {
-        if localLibrary.isScanning {
+        if isScanningForModels {
             return "Scanning for models…"
         }
-        return localLibrary.error ?? "No installed image models"
+        return modelScanError ?? "No compatible image models"
     }
 
     private var modelPickerHelp: String {
@@ -364,8 +403,11 @@ private struct ImageGenerationComposer: View {
         return "Change image model"
     }
 
-    private var modelScanKey: String {
-        model.settings.localModelSearchPaths.cacheKey
+    private var unavailableReason: String? {
+        if !model.isRunning {
+            return "Server is stopped."
+        }
+        return nil
     }
 
     private var actionButtonColor: Color {
@@ -401,7 +443,7 @@ private struct ImageGenerationComposer: View {
         model.requestPreloadedModelSwitch(
             to: localModel,
             for: .imageGeneration,
-            availableModels: localLibrary.models
+            availableModels: localModels
         ) {
             viewModel.applyDefaultModel(localModel.repoID)
         }
@@ -682,19 +724,57 @@ private struct ImageAttachmentPreview: View {
 
 private struct ImageGenerationEmptyView: View {
     let isRunning: Bool
+    let selectedModelID: String?
+    let modelLoadingProgress: Double?
 
     var body: some View {
-        ContentUnavailableView {
-            Label("Create with Images", systemImage: "photo.artframe")
-        } description: {
-            Text(description)
+        VStack(spacing: 16) {
+            Image("NativMark")
+                .resizable()
+                .renderingMode(.template)
+                .scaledToFit()
+                .frame(width: 64)
+                .foregroundStyle(.secondary)
+
+            if let modelLoadingProgress {
+                ProgressView(value: modelLoadingProgress)
+                    .progressViewStyle(.linear)
+                    .frame(width: 180)
+            }
+
+            VStack(spacing: 7) {
+                Text(title)
+                    .font(.headline)
+                Text(detail)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
         }
-        .frame(maxWidth: 520)
     }
 
-    private var description: String {
+    private var title: String {
+        if modelLoadingProgress != nil {
+            return "Loading image model"
+        }
         if !isRunning {
-            return "Start the server, then describe an image below. Attach a reference to edit it."
+            return "Server is stopped"
+        }
+        if selectedModelID == nil {
+            return "No image model downloaded"
+        }
+        return "Create with Images"
+    }
+
+    private var detail: String {
+        if let modelLoadingProgress {
+            let percentage = Int((modelLoadingProgress * 100).rounded())
+            return "\(selectedModelID ?? "Image model") · \(percentage)%"
+        }
+        if !isRunning {
+            return "Start the server to create images."
+        }
+        if selectedModelID == nil {
+            return "Download an image model in Models."
         }
         return "Describe an image below. Attach a reference to edit it, then continue iterating from any result."
     }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -334,6 +334,8 @@ struct ModelsView: View {
         section = .discover
         typeFilter = .image
         hubQuery = ""
+        hubSort = .downloads
+        hubSortDirection = .descending
         hubCapabilityFilters = [imageModelDiscoveryCapability]
         hubAccessFilter = .all
     }


### PR DESCRIPTION
Closes #297 

- Prevents deleted or unavailable image models from remaining selected.
- Mirrors Chat’s no-model, server-stopped, and model-loading states.
- Shows “No compatible image models” inside the model picker.
- Adds a “Browse Image Models…” CTA that opens the model browser with image-generation filters applied.
- Sorts discovered image models by downloads in descending order.
- Disables image generation until a compatible model is installed and selected.

<img width="925" height="170" alt="Screenshot 2026-08-13 at 6 54 08 PM" src="https://github.com/user-attachments/assets/dff3d373-920d-4f7d-9800-b53a72f3dd6e" />
