### PR TITLE
improve xet download progress bar UI

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -1563,11 +1563,11 @@ struct HuggingFaceDownloadProgressState: Equatable {
         let estimatedBytes = checkpointDisplayedBytes
             + Int64(Double(transferDelta) * logicalBytesPerTransferByte)
         // Transfer bytes are only an estimate of reconstructed bytes. Cap the
-        // estimate at the first finalizing byte so it cannot show 100%, but can
-        // still switch the UI and stall watchdog into their finalizing state.
+        // estimate at the first finishing byte so it cannot show 100%, but can
+        // still switch the UI and stall watchdog into their finishing state.
         let activeLimit = min(
             Int64(
-                (Double(totalBytes) * ModelDownloadProgressPresentation.finalizingThreshold)
+                (Double(totalBytes) * ModelDownloadProgressPresentation.finishingThreshold)
                     .rounded(.up)
             ),
             totalBytes
@@ -1599,19 +1599,19 @@ struct HuggingFaceDownloadProgressState: Equatable {
         !isPaused && now.timeIntervalSince(lastActivity) >= timeout
     }
 
-    var isFinalizing: Bool {
-        ModelDownloadProgressPresentation.isFinalizing(progress?.fractionCompleted ?? 0)
+    var isFinishing: Bool {
+        ModelDownloadProgressPresentation.isFinishing(progress?.fractionCompleted ?? 0)
     }
 }
 
 enum ModelDownloadProgressPresentation {
-    /// The final fraction of a download is spent committing blobs and creating
-    /// the snapshot. Keep 100% reserved for a download that has actually
-    /// completed and disappeared from the active-download UI.
-    static let finalizingThreshold = 0.995
+    /// Xet can continue reconstructing model files after the measurable
+    /// transfer estimate reaches its safe limit. Present that interval as a
+    /// distinct finishing state instead of leaving a percentage visibly stuck.
+    static let finishingThreshold = 0.95
 
-    static func isFinalizing(_ progress: Double) -> Bool {
-        progress >= finalizingThreshold
+    static func isFinishing(_ progress: Double) -> Bool {
+        progress >= finishingThreshold
     }
 
     static func activePercentage(_ progress: Double) -> Int {
@@ -1678,8 +1678,8 @@ private final class HuggingFaceDownloadActivity: @unchecked Sendable {
         lock.withLock { state.isStalled(timeout: timeout, isPaused: isPaused) }
     }
 
-    var isFinalizing: Bool {
-        lock.withLock { state.isFinalizing }
+    var isFinishing: Bool {
+        lock.withLock { state.isFinishing }
     }
 }
 
@@ -2016,7 +2016,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
             }
             if !flags.paused {
                 transferSpeed(activity.bytesPerSecond)
-                let timeout = activity.isFinalizing
+                let timeout = activity.isFinishing
                     ? Self.finalizationStallTimeout
                     : Self.stallTimeout
                 if activity.isStalled(timeout: timeout, isPaused: false) {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1745,6 +1745,7 @@ private struct ActiveDownloadBannerRow: View {
     let onPauseResume: () -> Void
     let onRemove: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isConfirmingRemoval = false
 
     var body: some View {
@@ -1755,15 +1756,22 @@ private struct ActiveDownloadBannerRow: View {
                         .font(.headline)
                         .lineLimit(1)
 
-                    HStack(spacing: 4) {
-                        Text(statusText)
-                            .foregroundStyle(.secondary)
-                        Text("·")
-                            .foregroundStyle(.secondary)
-                            .accessibilityHidden(true)
-                        Text("\(percentage)%")
-                            .bold()
-                            .monospacedDigit()
+                    Group {
+                        if isFinishing {
+                            Text("Finishing…")
+                                .bold()
+                        } else {
+                            HStack(spacing: 4) {
+                                Text(statusText)
+                                    .foregroundStyle(.secondary)
+                                Text("·")
+                                    .foregroundStyle(.secondary)
+                                    .accessibilityHidden(true)
+                                Text("\(percentage)%")
+                                    .bold()
+                                    .monospacedDigit()
+                            }
+                        }
                     }
                     .font(.subheadline)
                 }
@@ -1797,17 +1805,33 @@ private struct ActiveDownloadBannerRow: View {
                 .controlSize(.large)
             }
 
-            ProgressView(value: displayedProgress)
-                .progressViewStyle(.linear)
-                .tint(download.state == .paused ? .secondary : .accentColor)
-                .accessibilityLabel("Download progress")
-                .accessibilityValue("\(percentage) percent")
+            Group {
+                if isFinishing {
+                    ProgressView()
+                        .accessibilityLabel("Finishing download")
+                        .accessibilityValue("Assembling downloaded model files")
+                } else {
+                    ProgressView(value: displayedProgress)
+                        .animation(
+                            reduceMotion ? nil : .linear(duration: 0.25),
+                            value: displayedProgress
+                        )
+                        .accessibilityLabel("Download progress")
+                        .accessibilityValue("\(percentage) percent")
+                }
+            }
+            .progressViewStyle(.linear)
+            .tint(download.state == .paused ? .secondary : .accentColor)
 
             HStack(spacing: 6) {
-                Text(byteProgress ?? "Calculating download size…")
-                    .monospacedDigit()
+                if isFinishing {
+                    Text("Assembling downloaded model files…")
+                } else {
+                    Text(byteProgress ?? "Calculating download size…")
+                        .monospacedDigit()
+                }
 
-                if let speed {
+                if !isFinishing, let speed {
                     Text("·")
                         .accessibilityHidden(true)
                     Text(speed)
@@ -1837,6 +1861,12 @@ private struct ActiveDownloadBannerRow: View {
         min(max(download.progress, 0), 0.99)
     }
 
+    private var isFinishing: Bool {
+        download.state == .downloading
+            && (download.phase == .finalizing
+                || ModelDownloadProgressPresentation.isFinishing(download.progress))
+    }
+
     private var pauseResumeTitle: String {
         download.state == .paused ? "Resume download" : "Pause download"
     }
@@ -1858,13 +1888,10 @@ private struct ActiveDownloadBannerRow: View {
         if download.state == .paused {
             return "Paused"
         }
-        if ModelDownloadProgressPresentation.isFinalizing(download.progress) {
-            return "Finalizing"
-        }
         switch download.phase {
         case .preparing: return "Preparing"
         case .downloading: return "Downloading"
-        case .finalizing: return "Finalizing"
+        case .finalizing: return "Finishing"
         case .retrying: return "Retrying"
         }
     }
@@ -2328,8 +2355,8 @@ struct ModelDownloadProgressControl: View {
         if isPaused {
             return "Download paused"
         }
-        if ModelDownloadProgressPresentation.isFinalizing(progress) {
-            return "Finalizing download"
+        if ModelDownloadProgressPresentation.isFinishing(progress) {
+            return "Finishing download"
         }
         return "Downloading \(ModelDownloadProgressPresentation.activePercentage(progress)) percent"
     }

--- a/Tests/NativTests/LocalModelProviderTests.swift
+++ b/Tests/NativTests/LocalModelProviderTests.swift
@@ -450,19 +450,19 @@ final class HuggingFaceDownloadProgressStateTests: XCTestCase {
         )
     }
 
-    func testNearCompleteProgressUsesFinalizingState() throws {
+    func testNearCompleteProgressUsesFinishingState() throws {
         let start = Date(timeIntervalSinceReferenceDate: 3_000)
         var state = HuggingFaceDownloadProgressState(now: start)
         let progress = try XCTUnwrap(
-            ModelDownloadProgress(completedBytes: 995, totalBytes: 1_000)
+            ModelDownloadProgress(completedBytes: 950, totalBytes: 1_000)
         )
 
         _ = state.recordProgress(progress, at: start)
 
-        XCTAssertTrue(state.isFinalizing)
+        XCTAssertTrue(state.isFinishing)
     }
 
-    func testTransferEstimateCeilingUsesFinalizingState() throws {
+    func testTransferEstimateCeilingUsesFinishingState() throws {
         let start = Date(timeIntervalSinceReferenceDate: 3_500)
         var state = HuggingFaceDownloadProgressState(now: start)
         let initial = try XCTUnwrap(
@@ -474,9 +474,9 @@ final class HuggingFaceDownloadProgressStateTests: XCTestCase {
             state.recordTransferredBytes(2_000, at: start.addingTimeInterval(1))
         )
 
-        XCTAssertEqual(capped.completedBytes, 996)
+        XCTAssertEqual(capped.completedBytes, 951)
         XCTAssertLessThan(capped.fractionCompleted, 1)
-        XCTAssertTrue(state.isFinalizing)
+        XCTAssertTrue(state.isFinishing)
     }
 
     func testTransferredBytesProduceSmoothedTransferSpeed() {
@@ -531,10 +531,10 @@ final class ModelDownloadProgressPresentationTests: XCTestCase {
         XCTAssertEqual(ModelDownloadProgressPresentation.activePercentage(1), 99)
     }
 
-    func testNearCompleteDownloadUsesFinalizingState() {
-        XCTAssertFalse(ModelDownloadProgressPresentation.isFinalizing(0.994))
-        XCTAssertTrue(ModelDownloadProgressPresentation.isFinalizing(0.995))
-        XCTAssertTrue(ModelDownloadProgressPresentation.isFinalizing(1))
+    func testNearCompleteDownloadUsesFinishingState() {
+        XCTAssertFalse(ModelDownloadProgressPresentation.isFinishing(0.949))
+        XCTAssertTrue(ModelDownloadProgressPresentation.isFinishing(0.95))
+        XCTAssertTrue(ModelDownloadProgressPresentation.isFinishing(1))
     }
 
     func testActiveProgressRingDoesNotBecomeComplete() {


### PR DESCRIPTION
- Keep Xet download progress moving between reconstruction updates.
- Reserve the final 5% for work Xet cannot measure precisely.
- Show a clear “Finishing…” state with an indeterminate progress bar.
- Explain that downloaded model files are being assembled.

## Problem

Xet reports network transfer and model-file reconstruction separately. Reconstruction updates can arrive in bursts, making progress appear stuck even while work continues.