### PR TITLE
Add reranking capability discovery

### DIFF
--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -152,6 +152,9 @@ private final class ModelMenuRowView: NSView {
             case .embeddings:
                 symbolName = "circle.grid.3x3.fill"
                 description = capability.displayName
+            case .reranking:
+                symbolName = "arrow.up.arrow.down.circle.fill"
+                description = capability.displayName
             case .reasoning:
                 symbolName = "brain.fill"
                 description = capability.displayName

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -1587,6 +1587,7 @@ private struct ServerEndpoint: Identifiable {
         .init(method: .post, path: "/v1/images/edits", category: .openAI),
         .init(method: .get, path: "/v1/models", category: .openAI),
         .init(method: .post, path: "/v1/embeddings", category: .openAI),
+        .init(method: .post, path: "/v1/rerank", category: .openAI),
         .init(method: .post, path: "/v1/audio/speech", category: .openAI),
         .init(method: .post, path: "/v1/audio/transcriptions", category: .openAI),
         .init(method: .post, path: "/v1/audio/translations", category: .openAI),

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -117,6 +117,8 @@ enum HuggingFaceCapabilityFilter {
             return "text-to-speech"
         case .embeddings:
             return "feature-extraction"
+        case .reranking:
+            return "text-ranking"
         case .reasoning, .tools, .drafter:
             return nil
         }
@@ -353,6 +355,12 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
             || descriptors.contains("embedding")
             || descriptors.contains("sentence-transformers") {
             result.insert(.embeddings)
+        }
+
+        if pipeline == "text-ranking"
+            || descriptors.contains("reranker")
+            || descriptors.contains("reranking") {
+            result.insert(.reranking)
         }
 
         if descriptors.contains("reasoning") || descriptors.contains("thinking") {

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -35,6 +35,7 @@ enum LocalModelCapability: String, CaseIterable, Hashable, Sendable {
     case speechToText
     case textToSpeech
     case embeddings
+    case reranking
     case reasoning
     case tools
     case drafter
@@ -59,6 +60,8 @@ enum LocalModelCapability: String, CaseIterable, Hashable, Sendable {
             "Text to Speech"
         case .embeddings:
             "Embeddings"
+        case .reranking:
+            "Reranking"
         case .reasoning:
             "Reasoning"
         case .tools:
@@ -113,7 +116,7 @@ struct LocalModel: Identifiable, Equatable, Sendable {
     var isEligibleForLanguageModelPicker: Bool {
         // Any text-generative model qualifies (chat + omni), even if it also carries an
         // image-generation tag. A vision model qualifies only when it isn't image-gen/editing.
-        guard !capabilities.contains(.drafter) else {
+        guard !capabilities.contains(.drafter), !capabilities.contains(.reranking) else {
             return false
         }
         return capabilities.contains(.text)
@@ -1303,6 +1306,12 @@ enum LocalModelDiscovery {
             if isEmbeddingModel && !capabilities.contains(.vision) {
                 capabilities.insert(.embeddings)
             }
+        }
+
+        if model.localizedCaseInsensitiveContains("rerank")
+            || descriptors.contains("reranker")
+            || descriptors.contains("reranking") {
+            capabilities.insert(.reranking)
         }
 
         if capabilities.contains(.text)

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -24,6 +24,7 @@ private enum ModelsTypeFilter: String, CaseIterable, Identifiable {
     case image = "Image"
     case speech = "Speech"
     case embeddings = "Embeddings"
+    case reranking = "Reranking"
 
     var id: String { rawValue }
 
@@ -39,6 +40,8 @@ private enum ModelsTypeFilter: String, CaseIterable, Identifiable {
             !capabilities.isDisjoint(with: [.audio, .speechToText, .textToSpeech])
         case .embeddings:
             capabilities.contains(.embeddings)
+        case .reranking:
+            capabilities.contains(.reranking)
         }
     }
 
@@ -796,7 +799,8 @@ struct ModelsView: View {
 
     private func preloadSlots(for localModel: LocalModel) -> [ModelPreloadSlot] {
         var slots: [ModelPreloadSlot] = []
-        if localModel.capabilities.contains(.text) {
+        if localModel.capabilities.contains(.text)
+            && !localModel.capabilities.contains(.reranking) {
             slots.append(.language)
         }
         if localModel.capabilities.contains(.imageGeneration) {
@@ -829,6 +833,8 @@ struct ModelsView: View {
                 nil
             case .embeddings:
                 .embeddings
+            case .reranking:
+                nil
             }
         if let preferredSlot, slots.contains(preferredSlot) {
             return preferredSlot
@@ -2504,6 +2510,7 @@ extension LocalModelCapability {
         .speechToText,
         .textToSpeech,
         .embeddings,
+        .reranking,
     ]
 
     fileprivate static let discoverFeatureFilters: [Self] = [
@@ -2532,6 +2539,8 @@ extension LocalModelCapability {
             URLQueryItem(name: "pipeline_tag", value: "text-to-speech")
         case .embeddings:
             URLQueryItem(name: "pipeline_tag", value: "feature-extraction")
+        case .reranking:
+            URLQueryItem(name: "pipeline_tag", value: "text-ranking")
         case .reasoning:
             URLQueryItem(name: "other", value: "reasoning")
         case .tools:
@@ -2552,6 +2561,7 @@ extension LocalModelCapability {
         case .speechToText: "captions.bubble"
         case .textToSpeech: "speaker.wave.2"
         case .embeddings: "circle.grid.3x3"
+        case .reranking: "arrow.up.arrow.down.circle"
         case .reasoning: "brain.fill"
         case .tools: "hammer"
         case .drafter: "hare"

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -33,7 +33,7 @@ private enum ModelsTypeFilter: String, CaseIterable, Identifiable {
         case .all:
             true
         case .language:
-            capabilities.contains(.text)
+            capabilities.contains(.text) && !capabilities.contains(.reranking)
         case .image:
             !capabilities.isDisjoint(with: [.imageGeneration, .imageEditing])
         case .speech:

--- a/Tests/NativTests/LocalModelDiscoveryTests.swift
+++ b/Tests/NativTests/LocalModelDiscoveryTests.swift
@@ -494,6 +494,20 @@ final class LocalModelDiscoveryTests: XCTestCase {
         XCTAssertTrue(chatModel.isEligibleForLanguageModelPicker)
     }
 
+    func testRerankerIsClassifiedAndExcludedFromLanguageModelPicker() async throws {
+        try makeTextModelSnapshot(
+            repoID: "mlx-community/Qwen3-Reranker-0.6B-mxfp8",
+            modelType: "qwen3",
+            architectures: ["Qwen3ForCausalLM"],
+            sentenceTransformer: false
+        )
+
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+        let reranker = try XCTUnwrap(models.first)
+        XCTAssertTrue(reranker.capabilities.contains(.reranking))
+        XCTAssertFalse(reranker.isEligibleForLanguageModelPicker)
+    }
+
     private func write(_ string: String, to url: URL) throws {
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),

--- a/Tests/NativTests/LocalModelProviderTests.swift
+++ b/Tests/NativTests/LocalModelProviderTests.swift
@@ -184,6 +184,10 @@ final class HuggingFaceCapabilityFilterTests: XCTestCase {
             HuggingFaceCapabilityFilter.pipelineTag(for: [.embeddings]),
             "feature-extraction"
         )
+        XCTAssertEqual(
+            HuggingFaceCapabilityFilter.pipelineTag(for: [.reranking]),
+            "text-ranking"
+        )
     }
 
     func testFeatureTagCanBeCombinedWithPipelineTask() {
@@ -218,12 +222,15 @@ final class HuggingFaceCapabilityFilterTests: XCTestCase {
             try capabilities(for: "sentence-similarity"),
             [.embeddings]
         )
+        XCTAssertEqual(
+            try capabilities(for: "text-ranking"),
+            [.reranking]
+        )
     }
 
     func testUnsupportedWorkflowTagsAreNotTreatedAsRunnableModels() throws {
         XCTAssertTrue(try capabilities(for: "any-to-any").isEmpty)
         XCTAssertTrue(try capabilities(for: "translation").isEmpty)
-        XCTAssertTrue(try capabilities(for: "text-ranking").isEmpty)
     }
 
     func testDrafterAliasesResolveToDrafterCapability() throws {


### PR DESCRIPTION
## Summary

- recognize Hugging Face `text-ranking` models as a dedicated reranking capability
- keep rerankers out of the chat/language model picker
- add Models filtering/badges and list `/v1/rerank` in Developer endpoints
- add focused Hub and installed-model discovery tests

Closes #301.
Depends on Blaizzy/mlx-vlm#1853 for the actual reranking runtime and `/v1/rerank` lifecycle.

## Verification

- `git diff --check`: passed
- `xcrun swiftc -parse` over all seven changed Swift files: passed
- mlx-vlm#1853 real offline runtime proof with `mlx-community/Qwen3-Reranker-0.6B-mxfp8`: `/v1/rerank` HTTP 200, relevant document ranked first, `loaded_models.reranker` readback present, unload successful
- local focused Xcode tests: not completed; Xcode 26 remained at `Resolve Package Graph` even with `Package.resolved`, updates disabled, and the existing SourcePackages cache
- upstream Dev Build workflow: `action_required` because this is a first-time fork contribution and requires maintainer approval before jobs run

This is intentionally a draft until CI or a clean focused Xcode run proves the Swift changes. No runtime, service, or installed Nativ app was modified.