### PR TITLE
fix core audio callback isolation

### DIFF
--- a/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
@@ -48,16 +48,19 @@ final class AudioInputLevelMonitor: ObservableObject {
                 throw VoiceAudioRecorderError.couldNotStart
             }
 
-            inputNode.installTap(
-                onBus: 0,
-                bufferSize: 1_024,
-                format: format
-            ) { [weak self] buffer, _ in
+            let tap: @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void = {
+                [weak self] buffer, _ in
                 let level = Self.normalizedLevel(from: buffer)
                 Task { @MainActor [weak self] in
                     self?.update(level: level)
                 }
             }
+            inputNode.installTap(
+                onBus: 0,
+                bufferSize: 1_024,
+                format: format,
+                block: tap
+            )
             engine.prepare()
             try engine.start()
             audioEngine = engine

--- a/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
@@ -193,11 +193,8 @@ final class VoiceAudioRecorder {
             audioFile: audioFile,
             sampleRate: inputFormat.sampleRate
         )
-        inputNode.installTap(
-            onBus: 0,
-            bufferSize: 1_024,
-            format: inputFormat
-        ) { [weak self, writer] buffer, _ in
+        let tap: @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void = {
+            [weak self, writer] buffer, _ in
             let measurement = writer.append(buffer)
             Task { @MainActor [weak self] in
                 self?.updateMeter(
@@ -206,6 +203,12 @@ final class VoiceAudioRecorder {
                 )
             }
         }
+        inputNode.installTap(
+            onBus: 0,
+            bufferSize: 1_024,
+            format: inputFormat,
+            block: tap
+        )
 
         do {
             audioEngine.prepare()


### PR DESCRIPTION
Closes #319 

- Mark Core Audio tap callbacks as `@Sendable` so they can safely run on the real-time audio thread.
- Keep audio meter and observable-state updates on the main actor.
- Apply the same correction to voice recording, which used the same callback pattern.
