### PR TITLE
Restrict the state observed by the sidebar to reduce steady state relayout

### DIFF
--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import NativServerKit
 import NativExtensionSDK
 import SwiftUI
@@ -119,6 +120,297 @@ final class ControlPanelNavigation: ObservableObject {
         }
         consumedCollapseAllSectionsRequest = collapseAllSectionsRequest
         return true
+    }
+}
+
+@MainActor
+final class ControlPanelDependencies: ObservableObject {
+    lazy var chat = ChatViewModel()
+    lazy var mcpHost = MCPHostManager()
+    lazy var imageGeneration = ImageGenerationViewModel()
+    lazy var artifacts = ArtifactStore()
+    lazy var dashboard = DashboardViewModel()
+    lazy var systemMonitor = SystemMonitorStore()
+    lazy var launchAtLogin = LaunchAtLoginController()
+    lazy var downloads = HuggingFaceDownloadManager.shared
+    lazy var embeddingLibrary = LocalModelLibrary()
+    lazy var routineStore = RoutineStore.shared
+    lazy var routineModelLibrary = LocalModelLibrary()
+}
+
+/// Filters `NativModel` down to values that can change control-panel chrome.
+@MainActor
+final class ControlPanelChromeState: ObservableObject {
+    struct ArtifactSettings: Equatable {
+        let serverPort: Int
+        let serverAPIKey: String?
+        let modelSearchPath: String
+        let localModelSearchPaths: LocalModelSearchPaths
+    }
+
+    private struct SettingsProjection: Equatable {
+        let languageModelID: String?
+        let sidebarPinnedCollapsed: Bool
+        let sidebarFoldersCollapsed: Bool
+        let sidebarSessionsCollapsed: Bool
+        let artifactSettings: ArtifactSettings
+    }
+
+    private struct Snapshot: Equatable {
+        var isRunning: Bool
+        var modelSwitchInProgress: Bool
+        var modelLoadingPercentage: Int?
+        var metricsLoading: Bool
+        var modelLoadFailure: ModelLoadFailure?
+        var modelPreloadMemoryWarning: ModelPreloadMemoryWarning?
+        var languageModelID: String?
+        var sidebarPinnedCollapsed: Bool
+        var sidebarFoldersCollapsed: Bool
+        var sidebarSessionsCollapsed: Bool
+        var artifactSettings: ArtifactSettings
+    }
+
+    @Published private var snapshot: Snapshot
+    private var cancellables = Set<AnyCancellable>()
+
+    init(model: NativModel) {
+        let settings = Self.settingsProjection(model.settings)
+        snapshot = Snapshot(
+            isRunning: model.isRunning,
+            modelSwitchInProgress: model.modelSwitchInProgress,
+            modelLoadingPercentage: Self.loadingPercentage(model.modelLoadingProgress),
+            metricsLoading: model.metricsLoading,
+            modelLoadFailure: model.modelLoadFailure,
+            modelPreloadMemoryWarning: model.modelPreloadMemoryWarning,
+            languageModelID: settings.languageModelID,
+            sidebarPinnedCollapsed: settings.sidebarPinnedCollapsed,
+            sidebarFoldersCollapsed: settings.sidebarFoldersCollapsed,
+            sidebarSessionsCollapsed: settings.sidebarSessionsCollapsed,
+            artifactSettings: settings.artifactSettings
+        )
+
+        model.$isRunning
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.isRunning = value } }
+            .store(in: &cancellables)
+        model.$modelSwitchInProgress
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.modelSwitchInProgress = value } }
+            .store(in: &cancellables)
+        model.$modelLoadingProgress
+            .map(Self.loadingPercentage)
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.modelLoadingPercentage = value } }
+            .store(in: &cancellables)
+        model.$metricsLoading
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.metricsLoading = value } }
+            .store(in: &cancellables)
+        model.$modelLoadFailure
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.modelLoadFailure = value } }
+            .store(in: &cancellables)
+        model.$modelPreloadMemoryWarning
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.modelPreloadMemoryWarning = value } }
+            .store(in: &cancellables)
+        model.$settings
+            .map(Self.settingsProjection)
+            .removeDuplicates()
+            .sink { [weak self] value in
+                self?.update {
+                    $0.languageModelID = value.languageModelID
+                    $0.sidebarPinnedCollapsed = value.sidebarPinnedCollapsed
+                    $0.sidebarFoldersCollapsed = value.sidebarFoldersCollapsed
+                    $0.sidebarSessionsCollapsed = value.sidebarSessionsCollapsed
+                    $0.artifactSettings = value.artifactSettings
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    var isRunning: Bool { snapshot.isRunning }
+    var modelSwitchInProgress: Bool { snapshot.modelSwitchInProgress }
+    var modelLoadFailure: ModelLoadFailure? { snapshot.modelLoadFailure }
+    var modelPreloadMemoryWarning: ModelPreloadMemoryWarning? {
+        snapshot.modelPreloadMemoryWarning
+    }
+    var sidebarPinnedCollapsed: Bool { snapshot.sidebarPinnedCollapsed }
+    var sidebarFoldersCollapsed: Bool { snapshot.sidebarFoldersCollapsed }
+    var sidebarSessionsCollapsed: Bool { snapshot.sidebarSessionsCollapsed }
+    var artifactSettings: ArtifactSettings { snapshot.artifactSettings }
+
+    var isModelLoading: Bool {
+        snapshot.modelSwitchInProgress
+            || (snapshot.languageModelID != nil
+                && (snapshot.metricsLoading || snapshot.modelLoadingPercentage != nil))
+    }
+
+    var modelLoadingPercentageText: String? {
+        snapshot.modelLoadingPercentage.map { "\($0)%" }
+    }
+
+    private func update(_ mutate: (inout Snapshot) -> Void) {
+        var next = snapshot
+        mutate(&next)
+        guard next != snapshot else { return }
+        snapshot = next
+    }
+
+    private static func loadingPercentage(_ progress: Double?) -> Int? {
+        progress.map { min(max(Int(($0 * 100).rounded()), 0), 100) }
+    }
+
+    private static func settingsProjection(_ value: NativSettings) -> SettingsProjection {
+        let settings = value.normalized()
+        return SettingsProjection(
+            languageModelID: settings.languageModelID,
+            sidebarPinnedCollapsed: settings.sidebarPinnedCollapsed,
+            sidebarFoldersCollapsed: settings.sidebarFoldersCollapsed,
+            sidebarSessionsCollapsed: settings.sidebarSessionsCollapsed,
+            artifactSettings: ArtifactSettings(
+                serverPort: settings.serverPort,
+                serverAPIKey: settings.serverAPIKey,
+                modelSearchPath: settings.modelSearchPath,
+                localModelSearchPaths: settings.localModelSearchPaths
+            )
+        )
+    }
+}
+
+/// Projects the low-frequency feature state needed by the sidebar and global
+/// presentation. High-frequency page state remains observed by its leaf views.
+@MainActor
+final class ControlPanelContentState: ObservableObject {
+    private struct Snapshot: Equatable {
+        var chatSessions: [ChatSessionSummary]
+        var chatFolders: [ChatFolder]
+        var currentChatSessionID: UUID?
+        var imageSessions: [ImageGenerationSessionSummary]
+        var currentImageSessionID: UUID?
+        var isGeneratingImage: Bool
+        var activeDownloadCount: Int
+        var extensionSidebarContributions: [NativSidebarContribution]
+        var routines: [Routine]
+        var routineRuns: [RoutineRun]
+        var launchAtLoginErrorMessage: String?
+    }
+
+    @Published private var snapshot: Snapshot
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        dependencies: ControlPanelDependencies,
+        extensionManager: NativExtensionManager
+    ) {
+        snapshot = Snapshot(
+            chatSessions: dependencies.chat.sessions,
+            chatFolders: dependencies.chat.folders,
+            currentChatSessionID: dependencies.chat.currentSessionID,
+            imageSessions: dependencies.imageGeneration.sessions,
+            currentImageSessionID: dependencies.imageGeneration.currentSessionID,
+            isGeneratingImage: dependencies.imageGeneration.isGenerating,
+            activeDownloadCount: dependencies.downloads.activeCount,
+            extensionSidebarContributions: extensionManager.enabledSidebarContributions,
+            routines: dependencies.routineStore.routines,
+            routineRuns: dependencies.routineStore.runs,
+            launchAtLoginErrorMessage: dependencies.launchAtLogin.errorMessage
+        )
+
+        dependencies.chat.$sessions
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.chatSessions = value } }
+            .store(in: &cancellables)
+        dependencies.chat.$folders
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.chatFolders = value } }
+            .store(in: &cancellables)
+        dependencies.chat.$currentSessionID
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.currentChatSessionID = value } }
+            .store(in: &cancellables)
+        dependencies.imageGeneration.$sessions
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.imageSessions = value } }
+            .store(in: &cancellables)
+        dependencies.imageGeneration.$currentSessionID
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.currentImageSessionID = value } }
+            .store(in: &cancellables)
+        dependencies.imageGeneration.$isGenerating
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.isGeneratingImage = value } }
+            .store(in: &cancellables)
+        dependencies.downloads.$downloads
+            .map(\.count)
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.activeDownloadCount = value } }
+            .store(in: &cancellables)
+        extensionManager.$records
+            .map(Self.enabledSidebarContributions)
+            .removeDuplicates()
+            .sink { [weak self] value in
+                self?.update { $0.extensionSidebarContributions = value }
+            }
+            .store(in: &cancellables)
+        dependencies.routineStore.$routines
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.routines = value } }
+            .store(in: &cancellables)
+        dependencies.routineStore.$runs
+            .removeDuplicates()
+            .sink { [weak self] value in self?.update { $0.routineRuns = value } }
+            .store(in: &cancellables)
+        dependencies.launchAtLogin.$errorMessage
+            .removeDuplicates()
+            .sink { [weak self] value in
+                self?.update { $0.launchAtLoginErrorMessage = value }
+            }
+            .store(in: &cancellables)
+    }
+
+    var chatSessions: [ChatSessionSummary] { snapshot.chatSessions }
+    var chatFolders: [ChatFolder] { snapshot.chatFolders }
+    var currentChatSessionID: UUID? { snapshot.currentChatSessionID }
+    var imageSessions: [ImageGenerationSessionSummary] { snapshot.imageSessions }
+    var currentImageSessionID: UUID? { snapshot.currentImageSessionID }
+    var isGeneratingImage: Bool { snapshot.isGeneratingImage }
+    var activeDownloadCount: Int { snapshot.activeDownloadCount }
+    var extensionSidebarContributions: [NativSidebarContribution] {
+        snapshot.extensionSidebarContributions
+    }
+    var launchAtLoginErrorMessage: String? { snapshot.launchAtLoginErrorMessage }
+
+    func routine(forSession sessionID: UUID) -> Routine? {
+        snapshot.routines.first { $0.sourceSessionID == sessionID }
+    }
+
+    func isRoutineRunning(forSession sessionID: UUID) -> Bool {
+        guard let routine = routine(forSession: sessionID) else { return false }
+        return snapshot.routineRuns.contains {
+            $0.routineID == routine.id && $0.status == .running
+        }
+    }
+
+    private func update(_ mutate: (inout Snapshot) -> Void) {
+        var next = snapshot
+        mutate(&next)
+        guard next != snapshot else { return }
+        snapshot = next
+    }
+
+    private static func enabledSidebarContributions(
+        records: [NativExtensionRecord]
+    ) -> [NativSidebarContribution] {
+        records
+            .filter { $0.isEnabled && $0.hasRuntime }
+            .flatMap(\.manifest.contributions.sidebar)
+            .sorted {
+                if $0.order == $1.order {
+                    return $0.title.localizedStandardCompare($1.title) == .orderedAscending
+                }
+                return $0.order < $1.order
+            }
     }
 }
 
@@ -259,87 +551,24 @@ private struct GlobalModelLoadFailureBanner: View {
 
 struct ControlPanelView: View {
     @Environment(\.displayScale) private var displayScale
-    @ObservedObject var model: NativModel
-    @ObservedObject var navigation: ControlPanelNavigation
-    // Only the Developer page observes live runtime values. Keeping this as a
-    // plain reference prevents its one-second polling cycle from invalidating
-    // the entire control panel (including the Models result list).
+
+    let model: NativModel
+    let navigation: ControlPanelNavigation
     let runtime: SystemRuntimeMonitor
-    @ObservedObject var extensionManager: NativExtensionManager
+    let extensionManager: NativExtensionManager
     let softwareUpdater: SoftwareUpdater
-    @StateObject private var chat = ChatViewModel()
-    @StateObject private var mcpHost = MCPHostManager()
-    @StateObject private var imageGeneration = ImageGenerationViewModel()
-    @StateObject private var artifacts = ArtifactStore()
-    @StateObject private var dashboard = DashboardViewModel()
-    @StateObject private var systemMonitor = SystemMonitorStore()
-    @StateObject private var launchAtLogin = LaunchAtLoginController()
-    @ObservedObject private var downloads = HuggingFaceDownloadManager.shared
-    @StateObject private var embeddingLibrary = LocalModelLibrary()
 
-    private static let embeddingModelID = "mlx-community/Qwen3-VL-Embedding-2B-bf16"
-    private static let embeddingModelSize: Int64 = 4_300_000_000
-
-    private var artifactSemanticSearch: ArtifactSemanticSearchConfig? {
-        guard ProcessInfo.processInfo.physicalMemory >= 16_000_000_000 else {
-            return nil
-        }
-        let settings = model.settings.normalized()
-        let baseURL = URL(string: "http://127.0.0.1:\(settings.serverPort)")
-            ?? URL(string: "http://127.0.0.1:8080")!
-        let modelID = Self.embeddingModelID
-        let insufficientReason = downloads.capacityBlocker(
-            sizeBytes: Self.embeddingModelSize,
-            cachePath: settings.modelSearchPath
-        )
-        return ArtifactSemanticSearchConfig(
-            modelID: modelID,
-            sizeBytes: Self.embeddingModelSize,
-            client: NativEmbeddingsClient(baseURL: baseURL, apiKey: settings.serverAPIKey),
-            isModelInstalled: embeddingLibrary.models.contains { $0.repoID == modelID },
-            isDownloading: downloads.isDownloading(modelID),
-            downloadProgress: downloads.progress(for: modelID),
-            canInstall: insufficientReason == nil,
-            insufficientReason: insufficientReason,
-            onEnable: {
-                downloads.download(
-                    repoID: modelID,
-                    sizeBytes: Self.embeddingModelSize,
-                    cachePath: settings.modelSearchPath,
-                    token: model.effectiveHuggingFaceToken
-                ) {
-                    EmbeddingModelPreparer.prepare(
-                        repoID: modelID,
-                        searchPath: settings.modelSearchPath
-                    )
-                    embeddingLibrary.scan(searchPaths: settings.localModelSearchPaths)
-                    NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
-                }
-                navigation.open(.models)
-            },
-            onRemove: {
-                Task {
-                    try? await LocalModelDiscovery.delete(
-                        repoID: modelID,
-                        path: settings.modelSearchPath
-                    )
-                    embeddingLibrary.scan(searchPaths: settings.localModelSearchPaths)
-                    NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
-                }
-            },
-            prepareModel: {
-                EmbeddingModelPreparer.prepare(
-                    repoID: modelID,
-                    searchPath: settings.modelSearchPath
-                )
-            }
-        )
-    }
+    private let dependencies: ControlPanelDependencies
+    @StateObject private var chromeState: ControlPanelChromeState
+    @StateObject private var contentState: ControlPanelContentState
     @AppStorage(ControlPanelOnboarding.extensionsBadgeDismissedKey)
     private var isExtensionsBadgeDismissed = false
     @State private var sidebarSelection: ControlPanelSidebarSelection = .tab(.chat)
     @State private var selectedTab: ControlPanelTab = .chat
     @State private var chatWorkspaceMode: ChatWorkspaceMode = .chat
+    @State private var speechModelDiscoveryRequest: Int
+    @State private var imageModelDiscoveryRequest: Int
+    @State private var imageModelDiscoveryCapability: LocalModelCapability
     @State private var hoveredFooterControl: FooterControl?
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .all
     @State private var sidebarWidth = ControlPanelLayout.sidebarIdealWidth
@@ -348,8 +577,6 @@ struct ControlPanelView: View {
     @State private var detailTransitionOffset: CGFloat = 0
     @State private var isSidebarTransitioning = false
     @State private var sidebarTransitionGeneration = 0
-    @ObservedObject private var routineStore = RoutineStore.shared
-    @StateObject private var routineModelLibrary = LocalModelLibrary()
     @State private var schedulingRoutineDraft: RoutineDraft?
     @State private var isModelConfigurationVisible = false
     @State private var selectedDevSection: DevHubView.Section = .integrations
@@ -367,6 +594,50 @@ struct ControlPanelView: View {
     @State private var pendingDeleteRecent: ControlPanelRecentSession?
     @State private var pendingDeleteFolder: ChatFolder?
     @State private var isConfirmingBulkDelete = false
+
+    private var chat: ChatViewModel { dependencies.chat }
+    private var mcpHost: MCPHostManager { dependencies.mcpHost }
+    private var imageGeneration: ImageGenerationViewModel { dependencies.imageGeneration }
+    private var artifacts: ArtifactStore { dependencies.artifacts }
+    private var dashboard: DashboardViewModel { dependencies.dashboard }
+    private var systemMonitor: SystemMonitorStore { dependencies.systemMonitor }
+    private var launchAtLogin: LaunchAtLoginController { dependencies.launchAtLogin }
+    private var downloads: HuggingFaceDownloadManager { dependencies.downloads }
+    private var embeddingLibrary: LocalModelLibrary { dependencies.embeddingLibrary }
+    private var routineStore: RoutineStore { dependencies.routineStore }
+    private var routineModelLibrary: LocalModelLibrary { dependencies.routineModelLibrary }
+
+    init(
+        model: NativModel,
+        navigation: ControlPanelNavigation,
+        runtime: SystemRuntimeMonitor,
+        extensionManager: NativExtensionManager,
+        softwareUpdater: SoftwareUpdater,
+        dependencies: ControlPanelDependencies
+    ) {
+        self.model = model
+        self.navigation = navigation
+        self.runtime = runtime
+        self.extensionManager = extensionManager
+        self.softwareUpdater = softwareUpdater
+        self.dependencies = dependencies
+        _chromeState = StateObject(wrappedValue: ControlPanelChromeState(model: model))
+        _contentState = StateObject(
+            wrappedValue: ControlPanelContentState(
+                dependencies: dependencies,
+                extensionManager: extensionManager
+            )
+        )
+        _speechModelDiscoveryRequest = State(
+            initialValue: navigation.speechModelDiscoveryRequest
+        )
+        _imageModelDiscoveryRequest = State(
+            initialValue: navigation.imageModelDiscoveryRequest
+        )
+        _imageModelDiscoveryCapability = State(
+            initialValue: navigation.imageModelDiscoveryCapability
+        )
+    }
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -404,7 +675,7 @@ struct ControlPanelView: View {
         .frame(minWidth: 1040, minHeight: 600)
         .overlay(alignment: .top) {
             Group {
-                if selectedTab != .models, let failure = model.modelLoadFailure {
+                if selectedTab != .models, let failure = chromeState.modelLoadFailure {
                     GlobalModelLoadFailureBanner(
                         failure: failure,
                         onOpenModels: { navigation.open(.models) },
@@ -437,7 +708,7 @@ struct ControlPanelView: View {
         .onAppear {
             applySidebarSelection(navigation.requestedTab.map(ControlPanelSidebarSelection.tab) ?? sidebarSelection)
             handleNewChatRequest()
-            embeddingLibrary.scan(searchPaths: model.settings.localModelSearchPaths)
+            embeddingLibrary.scan(searchPaths: chromeState.artifactSettings.localModelSearchPaths)
             artifacts.onDeleteArtifact = { artifact in
                 switch artifact.source {
                 case .uploaded:
@@ -463,23 +734,32 @@ struct ControlPanelView: View {
             guard let pageID else { return }
             applySidebarSelection(.extensionPage(pageID))
         }
-        .onChange(of: extensionManager.records) { _, _ in
+        .onChange(of: contentState.extensionSidebarContributions) { _, contributions in
             guard case .extensionPage(let pageID) = sidebarSelection,
-                  !extensionManager.enabledSidebarContributions.contains(
+                  !contributions.contains(
                     where: { $0.id == pageID }
                   ) else {
                 return
             }
             applySidebarSelection(.tab(.extensions))
         }
-        .onChange(of: navigation.newChatRequest) { _, _ in
+        .onReceive(navigation.$newChatRequest) { _ in
             handleNewChatRequest()
         }
-        .onChange(of: navigation.toggleSidebarRequest) { _, _ in
+        .onReceive(navigation.$toggleSidebarRequest) { _ in
             handleToggleSidebarRequest()
         }
-        .onChange(of: navigation.collapseAllSectionsRequest) { _, _ in
+        .onReceive(navigation.$collapseAllSectionsRequest) { _ in
             handleCollapseAllSectionsRequest()
+        }
+        .onReceive(navigation.$speechModelDiscoveryRequest) { request in
+            speechModelDiscoveryRequest = request
+        }
+        .onReceive(navigation.$imageModelDiscoveryRequest) { request in
+            imageModelDiscoveryRequest = request
+        }
+        .onReceive(navigation.$imageModelDiscoveryCapability) { capability in
+            imageModelDiscoveryCapability = capability
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.willEnterFullScreenNotification)) { _ in
             isFullScreen = true
@@ -497,7 +777,7 @@ struct ControlPanelView: View {
         .alert(
             "Unable to Update Start at Login",
             isPresented: Binding(
-                get: { launchAtLogin.errorMessage != nil },
+                get: { contentState.launchAtLoginErrorMessage != nil },
                 set: { isPresented in
                     if !isPresented {
                         launchAtLogin.errorMessage = nil
@@ -510,7 +790,7 @@ struct ControlPanelView: View {
             }
             .keyboardShortcut(.defaultAction)
         } message: {
-            Text(launchAtLogin.errorMessage ?? "An unknown error occurred.")
+            Text(contentState.launchAtLoginErrorMessage ?? "An unknown error occurred.")
         }
     }
 
@@ -603,7 +883,7 @@ struct ControlPanelView: View {
             }
         } message: { recent in
             if case .chat(let sessionID) = recent.selection,
-               let routine = routineStore.routine(forSession: sessionID) {
+               let routine = contentState.routine(forSession: sessionID) {
                 Text("“\(recent.title)” has a routine (\(RoutineFormatting.summary(routine))). Deleting the chat cancels the routine.")
             } else {
                 Text("“\(recent.title)” will be permanently deleted.")
@@ -641,28 +921,19 @@ struct ControlPanelView: View {
             Text("The selected chats are permanently deleted. Selected folders are removed but their chats are kept.")
         }
         .sheet(item: $schedulingRoutineDraft) { draft in
-            let textModelIDs = routineModelLibrary.models
-                .filter { $0.capabilities.contains(.text) }
-                .map(\.repoID)
-            let snapshotModelID = draft.routine.modelID
-            let availableModelIDs = (
-                snapshotModelID.isEmpty || textModelIDs.contains(snapshotModelID)
-                    ? textModelIDs
-                    : textModelIDs + [snapshotModelID]
-            ).sorted()
-            let isExistingRoutine = RoutineStore.shared.routine(id: draft.routine.id) != nil
-            RoutineEditor(
+            RoutineEditorSheetHost(
                 draft: draft,
-                availableModelIDs: availableModelIDs,
+                modelLibrary: routineModelLibrary,
+                routineStore: routineStore,
                 onSave: { routine in
                     saveScheduledRoutine(routine)
                     schedulingRoutineDraft = nil
                 },
                 onCancel: { schedulingRoutineDraft = nil },
-                onDelete: isExistingRoutine ? {
-                    RoutineStore.shared.delete(id: draft.routine.id)
+                onDelete: {
+                    routineStore.delete(id: draft.routine.id)
                     schedulingRoutineDraft = nil
-                } : nil
+                }
             )
         }
     }
@@ -736,7 +1007,7 @@ struct ControlPanelView: View {
                 sidebarTabButton(tab)
 
                 if tab == .chat {
-                    ForEach(extensionManager.enabledSidebarContributions) { contribution in
+                    ForEach(contentState.extensionSidebarContributions) { contribution in
                         extensionSidebarButton(contribution)
                     }
                 }
@@ -763,15 +1034,15 @@ struct ControlPanelView: View {
                 Spacer(minLength: 0)
                 if tab == .models {
                     HStack(spacing: 6) {
-                        if model.isModelLoading,
-                           let percentage = model.modelLoadingPercentageText {
+                        if chromeState.isModelLoading,
+                           let percentage = chromeState.modelLoadingPercentageText {
                             Text(percentage)
                                 .font(.caption.monospacedDigit())
                                 .foregroundStyle(.secondary)
                                 .frame(width: 34, alignment: .trailing)
                         }
-                        if downloads.activeCount > 0 {
-                            ModelsDownloadArrow(count: downloads.activeCount)
+                        if contentState.activeDownloadCount > 0 {
+                            ModelsDownloadArrow(count: contentState.activeDownloadCount)
                         }
                     }
                 }
@@ -808,7 +1079,7 @@ struct ControlPanelView: View {
                 .padding(.trailing, 10)
                 .padding(.bottom, 4)
 
-            if !model.settings.sidebarPinnedCollapsed {
+            if !chromeState.sidebarPinnedCollapsed {
                 Group {
                     if pinnedSessions.isEmpty && pinnedFolders.isEmpty {
                         emptyPinnedHint
@@ -852,7 +1123,7 @@ struct ControlPanelView: View {
                 .padding(.top, showsPinnedSection || showsFoldersSection ? 12 : 0)
                 .padding(.bottom, 4)
 
-            if !model.settings.sidebarSessionsCollapsed {
+            if !chromeState.sidebarSessionsCollapsed {
                 ForEach(ungroupedSessions) { recent in
                     draggableRow(recent, isPinnedRow: false)
                         .overlay(alignment: .top) {
@@ -882,7 +1153,7 @@ struct ControlPanelView: View {
                 .padding(.top, 12)
                 .padding(.bottom, 4)
 
-            if !model.settings.sidebarFoldersCollapsed {
+            if !chromeState.sidebarFoldersCollapsed {
                 if unpinnedFolders.isEmpty {
                     emptyFoldersHint
                 } else {
@@ -1051,7 +1322,7 @@ struct ControlPanelView: View {
         isPinnedRow: Bool
     ) {
         guard let draggedID = UUID(uuidString: draggedPayload),
-              chat.sessions.contains(where: { $0.id == draggedID }),
+              contentState.chatSessions.contains(where: { $0.id == draggedID }),
               let targetID = target.chatID,
               draggedID != targetID
         else {
@@ -1082,7 +1353,7 @@ struct ControlPanelView: View {
         reorderTargetID = nil
         reorderInsertAfter = false
         guard let draggedID = UUID(uuidString: draggedPayload),
-              chat.sessions.contains(where: { $0.id == draggedID }),
+              contentState.chatSessions.contains(where: { $0.id == draggedID }),
               let targetID = target.chatID,
               draggedID != targetID
         else {
@@ -1158,7 +1429,7 @@ struct ControlPanelView: View {
                     .foregroundStyle(Color.secondary.opacity(0.7))
             }
             .buttonStyle(.plain)
-            .disabled(recentSessions.isEmpty && chat.folders.isEmpty)
+            .disabled(recentSessions.isEmpty && contentState.chatFolders.isEmpty)
             .help("Select multiple")
 
             Menu {
@@ -1186,7 +1457,7 @@ struct ControlPanelView: View {
             .disabled(
                 selectedTab == .chat
                     && chatWorkspaceMode == .images
-                    && imageGeneration.isGenerating
+                    && contentState.isGeneratingImage
             )
             .help(newRecentHelp)
             .onHover { isNewChatHovering = $0 }
@@ -1279,7 +1550,7 @@ struct ControlPanelView: View {
     private var sidebarPinnedHeader: some View {
         sidebarSectionHeader(
             title: "Pinned",
-            isCollapsed: model.settings.sidebarPinnedCollapsed,
+            isCollapsed: chromeState.sidebarPinnedCollapsed,
             onToggle: { model.settings.sidebarPinnedCollapsed.toggle() }
         ) {
             EmptyView()
@@ -1289,7 +1560,7 @@ struct ControlPanelView: View {
     private var sidebarFoldersHeader: some View {
         sidebarSectionHeader(
             title: "Folders",
-            isCollapsed: model.settings.sidebarFoldersCollapsed,
+            isCollapsed: chromeState.sidebarFoldersCollapsed,
             onToggle: { model.settings.sidebarFoldersCollapsed.toggle() }
         ) {
             Button {
@@ -1311,7 +1582,7 @@ struct ControlPanelView: View {
     private var sidebarRecentsHeader: some View {
         sidebarSectionHeader(
             title: "Sessions",
-            isCollapsed: model.settings.sidebarSessionsCollapsed,
+            isCollapsed: chromeState.sidebarSessionsCollapsed,
             onToggle: { model.settings.sidebarSessionsCollapsed.toggle() }
         ) {
             EmptyView()
@@ -1319,8 +1590,10 @@ struct ControlPanelView: View {
     }
 
     private var allSidebarSectionsCollapsed: Bool {
-        model.settings.allSidebarSectionsCollapsed
-            && !chat.folders.contains { !$0.isCollapsed }
+        chromeState.sidebarPinnedCollapsed
+            && chromeState.sidebarFoldersCollapsed
+            && chromeState.sidebarSessionsCollapsed
+            && !contentState.chatFolders.contains { !$0.isCollapsed }
     }
 
     private func revealSidebarSection(_ keyPath: WritableKeyPath<NativSettings, Bool>) {
@@ -1418,15 +1691,15 @@ struct ControlPanelView: View {
     private var serverToggleButton: some View {
         footerControl(
             .server,
-            tooltip: model.isRunning ? "Stop Server" : "Start Server"
+            tooltip: chromeState.isRunning ? "Stop Server" : "Start Server"
         ) {
             Button {
                 model.toggleServer()
             } label: {
-                footerIcon(systemName: model.isRunning ? "stop.circle" : "play.circle")
+                footerIcon(systemName: chromeState.isRunning ? "stop.circle" : "play.circle")
             }
             .buttonStyle(.plain)
-            .disabled(model.modelSwitchInProgress)
+            .disabled(chromeState.modelSwitchInProgress)
         }
     }
 
@@ -1513,8 +1786,8 @@ struct ControlPanelView: View {
 
     private var recentSessions: [ControlPanelRecentSession] {
         (
-            chat.sessions.map(ControlPanelRecentSession.init(chat:))
-                + imageGeneration.sessions.map(ControlPanelRecentSession.init(imageGeneration:))
+            contentState.chatSessions.map(ControlPanelRecentSession.init(chat:))
+                + contentState.imageSessions.map(ControlPanelRecentSession.init(imageGeneration:))
         )
             .sorted(by: ControlPanelRecentSession.recencySort)
     }
@@ -1530,7 +1803,7 @@ struct ControlPanelView: View {
     }
 
     private var ungroupedSessions: [ControlPanelRecentSession] {
-        let folderIDs = Set(chat.folders.map(\.id))
+        let folderIDs = Set(contentState.chatFolders.map(\.id))
         return unpinnedSessions.filter { recent in
             guard let folderID = recent.folderID else {
                 return true
@@ -1540,11 +1813,11 @@ struct ControlPanelView: View {
     }
 
     private var pinnedFolders: [ChatFolder] {
-        chat.folders.filter(\.isPinned)
+        contentState.chatFolders.filter(\.isPinned)
     }
 
     private var unpinnedFolders: [ChatFolder] {
-        chat.folders.filter { !$0.isPinned }
+        contentState.chatFolders.filter { !$0.isPinned }
     }
 
     private func sessions(inFolder folderID: UUID) -> [ControlPanelRecentSession] {
@@ -1595,7 +1868,7 @@ struct ControlPanelView: View {
             onEditRoutine: {
                 editRoutine(for: recent)
             },
-            folders: chat.folders,
+            folders: contentState.chatFolders,
             onMoveToFolder: { folderID in
                 moveRecentToFolder(recent, folderID: folderID)
             },
@@ -1614,11 +1887,11 @@ struct ControlPanelView: View {
 
     private func routineStatus(for recent: ControlPanelRecentSession) -> RoutineRowStatus {
         guard case .chat(let sessionID) = recent.selection,
-              let routine = routineStore.routine(forSession: sessionID)
+              let routine = contentState.routine(forSession: sessionID)
         else {
             return .none
         }
-        if routineStore.isRoutineRunning(forSession: sessionID) {
+        if contentState.isRoutineRunning(forSession: sessionID) {
             return .running
         }
         return routine.isEnabled ? .scheduled : .disabled
@@ -1628,9 +1901,8 @@ struct ControlPanelView: View {
         guard case .chat(let sessionID) = recent.selection else {
             return
         }
-        let settings = model.settings.normalized()
-        routineModelLibrary.scan(searchPaths: settings.localModelSearchPaths)
-        guard let existing = RoutineStore.shared.routine(forSession: sessionID) else {
+        routineModelLibrary.scan(searchPaths: chromeState.artifactSettings.localModelSearchPaths)
+        guard let existing = routineStore.routine(forSession: sessionID) else {
             return
         }
         schedulingRoutineDraft = RoutineDraft(routine: existing)
@@ -1638,7 +1910,7 @@ struct ControlPanelView: View {
 
     private func presentNewRoutine() {
         let settings = model.settings.normalized()
-        routineModelLibrary.scan(searchPaths: settings.localModelSearchPaths)
+        routineModelLibrary.scan(searchPaths: chromeState.artifactSettings.localModelSearchPaths)
         schedulingRoutineDraft = RoutineDraft(
             routine: Routine(modelID: settings.languageModelID ?? "")
         )
@@ -1680,7 +1952,7 @@ struct ControlPanelView: View {
     private func draggedChatID(from items: [String]) -> UUID? {
         for item in items {
             if let id = UUID(uuidString: item),
-               chat.sessions.contains(where: { $0.id == id }) {
+               contentState.chatSessions.contains(where: { $0.id == id }) {
                 return id
             }
         }
@@ -1729,7 +2001,7 @@ struct ControlPanelView: View {
         guard dragged != target else {
             return
         }
-        var order = chat.folders.map(\.id)
+        var order = contentState.chatFolders.map(\.id)
         order.removeAll { $0 == dragged }
         if let index = order.firstIndex(of: target) {
             order.insert(dragged, at: index)
@@ -1776,7 +2048,7 @@ struct ControlPanelView: View {
     }
 
     private var selectedFolders: [ChatFolder] {
-        chat.folders.filter { selectedFolderIDs.contains($0.id) }
+        contentState.chatFolders.filter { selectedFolderIDs.contains($0.id) }
     }
 
     private var hasSelectedPinnable: Bool {
@@ -1912,7 +2184,7 @@ struct ControlPanelView: View {
         .alert(
             "Models May Not Fit in Memory",
             isPresented: Binding(
-                get: { model.modelPreloadMemoryWarning != nil },
+                get: { chromeState.modelPreloadMemoryWarning != nil },
                 set: { isPresented in
                     if !isPresented {
                         model.cancelPendingModelPreloadSwitch()
@@ -1928,7 +2200,7 @@ struct ControlPanelView: View {
                 model.cancelPendingModelPreloadSwitch()
             }
         } message: {
-            Text(model.modelPreloadMemoryWarning?.message ?? "")
+            Text(chromeState.modelPreloadMemoryWarning?.message ?? "")
         }
     }
 
@@ -1950,10 +2222,14 @@ struct ControlPanelView: View {
                 onExploreImageModels: navigation.openImageModelDiscovery
             )
         case .artifacts:
-            ArtifactsView(
+            ArtifactsPageHost(
                 store: artifacts,
-                semanticSearch: artifactSemanticSearch,
+                model: model,
+                downloads: downloads,
+                embeddingLibrary: embeddingLibrary,
+                settings: chromeState.artifactSettings,
                 titleLeadingInset: detailTitleLeadingInset,
+                onOpenModels: { navigation.open(.models) },
                 onOpenChat: { artifact in
                     switch artifact.source {
                     case .uploaded:
@@ -1994,9 +2270,9 @@ struct ControlPanelView: View {
                 model: model,
                 showsConfiguration: $isModelConfigurationVisible,
                 titleLeadingInset: detailTitleLeadingInset,
-                speechModelDiscoveryRequest: navigation.speechModelDiscoveryRequest,
-                imageModelDiscoveryRequest: navigation.imageModelDiscoveryRequest,
-                imageModelDiscoveryCapability: navigation.imageModelDiscoveryCapability
+                speechModelDiscoveryRequest: speechModelDiscoveryRequest,
+                imageModelDiscoveryRequest: imageModelDiscoveryRequest,
+                imageModelDiscoveryCapability: imageModelDiscoveryCapability
             )
             .equatable()
         case .extensions:
@@ -2055,7 +2331,7 @@ struct ControlPanelView: View {
             }
             if tab == .chat {
                 switch chatWorkspaceMode {
-                case .chat where chat.currentSessionID == nil:
+                case .chat where contentState.currentChatSessionID == nil:
                     chat.createSession()
                 default:
                     break
@@ -2064,7 +2340,7 @@ struct ControlPanelView: View {
             sidebarSelection = selection
             selectedTab = tab
         case .extensionPage(let pageID):
-            guard extensionManager.enabledSidebarContributions.contains(
+            guard contentState.extensionSidebarContributions.contains(
                 where: { $0.id == pageID }
             ) else {
                 sidebarSelection = .tab(.extensions)
@@ -2074,7 +2350,7 @@ struct ControlPanelView: View {
             sidebarSelection = selection
             selectedTab = .extensions
         case .chat(let sessionID):
-            if chat.sessions.contains(where: { $0.id == sessionID }) {
+            if contentState.chatSessions.contains(where: { $0.id == sessionID }) {
                 chat.selectSession(sessionID)
                 sidebarSelection = selection
             } else {
@@ -2083,7 +2359,7 @@ struct ControlPanelView: View {
             chatWorkspaceMode = .chat
             selectedTab = .chat
         case .imageGeneration(let sessionID):
-            if imageGeneration.sessions.contains(where: { $0.id == sessionID }) {
+            if contentState.imageSessions.contains(where: { $0.id == sessionID }) {
                 imageGeneration.selectSession(sessionID)
                 sidebarSelection = selection
             } else {
@@ -2195,7 +2471,8 @@ struct ControlPanelView: View {
             guard let text = chat.conversationText(for: sessionID) else {
                 continue
             }
-            let title = chat.sessions.first { $0.id == sessionID }?.title ?? sessionID.uuidString
+            let title = contentState.chatSessions.first { $0.id == sessionID }?.title
+                ?? sessionID.uuidString
             let base = sanitizedFileName(title)
             var candidate = base
             var suffix = 2
@@ -2288,9 +2565,10 @@ struct ControlPanelView: View {
         }
         switch (sidebarSelection, recent.selection) {
         case (.tab(.chat), .chat(let sessionID)):
-            return chatWorkspaceMode == .chat && sessionID == chat.currentSessionID
+            return chatWorkspaceMode == .chat && sessionID == contentState.currentChatSessionID
         case (.tab(.chat), .imageGeneration(let sessionID)):
-            return chatWorkspaceMode == .images && sessionID == imageGeneration.currentSessionID
+            return chatWorkspaceMode == .images
+                && sessionID == contentState.currentImageSessionID
         default:
             return false
         }
@@ -2299,9 +2577,9 @@ struct ControlPanelView: View {
     private func isCurrentRecent(_ recent: ControlPanelRecentSession) -> Bool {
         switch recent.selection {
         case .chat(let sessionID):
-            return sessionID == chat.currentSessionID
+            return sessionID == contentState.currentChatSessionID
         case .imageGeneration(let sessionID):
-            return sessionID == imageGeneration.currentSessionID
+            return sessionID == contentState.currentImageSessionID
         case .tab, .extensionPage:
             return false
         }
@@ -2315,7 +2593,7 @@ struct ControlPanelView: View {
             // stream never finished permanently undeletable.
             return false
         case .imageGeneration:
-            return imageGeneration.isGenerating
+            return contentState.isGeneratingImage
         case .tab, .extensionPage:
             return false
         }
@@ -2326,7 +2604,7 @@ struct ControlPanelView: View {
         case .chat:
             return false
         case .imageGeneration:
-            return imageGeneration.isGenerating
+            return contentState.isGeneratingImage
         case .tab, .extensionPage:
             return false
         }
@@ -2369,32 +2647,153 @@ struct ControlPanelView: View {
     }
 
     private func showChatWorkspace() {
-        if chat.currentSessionID == nil {
+        if contentState.currentChatSessionID == nil {
             chat.createSession()
         }
         chatWorkspaceMode = .chat
         selectedTab = .chat
-        sidebarSelection = chat.currentSessionID.map(ControlPanelSidebarSelection.chat)
+        sidebarSelection = contentState.currentChatSessionID.map(ControlPanelSidebarSelection.chat)
             ?? .tab(.chat)
     }
 
     private func showImageWorkspace() {
         chatWorkspaceMode = .images
         selectedTab = .chat
-        sidebarSelection = imageGeneration.currentSessionID
+        sidebarSelection = contentState.currentImageSessionID
             .map(ControlPanelSidebarSelection.imageGeneration)
             ?? .tab(.chat)
     }
 
 }
 
+private struct RoutineEditorSheetHost: View {
+    let draft: RoutineDraft
+    @ObservedObject var modelLibrary: LocalModelLibrary
+    @ObservedObject var routineStore: RoutineStore
+    let onSave: (Routine) -> Void
+    let onCancel: () -> Void
+    let onDelete: () -> Void
+
+    private var availableModelIDs: [String] {
+        let textModelIDs = modelLibrary.models
+            .filter { $0.capabilities.contains(.text) }
+            .map(\.repoID)
+        let snapshotModelID = draft.routine.modelID
+        return (
+            snapshotModelID.isEmpty || textModelIDs.contains(snapshotModelID)
+                ? textModelIDs
+                : textModelIDs + [snapshotModelID]
+        ).sorted()
+    }
+
+    var body: some View {
+        RoutineEditor(
+            draft: draft,
+            availableModelIDs: availableModelIDs,
+            onSave: onSave,
+            onCancel: onCancel,
+            onDelete: routineStore.routine(id: draft.routine.id) == nil ? nil : onDelete
+        )
+    }
+}
+
+private struct ArtifactsPageHost: View {
+    private static let embeddingModelID = "mlx-community/Qwen3-VL-Embedding-2B-bf16"
+    private static let embeddingModelSize: Int64 = 4_300_000_000
+
+    let store: ArtifactStore
+    let model: NativModel
+    @ObservedObject var downloads: HuggingFaceDownloadManager
+    @ObservedObject var embeddingLibrary: LocalModelLibrary
+    let settings: ControlPanelChromeState.ArtifactSettings
+    let titleLeadingInset: CGFloat
+    let onOpenModels: () -> Void
+    let onOpenChat: (Artifact) -> Void
+    let onUseInChat: (Artifact) -> Void
+    let onUseAsReference: (Artifact) -> Void
+
+    private var semanticSearch: ArtifactSemanticSearchConfig? {
+        guard ProcessInfo.processInfo.physicalMemory >= 16_000_000_000 else {
+            return nil
+        }
+        let baseURL = URL(string: "http://127.0.0.1:\(settings.serverPort)")
+            ?? URL(string: "http://127.0.0.1:8080")!
+        let modelID = Self.embeddingModelID
+        let insufficientReason = downloads.capacityBlocker(
+            sizeBytes: Self.embeddingModelSize,
+            cachePath: settings.modelSearchPath
+        )
+        return ArtifactSemanticSearchConfig(
+            modelID: modelID,
+            sizeBytes: Self.embeddingModelSize,
+            client: NativEmbeddingsClient(baseURL: baseURL, apiKey: settings.serverAPIKey),
+            isModelInstalled: embeddingLibrary.models.contains { $0.repoID == modelID },
+            isDownloading: downloads.isDownloading(modelID),
+            downloadProgress: downloads.progress(for: modelID),
+            canInstall: insufficientReason == nil,
+            insufficientReason: insufficientReason,
+            onEnable: enableSemanticSearch,
+            onRemove: removeSemanticSearchModel,
+            prepareModel: prepareSemanticSearchModel
+        )
+    }
+
+    var body: some View {
+        ArtifactsView(
+            store: store,
+            semanticSearch: semanticSearch,
+            titleLeadingInset: titleLeadingInset,
+            onOpenChat: onOpenChat,
+            onUseInChat: onUseInChat,
+            onUseAsReference: onUseAsReference
+        )
+    }
+
+    private func enableSemanticSearch() {
+        let modelID = Self.embeddingModelID
+        downloads.download(
+            repoID: modelID,
+            sizeBytes: Self.embeddingModelSize,
+            cachePath: settings.modelSearchPath,
+            token: model.effectiveHuggingFaceToken
+        ) {
+            EmbeddingModelPreparer.prepare(
+                repoID: modelID,
+                searchPath: settings.modelSearchPath
+            )
+            embeddingLibrary.scan(searchPaths: settings.localModelSearchPaths)
+            NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
+        }
+        onOpenModels()
+    }
+
+    private func removeSemanticSearchModel() {
+        let modelID = Self.embeddingModelID
+        Task {
+            try? await LocalModelDiscovery.delete(
+                repoID: modelID,
+                path: settings.modelSearchPath
+            )
+            embeddingLibrary.scan(searchPaths: settings.localModelSearchPaths)
+            NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
+        }
+    }
+
+    private func prepareSemanticSearchModel() {
+        EmbeddingModelPreparer.prepare(
+            repoID: Self.embeddingModelID,
+            searchPath: settings.modelSearchPath
+        )
+    }
+}
+
 private struct ChatWorkspaceView: View {
     let mode: ChatWorkspaceMode
     let onSelectMode: (ChatWorkspaceMode) -> Void
-    @ObservedObject var model: NativModel
+    let model: NativModel
     let chat: ChatViewModel
-    @ObservedObject var mcpHost: MCPHostManager
-    @ObservedObject var imageGeneration: ImageGenerationViewModel
+    let mcpHost: MCPHostManager
+    let imageGeneration: ImageGenerationViewModel
     @Binding var showsConfiguration: Bool
     let conversationWidthReduction: CGFloat
     let onExploreImageModels: (ChatImageOperation) -> Void
@@ -4280,6 +4679,7 @@ private extension View {
         navigation: .init(),
         runtime: .init(),
         extensionManager: .init(builtInExtensions: []),
-        softwareUpdater: .init()
+        softwareUpdater: .init(),
+        dependencies: .init()
     )
 }

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -278,18 +278,125 @@ final class ControlPanelChromeState: ObservableObject {
     }
 }
 
-/// Projects the low-frequency feature state needed by the sidebar and global
-/// presentation. High-frequency page state remains observed by its leaf views.
+/// Precomputes the merged recents index so the sidebar does not repeatedly map,
+/// merge, filter, and sort sessions during view evaluation.
+private struct SidebarRecentsSnapshot: Equatable {
+    let recentSessions: [ControlPanelRecentSession]
+    let pinnedSessions: [ControlPanelRecentSession]
+    let unpinnedSessions: [ControlPanelRecentSession]
+    let ungroupedSessions: [ControlPanelRecentSession]
+    let folders: [ChatFolder]
+    let pinnedFolders: [ChatFolder]
+    let unpinnedFolders: [ChatFolder]
+    private let sessionsByFolder: [UUID: [ControlPanelRecentSession]]
+    private let chatSessionIDs: Set<UUID>
+    private let imageSessionIDs: Set<UUID>
+
+    init(
+        chatSessions: [ChatSessionSummary],
+        folders: [ChatFolder],
+        imageSessions: [ImageGenerationSessionSummary]
+    ) {
+        let recentSessions = (
+            chatSessions.map(ControlPanelRecentSession.init(chat:))
+                + imageSessions.map(ControlPanelRecentSession.init(imageGeneration:))
+        ).sorted(by: ControlPanelRecentSession.recencySort)
+        let pinnedSessions = recentSessions
+            .filter(\.pinned)
+            .sorted(by: ControlPanelRecentSession.pinnedSort)
+        let unpinnedSessions = recentSessions
+            .filter { !$0.pinned }
+            .sorted(by: ControlPanelRecentSession.sessionSort)
+        let folderIDs = Set(folders.map(\.id))
+
+        self.recentSessions = recentSessions
+        self.pinnedSessions = pinnedSessions
+        self.unpinnedSessions = unpinnedSessions
+        ungroupedSessions = unpinnedSessions.filter { recent in
+            guard let folderID = recent.folderID else { return true }
+            return !folderIDs.contains(folderID)
+        }
+        self.folders = folders
+        pinnedFolders = folders.filter(\.isPinned)
+        unpinnedFolders = folders.filter { !$0.isPinned }
+        var sessionsByFolder: [UUID: [ControlPanelRecentSession]] = [:]
+        for recent in unpinnedSessions {
+            guard let folderID = recent.folderID else { continue }
+            sessionsByFolder[folderID, default: []].append(recent)
+        }
+        self.sessionsByFolder = sessionsByFolder
+        chatSessionIDs = Set(chatSessions.map(\.id))
+        imageSessionIDs = Set(imageSessions.map(\.id))
+    }
+
+    func sessions(inFolder folderID: UUID) -> [ControlPanelRecentSession] {
+        sessionsByFolder[folderID] ?? []
+    }
+
+    func containsChatSession(_ sessionID: UUID) -> Bool {
+        chatSessionIDs.contains(sessionID)
+    }
+
+    func containsImageSession(_ sessionID: UUID) -> Bool {
+        imageSessionIDs.contains(sessionID)
+    }
+
+    func chatTitle(for sessionID: UUID) -> String? {
+        recentSessions.first { $0.chatID == sessionID }?.title
+    }
+}
+
+/// Exposes only the session index consumed by the control-panel sidebar. The
+/// transcript, composer, attachment, streaming, and tool state remain observed
+/// exclusively by `ChatView` and cannot invalidate the recents surface.
+@MainActor
+private final class ChatSidebarState: ObservableObject {
+    @Published private(set) var recents: SidebarRecentsSnapshot
+    @Published private(set) var currentChatSessionID: UUID?
+    @Published private(set) var currentImageSessionID: UUID?
+    @Published private(set) var isGeneratingImage: Bool
+
+    init(chat: ChatViewModel, imageGeneration: ImageGenerationViewModel) {
+        recents = SidebarRecentsSnapshot(
+            chatSessions: chat.sessions,
+            folders: chat.folders,
+            imageSessions: imageGeneration.sessions
+        )
+        currentChatSessionID = chat.currentSessionID
+        currentImageSessionID = imageGeneration.currentSessionID
+        isGeneratingImage = imageGeneration.isGenerating
+
+        Publishers.CombineLatest3(
+            chat.$sessions.removeDuplicates(),
+            chat.$folders.removeDuplicates(),
+            imageGeneration.$sessions.removeDuplicates()
+        )
+        .map { sessions, folders, imageSessions in
+            SidebarRecentsSnapshot(
+                chatSessions: sessions,
+                folders: folders,
+                imageSessions: imageSessions
+            )
+        }
+        .removeDuplicates()
+        .assign(to: &$recents)
+        chat.$currentSessionID
+            .removeDuplicates()
+            .assign(to: &$currentChatSessionID)
+        imageGeneration.$currentSessionID
+            .removeDuplicates()
+            .assign(to: &$currentImageSessionID)
+        imageGeneration.$isGenerating
+            .removeDuplicates()
+            .assign(to: &$isGeneratingImage)
+    }
+}
+
+/// Projects the remaining low-frequency global presentation state. High-frequency
+/// page state remains observed by its leaf views.
 @MainActor
 final class ControlPanelContentState: ObservableObject {
     private struct Snapshot: Equatable {
-        var chatSessions: [ChatSessionSummary]
-        var chatFolders: [ChatFolder]
-        var currentChatSessionID: UUID?
-        var imageSessions: [ImageGenerationSessionSummary]
-        var currentImageSessionID: UUID?
-        var isGeneratingImage: Bool
-        var activeDownloadCount: Int
         var extensionSidebarContributions: [NativSidebarContribution]
         var routines: [Routine]
         var routineRuns: [RoutineRun]
@@ -304,48 +411,12 @@ final class ControlPanelContentState: ObservableObject {
         extensionManager: NativExtensionManager
     ) {
         snapshot = Snapshot(
-            chatSessions: dependencies.chat.sessions,
-            chatFolders: dependencies.chat.folders,
-            currentChatSessionID: dependencies.chat.currentSessionID,
-            imageSessions: dependencies.imageGeneration.sessions,
-            currentImageSessionID: dependencies.imageGeneration.currentSessionID,
-            isGeneratingImage: dependencies.imageGeneration.isGenerating,
-            activeDownloadCount: dependencies.downloads.activeCount,
             extensionSidebarContributions: extensionManager.enabledSidebarContributions,
             routines: dependencies.routineStore.routines,
             routineRuns: dependencies.routineStore.runs,
             launchAtLoginErrorMessage: dependencies.launchAtLogin.errorMessage
         )
 
-        dependencies.chat.$sessions
-            .removeDuplicates()
-            .sink { [weak self] value in self?.update { $0.chatSessions = value } }
-            .store(in: &cancellables)
-        dependencies.chat.$folders
-            .removeDuplicates()
-            .sink { [weak self] value in self?.update { $0.chatFolders = value } }
-            .store(in: &cancellables)
-        dependencies.chat.$currentSessionID
-            .removeDuplicates()
-            .sink { [weak self] value in self?.update { $0.currentChatSessionID = value } }
-            .store(in: &cancellables)
-        dependencies.imageGeneration.$sessions
-            .removeDuplicates()
-            .sink { [weak self] value in self?.update { $0.imageSessions = value } }
-            .store(in: &cancellables)
-        dependencies.imageGeneration.$currentSessionID
-            .removeDuplicates()
-            .sink { [weak self] value in self?.update { $0.currentImageSessionID = value } }
-            .store(in: &cancellables)
-        dependencies.imageGeneration.$isGenerating
-            .removeDuplicates()
-            .sink { [weak self] value in self?.update { $0.isGeneratingImage = value } }
-            .store(in: &cancellables)
-        dependencies.downloads.$downloads
-            .map(\.count)
-            .removeDuplicates()
-            .sink { [weak self] value in self?.update { $0.activeDownloadCount = value } }
-            .store(in: &cancellables)
         extensionManager.$records
             .map(Self.enabledSidebarContributions)
             .removeDuplicates()
@@ -369,13 +440,6 @@ final class ControlPanelContentState: ObservableObject {
             .store(in: &cancellables)
     }
 
-    var chatSessions: [ChatSessionSummary] { snapshot.chatSessions }
-    var chatFolders: [ChatFolder] { snapshot.chatFolders }
-    var currentChatSessionID: UUID? { snapshot.currentChatSessionID }
-    var imageSessions: [ImageGenerationSessionSummary] { snapshot.imageSessions }
-    var currentImageSessionID: UUID? { snapshot.currentImageSessionID }
-    var isGeneratingImage: Bool { snapshot.isGeneratingImage }
-    var activeDownloadCount: Int { snapshot.activeDownloadCount }
     var extensionSidebarContributions: [NativSidebarContribution] {
         snapshot.extensionSidebarContributions
     }
@@ -495,6 +559,33 @@ private struct ModelsDownloadArrow: View {
     }
 }
 
+/// Owns the control-panel's download-count projection and listens only for the
+/// manager's structural add/remove signal, not its progress publications.
+private struct ModelsDownloadBadge: View {
+    let downloads: HuggingFaceDownloadManager
+    @State private var activeCount: Int
+
+    init(downloads: HuggingFaceDownloadManager) {
+        self.downloads = downloads
+        _activeCount = State(initialValue: downloads.activeCount)
+    }
+
+    var body: some View {
+        Group {
+            if activeCount > 0 {
+                ModelsDownloadArrow(count: activeCount)
+            }
+        }
+        .onReceive(
+            downloads.rowUpdates
+                .compactMap { updatedModelID in
+                    updatedModelID == nil ? downloads.activeCount : nil
+                }
+                .removeDuplicates()
+        ) { activeCount = $0 }
+    }
+}
+
 private struct SidebarNavigationLabelStyle: LabelStyle {
     func makeBody(configuration: Configuration) -> some View {
         HStack(spacing: 8) {
@@ -560,6 +651,7 @@ struct ControlPanelView: View {
 
     private let dependencies: ControlPanelDependencies
     @StateObject private var chromeState: ControlPanelChromeState
+    @StateObject private var sidebarState: ChatSidebarState
     @StateObject private var contentState: ControlPanelContentState
     @AppStorage(ControlPanelOnboarding.extensionsBadgeDismissedKey)
     private var isExtensionsBadgeDismissed = false
@@ -622,6 +714,12 @@ struct ControlPanelView: View {
         self.softwareUpdater = softwareUpdater
         self.dependencies = dependencies
         _chromeState = StateObject(wrappedValue: ControlPanelChromeState(model: model))
+        _sidebarState = StateObject(
+            wrappedValue: ChatSidebarState(
+                chat: dependencies.chat,
+                imageGeneration: dependencies.imageGeneration
+            )
+        )
         _contentState = StateObject(
             wrappedValue: ControlPanelContentState(
                 dependencies: dependencies,
@@ -1041,9 +1139,7 @@ struct ControlPanelView: View {
                                 .foregroundStyle(.secondary)
                                 .frame(width: 34, alignment: .trailing)
                         }
-                        if contentState.activeDownloadCount > 0 {
-                            ModelsDownloadArrow(count: contentState.activeDownloadCount)
-                        }
+                        ModelsDownloadBadge(downloads: downloads)
                     }
                 }
             }
@@ -1322,7 +1418,7 @@ struct ControlPanelView: View {
         isPinnedRow: Bool
     ) {
         guard let draggedID = UUID(uuidString: draggedPayload),
-              contentState.chatSessions.contains(where: { $0.id == draggedID }),
+              sidebarState.recents.containsChatSession(draggedID),
               let targetID = target.chatID,
               draggedID != targetID
         else {
@@ -1353,7 +1449,7 @@ struct ControlPanelView: View {
         reorderTargetID = nil
         reorderInsertAfter = false
         guard let draggedID = UUID(uuidString: draggedPayload),
-              contentState.chatSessions.contains(where: { $0.id == draggedID }),
+              sidebarState.recents.containsChatSession(draggedID),
               let targetID = target.chatID,
               draggedID != targetID
         else {
@@ -1429,7 +1525,7 @@ struct ControlPanelView: View {
                     .foregroundStyle(Color.secondary.opacity(0.7))
             }
             .buttonStyle(.plain)
-            .disabled(recentSessions.isEmpty && contentState.chatFolders.isEmpty)
+            .disabled(recentSessions.isEmpty && sidebarState.recents.folders.isEmpty)
             .help("Select multiple")
 
             Menu {
@@ -1457,7 +1553,7 @@ struct ControlPanelView: View {
             .disabled(
                 selectedTab == .chat
                     && chatWorkspaceMode == .images
-                    && contentState.isGeneratingImage
+                    && sidebarState.isGeneratingImage
             )
             .help(newRecentHelp)
             .onHover { isNewChatHovering = $0 }
@@ -1593,7 +1689,7 @@ struct ControlPanelView: View {
         chromeState.sidebarPinnedCollapsed
             && chromeState.sidebarFoldersCollapsed
             && chromeState.sidebarSessionsCollapsed
-            && !contentState.chatFolders.contains { !$0.isCollapsed }
+            && !sidebarState.recents.folders.contains { !$0.isCollapsed }
     }
 
     private func revealSidebarSection(_ keyPath: WritableKeyPath<NativSettings, Bool>) {
@@ -1785,45 +1881,31 @@ struct ControlPanelView: View {
     }
 
     private var recentSessions: [ControlPanelRecentSession] {
-        (
-            contentState.chatSessions.map(ControlPanelRecentSession.init(chat:))
-                + contentState.imageSessions.map(ControlPanelRecentSession.init(imageGeneration:))
-        )
-            .sorted(by: ControlPanelRecentSession.recencySort)
+        sidebarState.recents.recentSessions
     }
 
     private var pinnedSessions: [ControlPanelRecentSession] {
-        recentSessions
-            .filter(\.pinned)
-            .sorted(by: ControlPanelRecentSession.pinnedSort)
+        sidebarState.recents.pinnedSessions
     }
 
     private var unpinnedSessions: [ControlPanelRecentSession] {
-        recentSessions.filter { !$0.pinned }.sorted(by: ControlPanelRecentSession.sessionSort)
+        sidebarState.recents.unpinnedSessions
     }
 
     private var ungroupedSessions: [ControlPanelRecentSession] {
-        let folderIDs = Set(contentState.chatFolders.map(\.id))
-        return unpinnedSessions.filter { recent in
-            guard let folderID = recent.folderID else {
-                return true
-            }
-            return !folderIDs.contains(folderID)
-        }
+        sidebarState.recents.ungroupedSessions
     }
 
     private var pinnedFolders: [ChatFolder] {
-        contentState.chatFolders.filter(\.isPinned)
+        sidebarState.recents.pinnedFolders
     }
 
     private var unpinnedFolders: [ChatFolder] {
-        contentState.chatFolders.filter { !$0.isPinned }
+        sidebarState.recents.unpinnedFolders
     }
 
     private func sessions(inFolder folderID: UUID) -> [ControlPanelRecentSession] {
-        recentSessions
-            .filter { !$0.pinned && $0.folderID == folderID }
-            .sorted(by: ControlPanelRecentSession.sessionSort)
+        sidebarState.recents.sessions(inFolder: folderID)
     }
 
     @ViewBuilder
@@ -1868,7 +1950,7 @@ struct ControlPanelView: View {
             onEditRoutine: {
                 editRoutine(for: recent)
             },
-            folders: contentState.chatFolders,
+            folders: sidebarState.recents.folders,
             onMoveToFolder: { folderID in
                 moveRecentToFolder(recent, folderID: folderID)
             },
@@ -1952,7 +2034,7 @@ struct ControlPanelView: View {
     private func draggedChatID(from items: [String]) -> UUID? {
         for item in items {
             if let id = UUID(uuidString: item),
-               contentState.chatSessions.contains(where: { $0.id == id }) {
+               sidebarState.recents.containsChatSession(id) {
                 return id
             }
         }
@@ -2001,7 +2083,7 @@ struct ControlPanelView: View {
         guard dragged != target else {
             return
         }
-        var order = contentState.chatFolders.map(\.id)
+        var order = sidebarState.recents.folders.map(\.id)
         order.removeAll { $0 == dragged }
         if let index = order.firstIndex(of: target) {
             order.insert(dragged, at: index)
@@ -2048,7 +2130,7 @@ struct ControlPanelView: View {
     }
 
     private var selectedFolders: [ChatFolder] {
-        contentState.chatFolders.filter { selectedFolderIDs.contains($0.id) }
+        sidebarState.recents.folders.filter { selectedFolderIDs.contains($0.id) }
     }
 
     private var hasSelectedPinnable: Bool {
@@ -2331,7 +2413,7 @@ struct ControlPanelView: View {
             }
             if tab == .chat {
                 switch chatWorkspaceMode {
-                case .chat where contentState.currentChatSessionID == nil:
+                case .chat where sidebarState.currentChatSessionID == nil:
                     chat.createSession()
                 default:
                     break
@@ -2350,7 +2432,7 @@ struct ControlPanelView: View {
             sidebarSelection = selection
             selectedTab = .extensions
         case .chat(let sessionID):
-            if contentState.chatSessions.contains(where: { $0.id == sessionID }) {
+            if sidebarState.recents.containsChatSession(sessionID) {
                 chat.selectSession(sessionID)
                 sidebarSelection = selection
             } else {
@@ -2359,7 +2441,7 @@ struct ControlPanelView: View {
             chatWorkspaceMode = .chat
             selectedTab = .chat
         case .imageGeneration(let sessionID):
-            if contentState.imageSessions.contains(where: { $0.id == sessionID }) {
+            if sidebarState.recents.containsImageSession(sessionID) {
                 imageGeneration.selectSession(sessionID)
                 sidebarSelection = selection
             } else {
@@ -2471,8 +2553,7 @@ struct ControlPanelView: View {
             guard let text = chat.conversationText(for: sessionID) else {
                 continue
             }
-            let title = contentState.chatSessions.first { $0.id == sessionID }?.title
-                ?? sessionID.uuidString
+            let title = sidebarState.recents.chatTitle(for: sessionID) ?? sessionID.uuidString
             let base = sanitizedFileName(title)
             var candidate = base
             var suffix = 2
@@ -2565,10 +2646,10 @@ struct ControlPanelView: View {
         }
         switch (sidebarSelection, recent.selection) {
         case (.tab(.chat), .chat(let sessionID)):
-            return chatWorkspaceMode == .chat && sessionID == contentState.currentChatSessionID
+            return chatWorkspaceMode == .chat && sessionID == sidebarState.currentChatSessionID
         case (.tab(.chat), .imageGeneration(let sessionID)):
             return chatWorkspaceMode == .images
-                && sessionID == contentState.currentImageSessionID
+                && sessionID == sidebarState.currentImageSessionID
         default:
             return false
         }
@@ -2577,9 +2658,9 @@ struct ControlPanelView: View {
     private func isCurrentRecent(_ recent: ControlPanelRecentSession) -> Bool {
         switch recent.selection {
         case .chat(let sessionID):
-            return sessionID == contentState.currentChatSessionID
+            return sessionID == sidebarState.currentChatSessionID
         case .imageGeneration(let sessionID):
-            return sessionID == contentState.currentImageSessionID
+            return sessionID == sidebarState.currentImageSessionID
         case .tab, .extensionPage:
             return false
         }
@@ -2593,7 +2674,7 @@ struct ControlPanelView: View {
             // stream never finished permanently undeletable.
             return false
         case .imageGeneration:
-            return contentState.isGeneratingImage
+            return sidebarState.isGeneratingImage
         case .tab, .extensionPage:
             return false
         }
@@ -2604,7 +2685,7 @@ struct ControlPanelView: View {
         case .chat:
             return false
         case .imageGeneration:
-            return contentState.isGeneratingImage
+            return sidebarState.isGeneratingImage
         case .tab, .extensionPage:
             return false
         }
@@ -2647,19 +2728,19 @@ struct ControlPanelView: View {
     }
 
     private func showChatWorkspace() {
-        if contentState.currentChatSessionID == nil {
+        if sidebarState.currentChatSessionID == nil {
             chat.createSession()
         }
         chatWorkspaceMode = .chat
         selectedTab = .chat
-        sidebarSelection = contentState.currentChatSessionID.map(ControlPanelSidebarSelection.chat)
+        sidebarSelection = sidebarState.currentChatSessionID.map(ControlPanelSidebarSelection.chat)
             ?? .tab(.chat)
     }
 
     private func showImageWorkspace() {
         chatWorkspaceMode = .images
         selectedTab = .chat
-        sidebarSelection = contentState.currentImageSessionID
+        sidebarSelection = sidebarState.currentImageSessionID
             .map(ControlPanelSidebarSelection.imageGeneration)
             ?? .tab(.chat)
     }

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -15,11 +15,12 @@ enum WelcomePreferences {
 
 struct WelcomeGateView: View {
     @AppStorage(WelcomePreferences.completionKey) private var hasCompletedWelcome = false
+    @StateObject private var controlPanelDependencies = ControlPanelDependencies()
 
-    @ObservedObject var model: NativModel
-    @ObservedObject var navigation: ControlPanelNavigation
-    @ObservedObject var runtime: SystemRuntimeMonitor
-    @ObservedObject var extensionManager: NativExtensionManager
+    let model: NativModel
+    let navigation: ControlPanelNavigation
+    let runtime: SystemRuntimeMonitor
+    let extensionManager: NativExtensionManager
     let softwareUpdater: SoftwareUpdater
     let onComplete: (_ modelID: String?, _ serverAPIKey: String?) -> Void
 
@@ -31,7 +32,8 @@ struct WelcomeGateView: View {
                     navigation: navigation,
                     runtime: runtime,
                     extensionManager: extensionManager,
-                    softwareUpdater: softwareUpdater
+                    softwareUpdater: softwareUpdater,
+                    dependencies: controlPanelDependencies
                 )
             } else {
                 WelcomeView(model: model) { modelID, serverAPIKey in


### PR DESCRIPTION
The monolithic NativModel observation is kind of an anti-pattern in SwiftUI, so I'm incrementally untangling the other views from it. This updates the sidebar to only observe properties it needs to render, which brings its steady state rendering down to zero SwiftUI View updates instead of a constant trickle.