### PR TITLE
Fix dashboard token usage chart layout

### DIFF
--- a/Sources/Nativ/Features/Dashboard/DashboardViewModel.swift
+++ b/Sources/Nativ/Features/Dashboard/DashboardViewModel.swift
@@ -162,6 +162,7 @@ final class DashboardViewModel: ObservableObject {
     @Published private(set) var hourlyActivityPoints: [ActivityPoint] = []
     @Published private(set) var modelPerformance: [ModelPerformance] = []
     @Published private(set) var modelTokenPoints: [ModelTokenPoint] = []
+    @Published private(set) var tokenUsageModels: [TokenUsageModel] = []
     @Published private(set) var recentRequestEvents: [NativAnalyticsRequestEvent] = []
     @Published private(set) var isLoadingHistory = false
     @Published private(set) var localModelError: String?
@@ -300,12 +301,19 @@ final class DashboardViewModel: ObservableObject {
                     leadingModelIDs: leadingModelIDs,
                     groupsRemainingModels: modelPerformance.count > 12
                 )
+                let tokenUsageModels = TokenUsageModel.grouped(Self.modelTokenPoints(
+                    from: modelBuckets,
+                    bucketDates: points.map(\.bucketStart),
+                    leadingModelIDs: [],
+                    groupsRemainingModels: false
+                ))
                 return DashboardSnapshot(
                     summary: summary,
                     points: points,
                     activityPoints: activityPoints,
                     modelPerformance: modelPerformance,
                     modelTokenPoints: modelTokenPoints,
+                    tokenUsageModels: tokenUsageModels,
                     knownModelIDs: knownModelIDs,
                     recentRequestEvents: recentRequestEvents
                 )
@@ -323,6 +331,7 @@ final class DashboardViewModel: ObservableObject {
             hourlyActivityPoints = snapshot.activityPoints
             modelPerformance = snapshot.modelPerformance
             modelTokenPoints = snapshot.modelTokenPoints
+            tokenUsageModels = snapshot.tokenUsageModels
             appliedModelID = selectedModelID ?? ModelOption.allID
             historicalModelIDs = snapshot.knownModelIDs
             rebuildAvailableModels()
@@ -413,6 +422,7 @@ private extension DashboardViewModel {
         let activityPoints: [ActivityPoint]
         let modelPerformance: [ModelPerformance]
         let modelTokenPoints: [ModelTokenPoint]
+        let tokenUsageModels: [TokenUsageModel]
         let knownModelIDs: [String]
         let recentRequestEvents: [NativAnalyticsRequestEvent]
     }
@@ -682,5 +692,51 @@ private extension DashboardViewModel {
         case .day:
             return calendar.startOfDay(for: date)
         }
+    }
+}
+
+struct TokenUsageModel: Identifiable, Equatable, Sendable {
+    let id: String
+    let totalTokens: Int
+    let points: [DashboardViewModel.ModelTokenPoint]
+
+    static func grouped(_ points: [DashboardViewModel.ModelTokenPoint]) -> [Self] {
+        Dictionary(grouping: points, by: \.modelID)
+            .map { modelID, points in
+                Self(id: modelID, totalTokens: points.reduce(0) { $0 + $1.totalTokens }, points: points)
+            }
+            .sorted {
+                if $0.totalTokens != $1.totalTokens { return $0.totalTokens > $1.totalTokens }
+                return $0.id.localizedStandardCompare($1.id) == .orderedAscending
+            }
+    }
+}
+
+struct TokenUsageModelPage {
+    static let size = 8
+
+    let models: [TokenUsageModel]
+    let index: Int
+    let matchingCount: Int
+    let showsControls: Bool
+
+    init(models: [TokenUsageModel], query: String, index: Int) {
+        showsControls = models.count > Self.size
+        let query = showsControls ? query.trimmingCharacters(in: .whitespacesAndNewlines) : ""
+        let matches = query.isEmpty ? models : models.filter { $0.id.localizedStandardContains(query) }
+        matchingCount = matches.count
+        self.index = min(max(index, 0), max((matches.count - 1) / Self.size, 0))
+        let start = self.index * Self.size
+        self.models = Array(matches.dropFirst(start).prefix(Self.size))
+    }
+
+    var hasPrevious: Bool { index > 0 }
+    var hasNext: Bool { (index + 1) * Self.size < matchingCount }
+    var points: [DashboardViewModel.ModelTokenPoint] { models.flatMap(\.points) }
+
+    var rangeLabel: String {
+        guard matchingCount > 0 else { return "0 of 0" }
+        let first = index * Self.size + 1
+        return "\(first)–\(first + models.count - 1) of \(matchingCount)"
     }
 }

--- a/Sources/Nativ/Features/Dashboard/StatsView.swift
+++ b/Sources/Nativ/Features/Dashboard/StatsView.swift
@@ -108,6 +108,7 @@ private struct DashboardContentView: View, @MainActor Equatable {
     @ObservedObject var dashboard: DashboardViewModel
     let titleLeadingInset: CGFloat
     @FocusState private var isModelSearchFocused: Bool
+    @FocusState private var isTokenUsageSearchFocused: Bool
     @State private var selectedChartMetric: DashboardOverviewMetric = .tokens
     @State private var isActivityExpanded = false
 
@@ -131,7 +132,7 @@ private struct DashboardContentView: View, @MainActor Equatable {
                     VStack(alignment: .leading, spacing: 24) {
                         filterBar
                         overviewCards
-                        analyticsGrid
+                        analyticsGrid(availableWidth: min(geometry.size.width, 1500) - 44)
                         modelPerformanceSection
                         recentRequestsSection
                     }
@@ -152,6 +153,7 @@ private struct DashboardContentView: View, @MainActor Equatable {
         .contentShape(Rectangle())
         .onTapGesture {
             isModelSearchFocused = false
+            isTokenUsageSearchFocused = false
         }
         .onAppear {
             syncDashboardState(scanModels: true, reloadHistory: true)
@@ -279,26 +281,24 @@ private struct DashboardContentView: View, @MainActor Equatable {
         }
     }
 
-    private var analyticsGrid: some View {
+    private func analyticsGrid(availableWidth: CGFloat) -> some View {
         Group {
             if isActivityExpanded {
                 userActivityPanel
                     .frame(maxWidth: .infinity)
+            } else if availableWidth >= 680 + 350 + 14 {
+                HStack(alignment: .top, spacing: 14) {
+                    analyticsChart
+
+                    userActivityPanel
+                        .frame(width: 350)
+                }
+                .fixedSize(horizontal: false, vertical: true)
             } else {
-                ViewThatFits(in: .horizontal) {
-                    HStack(alignment: .top, spacing: 14) {
-                        analyticsChart
-                            .frame(minWidth: 680, maxWidth: .infinity)
-
-                        userActivityPanel
-                            .frame(width: 350)
-                    }
-
-                    VStack(alignment: .leading, spacing: 14) {
-                        analyticsChart
-                        userActivityPanel
-                            .frame(maxWidth: .infinity)
-                    }
+                VStack(alignment: .leading, spacing: 14) {
+                    analyticsChart
+                    userActivityPanel
+                        .frame(maxWidth: .infinity)
                 }
             }
         }
@@ -309,11 +309,13 @@ private struct DashboardContentView: View, @MainActor Equatable {
         TokenUsagePanel(
             metric: selectedChartMetric,
             points: dashboard.bucketPoints,
-            modelPoints: dashboard.modelTokenPoints,
+            overviewModelPoints: dashboard.modelTokenPoints,
+            tokenUsageModels: dashboard.tokenUsageModels,
             range: dashboard.selectedRange,
-            showsAllModels: dashboard.appliedModelID == DashboardViewModel.ModelOption.allID
+            showsAllModels: dashboard.appliedModelID == DashboardViewModel.ModelOption.allID,
+            searchFocus: $isTokenUsageSearchFocused
         )
-        .frame(maxWidth: .infinity)
+        .frame(minWidth: 0, maxWidth: .infinity)
     }
 
     private var userActivityPanel: some View {
@@ -654,6 +656,7 @@ private struct UserActivityPanel: View {
             heatmap
             periodBreakdown
         }
+        .frame(maxHeight: .infinity, alignment: .top)
         .padding(18)
         .nativPanelStyle(cornerRadius: .large)
         .animation(.snappy(duration: 0.24), value: isExpanded)
@@ -693,6 +696,7 @@ private struct UserActivityPanel: View {
         .frame(
             maxWidth: .infinity,
             minHeight: isExpanded ? 240 : 180,
+            maxHeight: .infinity,
             alignment: isExpanded ? .center : .leading
         )
         .accessibilityElement(children: .contain)
@@ -1200,6 +1204,128 @@ private struct SuccessRateModelSummary: Identifiable {
     }
 }
 
+private struct TokenUsageModelLegend: View {
+    let page: TokenUsageModelPage
+    let colorDomain: [String]
+    @Binding var query: String
+    @Binding var pageIndex: Int
+    let searchFocus: FocusState<Bool>.Binding
+    @State private var hoveredModelID: String?
+    @ScaledMetric(relativeTo: .callout) private var rowHeight: CGFloat = 18
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if page.showsControls {
+                HStack(spacing: 12) {
+                    TextField("Search models", text: $query)
+                        .textFieldStyle(.roundedBorder)
+                        .focused(searchFocus)
+                        .frame(minWidth: 120, idealWidth: 200, maxWidth: 200)
+                        .accessibilityLabel("Search token usage models")
+                        .accessibilityIdentifier("tokenUsageModelSearch")
+
+                    Spacer(minLength: 0)
+
+                    Text(page.rangeLabel)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .fixedSize()
+                        .accessibilityLabel("Models \(page.rangeLabel)")
+
+                    Button("Previous models", systemImage: "chevron.left", action: previousPage)
+                        .disabled(!page.hasPrevious)
+                        .help("Previous models")
+                    Button("Next models", systemImage: "chevron.right", action: nextPage)
+                        .disabled(!page.hasNext)
+                        .help("Next models")
+                }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+            }
+
+            modelGrid
+        }
+        .font(.callout)
+        .onChange(of: page.models.map(\.id)) { _, _ in hoveredModelID = nil }
+        .onDisappear { hoveredModelID = nil }
+    }
+
+    private var modelGrid: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(minimum: 0), spacing: 16), count: 4),
+            alignment: .leading,
+            spacing: 10
+        ) {
+            ForEach(Array(page.models.enumerated()), id: \.element.id) { index, model in
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(DashboardModelColorScale.color(for: model.id, in: colorDomain))
+                        .frame(width: 8, height: 8)
+                        .accessibilityHidden(true)
+                    Text(model.id)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                        .onHover { isHovering in
+                            if isHovering {
+                                hoveredModelID = model.id
+                            } else if hoveredModelID == model.id {
+                                hoveredModelID = nil
+                            }
+                        }
+                    Text(NativFormatting.compactCount(model.totalTokens).display)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .fixedSize()
+                }
+                .frame(height: rowHeight)
+                .textSelection(.disabled)
+                .overlay(alignment: index.isMultiple(of: 4) ? .topLeading : .topTrailing) {
+                    if hoveredModelID == model.id {
+                        Text(model.id)
+                            .font(.caption)
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(width: 280, alignment: .leading)
+                            .padding(8)
+                            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 7))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 7)
+                                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.6)
+                            }
+                            .shadow(color: .black.opacity(0.18), radius: 8, y: 3)
+                            .frame(height: 0, alignment: .bottom)
+                            .offset(y: -6)
+                            .allowsHitTesting(false)
+                            .accessibilityHidden(true)
+                    }
+                }
+                .zIndex(hoveredModelID == model.id ? 1 : 0)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(model.id)
+                .accessibilityValue("\(model.totalTokens.formatted()) tokens")
+            }
+            if page.showsControls {
+                ForEach(page.models.count..<TokenUsageModelPage.size, id: \.self) { _ in
+                    Color.clear.frame(height: rowHeight).accessibilityHidden(true)
+                }
+            }
+        }
+        .frame(minWidth: 0, maxWidth: .infinity)
+    }
+
+    private func previousPage() {
+        searchFocus.wrappedValue = false
+        pageIndex = page.index - 1
+    }
+
+    private func nextPage() {
+        searchFocus.wrappedValue = false
+        pageIndex = page.index + 1
+    }
+}
+
 private struct TokenUsagePanel: View {
     struct HistogramSegment: Identifiable {
         let modelID: String
@@ -1238,11 +1364,25 @@ private struct TokenUsagePanel: View {
 
     let metric: DashboardOverviewMetric
     let points: [DashboardViewModel.BucketPoint]
-    let modelPoints: [DashboardViewModel.ModelTokenPoint]
+    let overviewModelPoints: [DashboardViewModel.ModelTokenPoint]
+    let tokenUsageModels: [TokenUsageModel]
     let range: DashboardViewModel.RangeOption
     let showsAllModels: Bool
+    let searchFocus: FocusState<Bool>.Binding
     @State private var hoveredPointID: Date?
     @State private var allModelsDisplay: AllModelsDisplay = .lines
+    @State private var modelSearch = ""
+    @State private var modelPageIndex = 0
+
+    private var modelPage: TokenUsageModelPage {
+        TokenUsageModelPage(models: tokenUsageModels, query: modelSearch, index: modelPageIndex)
+    }
+
+    private var showsModelPage: Bool { metric == .tokens && showsAllModels }
+
+    private var modelPoints: [DashboardViewModel.ModelTokenPoint] {
+        showsModelPage ? modelPage.points : overviewModelPoints
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -1269,6 +1409,9 @@ private struct TokenUsagePanel: View {
             if points.isEmpty {
                 DashboardEmptyChart()
                     .frame(minHeight: 230)
+            } else if showsModelPage && modelPage.models.isEmpty {
+                ContentUnavailableView.search(text: modelSearch)
+                    .frame(height: 250)
             } else if usesSuccessRateComparison {
                 SuccessRateModelComparisonChart(summaries: modelSuccessSummaries)
             } else {
@@ -1276,7 +1419,7 @@ private struct TokenUsagePanel: View {
                     usageMarks
                     hoverMarks
                 }
-                .chartLegend(showsAllModels ? .visible : .hidden)
+                .chartLegend(showsAllModels && !showsModelPage ? .visible : .hidden)
                 .chartForegroundStyleScale(
                     domain: modelColorDomain,
                     range: DashboardModelColorScale.colors(for: modelColorDomain)
@@ -1406,9 +1549,38 @@ private struct TokenUsagePanel: View {
                 }
                 .animation(.easeInOut(duration: 0.2), value: metric)
             }
+
+            if showsModelPage && !tokenUsageModels.isEmpty {
+                Divider()
+                TokenUsageModelLegend(
+                    page: modelPage,
+                    colorDomain: modelColorDomain,
+                    query: $modelSearch,
+                    pageIndex: $modelPageIndex,
+                    searchFocus: searchFocus
+                )
+            }
         }
+        .frame(maxHeight: .infinity, alignment: .top)
         .padding(18)
         .nativPanelStyle(cornerRadius: .large)
+        .onChange(of: modelSearch) { _, _ in resetModelPage() }
+        .onChange(of: range) { _, _ in resetModelPage() }
+        .onChange(of: tokenUsageModels.map(\.id)) { _, _ in
+            if tokenUsageModels.count <= TokenUsageModelPage.size { modelSearch = "" }
+            modelPageIndex = modelPage.index
+            hoveredPointID = nil
+        }
+        .onChange(of: modelPageIndex) { _, _ in hoveredPointID = nil }
+        .onChange(of: showsAllModels) { _, _ in
+            modelSearch = ""
+            resetModelPage()
+        }
+    }
+
+    private func resetModelPage() {
+        modelPageIndex = 0
+        hoveredPointID = nil
     }
 
     private var chartTitle: String {
@@ -1867,7 +2039,9 @@ private struct TokenUsagePanel: View {
     }
 
     private var modelColorDomain: [String] {
-        DashboardModelColorScale.domain(for: modelPoints.map(\.modelID))
+        showsModelPage
+            ? tokenUsageModels.map(\.id)
+            : DashboardModelColorScale.domain(for: modelPoints.map(\.modelID))
     }
 
     private var successRatePoints: [DashboardViewModel.BucketPoint] {

--- a/Tests/NativTests/ControlPanelDependencyOwnershipTests.swift
+++ b/Tests/NativTests/ControlPanelDependencyOwnershipTests.swift
@@ -1,3 +1,5 @@
+import Foundation
+import SQLite3
 import XCTest
 
 @MainActor
@@ -38,5 +40,129 @@ final class ControlPanelDependencyOwnershipTests: XCTestCase {
         XCTAssertFalse(first.dashboard === second.dashboard)
         XCTAssertFalse(first.embeddingLibrary === second.embeddingLibrary)
         XCTAssertFalse(first.routineModelLibrary === second.routineModelLibrary)
+    }
+}
+
+final class TokenUsageModelPageTests: XCTestCase {
+    @MainActor
+    func testDashboardLoadsEveryModelForTokenUsageWhileKeepingOtherMetricsGrouped() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("Analytics.sqlite3")
+        _ = NativAnalyticsStore(databaseURL: databaseURL)
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(databaseURL.path, &database), SQLITE_OK)
+        defer { sqlite3_close(database) }
+        let date = Calendar.current.startOfDay(for: .now).timeIntervalSince1970
+        for index in 0..<17 {
+            let sql = """
+            INSERT INTO analytics_buckets (
+                granularity, bucket_start, model_id, requests_started, requests_completed,
+                requests_failed, streaming_requests, prompt_tokens_total, completion_tokens_total,
+                generated_tokens_total, request_elapsed_ms_total, decode_elapsed_ms_total, updated_at
+            ) VALUES ('hour', \(date), 'org/model-\(index)', 1, 1, 0, 0, \(17 - index), 0, 0, 1000, 1000, \(date));
+            """
+            XCTAssertEqual(sqlite3_exec(database, sql, nil, nil, nil), SQLITE_OK)
+        }
+        let dashboard = DashboardViewModel(analyticsDatabaseURL: databaseURL)
+        dashboard.selectedRange = .allTime
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while dashboard.isLoadingHistory, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertFalse(dashboard.isLoadingHistory)
+        XCTAssertEqual(dashboard.tokenUsageModels.count, 17)
+        XCTAssertEqual(dashboard.tokenUsageModels.map(\.totalTokens), Array((1...17).reversed()))
+        XCTAssertFalse(dashboard.tokenUsageModels.contains { $0.id == "Other" })
+        XCTAssertEqual(Set(dashboard.modelTokenPoints.map(\.modelID)).count, 13)
+        XCTAssertTrue(dashboard.modelTokenPoints.contains { $0.modelID == "Other" })
+    }
+
+    func testRanksModelsByTotalUsageWithStableTies() {
+        let models = TokenUsageModel.grouped([
+            point("org/B", tokens: 30), point("org/A", tokens: 10),
+            point("org/A", tokens: 20, hour: 1), point("org/C", tokens: 50),
+        ])
+        XCTAssertEqual(models.map(\.id), ["org/C", "org/A", "org/B"])
+        XCTAssertEqual(models.map(\.totalTokens), [50, 30, 30])
+        XCTAssertEqual(models[1].points.count, 2)
+    }
+
+    func testAll225ModelsAreReachableWithoutAnOtherGroup() {
+        let models = fixture(count: 225)
+        let pages = (0..<29).map { TokenUsageModelPage(models: models, query: "", index: $0) }
+        XCTAssertEqual(pages.flatMap(\.models).map(\.id), models.map(\.id))
+        XCTAssertTrue(pages.allSatisfy { $0.models.count <= 8 })
+        XCTAssertEqual(pages.first?.rangeLabel, "1–8 of 225")
+        XCTAssertEqual(pages.last?.rangeLabel, "225–225 of 225")
+        XCTAssertEqual(pages.first?.hasPrevious, false)
+        XCTAssertEqual(pages.last?.hasNext, false)
+    }
+
+    func testSearchFiltersTheWholeListBeforePaginatingAndPreservesUsageOrder() {
+        let models = fixture(count: 40)
+        let page = TokenUsageModelPage(models: models, query: "  QWEN/  ", index: 1)
+        let matches = models.filter { $0.id.hasPrefix("qwen/") }
+        XCTAssertEqual(page.models.map(\.id), Array(matches.dropFirst(8).prefix(8)).map(\.id))
+        XCTAssertEqual(page.rangeLabel, "9–16 of 20")
+        XCTAssertTrue(page.hasPrevious)
+        XCTAssertTrue(page.hasNext)
+    }
+
+    func testChartPointsContainExactlyTheCurrentPageModels() {
+        let models = fixture(count: 17)
+        let page = TokenUsageModelPage(models: models, query: "", index: 1)
+        XCTAssertEqual(Set(page.points.map(\.modelID)), Set(page.models.map(\.id)))
+        XCTAssertEqual(page.points.reduce(0) { $0 + $1.totalTokens }, page.models.reduce(0) { $0 + $1.totalTokens })
+        XCTAssertTrue(Set(page.points.map(\.modelID)).isDisjoint(with: models.prefix(8).map(\.id)))
+    }
+
+    func testClampsPagesAfterTheResultSetShrinks() {
+        let models = fixture(count: 17)
+        let last = TokenUsageModelPage(models: models, query: "", index: 100)
+        XCTAssertEqual(last.index, 2)
+        XCTAssertEqual(last.models.count, 1)
+        XCTAssertFalse(last.hasNext)
+        XCTAssertEqual(TokenUsageModelPage(models: models, query: "", index: -1).index, 0)
+        XCTAssertEqual(TokenUsageModelPage(models: models, query: "model-16", index: 2).index, 0)
+    }
+
+    func testSearchAndPaginationHideForEightOrFewerModels() {
+        for count in [0, 1, 8] {
+            let page = TokenUsageModelPage(models: fixture(count: count), query: "old search", index: 9)
+            XCTAssertFalse(page.showsControls)
+            XCTAssertEqual(page.index, 0)
+            XCTAssertEqual(page.models.count, count, "A hidden search must not hide models")
+        }
+    }
+
+    func testSearchControlsRemainAvailableWhenOnlyOneModelMatches() {
+        let page = TokenUsageModelPage(models: fixture(count: 40), query: "model-39", index: 0)
+        XCTAssertTrue(page.showsControls)
+        XCTAssertEqual(page.rangeLabel, "1–1 of 1")
+        XCTAssertFalse(page.hasNext)
+        XCTAssertFalse(page.hasPrevious)
+    }
+
+    func testNoMatchesProducesAnEmptyChartAndDisabledPagination() {
+        let page = TokenUsageModelPage(models: fixture(count: 40), query: "missing model", index: 2)
+        XCTAssertTrue(page.showsControls)
+        XCTAssertTrue(page.points.isEmpty)
+        XCTAssertEqual(page.rangeLabel, "0 of 0")
+        XCTAssertEqual(page.index, 0)
+        XCTAssertFalse(page.hasNext)
+        XCTAssertFalse(page.hasPrevious)
+    }
+
+    private func fixture(count: Int) -> [TokenUsageModel] {
+        TokenUsageModel.grouped((0..<count).map { index in
+            point("\(index.isMultiple(of: 2) ? "qwen" : "mlx-community")/model-\(index)", tokens: count - index)
+        })
+    }
+
+    private func point(_ model: String, tokens: Int, hour: Int = 0) -> DashboardViewModel.ModelTokenPoint {
+        .init(modelID: model, bucketStart: Date(timeIntervalSince1970: Double(hour * 3_600)),
+              totalTokens: tokens, requestsCompleted: 1, requestsFailed: 0,
+              generatedTokensTotal: tokens, decodeTokensTotal: tokens, decodeTimeTotalMilliseconds: 1_000)
     }
 }


### PR DESCRIPTION
- prevent the token usage model legend from overflowing its container
- display models inside a bounded, vertically scrollable legend
- add clear visual and accessibility cues that the model list is scrollable
- keep the token usage and user activity panels at the same height

<img width="1434" height="492" alt="image" src="https://github.com/user-attachments/assets/554631b8-3ae0-47f8-a5b4-5dabcf275ae9" />
