### PR TITLE
Update language mode to Swift 6.3 and fix all concurrency warnings

### DIFF
--- a/Extensions/VoiceDictation/Runtime/VoiceDictationExtensionRuntime.swift
+++ b/Extensions/VoiceDictation/Runtime/VoiceDictationExtensionRuntime.swift
@@ -4,7 +4,8 @@ import NativExtensionSDK
 
 private final class VoiceDictationRuntimeService:
     NSObject,
-    NativExtensionXPCProtocol
+    NativExtensionXPCProtocol,
+    @unchecked Sendable
 {
     private let lock = NSLock()
     private var activationContext: NativExtensionActivationContext?

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -1564,6 +1564,7 @@
 			baseConfigurationReference = 42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */;
 			buildSettings = {
 				ARCHS = arm64;
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1619,6 +1620,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -1631,14 +1633,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.3;
 			};
 			name = Release;
 		};
@@ -1647,6 +1649,7 @@
 			baseConfigurationReference = 42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */;
 			buildSettings = {
 				ARCHS = arm64;
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1659,7 +1662,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(NATIV_EXTENSION_SDK_BUNDLE_IDENTIFIER)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1676,6 +1679,7 @@
 				CODE_SIGN_ENTITLEMENTS = Configuration/Nativ.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 7;
+				ENABLE_HARDENED_RUNTIME = YES;
 				EX_ENABLE_EXTENSION_POINT_GENERATION = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Configuration/Nativ-Info.plist";
@@ -1699,6 +1703,7 @@
 				ARCHS = arm64;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 7;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Configuration/AudioExtension-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
@@ -1719,6 +1724,7 @@
 				CODE_SIGN_ENTITLEMENTS = Configuration/Nativ.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 7;
+				ENABLE_HARDENED_RUNTIME = YES;
 				EX_ENABLE_EXTENSION_POINT_GENERATION = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Configuration/Nativ-Info.plist";
@@ -1740,6 +1746,7 @@
 			baseConfigurationReference = 42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */;
 			buildSettings = {
 				ARCHS = arm64;
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1767,6 +1774,7 @@
 				ARCHS = arm64;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 7;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Configuration/AudioExtension-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
@@ -1783,6 +1791,7 @@
 			baseConfigurationReference = 42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */;
 			buildSettings = {
 				ARCHS = arm64;
+				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1795,7 +1804,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(NATIV_EXTENSION_SDK_BUNDLE_IDENTIFIER)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1854,6 +1863,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1872,7 +1882,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1880,7 +1890,7 @@
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.3;
 			};
 			name = Debug;
 		};

--- a/Nativ.xcodeproj/xcshareddata/xcschemes/Nativ.xcscheme
+++ b/Nativ.xcodeproj/xcshareddata/xcschemes/Nativ.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
-   version = "1.7">
+   LastUpgradeVersion = "2660"
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -27,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -51,8 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -74,8 +70,6 @@
             ReferencedContainer = "container:Nativ.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -93,8 +87,6 @@
             ReferencedContainer = "container:Nativ.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Sources/Nativ/ControlPanelView.swift
+++ b/Sources/Nativ/ControlPanelView.swift
@@ -1477,7 +1477,7 @@ struct ControlPanelView: View {
     @discardableResult
     private func loadDropString(
         _ providers: [NSItemProvider],
-        _ handler: @escaping (String) -> Void
+        _ handler: @escaping @MainActor @Sendable (String) -> Void
     ) -> Bool {
         guard let provider = providers.first else {
             return false
@@ -2810,6 +2810,7 @@ private struct ArtifactsPageHost: View {
         let baseURL = URL(string: "http://127.0.0.1:\(settings.serverPort)")
             ?? URL(string: "http://127.0.0.1:8080")!
         let modelID = Self.embeddingModelID
+        let modelSearchPath = settings.modelSearchPath
         let insufficientReason = downloads.capacityBlocker(
             sizeBytes: Self.embeddingModelSize,
             cachePath: settings.modelSearchPath
@@ -2823,9 +2824,18 @@ private struct ArtifactsPageHost: View {
             downloadProgress: downloads.progress(for: modelID),
             canInstall: insufficientReason == nil,
             insufficientReason: insufficientReason,
-            onEnable: enableSemanticSearch,
-            onRemove: removeSemanticSearchModel,
-            prepareModel: prepareSemanticSearchModel
+            onEnable: {
+                enableSemanticSearch()
+            },
+            onRemove: {
+                removeSemanticSearchModel()
+            },
+            prepareModel: {
+                EmbeddingModelPreparer.prepare(
+                    repoID: modelID,
+                    searchPath: modelSearchPath
+                )
+            }
         )
     }
 
@@ -2870,12 +2880,6 @@ private struct ArtifactsPageHost: View {
         }
     }
 
-    private func prepareSemanticSearchModel() {
-        EmbeddingModelPreparer.prepare(
-            repoID: Self.embeddingModelID,
-            searchPath: settings.modelSearchPath
-        )
-    }
 }
 
 private struct ChatWorkspaceView: View {
@@ -2995,7 +2999,11 @@ private struct ControlPanelSurfaceReader: NSViewRepresentable {
     }
 }
 
-private var controlPanelBackdropCornerRadiusObservationContext = 0
+nonisolated(unsafe) private var controlPanelBackdropCornerRadiusObservationContext = 0
+
+private struct ControlPanelObservedObject: @unchecked Sendable {
+    let value: Any?
+}
 
 @MainActor
 private final class ControlPanelSurfaceReaderView: NSView {
@@ -3018,7 +3026,7 @@ private final class ControlPanelSurfaceReaderView: NSView {
     private var localMouseEventMonitor: Any?
     private var isFullScreen = false
 
-    deinit {
+    isolated deinit {
         cornerCorrectionTimer?.invalidate()
         liveResizeCornerCorrectionTimer?.invalidate()
         liveResizeStopWorkItem?.cancel()
@@ -3222,11 +3230,13 @@ private final class ControlPanelSurfaceReaderView: NSView {
                 \.cornerRadius,
                 options: [.new]
             ) { surface, _ in
-                guard surface.cornerRadius != 0 else { return }
-                NSAnimationContext.runAnimationGroup { context in
-                    context.duration = 0
-                    context.allowsImplicitAnimation = false
-                    surface.cornerRadius = 0
+                MainActor.assumeIsolated {
+                    guard surface.cornerRadius != 0 else { return }
+                    NSAnimationContext.runAnimationGroup { context in
+                        context.duration = 0
+                        context.allowsImplicitAnimation = false
+                        surface.cornerRadius = 0
+                    }
                 }
             }
             glassFrameObservation = glassSurface.observe(
@@ -3390,8 +3400,7 @@ private final class ControlPanelSurfaceReaderView: NSView {
         change: [NSKeyValueChangeKey: Any]?,
         context: UnsafeMutableRawPointer?
     ) {
-        guard context == &controlPanelBackdropCornerRadiusObservationContext,
-              let backdropView = object as? NSView else {
+        guard context == &controlPanelBackdropCornerRadiusObservationContext else {
             super.observeValue(
                 forKeyPath: keyPath,
                 of: object,
@@ -3401,14 +3410,20 @@ private final class ControlPanelSurfaceReaderView: NSView {
             return
         }
 
-        let cornerRadius =
-            (backdropView.value(forKey: "punchOutCornerRadius") as? NSNumber)?
-            .doubleValue ?? 0
-        if cornerRadius != 0 {
-            setBackdropCornerRadiusToZero(
-                on: backdropView,
-                key: "punchOutCornerRadius"
-            )
+        let observedObject = ControlPanelObservedObject(value: object)
+        MainActor.assumeIsolated {
+            guard let backdropView = observedObject.value as? NSView else {
+                return
+            }
+            let cornerRadius =
+                (backdropView.value(forKey: "punchOutCornerRadius") as? NSNumber)?
+                .doubleValue ?? 0
+            if cornerRadius != 0 {
+                setBackdropCornerRadiusToZero(
+                    on: backdropView,
+                    key: "punchOutCornerRadius"
+                )
+            }
         }
     }
 
@@ -3647,7 +3662,7 @@ private final class ControlPanelCollapseButtonsView: NSView {
     private weak var actionWindow: NSWindow?
     private var localMouseEventMonitor: Any?
 
-    deinit {
+    isolated deinit {
         if let localMouseEventMonitor {
             NSEvent.removeMonitor(localMouseEventMonitor)
         }
@@ -3953,7 +3968,7 @@ private final class ControlPanelWindowControlsOverlayView: NSView {
         nil
     }
 
-    deinit {
+    isolated deinit {
         NotificationCenter.default.removeObserver(self)
         if let localMouseEventMonitor {
             NSEvent.removeMonitor(localMouseEventMonitor)

--- a/Sources/Nativ/Features/Artifacts/ArtifactSemanticSearch.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactSemanticSearch.swift
@@ -1,7 +1,7 @@
 import Foundation
 import NativServerKit
 
-struct ArtifactSemanticSearchConfig {
+struct ArtifactSemanticSearchConfig: Sendable {
     let modelID: String
     let sizeBytes: Int64
     let client: NativEmbeddingsClient
@@ -10,9 +10,9 @@ struct ArtifactSemanticSearchConfig {
     let downloadProgress: Double
     let canInstall: Bool
     let insufficientReason: String?
-    let onEnable: () -> Void
-    var onRemove: () -> Void = {}
-    var prepareModel: () -> Void = {}
+    let onEnable: @MainActor @Sendable () -> Void
+    var onRemove: @MainActor @Sendable () -> Void = {}
+    var prepareModel: @Sendable () -> Void = {}
 
     var sizeLabel: String {
         ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)

--- a/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
@@ -366,7 +366,11 @@ struct ArtifactsView: View {
         }.value
     }
 
-    private static func chunkedText(_ text: String, maxChunks: Int, chunkSize: Int) -> [String] {
+    nonisolated private static func chunkedText(
+        _ text: String,
+        maxChunks: Int,
+        chunkSize: Int
+    ) -> [String] {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             return []

--- a/Sources/Nativ/Features/Artifacts/EmbeddingModelPreparer.swift
+++ b/Sources/Nativ/Features/Artifacts/EmbeddingModelPreparer.swift
@@ -13,7 +13,7 @@ enum EmbeddingModelPreparer {
         "qwen3_vl": "qwen3_vl_embedding"
     ]
 
-    static func prepare(repoID: String, searchPath: String) {
+    nonisolated static func prepare(repoID: String, searchPath: String) {
         guard let configURL = configURL(repoID: repoID, searchPath: searchPath),
               let data = try? Data(contentsOf: configURL),
               var object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
@@ -32,7 +32,7 @@ enum EmbeddingModelPreparer {
         try? updated.write(to: configURL, options: .atomic)
     }
 
-    private static func configURL(repoID: String, searchPath: String) -> URL? {
+    nonisolated private static func configURL(repoID: String, searchPath: String) -> URL? {
         let root = URL(
             fileURLWithPath: (searchPath as NSString).expandingTildeInPath,
             isDirectory: true

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -1820,6 +1820,7 @@ struct ChatComposerTextEditor: NSViewRepresentable {
         context.coordinator.requestFocus(ifNeeded: focusToken)
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         @Binding private var text: String
         var onSubmit: () -> Void

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -5,7 +5,7 @@ typealias ChatImageModelSelectionHandler = @MainActor @Sendable (
     ChatImageModelSelectionRequest
 ) async throws -> String
 
-struct ChatToolExecutionContext {
+struct ChatToolExecutionContext: Sendable {
     let imageGenerationModelID: String?
     let baseURL: URL
     let apiKey: String?
@@ -19,7 +19,7 @@ struct ChatToolExecutionContext {
     var imageExecutionWillStart: (@MainActor @Sendable (String) -> Void)? = nil
 }
 
-struct ChatToolExecutionOutcome {
+struct ChatToolExecutionOutcome: Sendable {
     let content: String
     let attachments: [ChatImageAttachment]
 }
@@ -96,22 +96,43 @@ enum ChatToolRegistry {
 }
 
 enum ChatToolDispatcher {
-    private typealias Handler = (MLXChatToolCall, ChatToolExecutionContext) async throws -> ChatToolExecutionOutcome
-    private typealias FailureHandler = (String, Error) -> String
+    private typealias Handler = @Sendable (
+        MLXChatToolCall,
+        ChatToolExecutionContext
+    ) async throws -> ChatToolExecutionOutcome
+    private typealias FailureHandler = @Sendable (String, Error) -> String
 
     private static let handlers: [String: Handler] = [
-        ChatImageToolRegistry.generateToolName: executeImageTool,
-        ChatImageToolRegistry.editToolName: executeImageTool,
-        ChatSystemMonitorToolRegistry.toolName: executeSystemMonitorTool,
-        ChatModelLibraryToolRegistry.toolName: executeModelLibraryTool,
-        ChatServerStatsToolRegistry.toolName: executeServerStatsTool,
-        ChatWebSearchToolRegistry.toolName: executeWebSearchTool,
-        ChatWebReadToolRegistry.toolName: executeWebReadTool,
+        ChatImageToolRegistry.generateToolName: { call, context in
+            try await executeImageTool(call: call, context: context)
+        },
+        ChatImageToolRegistry.editToolName: { call, context in
+            try await executeImageTool(call: call, context: context)
+        },
+        ChatSystemMonitorToolRegistry.toolName: { call, context in
+            try await executeSystemMonitorTool(call: call, context: context)
+        },
+        ChatModelLibraryToolRegistry.toolName: { call, context in
+            try await executeModelLibraryTool(call: call, context: context)
+        },
+        ChatServerStatsToolRegistry.toolName: { call, context in
+            try await executeServerStatsTool(call: call, context: context)
+        },
+        ChatWebSearchToolRegistry.toolName: { call, context in
+            try await executeWebSearchTool(call: call, context: context)
+        },
+        ChatWebReadToolRegistry.toolName: { call, context in
+            try await executeWebReadTool(call: call, context: context)
+        },
     ]
 
     private static let failureHandlers: [String: FailureHandler] = [
-        ChatImageToolRegistry.generateToolName: failurePayloadForImageTool,
-        ChatImageToolRegistry.editToolName: failurePayloadForImageTool,
+        ChatImageToolRegistry.generateToolName: { name, error in
+            failurePayloadForImageTool(name: name, error: error)
+        },
+        ChatImageToolRegistry.editToolName: { name, error in
+            failurePayloadForImageTool(name: name, error: error)
+        },
         ChatSystemMonitorToolRegistry.toolName: { name, error in
             ChatSystemMonitorToolExecutor().failurePayload(operation: name, error: error)
         },
@@ -263,16 +284,19 @@ final class ChatToolConsentGate {
     }
 
     func awaitDecision(for id: UUID) async -> Bool {
-        await withTaskCancellationHandler {
+        let denyRequest: @MainActor @Sendable () -> Void = { [weak self] in
+            self?.deny(id)
+        }
+        return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 pending[id] = continuation
                 if Task.isCancelled {
                     pending.removeValue(forKey: id)?.resume(returning: false)
                 }
             }
-        } onCancel: { [weak self] in
+        } onCancel: {
             Task { @MainActor in
-                self?.pending.removeValue(forKey: id)?.resume(returning: false)
+                denyRequest()
             }
         }
     }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1351,14 +1351,18 @@ final class ChatViewModel: ObservableObject {
                 throw NativChatError.invalidResponse
             }
 
-            let completion = try await client.streamChat(request, onEvent: { [weak self] event in
-                await MainActor.run {
-                    self?.append(
-                        event: event,
-                        to: assistantMessageID,
-                        in: queuedRequest.sessionID
-                    )
-                }
+            let streamingMessageID = assistantMessageID
+            let streamingSessionID = queuedRequest.sessionID
+            let appendEvent: @MainActor @Sendable (MLXChatStreamDelta) -> Void = {
+                [weak self] event in
+                self?.append(
+                    event: event,
+                    to: streamingMessageID,
+                    in: streamingSessionID
+                )
+            }
+            let completion = try await client.streamChat(request, onEvent: { event in
+                await appendEvent(event)
             })
             let toolCalls = normalizedToolCalls(completion.toolCalls)
             finishAssistantMessage(
@@ -2359,7 +2363,7 @@ final class ChatViewModel: ObservableObject {
     }
 }
 
-private struct ChatMessageRow: View, Equatable {
+private struct ChatMessageRow: View, @MainActor Equatable {
     private static let maximumUserBubbleWidth: CGFloat = 560
 
     let message: ChatTranscriptMessage
@@ -2804,9 +2808,9 @@ private struct ChatAgentStepCell: View {
 
     private var consentDescription: Text {
         if message.toolName == ChatSwitchModelToolRegistry.toolName {
-            return Text("The model wants to switch to ")
-                + Text(verbatim: requestedModelID).bold()
-                + Text(". The server restarts briefly; your session is kept.")
+            return Text(
+                "The model wants to switch to \(Text(verbatim: requestedModelID).bold()). The server restarts briefly; your session is kept."
+            )
         }
         return Text("The model wants to run this script tool on your Mac. Confirm to allow its code to run.")
     }

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
@@ -387,9 +387,12 @@ final class ChatImageModelSelectionGate {
 
     func awaitSelection(
         for requestID: UUID,
-        onReady: () -> Void
+        onReady: @MainActor @Sendable () -> Void
     ) async -> String? {
-        await withTaskCancellationHandler {
+        let cancelSelection: @MainActor @Sendable () -> Void = { [weak self] in
+            self?.cancel(requestID)
+        }
+        return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 pending.removeValue(forKey: requestID)?.resume(returning: nil)
                 pending[requestID] = continuation
@@ -398,9 +401,9 @@ final class ChatImageModelSelectionGate {
                     pending.removeValue(forKey: requestID)?.resume(returning: nil)
                 }
             }
-        } onCancel: { [weak self] in
+        } onCancel: {
             Task { @MainActor in
-                self?.pending.removeValue(forKey: requestID)?.resume(returning: nil)
+                cancelSelection()
             }
         }
     }

--- a/Sources/Nativ/Features/Dashboard/StatsView.swift
+++ b/Sources/Nativ/Features/Dashboard/StatsView.swift
@@ -103,7 +103,7 @@ private struct DashboardModelState: Equatable {
     }
 }
 
-private struct DashboardContentView: View, Equatable {
+private struct DashboardContentView: View, @MainActor Equatable {
     let modelState: DashboardModelState
     @ObservedObject var dashboard: DashboardViewModel
     let titleLeadingInset: CGFloat
@@ -3605,7 +3605,7 @@ private struct TokenUsagePanelHeightReader: View {
 }
 
 private struct TokenUsagePanelHeightPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
+    static let defaultValue: CGFloat = 0
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -2043,7 +2043,11 @@ private enum SystemRuntimeInfo {
         let usedPages = UInt64(statistics.active_count)
             + UInt64(statistics.wire_count)
             + UInt64(statistics.compressor_page_count)
-        let usedBytes = usedPages * UInt64(vm_kernel_page_size)
+        var kernelPageSize: vm_size_t = 0
+        guard host_page_size(mach_host_self(), &kernelPageSize) == KERN_SUCCESS else {
+            return 0
+        }
+        let usedBytes = usedPages * UInt64(kernelPageSize)
         return min(usedBytes, ProcessInfo.processInfo.physicalMemory)
     }
 
@@ -2116,7 +2120,8 @@ private enum SystemRuntimeInfo {
         guard sysctlbyname(name, &value, &size, nil, 0) == 0 else {
             return nil
         }
-        return String(cString: value)
+        let bytes = value.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
     }
 }
 
@@ -2195,6 +2200,7 @@ private struct LogTextView: NSViewRepresentable {
     }
 }
 
+@MainActor
 private enum LogTextStyler {
     private static let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
 

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -102,11 +102,15 @@ struct ExtensionsHubView: View {
 }
 
 private struct OpenExtensionsHubSectionKey: EnvironmentKey {
-    static let defaultValue: (ExtensionsHubView.HubSection) -> Void = { _ in }
+    static let defaultValue: @MainActor @Sendable (
+        ExtensionsHubView.HubSection
+    ) -> Void = { _ in }
 }
 
 extension EnvironmentValues {
-    var openExtensionsHubSection: (ExtensionsHubView.HubSection) -> Void {
+    var openExtensionsHubSection: @MainActor @Sendable (
+        ExtensionsHubView.HubSection
+    ) -> Void {
         get { self[OpenExtensionsHubSectionKey.self] }
         set { self[OpenExtensionsHubSectionKey.self] = newValue }
     }

--- a/Sources/Nativ/Features/Extensions/NativExtensionHostBroker.swift
+++ b/Sources/Nativ/Features/Extensions/NativExtensionHostBroker.swift
@@ -37,16 +37,25 @@ private enum NativExtensionHostBrokerError: LocalizedError {
     }
 }
 
+private struct NativExtensionHostReply: @unchecked Sendable {
+    let body: (Data?, String?) -> Void
+
+    func callAsFunction(_ data: Data?, _ errorMessage: String?) {
+        body(data, errorMessage)
+    }
+}
+
 final class NativExtensionHostBroker:
     NSObject,
-    NativExtensionHostXPCProtocol
+    NativExtensionHostXPCProtocol,
+    @unchecked Sendable
 {
     private let extensionID: String
     private let hostVersion: String
     private let grantedPermissions: Set<NativExtensionPermission>
     private let storageDirectory: URL
     private let transcriptionConfiguration:
-        @MainActor () -> VoiceTranscriptionConfiguration?
+        @MainActor @Sendable () -> VoiceTranscriptionConfiguration?
 
     init(
         extensionID: String,
@@ -54,7 +63,7 @@ final class NativExtensionHostBroker:
         grantedPermissions: Set<NativExtensionPermission>,
         storageDirectory: URL,
         transcriptionConfiguration:
-            @escaping @MainActor () -> VoiceTranscriptionConfiguration?
+            @escaping @MainActor @Sendable () -> VoiceTranscriptionConfiguration?
     ) {
         self.extensionID = extensionID
         self.hostVersion = hostVersion
@@ -79,20 +88,24 @@ final class NativExtensionHostBroker:
             return
         }
 
-        Task { @MainActor in
+        let replyHandler = NativExtensionHostReply(body: reply)
+        Task { @MainActor [self, replyHandler] in
             do {
                 let responsePayload = try await handle(request)
                 let response = NativExtensionHostResponse(
                     requestID: request.requestID,
                     payload: responsePayload
                 )
-                reply(try JSONEncoder().encode(response), nil)
+                replyHandler(try JSONEncoder().encode(response), nil)
             } catch {
                 let response = NativExtensionHostResponse(
                     requestID: request.requestID,
                     errorMessage: error.localizedDescription
                 )
-                reply(try? JSONEncoder().encode(response), error.localizedDescription)
+                replyHandler(
+                    try? JSONEncoder().encode(response),
+                    error.localizedDescription
+                )
             }
         }
     }

--- a/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
+++ b/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
@@ -1,6 +1,6 @@
 import AppKit
 import AVFoundation
-import ExtensionFoundation
+@preconcurrency import ExtensionFoundation
 import Foundation
 import NativExtensionSDK
 import Observation
@@ -33,7 +33,8 @@ struct NativExtensionPageContext {
 }
 
 struct NativExtensionHostContext {
-    let transcriptionConfiguration: () -> VoiceTranscriptionConfiguration?
+    let transcriptionConfiguration:
+        @MainActor @Sendable () -> VoiceTranscriptionConfiguration?
     let openSpeechModels: () -> Void
     let showMainWindow: () -> Void
 }

--- a/Sources/Nativ/Features/MCP/GitHubOAuth.swift
+++ b/Sources/Nativ/Features/MCP/GitHubOAuth.swift
@@ -392,7 +392,7 @@ actor GitHubOAuthManager: GitHubOAuthAuthorizing {
         configuration: GitHubOAuthConfiguration,
         credentials: any GitHubOAuthCredentialStoring = KeychainGitHubOAuthCredentialStore(),
         transport: any GitHubOAuthTransporting = GitHubOAuthURLSessionTransport(),
-        now: @escaping @Sendable () -> Date = Date.init,
+        now: @escaping @Sendable () -> Date = { Date() },
         sleep: @escaping Sleeper = { seconds in
             try await Task.sleep(for: .seconds(seconds))
         }

--- a/Sources/Nativ/Features/MCP/MCPHostManager.swift
+++ b/Sources/Nativ/Features/MCP/MCPHostManager.swift
@@ -249,28 +249,32 @@ final class MCPHostManager: ObservableObject {
             return
         }
 
+        let showDeviceAuthorization: @MainActor @Sendable (
+            GitHubOAuthDeviceAuthorization
+        ) -> Void = { [weak self] authorization in
+            guard let self, generation == self.reloadGeneration else {
+                return
+            }
+            self.states[config.id] = .authorizingGitHub(
+                code: authorization.userCode,
+                verificationURL: authorization.verificationURL
+            )
+        }
+        let showInstallationRequired: @MainActor @Sendable (URL) -> Void = {
+            [weak self] installationURL in
+            guard let self, generation == self.reloadGeneration else {
+                return
+            }
+            self.states[config.id] = .installingGitHub(installationURL)
+        }
+
         do {
             let token = try await githubOAuth.accessToken(
-                onDeviceAuthorization: { [weak self] authorization in
-                    await MainActor.run {
-                        guard let self, generation == self.reloadGeneration else {
-                            return
-                        }
-                        self.states[config.id] = .authorizingGitHub(
-                            code: authorization.userCode,
-                            verificationURL: authorization.verificationURL
-                        )
-                    }
+                onDeviceAuthorization: { authorization in
+                    await showDeviceAuthorization(authorization)
                 },
-                onInstallationRequired: { [weak self] installationURL in
-                    await MainActor.run {
-                        guard let self, generation == self.reloadGeneration else {
-                            return
-                        }
-                        self.states[config.id] = .installingGitHub(
-                            installationURL
-                        )
-                    }
+                onInstallationRequired: { installationURL in
+                    await showInstallationRequired(installationURL)
                 }
             )
             guard generation == reloadGeneration else { return }

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -953,7 +953,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     private var progressUpdateTimes: [String: Date] = [:]
     private var freeDiskCache: [String: (timestamp: Date, bytes: Int64?)] = [:]
 
-    deinit {
+    isolated deinit {
         contexts.values.forEach {
             $0.operation?.cancel()
             $0.task?.cancel()
@@ -1521,6 +1521,31 @@ private enum HuggingFaceDownloadAttemptError: Error {
     case stalled
 }
 
+private final class HuggingFaceCapturedOutput: @unchecked Sendable {
+    private let lock = NSLock()
+    private let maximumBytes: Int
+    private var data = Data()
+
+    init(maximumBytes: Int) {
+        self.maximumBytes = maximumBytes
+    }
+
+    func append(_ newData: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        data.append(newData)
+        if data.count > maximumBytes {
+            data = Data(data.suffix(maximumBytes / 2))
+        }
+    }
+
+    func snapshot() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
+    }
+}
+
 private final class HuggingFaceDownloadOperation: @unchecked Sendable {
     private static let stallTimeout: TimeInterval = 60
     private static let finalizationStallTimeout: TimeInterval = 10 * 60
@@ -1691,22 +1716,18 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         process.standardError = pipe
 
         let outputGroup = DispatchGroup()
-        let outputLock = NSLock()
-        var output = Data()
+        let output = HuggingFaceCapturedOutput(
+            maximumBytes: Self.maximumCapturedOutputBytes
+        )
         outputGroup.enter()
         DispatchQueue.global(qos: .utility).async {
-            [activity, phase, progress, transferSpeed] in
+            [activity, phase, progress] in
             var lineBuffer = ""
             while true {
                 let data = pipe.fileHandleForReading.availableData
                 guard !data.isEmpty else { break }
 
-                outputLock.lock()
                 output.append(data)
-                if output.count > Self.maximumCapturedOutputBytes {
-                    output = Data(output.suffix(Self.maximumCapturedOutputBytes / 2))
-                }
-                outputLock.unlock()
 
                 lineBuffer += String(decoding: data, as: UTF8.self)
                     .replacingOccurrences(of: "\r", with: "\n")
@@ -1804,9 +1825,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
             throw HuggingFaceDownloadAttemptError.stalled
         }
         guard process.terminationStatus == 0 else {
-            outputLock.lock()
-            let message = String(decoding: output, as: UTF8.self)
-            outputLock.unlock()
+            let message = String(decoding: output.snapshot(), as: UTF8.self)
             let usefulMessage = message
                 .split(whereSeparator: { $0.isNewline || $0 == "\r" })
                 .suffix(4)

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -157,7 +157,7 @@ private final class ModelsNativState: ObservableObject {
 /// Stops unrelated `NativModel` publications in the parent control panel from
 /// walking the Models subtree. Relevant model changes arrive through
 /// `ModelsNativState` instead.
-struct ModelsViewHost: View, Equatable {
+struct ModelsViewHost: View, @MainActor Equatable {
     let model: NativModel
     @Binding var showsConfiguration: Bool
     var titleLeadingInset: CGFloat = 0
@@ -1277,6 +1277,7 @@ private struct DebouncedModelsSearchField: NSViewRepresentable {
         coordinator.cancelPendingCommit()
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSSearchFieldDelegate {
         var text: Binding<String>
         var identity: ModelsPageSection
@@ -1446,7 +1447,7 @@ private struct ModelReadmePanel: View {
     }
 }
 
-private struct InstalledModelRow: View, Equatable {
+private struct InstalledModelRow: View, @MainActor Equatable {
     let localModel: LocalModel
     let preloadSlots: [ModelPreloadSlot]
     let selectedPreloadSlots: Set<ModelPreloadSlot>
@@ -1812,7 +1813,7 @@ private struct HubModelMemoryFitWarning: Equatable {
     }
 }
 
-private struct HubModelRow: View, Equatable {
+private struct HubModelRow: View, @MainActor Equatable {
     let model: HuggingFaceModel
     let downloadSizeBytes: Int64?
     let isInstalled: Bool
@@ -2102,7 +2103,7 @@ private struct HubPaginationButton: View {
 
 /// Keeps download progress observation local to the affected row. The parent
 /// Discover view remains stable while a download reports progress.
-private struct HubModelRowContainer: View, Equatable {
+private struct HubModelRowContainer: View, @MainActor Equatable {
     private let downloadManager = HuggingFaceDownloadManager.shared
     @State private var downloadSnapshot: HuggingFaceDownloadManager.RowSnapshot
 

--- a/Sources/Nativ/Features/Routines/RoutineEditorView.swift
+++ b/Sources/Nativ/Features/Routines/RoutineEditorView.swift
@@ -58,7 +58,7 @@ struct RoutineEditor: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                if let onDelete {
+                if onDelete != nil {
                     Button("Delete", role: .destructive) {
                         isConfirmingDelete = true
                     }

--- a/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
+++ b/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
@@ -101,38 +101,37 @@ enum RoutineLaunchAgent {
     }
 }
 
+@MainActor
 enum RoutineHeadlessRun {
     private static var retainedRunner: RoutineRunner?
     private static var retainedModel: NativModel?
 
     static func execute(routineID: String) {
-        MainActor.assumeIsolated {
-            if anotherInstanceRunning() {
-                exit(EXIT_SUCCESS)
-            }
-            guard RoutineScheduler.hasSufficientBattery(),
-                  let routine = RoutineStore.shared.routine(id: routineID)
-            else {
-                exit(EXIT_SUCCESS)
-            }
-            let model = NativModel()
-            let runner = RoutineRunner(
-                model: model,
-                store: RoutineStore.shared,
-                sessionStore: ChatSessionStore()
-            )
-            retainedModel = model
-            retainedRunner = runner
-            runner.onRunCompleted = { _, _ in
-                model.stopServer()
-                exit(EXIT_SUCCESS)
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 600) {
-                MainActor.assumeIsolated { retainedModel?.stopServer() }
-                exit(EXIT_SUCCESS)
-            }
-            runner.run(routine, source: .scheduled)
+        if anotherInstanceRunning() {
+            exit(EXIT_SUCCESS)
         }
+        guard RoutineScheduler.hasSufficientBattery(),
+              let routine = RoutineStore.shared.routine(id: routineID)
+        else {
+            exit(EXIT_SUCCESS)
+        }
+        let model = NativModel()
+        let runner = RoutineRunner(
+            model: model,
+            store: RoutineStore.shared,
+            sessionStore: ChatSessionStore()
+        )
+        retainedModel = model
+        retainedRunner = runner
+        runner.onRunCompleted = { _, _ in
+            model.stopServer()
+            exit(EXIT_SUCCESS)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 600) {
+            retainedModel?.stopServer()
+            exit(EXIT_SUCCESS)
+        }
+        runner.run(routine, source: .scheduled)
         RunLoop.main.run()
     }
 

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
@@ -600,7 +600,11 @@ private actor SystemMetricsCollector {
             return SystemMemoryMetrics(totalBytes: ProcessInfo.processInfo.physicalMemory)
         }
 
-        let pageSize = UInt64(vm_kernel_page_size)
+        var kernelPageSize: vm_size_t = 0
+        guard host_page_size(mach_host_self(), &kernelPageSize) == KERN_SUCCESS else {
+            return SystemMemoryMetrics(totalBytes: ProcessInfo.processInfo.physicalMemory)
+        }
+        let pageSize = UInt64(kernelPageSize)
         let total = ProcessInfo.processInfo.physicalMemory
         let active = UInt64(statistics.active_count) * pageSize
         let wired = UInt64(statistics.wire_count) * pageSize
@@ -889,7 +893,8 @@ private actor SystemMetricsCollector {
         guard sysctlbyname(name, &value, &size, nil, 0) == 0 else {
             return nil
         }
-        return String(cString: value)
+        let bytes = value.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
     }
 
     private static func sysctlInteger(_ name: String) -> Int? {

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -612,6 +612,7 @@ private struct SystemDeviceArtwork: View {
     }
 }
 
+@MainActor
 private enum SystemDeviceArtworkProvider {
     private static let coreTypesResourcesURL = URL(
         fileURLWithPath: "/System/Library/CoreServices/CoreTypes.bundle"

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -74,10 +74,10 @@ enum AudioCaptureLibraryError: LocalizedError {
 }
 
 private final class AudioPlaybackDelegate: NSObject, AVAudioPlayerDelegate {
-    var onFinish: ((AVAudioPlayer) -> Void)?
+    var onFinish: (@Sendable (ObjectIdentifier) -> Void)?
 
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
-        onFinish?(player)
+        onFinish?(ObjectIdentifier(player))
     }
 }
 
@@ -94,13 +94,14 @@ final class AudioCaptureLibrary: ObservableObject {
     @Published private(set) var playingRecordID: String?
     @Published private(set) var isPlaybackPaused = false
 
-    var transcriptionConfigurationProvider: (() -> VoiceTranscriptionConfiguration?)?
+    var transcriptionConfigurationProvider:
+        (@MainActor @Sendable () -> VoiceTranscriptionConfiguration?)?
 
     private var audioPlayer: AVAudioPlayer?
     private lazy var playbackDelegate: AudioPlaybackDelegate = {
         let delegate = AudioPlaybackDelegate()
-        delegate.onFinish = { [weak self] player in
-            Task { @MainActor in self?.playbackDidFinish(player) }
+        delegate.onFinish = { [weak self] playerID in
+            Task { @MainActor in self?.playbackDidFinish(playerID) }
         }
         return delegate
     }()
@@ -489,8 +490,8 @@ final class AudioCaptureLibrary: ObservableObject {
         }
     }
 
-    private func playbackDidFinish(_ player: AVAudioPlayer) {
-        guard audioPlayer === player else {
+    private func playbackDidFinish(_ playerID: ObjectIdentifier) {
+        guard let audioPlayer, ObjectIdentifier(audioPlayer) == playerID else {
             return
         }
         stopPlayback()

--- a/Sources/Nativ/Features/VoiceCapture/AudioInputDevicePreferences.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioInputDevicePreferences.swift
@@ -53,7 +53,7 @@ final class AudioInputDevicePreferences: ObservableObject {
         ]
     }
 
-    deinit {
+    isolated deinit {
         for observer in observers {
             NotificationCenter.default.removeObserver(observer)
         }

--- a/Sources/Nativ/Features/VoiceCapture/SystemAudioMeetingRecorder.swift
+++ b/Sources/Nativ/Features/VoiceCapture/SystemAudioMeetingRecorder.swift
@@ -1,4 +1,4 @@
-import AVFoundation
+@preconcurrency import AVFoundation
 import CoreMedia
 import Foundation
 import ScreenCaptureKit
@@ -268,23 +268,31 @@ final class SystemAudioMeetingRecorder: NSObject {
             throw reader.error ?? SystemAudioMeetingRecorderError.couldNotCreateAudioFile
         }
         writer.startSession(atSourceTime: .zero)
+        let resources = MeetingAudioExportResources(
+            reader: reader,
+            readerOutput: readerOutput,
+            writer: writer,
+            writerInput: writerInput
+        )
 
         try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<Void, Error>) in
             let queue = DispatchQueue(label: "com.nativ.meeting-audio-export")
-            var completed = false
-            writerInput.requestMediaDataWhenReady(on: queue) {
-                guard !completed else {
+            let completionState = MeetingAudioExportCompletionState()
+            resources.writerInput.requestMediaDataWhenReady(on: queue) {
+                guard completionState.isPending else {
                     return
                 }
-                while writerInput.isReadyForMoreMediaData {
-                    if let sampleBuffer = readerOutput.copyNextSampleBuffer() {
-                        guard writerInput.append(sampleBuffer) else {
-                            completed = true
-                            reader.cancelReading()
-                            writer.cancelWriting()
+                while resources.writerInput.isReadyForMoreMediaData {
+                    if let sampleBuffer = resources.readerOutput.copyNextSampleBuffer() {
+                        guard resources.writerInput.append(sampleBuffer) else {
+                            guard completionState.claim() else {
+                                return
+                            }
+                            resources.reader.cancelReading()
+                            resources.writer.cancelWriting()
                             continuation.resume(
-                                throwing: writer.error
+                                throwing: resources.writer.error
                                     ?? SystemAudioMeetingRecorderError.couldNotCreateAudioFile
                             )
                             return
@@ -292,17 +300,19 @@ final class SystemAudioMeetingRecorder: NSObject {
                         continue
                     }
 
-                    completed = true
-                    writerInput.markAsFinished()
-                    writer.finishWriting {
-                        if writer.status == .completed,
-                           reader.status == .completed
+                    guard completionState.claim() else {
+                        return
+                    }
+                    resources.writerInput.markAsFinished()
+                    resources.writer.finishWriting {
+                        if resources.writer.status == .completed,
+                           resources.reader.status == .completed
                         {
                             continuation.resume()
                         } else {
                             continuation.resume(
-                                throwing: writer.error
-                                    ?? reader.error
+                                throwing: resources.writer.error
+                                    ?? resources.reader.error
                                     ?? SystemAudioMeetingRecorderError.couldNotCreateAudioFile
                             )
                         }
@@ -310,6 +320,44 @@ final class SystemAudioMeetingRecorder: NSObject {
                     return
                 }
             }
+        }
+    }
+}
+
+private final class MeetingAudioExportResources: @unchecked Sendable {
+    let reader: AVAssetReader
+    let readerOutput: AVAssetReaderAudioMixOutput
+    let writer: AVAssetWriter
+    let writerInput: AVAssetWriterInput
+
+    init(
+        reader: AVAssetReader,
+        readerOutput: AVAssetReaderAudioMixOutput,
+        writer: AVAssetWriter,
+        writerInput: AVAssetWriterInput
+    ) {
+        self.reader = reader
+        self.readerOutput = readerOutput
+        self.writer = writer
+        self.writerInput = writerInput
+    }
+}
+
+private final class MeetingAudioExportCompletionState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completed = false
+
+    var isPending: Bool {
+        lock.withLock { !completed }
+    }
+
+    func claim() -> Bool {
+        lock.withLock {
+            guard !completed else {
+                return false
+            }
+            completed = true
+            return true
         }
     }
 }
@@ -537,10 +585,10 @@ private final class MeetingAudioWriter: @unchecked Sendable {
 
                 self.systemInput?.markAsFinished()
                 self.microphoneInput?.markAsFinished()
-                writer.finishWriting {
-                    self.sampleQueue.async {
-                        let error = writer.error
-                        let succeeded = writer.status == .completed
+                writer.finishWriting { [self] in
+                    self.sampleQueue.async { [self] in
+                        let error = self.writer?.error
+                        let succeeded = self.writer?.status == .completed
                         self.resetLocked()
                         if succeeded {
                             continuation.resume()

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -1,7 +1,7 @@
 import AppKit
 import NativServerKit
 
-struct VoiceTranscriptionConfiguration {
+struct VoiceTranscriptionConfiguration: Sendable {
     let modelSearchPath: String
     let additionalModelSearchPaths: [String]
     let selectedModelID: String?
@@ -14,7 +14,8 @@ struct VoiceTranscriptionConfiguration {
 
 @MainActor
 final class VoiceCaptureCoordinator {
-    var transcriptionConfigurationProvider: (() -> VoiceTranscriptionConfiguration?)?
+    var transcriptionConfigurationProvider:
+        (@MainActor @Sendable () -> VoiceTranscriptionConfiguration?)?
     var onOpenSpeechModels: (() -> Void)?
 
     private let shortcutMonitor = FnControlShortcutMonitor()

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureOverlay.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureOverlay.swift
@@ -784,7 +784,7 @@ final class VoiceCaptureSoundPlayer {
                 cueName: "finish"
             )
         case .minimalPlay:
-            playBundled(
+            _ = playBundled(
                 data: minimalEndSoundData,
                 volume: 0.68,
                 cueName: "minimal finish"

--- a/Sources/Nativ/Features/VoiceCapture/VoiceTranscriptInserter.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceTranscriptInserter.swift
@@ -45,7 +45,7 @@ enum VoiceTranscriptInserter {
             NSRunningApplication(processIdentifier: $0.processIdentifier)
         }
         if let targetApplication, !targetApplication.isActive {
-            targetApplication.activate(options: [.activateIgnoringOtherApps])
+            targetApplication.activate()
         }
 
         do {

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -2,8 +2,26 @@ import AppKit
 import NativServerKit
 import SwiftUI
 
+private final class MetricsProbeResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var succeeded = false
+
+    func markSucceeded() {
+        lock.lock()
+        succeeded = true
+        lock.unlock()
+    }
+
+    var value: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return succeeded
+    }
+}
+
 @main
 enum Main {
+    @MainActor
     static func main() {
         if CommandLine.arguments.contains("--smoke-test") {
             do {
@@ -81,10 +99,11 @@ enum Main {
         }
 
         let semaphore = DispatchSemaphore(value: 0)
-        var didSucceed = false
+        let result = MetricsProbeResult()
         let task = URLSession.shared.dataTask(with: url) { _, response, _ in
-            if let httpResponse = response as? HTTPURLResponse {
-                didSucceed = (200..<300).contains(httpResponse.statusCode)
+            if let httpResponse = response as? HTTPURLResponse,
+               (200..<300).contains(httpResponse.statusCode) {
+                result.markSucceeded()
             }
             semaphore.signal()
         }
@@ -93,7 +112,7 @@ enum Main {
         if semaphore.wait(timeout: .now() + 5) == .timedOut {
             task.cancel()
         }
-        return didSucceed
+        return result.value
     }
 }
 

--- a/Sources/Nativ/Utilities/NativSystemPermissionController.swift
+++ b/Sources/Nativ/Utilities/NativSystemPermissionController.swift
@@ -1,5 +1,5 @@
 import AppKit
-import ApplicationServices
+@preconcurrency import ApplicationServices
 import AVFoundation
 
 enum NativSystemPermissionController {

--- a/Sources/Nativ/Utilities/ShellEnvironment.swift
+++ b/Sources/Nativ/Utilities/ShellEnvironment.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+private final class ShellOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        data.append(chunk)
+    }
+
+    func snapshot() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
+    }
+}
+
 /// Reads environment variables from the user's login shell.
 ///
 /// GUI apps on macOS inherit their environment from launchd, which knows
@@ -49,14 +66,11 @@ enum ShellEnvironment {
         process.standardOutput = stdout
         process.standardError = FileHandle.nullDevice
 
-        let output = NSMutableData()
-        let outputLock = NSLock()
+        let output = ShellOutputBuffer()
         stdout.fileHandleForReading.readabilityHandler = { handle in
             let chunk = handle.availableData
             guard !chunk.isEmpty else { return }
-            outputLock.lock()
             output.append(chunk)
-            outputLock.unlock()
         }
 
         do {
@@ -79,10 +93,8 @@ enum ShellEnvironment {
         // Drain whatever remains in the pipe after the handler stops.
         stdout.fileHandleForReading.readabilityHandler = nil
         let remainder = stdout.fileHandleForReading.readDataToEndOfFile()
-        outputLock.lock()
         output.append(remainder)
-        let data = output as Data
-        outputLock.unlock()
+        let data = output.snapshot()
 
         return parseEnvironment(String(decoding: data, as: UTF8.self), names: names)
     }

--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -613,7 +613,7 @@ public final class NativChatClient {
 
     public func streamChat(
         _ request: MLXChatCompletionRequest,
-        onDelta: @escaping (String) async -> Void
+        onDelta: @escaping @Sendable (String) async -> Void
     ) async throws -> MLXChatCompletion {
         try await streamChat(request, onEvent: { event in
             if let content = event.content, !content.isEmpty {
@@ -624,7 +624,7 @@ public final class NativChatClient {
 
     public func streamChat(
         _ request: MLXChatCompletionRequest,
-        onEvent: @escaping (MLXChatStreamDelta) async -> Void
+        onEvent: @escaping @Sendable (MLXChatStreamDelta) async -> Void
     ) async throws -> MLXChatCompletion {
         var payload = request
         payload.stream = true

--- a/Sources/NativServerKit/NativEmbeddingsClient.swift
+++ b/Sources/NativServerKit/NativEmbeddingsClient.swift
@@ -6,7 +6,7 @@ public enum NativEmbeddingsError: Error {
     case emptyResponse
 }
 
-public struct NativEmbeddingsClient {
+public struct NativEmbeddingsClient: Sendable {
     private let baseURL: URL
     private let apiKey: String?
     private let session: URLSession

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -588,7 +588,7 @@ public enum NativMetricsError: Error, LocalizedError, CustomStringConvertible {
     }
 }
 
-public final class NativMetricsClient {
+public final class NativMetricsClient: @unchecked Sendable {
     private let baseURL: URL
     private let session: URLSession
     private let timeout: TimeInterval
@@ -647,7 +647,7 @@ public final class NativMetricsClient {
     }
 }
 
-public final class NativProcessController {
+public final class NativProcessController: @unchecked Sendable {
     public typealias OutputHandler = @Sendable (String) -> Void
     public typealias TerminationHandler = @Sendable (Int32) -> Void
 
@@ -655,9 +655,18 @@ public final class NativProcessController {
     private var process: Process?
     private var outputPipe: Pipe?
     private var errorPipe: Pipe?
+    private var outputHandler: OutputHandler?
+    private var terminationHandler: TerminationHandler?
 
-    public var onOutput: OutputHandler?
-    public var onTermination: TerminationHandler?
+    public var onOutput: OutputHandler? {
+        get { lock.withLock { outputHandler } }
+        set { lock.withLock { outputHandler = newValue } }
+    }
+
+    public var onTermination: TerminationHandler? {
+        get { lock.withLock { terminationHandler } }
+        set { lock.withLock { terminationHandler = newValue } }
+    }
 
     public init() {}
 

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -66,8 +66,8 @@ final class AudioAnalyticsStoreTests: XCTestCase {
     private var temporaryDirectory: URL!
     private var store: AudioAnalyticsStore!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
         temporaryDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
@@ -79,11 +79,11 @@ final class AudioAnalyticsStoreTests: XCTestCase {
         )
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
         store = nil
         try FileManager.default.removeItem(at: temporaryDirectory)
         temporaryDirectory = nil
-        try super.tearDownWithError()
+        try await super.tearDown()
     }
 
     func testCalculatesWordsSpeedAndEstimatedTimeSaved() {

--- a/Tests/NativTests/ChatWebSearchToolTests.swift
+++ b/Tests/NativTests/ChatWebSearchToolTests.swift
@@ -466,7 +466,7 @@ final class ChatWebSearchToolTests: XCTestCase {
         viewModel.select(.exa)
         viewModel.draftAPIKey = "new-key"
 
-        await viewModel.testAndConnect()
+        _ = await viewModel.testAndConnect()
 
         XCTAssertEqual(credentials.storedKey(for: .exa), "new-key")
         XCTAssertEqual(preferences.searchProvider, .exa)
@@ -493,7 +493,7 @@ final class ChatWebSearchToolTests: XCTestCase {
         viewModel.select(.exa)
         viewModel.draftAPIKey = "exa-key"
 
-        await viewModel.testAndConnect()
+        _ = await viewModel.testAndConnect()
 
         XCTAssertEqual(preferences.searchProvider, .brave)
         XCTAssertEqual(preferences.pageReaderProvider, .exa)
@@ -516,7 +516,7 @@ final class ChatWebSearchToolTests: XCTestCase {
         )
         viewModel.draftAPIKey = "bad-replacement"
 
-        await viewModel.testAndConnect()
+        _ = await viewModel.testAndConnect()
 
         XCTAssertEqual(credentials.storedKey(for: .brave), "working-key")
         XCTAssertEqual(viewModel.selectedConnectionState, .connected)

--- a/Tests/NativTests/CustomToolTests.swift
+++ b/Tests/NativTests/CustomToolTests.swift
@@ -175,9 +175,44 @@ private struct FixedCredentialStore: CustomToolCredentialStoring {
 }
 
 private final class StubURLProtocol: URLProtocol {
-    static var lastRequest: URLRequest?
-    static var lastRequestBody: Data?
-    static var responseData = Data()
+    private final class State: @unchecked Sendable {
+        private let lock = NSLock()
+        private var request: URLRequest?
+        private var requestBody: Data?
+        private var response = Data()
+
+        var lastRequest: URLRequest? {
+            get { lock.withLock { request } }
+            set { lock.withLock { request = newValue } }
+        }
+
+        var lastRequestBody: Data? {
+            get { lock.withLock { requestBody } }
+            set { lock.withLock { requestBody = newValue } }
+        }
+
+        var responseData: Data {
+            get { lock.withLock { response } }
+            set { lock.withLock { response = newValue } }
+        }
+    }
+
+    private static let state = State()
+
+    static var lastRequest: URLRequest? {
+        get { state.lastRequest }
+        set { state.lastRequest = newValue }
+    }
+
+    static var lastRequestBody: Data? {
+        get { state.lastRequestBody }
+        set { state.lastRequestBody = newValue }
+    }
+
+    static var responseData: Data {
+        get { state.responseData }
+        set { state.responseData = newValue }
+    }
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }

--- a/project.yml
+++ b/project.yml
@@ -6,8 +6,9 @@ options:
   createIntermediateGroups: true
 settings:
   base:
-    SWIFT_VERSION: "5.0"
-    MACOSX_DEPLOYMENT_TARGET: "14.0"
+    SWIFT_VERSION: "6.3"
+    DEAD_CODE_STRIPPING: YES
+    MACOSX_DEPLOYMENT_TARGET: "26.0"
     ARCHS: arm64
     ENABLE_HARDENED_RUNTIME: YES
 packages:
@@ -49,7 +50,8 @@ targets:
     settings:
       base:
         ARCHS: arm64
-        MACOSX_DEPLOYMENT_TARGET: "14.0"
+        MACOSX_DEPLOYMENT_TARGET: "26.0"
+        CODE_SIGN_IDENTITY: ""
         PRODUCT_BUNDLE_IDENTIFIER: $(NATIV_EXTENSION_SDK_BUNDLE_IDENTIFIER)
         GENERATE_INFOPLIST_FILE: YES
         SKIP_INSTALL: YES
@@ -81,6 +83,7 @@ targets:
     settings:
       base:
         ARCHS: arm64
+        CODE_SIGN_IDENTITY: ""
         ENABLE_USER_SCRIPT_SANDBOXING: NO
         PRODUCT_BUNDLE_IDENTIFIER: $(NATIV_SERVER_KIT_BUNDLE_IDENTIFIER)
         GENERATE_INFOPLIST_FILE: YES
@@ -120,6 +123,7 @@ targets:
       base:
         ARCHS: arm64
         MACOSX_DEPLOYMENT_TARGET: "26.0"
+        ENABLE_HARDENED_RUNTIME: YES
         PRODUCT_BUNDLE_IDENTIFIER: $(NATIV_BUNDLE_IDENTIFIER)
         CODE_SIGN_ENTITLEMENTS: Configuration/Nativ.entitlements
         GENERATE_INFOPLIST_FILE: NO
@@ -145,6 +149,7 @@ targets:
       base:
         ARCHS: arm64
         MACOSX_DEPLOYMENT_TARGET: "26.0"
+        ENABLE_HARDENED_RUNTIME: YES
         PRODUCT_BUNDLE_IDENTIFIER: $(NATIV_VOICE_EXTENSION_BUNDLE_IDENTIFIER)
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Configuration/AudioExtension-Info.plist


### PR DESCRIPTION
This will help prevent concurrency-unsafe code from landing as Swift 6+ is much stricter around concurrency handling. No functionality change intended.