### PR TITLE
Add timestamps to developer logs

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		2C9DFB15B06C56CB650FC9A6 /* WebBrowsingTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB497800D0F8B237A1891EE1 /* WebBrowsingTransport.swift */; };
 		2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */; };
 		2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
+		2E79308E424CF839C7394DB1 /* TimestampedLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C55BE2FF566A7C9195EA333 /* TimestampedLog.swift */; };
 		31D67AFE2E2CD864C37D6CFA /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		326C969CB7D0F41F38467DFE /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
 		32E3DD03D61C201E783539AF /* ChatServerStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */; };
@@ -464,6 +465,7 @@
 		9A7A7ACB288953FD476C47E8 /* MCPServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerConfig.swift; sourceTree = "<group>"; };
 		9AF7F0D894C4EB6521F21D4D /* SystemMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorView.swift; sourceTree = "<group>"; };
 		9B95090B83C36E4F06C7C5E3 /* RoutineRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineRunner.swift; sourceTree = "<group>"; };
+		9C55BE2FF566A7C9195EA333 /* TimestampedLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimestampedLog.swift; sourceTree = "<group>"; };
 		9C57E985705899CDD8DB5996 /* MCPCatalog.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MCPCatalog.json; sourceTree = "<group>"; };
 		9F15F7E180170C5FA55BD38F /* WebReadContentSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebReadContentSelector.swift; sourceTree = "<group>"; };
 		9FB275767AC2B912FA2FEDEE /* UISFXMinimalPlay.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = UISFXMinimalPlay.mp3; sourceTree = "<group>"; };
@@ -610,6 +612,7 @@
 				E53ACF74DB78DD6DC7DD81C8 /* PersistentMenuActionView.swift */,
 				330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */,
 				5919AB4E9488642C73886266 /* ShellEnvironment.swift */,
+				9C55BE2FF566A7C9195EA333 /* TimestampedLog.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1449,6 +1452,7 @@
 				657DFF151F7E54EA66CC36F8 /* SystemSensorSampler.swift in Sources */,
 				086BDF7ECBBC6CF5F63C63CB /* TavilyBrowsingProvider.swift in Sources */,
 				8E717C7364F8B9DA2BDF0E20 /* TextShimmerWave.swift in Sources */,
+				2E79308E424CF839C7394DB1 /* TimestampedLog.swift in Sources */,
 				A1695BB51B153E19F4F73DE0 /* ToolsSectionView.swift in Sources */,
 				4CB31A9AACD344FA2CD1B6FD /* VoiceAnimationPreferences.swift in Sources */,
 				B71FD641DAB1197C15F4D9B7 /* VoiceAudioRecorder.swift in Sources */,

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -2207,7 +2207,7 @@ private enum LogTextStyler {
         ofSize: 11,
         weight: .medium
     )
-    private static let timestampColor = NSColor.white.withAlphaComponent(0.5)
+    private static let timestampColor = NSColor.secondaryLabelColor
     private static let timestampStyle = Date.FormatStyle(
         locale: Locale(identifier: "en_GB"),
         timeZone: .current

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -2203,20 +2203,25 @@ private struct LogTextView: NSViewRepresentable {
 @MainActor
 private enum LogTextStyler {
     private static let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+    private static let timestampFont = NSFont.monospacedDigitSystemFont(
+        ofSize: 11,
+        weight: .medium
+    )
+    private static let timestampColor = NSColor.white.withAlphaComponent(0.5)
+    private static let timestampStyle = Date.FormatStyle(
+        locale: Locale(identifier: "en_GB"),
+        timeZone: .current
+    )
+        .hour(.twoDigits(amPM: .omitted))
+        .minute(.twoDigits)
+        .second(.twoDigits)
 
     static func attributedString(_ text: String, searchQuery: String) -> NSAttributedString {
         let result = NSMutableAttributedString()
         let lines = text.components(separatedBy: "\n")
 
         for (index, line) in lines.enumerated() {
-            let attributedLine = NSMutableAttributedString(
-                string: line,
-                attributes: [
-                    .font: font,
-                    .foregroundColor: NSColor.labelColor,
-                ]
-            )
-            styleSeverity(in: attributedLine, line: line)
+            let attributedLine = attributedLine(for: line)
             styleHTTPStatus(in: attributedLine)
             result.append(attributedLine)
             if index < lines.count - 1 {
@@ -2226,6 +2231,38 @@ private enum LogTextStyler {
 
         highlightSearch(in: result, query: searchQuery)
         return result
+    }
+
+    private static func attributedLine(for line: String) -> NSMutableAttributedString {
+        guard let components = TimestampedLog.components(in: line) else {
+            let attributedLine = messageText(line)
+            styleSeverity(in: attributedLine, line: line)
+            return attributedLine
+        }
+
+        let message = messageText(components.message)
+        styleSeverity(in: message, line: components.message)
+
+        let timestamp = NSMutableAttributedString(
+            string: " \(timestampStyle.format(components.date)) ",
+            attributes: [
+                .font: timestampFont,
+                .foregroundColor: timestampColor,
+            ]
+        )
+        timestamp.append(NSAttributedString(string: "  ", attributes: [.font: font]))
+        timestamp.append(message)
+        return timestamp
+    }
+
+    private static func messageText(_ text: String) -> NSMutableAttributedString {
+        NSMutableAttributedString(
+            string: text,
+            attributes: [
+                .font: font,
+                .foregroundColor: NSColor.labelColor,
+            ]
+        )
     }
 
     private static func styleSeverity(in text: NSMutableAttributedString, line: String) {

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -79,6 +79,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     private var pendingServerRestartID: UUID?
     private var serverRestartTask: Task<Void, Never>?
     private var currentServerOutput = ""
+    private var isAtLogLineStart = true
 
     private let maxLogCharacters = 250_000
     private let maxCurrentServerOutputCharacters = 50_000
@@ -705,6 +706,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
     func clearLogs() {
         logText = ""
+        isAtLogLineStart = true
     }
 
     func reportModelLoadFailure(modelID: String?, error: Error) {
@@ -770,8 +772,9 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
     private func configureServerCallbacks() {
         server.onOutput = { [weak self] text in
+            let receivedAt = Date.now
             Task { @MainActor [weak self] in
-                self?.handleServerOutput(text)
+                self?.handleServerOutput(text, receivedAt: receivedAt)
             }
         }
         server.onTermination = { [weak self] status in
@@ -914,14 +917,17 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
         }
     }
 
-    private func appendLog(_ text: String) {
-        logText.append(text)
-        if logText.count > maxLogCharacters {
-            logText.removeFirst(logText.count - maxLogCharacters)
-        }
+    private func appendLog(_ text: String, receivedAt: Date = .now) {
+        TimestampedLog.append(
+            text,
+            receivedAt: receivedAt,
+            to: &logText,
+            isAtLineStart: &isAtLogLineStart,
+            maximumCharacterCount: maxLogCharacters
+        )
     }
 
-    private func handleServerOutput(_ text: String) {
+    private func handleServerOutput(_ text: String, receivedAt: Date) {
         let prefix = "__NATIV_MODEL_LOAD_PROGRESS__:"
         var visibleLines: [Substring] = []
 
@@ -948,7 +954,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
         let visibleText = visibleLines.joined(separator: "\n")
         if !visibleText.isEmpty {
-            appendLog(visibleText)
+            appendLog(visibleText, receivedAt: receivedAt)
             currentServerOutput.append(visibleText)
             if currentServerOutput.count > maxCurrentServerOutputCharacters {
                 currentServerOutput.removeFirst(

--- a/Sources/Nativ/Utilities/TimestampedLog.swift
+++ b/Sources/Nativ/Utilities/TimestampedLog.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+enum TimestampedLog {
+    private static let timestampParser = Date.ISO8601FormatStyle(
+        includingFractionalSeconds: true
+    )
+
+    static func append(
+        _ input: String,
+        receivedAt: Date = .now,
+        to output: inout String,
+        isAtLineStart: inout Bool,
+        maximumCharacterCount: Int
+    ) {
+        guard !input.isEmpty else { return }
+
+        let formattedDate = timestampParser.format(receivedAt)
+        let timestamp = "[\(formattedDate)] "
+        var timestampedInput = ""
+        timestampedInput.reserveCapacity(input.count + timestamp.count)
+
+        for character in input {
+            if isAtLineStart && !character.isNewline {
+                timestampedInput.append(timestamp)
+                isAtLineStart = false
+            }
+
+            timestampedInput.append(character)
+            if character.isNewline {
+                isAtLineStart = true
+            }
+        }
+
+        output.append(timestampedInput)
+        trim(&output, toMaximumCharacterCount: maximumCharacterCount)
+    }
+
+    static func components(in line: String) -> (date: Date, message: String)? {
+        guard line.first == "[",
+              let closingBracket = line.firstIndex(of: "]")
+        else {
+            return nil
+        }
+
+        let timestampStart = line.index(after: line.startIndex)
+        let rawTimestamp = String(line[timestampStart..<closingBracket])
+        guard let date = try? timestampParser.parse(rawTimestamp) else {
+            return nil
+        }
+
+        var messageStart = line.index(after: closingBracket)
+        if messageStart < line.endIndex, line[messageStart] == " " {
+            messageStart = line.index(after: messageStart)
+        }
+        return (date, String(line[messageStart...]))
+    }
+
+    private static func trim(_ output: inout String, toMaximumCharacterCount limit: Int) {
+        guard limit > 0, output.count > limit else { return }
+
+        let overflow = output.count - limit
+        let boundary = output.index(output.startIndex, offsetBy: overflow)
+
+        if boundary > output.startIndex {
+            let precedingCharacter = output[output.index(before: boundary)]
+            if precedingCharacter.isNewline {
+                output.removeSubrange(..<boundary)
+                return
+            }
+        }
+
+        if let nextLineBreak = output[boundary...].firstIndex(where: \.isNewline) {
+            output.removeSubrange(...nextLineBreak)
+        } else {
+            // A single unusually long event should stay bounded while retaining
+            // the timestamp at its beginning.
+            output = String(output.prefix(limit))
+        }
+    }
+}


### PR DESCRIPTION
Add timestamps to every developer log event.
Display timestamps as local HH:mm:ss in the UI.
Use subtle, semi-transparent white timestamp text.
Preserve the complete ISO 8601 timestamp when logs are copied.
Keep timestamp formatting and log retention logic in a dedicated utility.

From the logs UI timestamps are shown as hh.mm.ss, copying logs shows the exact timestamp. Example:

[2026-08-17T16:43:32.081Z] Fetching 11 files:   0%|          | 0/11 [00:00<?, ?it/s]
[2026-08-17T16:43:32.085Z] Fetching 11 files: 100%|██████████| 11/11 [00:00<00:00, 2783.38it/s]
[2026-08-17T16:43:32.318Z] 2026-08-17 18:43:32,318 - INFO - Image generation model ready.
[2026-08-17T16:43:32.318Z] INFO:     Application startup complete.
[2026-08-17T16:43:32.318Z] INFO:     Uvicorn running on http://127.0.0.1:8080 (Press CTRL+C to quit)


<img width="1216" height="165" alt="Screenshot 2026-08-17 at 7 07 31 PM" src="https://github.com/user-attachments/assets/10ba3ac3-0e85-4b25-b570-3a000cb1b4df" />
