### PR TITLE
Clean up built-in tools listing

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
+++ b/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
@@ -237,7 +237,7 @@ struct ChatCapabilitiesSheet: View {
         guard item.isAvailable else { return false }
         switch item.target {
         case .nativeTool(let toolName), .customTool(let toolName):
-            return !model.settings.disabledToolNames.contains(toolName)
+            return model.settings.isToolEnabled(toolName)
         case .skill(let id):
             return model.settings.skills.first { $0.id == id }?.isEnabled == true
         case .mcpServer(let id):
@@ -248,11 +248,10 @@ struct ChatCapabilitiesSheet: View {
     private func toggle(_ item: GlobalChatCapabilityItem) {
         switch item.target {
         case .nativeTool(let toolName), .customTool(let toolName):
-            if model.settings.disabledToolNames.contains(toolName) {
-                model.settings.disabledToolNames.removeAll { $0 == toolName }
-            } else {
-                model.settings.disabledToolNames.append(toolName)
-            }
+            model.settings.setToolEnabled(
+                !model.settings.isToolEnabled(toolName),
+                toolName: toolName
+            )
         case .skill(let id):
             guard let index = model.settings.skills.firstIndex(where: { $0.id == id }) else { return }
             model.settings.skills[index].isEnabled.toggle()

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -373,7 +373,7 @@ struct ChatComposer: View {
     }
 
     private func globalToolIsEnabled(_ toolName: String, isAvailable: Bool) -> Bool {
-        isAvailable && !model.settings.disabledToolNames.contains(toolName)
+        isAvailable && model.settings.isToolEnabled(toolName)
     }
 
     private func toggleGlobalBrowsingTool(
@@ -388,11 +388,10 @@ struct ChatComposer: View {
             return
         }
 
-        if model.settings.disabledToolNames.contains(toolName) {
-            model.settings.disabledToolNames.removeAll { $0 == toolName }
-        } else {
-            model.settings.disabledToolNames.append(toolName)
-        }
+        model.settings.setToolEnabled(
+            !model.settings.isToolEnabled(toolName),
+            toolName: toolName
+        )
         showsAddPanel = false
     }
 

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -66,6 +66,7 @@ enum ChatNativeToolConfiguration: Equatable {
 
 struct ChatNativeToolDescriptor {
     let definition: MLXChatToolDefinition
+    let displayDescription: String
     let configuration: ChatNativeToolConfiguration?
 }
 
@@ -75,20 +76,51 @@ enum ChatToolRegistry {
     }
 
     static func descriptors(canEditImage: Bool) -> [ChatNativeToolDescriptor] {
-        var definitions = ChatImageToolRegistry.definitions(canEdit: canEditImage)
-        definitions += ChatSystemMonitorToolRegistry.definitions()
-        definitions += ChatModelLibraryToolRegistry.definitions()
-        definitions += ChatServerStatsToolRegistry.definitions()
-        definitions += ChatSwitchModelToolRegistry.definitions()
-        var tools = definitions.map {
-            ChatNativeToolDescriptor(definition: $0, configuration: nil)
+        var tools = ChatImageToolRegistry.definitions(canEdit: canEditImage).map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: $0.function.name == ChatImageToolRegistry.editToolName
+                    ? "Edit an attached image by describing the changes."
+                    : "Create an image from a written description.",
+                configuration: nil
+            )
+        }
+        tools += ChatModelLibraryToolRegistry.definitions().map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: "List the models downloaded on this device.",
+                configuration: nil
+            )
+        }
+        tools += ChatSwitchModelToolRegistry.definitions().map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: "Change which model this chat uses.",
+                configuration: nil
+            )
+        }
+        tools += ChatSystemMonitorToolRegistry.definitions().map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: "Check this device's CPU, GPU, memory, and disk usage.",
+                configuration: nil
+            )
+        }
+        tools += ChatServerStatsToolRegistry.definitions().map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: "See the server’s speed, requests, and token usage.",
+                configuration: nil
+            )
         }
         tools.append(ChatNativeToolDescriptor(
             definition: ChatWebSearchToolRegistry.definition,
+            displayDescription: "Search the web for current information and sources.",
             configuration: .webSearch
         ))
         tools.append(ChatNativeToolDescriptor(
             definition: ChatWebReadToolRegistry.definition,
+            displayDescription: "Read and find relevant information on public web pages.",
             configuration: .webRead
         ))
         return tools

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -1345,7 +1345,7 @@ final class ChatViewModel: ObservableObject {
             let webSearchIsConfigured = ChatWebSearchToolRegistry.isConfigured()
             let webReadIsConfigured = ChatWebReadToolRegistry.isConfigured()
             toolDefinitions.removeAll {
-                settings.disabledToolNames.contains($0.function.name)
+                !settings.isToolEnabled($0.function.name)
                     || ($0.function.name == ChatWebSearchToolRegistry.toolName
                         && !webSearchIsConfigured)
                     || ($0.function.name == ChatWebReadToolRegistry.toolName

--- a/Sources/Nativ/Features/Extensions/ToolsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/ToolsSectionView.swift
@@ -9,6 +9,7 @@ struct ToolsSectionView: View {
     @State private var editingTool: CustomTool?
     @State private var toolPendingRemoval: CustomTool?
     @State private var toolManagementError: String?
+    @State private var browsingToolPendingEnablement: String?
 
     var body: some View {
         HubSectionScaffold(
@@ -37,19 +38,29 @@ struct ToolsSectionView: View {
                 }
             }
         }
-        .sheet(item: $inspecting) { tool in
+        .onAppear {
+            synchronizeBrowsingToolAvailability()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .webBrowsingConfigurationDidChange)) { _ in
+            synchronizeBrowsingToolAvailability()
+        }
+        .sheet(item: $inspecting, onDismiss: finishBrowsingToolConfiguration) { tool in
             switch tool.configuration {
             case .webSearch:
                 BrowsingToolConfigurationView(
                     toolName: tool.title,
                     capability: .search,
-                    onConfigurationChanged: { _ in }
+                    onConfigurationChanged: { _ in
+                        reconcileBrowsingTool(tool)
+                    }
                 )
             case .webRead:
                 BrowsingToolConfigurationView(
                     toolName: tool.title,
                     capability: .read,
-                    onConfigurationChanged: { _ in }
+                    onConfigurationChanged: { _ in
+                        reconcileBrowsingTool(tool)
+                    }
                 )
             case nil:
                 ToolInspectorView(tool: tool, host: host)
@@ -112,12 +123,78 @@ struct ToolsSectionView: View {
                 if index > 0 { Divider() }
                 ToolRow(
                     tool: tool,
-                    onInspect: { inspecting = tool },
+                    onInspect: { inspect(tool) },
                     onEdit: editAction(for: tool),
-                    onRemove: removeAction(for: tool)
+                    onRemove: removeAction(for: tool),
+                    isEnabled: enabledBinding(for: tool)
                 )
             }
         }
+    }
+
+    private func enabledBinding(for tool: ToolItem) -> Binding<Bool>? {
+        guard tool.isBuiltIn else { return nil }
+        return Binding(
+            get: {
+                model.settings.isToolEnabled(tool.name)
+                    && (tool.configuration?.isConfigured ?? true)
+            },
+            set: { enabled in
+                guard enabled else {
+                    model.settings.setToolEnabled(false, toolName: tool.name)
+                    return
+                }
+                guard let configuration = tool.configuration else {
+                    model.settings.setToolEnabled(true, toolName: tool.name)
+                    return
+                }
+                guard configuration.isConfigured else {
+                    model.settings.setToolEnabled(false, toolName: tool.name)
+                    browsingToolPendingEnablement = tool.name
+                    inspecting = tool
+                    return
+                }
+                model.settings.setToolEnabled(true, toolName: tool.name)
+            }
+        )
+    }
+
+    private func inspect(_ tool: ToolItem) {
+        if let configuration = tool.configuration,
+           configuration.isConfigured,
+           model.settings.isToolEnabled(tool.name) {
+            browsingToolPendingEnablement = tool.name
+        }
+        inspecting = tool
+    }
+
+    private func reconcileBrowsingTool(_ tool: ToolItem) {
+        guard let configuration = tool.configuration else { return }
+        let isConfigured = configuration.isConfigured
+        if !isConfigured || browsingToolPendingEnablement == tool.name {
+            model.settings.setToolEnabled(isConfigured, toolName: tool.name)
+        }
+    }
+
+    private func synchronizeBrowsingToolAvailability() {
+        for tool in nativeTools where tool.configuration != nil {
+            reconcileBrowsingTool(tool)
+        }
+    }
+
+    private func finishBrowsingToolConfiguration() {
+        guard let toolName = browsingToolPendingEnablement,
+              let tool = nativeTools.first(where: { $0.name == toolName }),
+              let configuration = tool.configuration
+        else {
+            browsingToolPendingEnablement = nil
+            return
+        }
+        model.settings.setToolEnabled(
+            configuration.isConfigured,
+            toolName: tool.name
+        )
+        browsingToolPendingEnablement = nil
     }
 
     private var nativeTools: [ToolItem] {
@@ -125,7 +202,7 @@ struct ToolsSectionView: View {
             ToolItem(
                 name: $0.definition.function.name,
                 title: $0.configuration?.displayName ?? humanized($0.definition.function.name),
-                detail: $0.definition.function.description,
+                detail: $0.displayDescription,
                 parameters: $0.definition.function.parameters,
                 isRunnable: false,
                 isBuiltIn: true,
@@ -215,6 +292,7 @@ private struct ToolRow: View {
     let onInspect: () -> Void
     var onEdit: (() -> Void)?
     var onRemove: (() -> Void)?
+    var isEnabled: Binding<Bool>?
     @State private var hovering = false
 
     var body: some View {
@@ -223,10 +301,6 @@ private struct ToolRow: View {
                 HStack(spacing: 6) {
                     Text(tool.title)
                         .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    if tool.isBuiltIn {
-                        NativStatusBadge(text: "Built-in")
-                            .help("Ships with Nativ")
-                    }
                 }
                 if !tool.detail.isEmpty {
                     Text(tool.detail)
@@ -243,6 +317,14 @@ private struct ToolRow: View {
             .buttonStyle(.plain)
             .opacity(hovering ? 1 : 0.35)
             .help(tool.configuration == nil ? "Inspect / try" : "Configure")
+            if let isEnabled {
+                Toggle("", isOn: isEnabled)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .help(isEnabled.wrappedValue ? "Disable \(tool.title)" : "Enable \(tool.title)")
+                    .accessibilityLabel("Enable \(tool.title)")
+            }
             if let onEdit, let onRemove {
                 Menu {
                     Button("Edit", action: onEdit)

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -808,6 +808,17 @@ struct NativSettings: Codable, Equatable {
             && !draftModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    func isToolEnabled(_ toolName: String) -> Bool {
+        !disabledToolNames.contains(toolName)
+    }
+
+    mutating func setToolEnabled(_ enabled: Bool, toolName: String) {
+        disabledToolNames.removeAll { $0 == toolName }
+        if !enabled {
+            disabledToolNames.append(toolName)
+        }
+    }
+
     func hasSameLaunchConfiguration(as other: Self) -> Bool {
         let lhs = normalized()
         let rhs = other.normalized()

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -69,6 +69,34 @@ private func makeCall(name: String, arguments: String = "{}") -> MLXChatToolCall
 }
 
 final class ChatToolRegistryTests: XCTestCase {
+    func testBuiltInToolsUseThePresentationOrder() {
+        let names = ChatToolRegistry.definitions(canEditImage: false)
+            .map(\.function.name)
+
+        XCTAssertEqual(names, [
+            ChatImageToolRegistry.generateToolName,
+            ChatModelLibraryToolRegistry.toolName,
+            ChatSwitchModelToolRegistry.toolName,
+            ChatSystemMonitorToolRegistry.toolName,
+            ChatServerStatsToolRegistry.toolName,
+            ChatWebSearchToolRegistry.toolName,
+            ChatWebReadToolRegistry.toolName,
+        ])
+    }
+
+    func testImageToolHasSeparateUserAndModelDescriptions() throws {
+        let descriptor = try XCTUnwrap(
+            ChatToolRegistry.descriptors(canEditImage: false).first
+        )
+
+        XCTAssertEqual(descriptor.displayDescription, "Create an image from a written description.")
+        XCTAssertTrue(descriptor.definition.function.description.contains("do not ask"))
+        XCTAssertNotEqual(
+            descriptor.displayDescription,
+            descriptor.definition.function.description
+        )
+    }
+
     func testDefinitionsAdvertiseBrowsingTools() {
         let names = ChatToolRegistry.definitions(canEditImage: false)
             .map(\.function.name)

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -2,6 +2,35 @@ import XCTest
 @testable import NativServerKit
 
 final class NativSettingsTests: XCTestCase {
+    func testToolsAreEnabledByDefaultAndCanBeDisabled() throws {
+        var settings = NativSettings()
+
+        XCTAssertTrue(settings.isToolEnabled("get_system_stats"))
+
+        settings.setToolEnabled(false, toolName: "get_system_stats")
+        XCTAssertFalse(settings.isToolEnabled("get_system_stats"))
+        XCTAssertEqual(settings.disabledToolNames, ["get_system_stats"])
+
+        settings = try PropertyListDecoder().decode(
+            NativSettings.self,
+            from: PropertyListEncoder().encode(settings)
+        )
+        XCTAssertFalse(settings.isToolEnabled("get_system_stats"))
+
+        settings.setToolEnabled(true, toolName: "get_system_stats")
+        XCTAssertTrue(settings.isToolEnabled("get_system_stats"))
+        XCTAssertTrue(settings.disabledToolNames.isEmpty)
+    }
+
+    func testDisablingAToolDoesNotCreateDuplicatePreferences() {
+        var settings = NativSettings()
+
+        settings.setToolEnabled(false, toolName: "get_system_stats")
+        settings.setToolEnabled(false, toolName: "get_system_stats")
+
+        XCTAssertEqual(settings.disabledToolNames, ["get_system_stats"])
+    }
+
     func testLocalModelSearchPathsIncludeNormalizedAdditionalFolders() {
         let settings = NativSettings(
             modelSearchPath: "~/managed-models",


### PR DESCRIPTION
1) Use a user-friendly tool description instead of the actual tool instructions.
2) Remove the duplicated "Built-in" badge from built-in tools.
3) Allow disabling built-in tools, as some small models (e.g. Qwen3-0.8B) will often make poor/irrelevant tool calls when present.
4) Reorganize the listing to group similar tools.
5) Only show the Web Search and Web Read tools as enabled if they are actually configured, and show the configuration sheet when enabling them.

<img width="933" height="504" alt="Screenshot 2026-08-15 at 3 12 06 PM" src="https://github.com/user-attachments/assets/4fb71483-a411-4266-88c8-e55755dcfa59" />

