### PR TITLE
Report temperature, fans, and power to the system stats tool

### DIFF
--- a/Sources/Nativ/Features/Chat/Tools/ChatSystemStatsTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatSystemStatsTool.swift
@@ -7,7 +7,7 @@ enum ChatSystemMonitorToolRegistry {
     static func definitions() -> [MLXChatToolDefinition] {
         [MLXChatToolDefinition(function: MLXChatFunctionDefinition(
             name: toolName,
-            description: "Get current CPU, GPU, memory, and disk usage on this Mac.",
+            description: "Get current CPU, GPU, memory, and disk usage on this Mac, plus temperature, fan speed, thermal pressure, and power draw.",
             parameters: .object([
                 "type": .string("object"),
                 "additionalProperties": .bool(false),
@@ -26,6 +26,13 @@ struct ChatSystemMonitorToolResultPayload: Encodable {
     let diskUsedGB: Double?
     let diskTotalGB: Double?
     let uptimeSeconds: Int?
+    let dieTemperatureCelsius: Double?
+    let hottestSensorName: String?
+    let fanRPM: Int?
+    let thermalPressure: String?
+    let cpuWatts: Double?
+    let gpuWatts: Double?
+    let packageWatts: Double?
     let error: String?
 
     enum CodingKeys: String, CodingKey {
@@ -37,6 +44,13 @@ struct ChatSystemMonitorToolResultPayload: Encodable {
         case diskUsedGB = "disk_used_gb"
         case diskTotalGB = "disk_total_gb"
         case uptimeSeconds = "uptime_seconds"
+        case dieTemperatureCelsius = "die_temperature_c"
+        case hottestSensorName = "hottest_sensor"
+        case fanRPM = "fan_rpm"
+        case thermalPressure = "thermal_pressure"
+        case cpuWatts = "cpu_watts"
+        case gpuWatts = "gpu_watts"
+        case packageWatts = "package_watts"
         case error
     }
 }
@@ -62,6 +76,13 @@ struct ChatSystemMonitorToolExecutor {
             diskUsedGB: snapshot.disk.usedBytes.map(gigabytes),
             diskTotalGB: snapshot.disk.totalBytes.map(gigabytes),
             uptimeSeconds: Int(snapshot.uptime),
+            dieTemperatureCelsius: snapshot.thermal.dieTemperatureCelsius.map(oneDecimal),
+            hottestSensorName: snapshot.thermal.hottestSensorName,
+            fanRPM: snapshot.thermal.maximumFanRPM,
+            thermalPressure: snapshot.thermal.thermalPressureLabel,
+            cpuWatts: snapshot.power.cpuWatts.map(oneDecimal),
+            gpuWatts: snapshot.power.gpuWatts.map(oneDecimal),
+            packageWatts: packageWatts(snapshot.power),
             error: nil
         )
         return try encodedPayload(payload)
@@ -87,6 +108,13 @@ struct ChatSystemMonitorToolExecutor {
             diskUsedGB: nil,
             diskTotalGB: nil,
             uptimeSeconds: nil,
+            dieTemperatureCelsius: nil,
+            hottestSensorName: nil,
+            fanRPM: nil,
+            thermalPressure: nil,
+            cpuWatts: nil,
+            gpuWatts: nil,
+            packageWatts: nil,
             error: error.localizedDescription
         )
         return (try? encodedPayload(payload))
@@ -95,6 +123,14 @@ struct ChatSystemMonitorToolExecutor {
 
     private func percent(_ usage: Double) -> Int {
         Int((usage * 100).rounded())
+    }
+
+    private func oneDecimal(_ value: Double) -> Double {
+        (value * 10).rounded() / 10
+    }
+
+    private func packageWatts(_ power: SystemPowerMetrics) -> Double? {
+        (power.socWatts ?? power.systemInputWatts).map(oneDecimal)
     }
 
     private func gigabytes(_ bytes: UInt64) -> Double {

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -622,6 +622,51 @@ final class ChatToolRegistryTests: XCTestCase {
         XCTAssertNil(object["cpu_usage_percent"])
     }
 
+    @MainActor
+    func testSystemMonitorReportsThermalAndPower() async throws {
+        var snapshot = SystemMonitorSnapshot()
+        snapshot.thermal.dieTemperatureCelsius = 62.37
+        snapshot.thermal.hottestSensorName = "PMU tdie1"
+        snapshot.thermal.fanSpeedsRPM = [1200, 2400]
+        snapshot.thermal.thermalPressure = .fair
+        snapshot.power.cpuWatts = 3.44
+        snapshot.power.gpuWatts = 8.06
+        snapshot.power.socWatts = 14.92
+
+        let payload = try await ChatSystemMonitorToolExecutor().execute(
+            call: makeCall(name: ChatSystemMonitorToolRegistry.toolName),
+            collect: { snapshot }
+        )
+        let object = try decode(payload)
+        XCTAssertEqual(object["die_temperature_c"] as? Double, 62.4)
+        XCTAssertEqual(object["hottest_sensor"] as? String, "PMU tdie1")
+        XCTAssertEqual(object["fan_rpm"] as? Int, 2400, "should report the fastest fan")
+        XCTAssertEqual(object["thermal_pressure"] as? String, "Fair")
+        XCTAssertEqual(object["cpu_watts"] as? Double, 3.4)
+        XCTAssertEqual(object["gpu_watts"] as? Double, 8.1)
+        XCTAssertEqual(object["package_watts"] as? Double, 14.9)
+    }
+
+    @MainActor
+    func testSystemMonitorOmitsUnavailableSensors() async throws {
+        var snapshot = SystemMonitorSnapshot()
+        snapshot.power.systemInputWatts = 21.5
+
+        let payload = try await ChatSystemMonitorToolExecutor().execute(
+            call: makeCall(name: ChatSystemMonitorToolRegistry.toolName),
+            collect: { snapshot }
+        )
+        let object = try decode(payload)
+        XCTAssertNil(object["die_temperature_c"], "machines without a die sensor report null")
+        XCTAssertNil(object["fan_rpm"], "fanless machines report null")
+        XCTAssertEqual(
+            object["package_watts"] as? Double,
+            21.5,
+            "falls back to battery-controller input power when SoC rails are absent"
+        )
+        XCTAssertEqual(object["thermal_pressure"] as? String, "Nominal")
+    }
+
     func testModelLibraryFailurePayloadShape() throws {
         let payload = ChatModelLibraryToolExecutor().failurePayload(operation: "x", error: FakeToolError())
         let object = try decode(payload)


### PR DESCRIPTION
The system monitor already samples temperature, fan speed, thermal pressure, and power on every snapshot, but `get_system_stats` only returned CPU/GPU/memory/disk.