### PR TITLE
fix: align disk usage with macOS storage

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */; };
 		FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
+		FD352DCFF32FE229BAB87AA7 /* SystemMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F4E2B8E8BCAD7B890346CB /* SystemMonitorTests.swift */; };
 		FEB97639F6A1334E409830CF /* ChatWebSearchToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA5142DB692E378ADE8DFA0 /* ChatWebSearchToolTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -330,6 +331,7 @@
 		42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		46B469F1D62E2DB0DE8CFAF1 /* NativPermissionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativPermissionsCard.swift; sourceTree = "<group>"; };
 		46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSemanticSearch.swift; sourceTree = "<group>"; };
+		46F4E2B8E8BCAD7B890346CB /* SystemMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorTests.swift; sourceTree = "<group>"; };
 		49B4556627CCB5BD1D3DE5F8 /* VoiceDictationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtension.swift; sourceTree = "<group>"; };
 		4C93856381B1D89C4DE61DCC /* VoiceCaptureOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureOverlay.swift; sourceTree = "<group>"; };
 		50843C4D4ABCEC290EE626AF /* RoutineRunCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineRunCoordinator.swift; sourceTree = "<group>"; };
@@ -918,6 +920,7 @@
 				E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */,
 				E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */,
 				3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */,
+				46F4E2B8E8BCAD7B890346CB /* SystemMonitorTests.swift */,
 			);
 			path = NativTests;
 			sourceTree = "<group>";
@@ -1321,6 +1324,7 @@
 				BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */,
 				36405D7EB30E430CF06956EB /* ShellEnvironmentTests.swift in Sources */,
 				293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */,
+				FD352DCFF32FE229BAB87AA7 /* SystemMonitorTests.swift in Sources */,
 				14CEDB8ACA6EB7BCF8A3430C /* SystemSensorSampler.swift in Sources */,
 				E180E254213BCD770141B872 /* VoiceAnimationPreferences.swift in Sources */,
 				A6E043CD0C3AD882D0D0AE66 /* VoiceAudioRecorder.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/Tools/ChatSystemStatsTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatSystemStatsTool.swift
@@ -59,8 +59,8 @@ struct ChatSystemMonitorToolExecutor {
             gpuUsagePercent: snapshot.gpu.deviceUsage.flatMap(percent),
             memoryUsedGB: gigabytes(snapshot.memory.usedBytes),
             memoryTotalGB: gigabytes(snapshot.memory.totalBytes),
-            diskUsedGB: gigabytes(snapshot.disk.usedBytes),
-            diskTotalGB: gigabytes(snapshot.disk.totalBytes),
+            diskUsedGB: snapshot.disk.usedBytes.map(gigabytes),
+            diskTotalGB: snapshot.disk.totalBytes.map(gigabytes),
             uptimeSeconds: Int(snapshot.uptime),
             error: nil
         )

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
@@ -59,20 +59,60 @@ struct SystemMemoryMetrics: Equatable, Sendable {
 }
 
 struct SystemDiskMetrics: Equatable, Sendable {
-    var totalBytes: UInt64 = 0
-    var availableBytes: UInt64 = 0
+    var totalBytes: UInt64?
+    var availableBytes: UInt64?
     var readBytesPerSecond: Double = 0
     var writeBytesPerSecond: Double = 0
     var cumulativeReadBytes: UInt64 = 0
     var cumulativeWriteBytes: UInt64 = 0
 
-    var usedBytes: UInt64 {
-        totalBytes > availableBytes ? totalBytes - availableBytes : 0
+    var usedBytes: UInt64? {
+        guard let totalBytes, let availableBytes, availableBytes <= totalBytes else {
+            return nil
+        }
+        return totalBytes - availableBytes
     }
 
-    var usage: Double {
-        guard totalBytes > 0 else { return 0 }
-        return min(max(Double(usedBytes) / Double(totalBytes), 0), 1)
+    var usage: Double? {
+        guard let totalBytes, totalBytes > 0, let usedBytes else { return nil }
+        return Double(usedBytes) / Double(totalBytes)
+    }
+
+    /// Resolves the capacities used by macOS storage UI.
+    ///
+    /// Important-usage capacity includes space the system can reclaim, such as
+    /// purgeable APFS data. Raw available capacity is retained as a fallback for
+    /// file systems that do not expose the preferred value. Inconsistent values
+    /// are rejected so a failed capacity read is not presented as an empty disk.
+    static func resolvedCapacity(
+        total: Int?,
+        availableForImportantUsage: Int64?,
+        available: Int?
+    ) -> (total: UInt64, available: UInt64)? {
+        guard let total = validatedBytes(total), total > 0 else { return nil }
+
+        if let important = validatedBytes(
+            availableForImportantUsage,
+            notExceeding: total
+        ) {
+            return (total, important)
+        }
+        guard let fallback = validatedBytes(available, notExceeding: total) else {
+            return nil
+        }
+        return (total, fallback)
+    }
+
+    private static func validatedBytes<Value: BinaryInteger>(
+        _ value: Value?,
+        notExceeding upperBound: UInt64 = .max
+    ) -> UInt64? {
+        guard let value,
+              let bytes = UInt64(exactly: value),
+              bytes <= upperBound else {
+            return nil
+        }
+        return bytes
     }
 }
 
@@ -669,10 +709,14 @@ private actor SystemMetricsCollector {
         let rootURL = URL(fileURLWithPath: "/")
         let values = try? rootURL.resourceValues(forKeys: [
             .volumeTotalCapacityKey,
+            .volumeAvailableCapacityForImportantUsageKey,
             .volumeAvailableCapacityKey,
         ])
-        let total = UInt64(max(values?.volumeTotalCapacity ?? 0, 0))
-        let available = UInt64(max(values?.volumeAvailableCapacity ?? 0, 0))
+        let capacity = SystemDiskMetrics.resolvedCapacity(
+            total: values?.volumeTotalCapacity,
+            availableForImportantUsage: values?.volumeAvailableCapacityForImportantUsage,
+            available: values?.volumeAvailableCapacity
+        )
 
         let interval = max(elapsed ?? 0, 0)
         let readRate: Double
@@ -694,8 +738,8 @@ private actor SystemMetricsCollector {
         }
 
         return SystemDiskMetrics(
-            totalBytes: total,
-            availableBytes: available,
+            totalBytes: capacity?.total,
+            availableBytes: capacity?.available,
             readBytesPerSecond: readRate,
             writeBytesPerSecond: writeRate,
             cumulativeReadBytes: current.readBytes,

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -304,8 +304,10 @@ private struct SystemOverviewPage: View {
                 )
                 SystemOverviewMetric(
                     title: "Disk",
-                    value: SystemMonitorFormat.percent(snapshot.disk.usage),
-                    detail: "\(SystemMonitorFormat.bytes(snapshot.disk.availableBytes)) free",
+                    value: SystemMonitorFormat.optionalPercent(snapshot.disk.usage),
+                    detail: snapshot.disk.availableBytes
+                        .map { "\(SystemMonitorFormat.bytes($0)) available" }
+                        ?? "Capacity unavailable",
                     icon: "internaldrive",
                     tint: SystemMonitorPalette.orange
                 )
@@ -333,7 +335,11 @@ private struct SystemOverviewPage: View {
                     )
                     SystemInfoRow(
                         "Disk",
-                        value: "\(snapshot.identity.disk.volumeName) · \(SystemMonitorFormat.bytes(snapshot.disk.totalBytes))"
+                        value: snapshot.disk.totalBytes
+                            .map {
+                                "\(snapshot.identity.disk.volumeName) · \(SystemMonitorFormat.bytes($0))"
+                            }
+                            ?? "\(snapshot.identity.disk.volumeName) · Unavailable"
                     )
                     SystemInfoRow(
                         "Display",
@@ -800,7 +806,8 @@ private struct SystemCPUPage: View {
                 HStack(spacing: 24) {
                     SystemUsageGauge(
                         value: snapshot.cpu.totalUsage,
-                        tint: SystemMonitorPalette.blue
+                        tint: SystemMonitorPalette.blue,
+                        label: "CPU usage"
                     )
 
                     VStack(alignment: .leading, spacing: 14) {
@@ -1092,7 +1099,8 @@ private struct SystemDiskPage: View {
                 HStack(spacing: 24) {
                     SystemUsageGauge(
                         value: snapshot.disk.usage,
-                        tint: diskUsageColor
+                        tint: diskUsageColor,
+                        label: "Disk usage"
                     )
 
                     VStack(alignment: .leading, spacing: 14) {
@@ -1105,23 +1113,32 @@ private struct SystemDiskPage: View {
                                     .foregroundStyle(.secondary)
                             }
                             Spacer()
-                            Text(SystemMonitorFormat.bytes(snapshot.disk.totalBytes))
+                            Text(
+                                snapshot.disk.totalBytes
+                                    .map(SystemMonitorFormat.bytes) ?? "Unavailable"
+                            )
                                 .font(.callout.weight(.medium))
                                 .foregroundStyle(.secondary)
                         }
 
-                        ProgressView(value: snapshot.disk.usage)
+                        ProgressView(value: snapshot.disk.usage ?? 0)
                             .tint(diskUsageColor)
+                            .accessibilityLabel("Disk usage")
+                            .accessibilityValue(
+                                SystemMonitorFormat.optionalPercent(snapshot.disk.usage)
+                            )
 
                         HStack(spacing: 20) {
                             SystemLegendItem(
                                 title: "Used",
-                                value: SystemMonitorFormat.bytes(snapshot.disk.usedBytes),
+                                value: snapshot.disk.usedBytes
+                                    .map(SystemMonitorFormat.bytes) ?? "Unavailable",
                                 color: diskUsageColor
                             )
                             SystemLegendItem(
-                                title: "Free",
-                                value: SystemMonitorFormat.bytes(snapshot.disk.availableBytes),
+                                title: "Available",
+                                value: snapshot.disk.availableBytes
+                                    .map(SystemMonitorFormat.bytes) ?? "Unavailable",
                                 color: Color.secondary.opacity(0.45)
                             )
                         }
@@ -1234,9 +1251,8 @@ private struct SystemDiskPage: View {
     }
 
     private var diskUsageColor: Color {
-        snapshot.disk.usage >= 0.90
-            ? SystemMonitorPalette.red
-            : SystemMonitorPalette.blue
+        guard let usage = snapshot.disk.usage else { return .secondary }
+        return usage >= 0.90 ? SystemMonitorPalette.red : SystemMonitorPalette.blue
     }
 }
 
@@ -1364,14 +1380,15 @@ private struct SystemInfoRow: View {
 }
 
 private struct SystemUsageGauge: View {
-    let value: Double
+    let value: Double?
     let tint: Color
+    let label: String
 
     var body: some View {
-        Gauge(value: value) {
-            EmptyView()
+        Gauge(value: value ?? 0) {
+            Text(label)
         } currentValueLabel: {
-            Text(SystemMonitorFormat.percent(value))
+            Text(SystemMonitorFormat.optionalPercent(value))
                 .font(.title3.weight(.semibold).monospacedDigit())
         }
         .gaugeStyle(.accessoryCircularCapacity)

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -1096,6 +1096,19 @@ final class ChatSystemMonitorToolExecutorTests: XCTestCase {
         XCTAssertNil(object["gpu_usage_percent"], "no GPU reading must omit the field, not report 0")
     }
 
+    func testDiskUsageOmittedWhenCapacityIsUnavailable() async throws {
+        let snapshot = SystemMonitorSnapshot()
+
+        let content = try await ChatSystemMonitorToolExecutor().execute(
+            call: makeCall(name: ChatSystemMonitorToolRegistry.toolName),
+            collect: { snapshot }
+        )
+        let object = try decode(content)
+
+        XCTAssertNil(object["disk_used_gb"], "no disk reading must omit the field, not report 0")
+        XCTAssertNil(object["disk_total_gb"], "no disk reading must omit the field, not report 0")
+    }
+
     private func decode(_ json: String) throws -> [String: Any] {
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])


### PR DESCRIPTION
Closes #303 

- use capacity available for important usage so purgeable APFS space is treated consistently with macOS
- fall back to raw available capacity when necessary
- represent invalid capacity readings as unavailable instead of reporting 0%
- update the disk UI and system-stats tool for unavailable readings

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/baeaa383-55ab-4538-b669-06dcaa47fdc8" />
