### PR TITLE
Import an audio file into the audio library

### DIFF
--- a/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
@@ -5,11 +5,14 @@ enum AudioRecordKind: String, Codable, CaseIterable, Sendable {
     case dictation
     case voiceNote
     case meeting
+    case imported
 
     var title: String {
         switch self {
         case .dictation:
             "Dictation"
+        case .imported:
+            "Imported"
         case .voiceNote, .meeting:
             "Recording"
         }
@@ -19,6 +22,8 @@ enum AudioRecordKind: String, Codable, CaseIterable, Sendable {
         switch self {
         case .dictation:
             "text.cursor"
+        case .imported:
+            "square.and.arrow.down"
         case .voiceNote, .meeting:
             "waveform.badge.mic"
         }

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -92,6 +92,7 @@ final class AudioCaptureLibrary: ObservableObject {
     @Published var lastErrorMessage: String?
     @Published private(set) var permissionRequiringSettings: NativPermission?
     @Published private(set) var playingRecordID: String?
+    @Published private(set) var importProgress: AudioImportProgress?
     @Published private(set) var isPlaybackPaused = false
 
     var transcriptionConfigurationProvider:
@@ -258,7 +259,7 @@ final class AudioCaptureLibrary: ObservableObject {
                     )
                     activeBackend = .microphone
                 }
-            case .dictation:
+            case .dictation, .imported:
                 return
             }
             captureStartedAt = Date()
@@ -372,6 +373,58 @@ final class AudioCaptureLibrary: ObservableObject {
             return
         }
         await discardCurrentCapture(hideOverlay: true)
+    }
+
+    func importFile(from source: URL) {
+        guard importProgress == nil else { return }
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.runImport(from: source)
+        }
+        importProgress = AudioImportProgress(
+            title: source.deletingPathExtension().lastPathComponent,
+            task: task
+        )
+    }
+
+    func cancelImport() {
+        importProgress?.task.cancel()
+        importProgress = nil
+    }
+
+    private func runImport(from source: URL) async {
+        let imported = await importAudio(from: source)
+        importProgress = nil
+        guard let imported else {
+            return
+        }
+
+        analytics.addCapture(
+            recordingURL: imported.url,
+            kind: .imported,
+            title: imported.title,
+            durationSeconds: imported.duration
+        )
+        processingRecordIDs.insert(imported.url.deletingPathExtension().lastPathComponent)
+        await processRecording(
+            imported.url,
+            kind: .imported,
+            title: imported.title,
+            duration: imported.duration,
+            automaticallySummarize: true
+        )
+    }
+
+    private func importAudio(from source: URL) async -> ImportedAudioFile? {
+        do {
+            let directory = try Self.recordingsDirectory
+            return try await AudioFileImporter().importFile(from: source, into: directory)
+        } catch is CancellationError {
+            return nil
+        } catch {
+            lastErrorMessage = error.localizedDescription
+            return nil
+        }
     }
 
     func summarize(_ record: AudioTranscriptionRecord) {

--- a/Sources/Nativ/Features/VoiceCapture/AudioFileImporter.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioFileImporter.swift
@@ -1,0 +1,267 @@
+import AVFoundation
+import Foundation
+import UniformTypeIdentifiers
+
+struct ImportedAudioFile: Equatable, Sendable {
+    let url: URL
+    let title: String
+    let duration: TimeInterval
+    let wasTranscoded: Bool
+}
+
+enum AudioFileImportError: LocalizedError, Equatable {
+    case unreadable
+    case empty
+    case tooLong(maximumMinutes: Int)
+    case unsupportedFormat(String)
+    case transcodeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .unreadable:
+            "Nativ could not read this audio file."
+        case .empty:
+            "This audio file does not contain any playable audio."
+        case .tooLong(let maximumMinutes):
+            "This audio is longer than \(maximumMinutes) minutes. Import a shorter file."
+        case .unsupportedFormat(let name):
+            "Nativ cannot read \(name) files. Convert it to M4A, MP3, or WAV first."
+        case .transcodeFailed:
+            "Nativ could not prepare this audio file for transcription."
+        }
+    }
+}
+
+struct AudioFileImporter: Sendable {
+    static let maximumDuration: TimeInterval = 50 * 60
+
+    static let transcriptionSampleRate: Double = 16_000
+
+    static let supportedContentTypes: [UTType] = [.audio]
+
+    enum Plan: Equatable {
+        case passthrough(fileExtension: String)
+        case transcode
+        case reject(format: String)
+    }
+
+    private enum Signature {
+        static let riff = Data("RIFF".utf8)
+        static let wave = Data("WAVE".utf8)
+        static let flac = Data("fLaC".utf8)
+        static let id3 = Data("ID3".utf8)
+        static let ogg = Data("OggS".utf8)
+        static let opus = Data("OpusHead".utf8)
+        static let matroska = Data([0x1A, 0x45, 0xDF, 0xA3])
+    }
+
+    static func plan(for source: URL) -> Plan {
+        guard let header = header(of: source) else { return .transcode }
+
+        if header.starts(with: Signature.matroska) {
+            return .reject(format: "WebM")
+        }
+        if header.starts(with: Signature.ogg) {
+            return header.range(of: Signature.opus) == nil
+                ? .passthrough(fileExtension: "ogg")
+                : .reject(format: "Opus")
+        }
+        if header.starts(with: Signature.riff), header.dropFirst(8).starts(with: Signature.wave) {
+            return .passthrough(fileExtension: "wav")
+        }
+        if header.starts(with: Signature.flac) {
+            return .passthrough(fileExtension: "flac")
+        }
+        if header.starts(with: Signature.id3) || isMPEGAudioFrame(header) {
+            return .passthrough(fileExtension: "mp3")
+        }
+        return .transcode
+    }
+
+    private static func header(of source: URL) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: source) else { return nil }
+        defer { try? handle.close() }
+        guard let header = try? handle.read(upToCount: 64), header.count >= 4 else { return nil }
+        return header
+    }
+
+    private static func isMPEGAudioFrame(_ header: Data) -> Bool {
+        var bytes = header.makeIterator()
+        guard let first = bytes.next(), let second = bytes.next() else { return false }
+        return first == 0xFF && second & 0xE0 == 0xE0
+    }
+
+    func importFile(from source: URL, into directory: URL) async throws -> ImportedAudioFile {
+        try await withThrowingTaskGroup(of: ImportedAudioFile.self) { group in
+            group.addTask(priority: .userInitiated) {
+                try Self.importSynchronously(from: source, into: directory)
+            }
+            guard let result = try await group.next() else {
+                throw AudioFileImportError.unreadable
+            }
+            return result
+        }
+    }
+
+    private static func importSynchronously(
+        from source: URL,
+        into directory: URL
+    ) throws -> ImportedAudioFile {
+        try Task.checkCancellation()
+
+        let plan = plan(for: source)
+        if case .reject(let format) = plan {
+            throw AudioFileImportError.unsupportedFormat(format)
+        }
+
+        let input: AVAudioFile
+        do {
+            input = try AVAudioFile(forReading: source)
+        } catch {
+            throw AudioFileImportError.unreadable
+        }
+
+        let duration = TimeInterval(input.length) / input.processingFormat.sampleRate
+        guard duration.isFinite, duration > 0 else {
+            throw AudioFileImportError.empty
+        }
+        guard duration <= maximumDuration else {
+            throw AudioFileImportError.tooLong(maximumMinutes: Int(maximumDuration / 60))
+        }
+
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+
+        let identifier = UUID().uuidString
+        let title = source.deletingPathExtension().lastPathComponent
+        let name = "Imported \(identifier)"
+
+        if case .passthrough(let fileExtension) = plan {
+            let destination = directory
+                .appendingPathComponent(name)
+                .appendingPathExtension(fileExtension)
+            try FileManager.default.copyItem(at: source, to: destination)
+            return ImportedAudioFile(
+                url: destination,
+                title: title,
+                duration: duration,
+                wasTranscoded: false
+            )
+        }
+
+        let destination = directory
+            .appendingPathComponent(name)
+            .appendingPathExtension("wav")
+        let staging = directory
+            .appendingPathComponent(".audio-import-\(identifier)")
+            .appendingPathExtension("wav")
+        defer { try? FileManager.default.removeItem(at: staging) }
+
+        do {
+            try transcodeForTranscription(input: input, destination: staging)
+            try FileManager.default.moveItem(at: staging, to: destination)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as AudioFileImportError {
+            throw error
+        } catch {
+            throw AudioFileImportError.transcodeFailed
+        }
+
+        return ImportedAudioFile(
+            url: destination,
+            title: title,
+            duration: duration,
+            wasTranscoded: true
+        )
+    }
+
+    private static func transcodeForTranscription(
+        input: AVAudioFile,
+        destination: URL
+    ) throws {
+        let inputFormat = input.processingFormat
+        guard let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: transcriptionSampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw AudioFileImportError.transcodeFailed
+        }
+        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            throw AudioFileImportError.transcodeFailed
+        }
+        let output = try AVAudioFile(
+            forWriting: destination,
+            settings: [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: transcriptionSampleRate,
+                AVNumberOfChannelsKey: 1,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false,
+            ]
+        )
+
+        let inputCapacity: AVAudioFrameCount = 16_384
+        let ratio = outputFormat.sampleRate / inputFormat.sampleRate
+        let outputCapacity = AVAudioFrameCount(Double(inputCapacity) * max(ratio, 1)) + 1_024
+        guard let inputBuffer = AVAudioPCMBuffer(
+            pcmFormat: inputFormat,
+            frameCapacity: inputCapacity
+        ), let outputBuffer = AVAudioPCMBuffer(
+            pcmFormat: outputFormat,
+            frameCapacity: outputCapacity
+        ) else {
+            throw AudioFileImportError.transcodeFailed
+        }
+
+        var readFailure: Error?
+        while true {
+            try Task.checkCancellation()
+            var conversionError: NSError?
+            let status = converter.convert(to: outputBuffer, error: &conversionError) { _, status in
+                guard input.framePosition < input.length else {
+                    status.pointee = .endOfStream
+                    return nil
+                }
+                do {
+                    try input.read(into: inputBuffer)
+                } catch {
+                    readFailure = error
+                    status.pointee = .endOfStream
+                    return nil
+                }
+                guard inputBuffer.frameLength > 0 else {
+                    status.pointee = .endOfStream
+                    return nil
+                }
+                status.pointee = .haveData
+                return inputBuffer
+            }
+            if let readFailure {
+                throw readFailure
+            }
+            if case .error = status {
+                if let conversionError {
+                    throw conversionError
+                }
+                throw AudioFileImportError.transcodeFailed
+            }
+            if outputBuffer.frameLength > 0 {
+                try output.write(from: outputBuffer)
+            }
+            if status != .haveData {
+                return
+            }
+        }
+    }
+}
+
+struct AudioImportProgress {
+    let title: String
+    let task: Task<Void, Never>
+}

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -3,6 +3,7 @@ import Carbon.HIToolbox
 import Charts
 import SwiftUI
 import Textual
+import UniformTypeIdentifiers
 
 private enum AudioDestination: String, CaseIterable, Identifiable {
     case overview
@@ -64,6 +65,7 @@ struct AudioView: View {
     @State private var editingShortcut: AudioShortcutKind?
     @State private var shortcutConflict: String?
     @State private var destination: AudioDestination = .record
+    @State private var isPresentingAudioImporter = false
     @State private var pendingDeleteDictation: AudioTranscriptionRecord?
     @State private var pendingDeleteRecording: AudioTranscriptionRecord?
     @State private var hoveredActivity: AudioDailyUsage?
@@ -1923,6 +1925,30 @@ struct AudioView: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
+                if let progress = captureLibrary.importProgress {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Importing \(progress.title)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: 160, alignment: .trailing)
+                    Button("Cancel") {
+                        captureLibrary.cancelImport()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                } else {
+                    Button {
+                        isPresentingAudioImporter = true
+                    } label: {
+                        Label("Import file", systemImage: "square.and.arrow.down")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .help("Transcribe and summarize an existing audio file")
+                }
                 Button {
                     destination = .record
                 } label: {
@@ -1936,12 +1962,16 @@ struct AudioView: View {
                 ContentUnavailableView {
                     Label("No saved recordings", systemImage: "waveform.badge.plus")
                 } description: {
-                    Text("Start a recording to create your local audio library.")
+                    Text("Record audio or import a file to create your local audio library.")
                 } actions: {
                     Button("Record audio") {
                         destination = .record
                     }
                     .buttonStyle(.borderedProminent)
+                    Button("Import a file") {
+                        isPresentingAudioImporter = true
+                    }
+                    .disabled(captureLibrary.importProgress != nil)
                 }
                 .frame(maxWidth: .infinity, minHeight: 170)
             } else {
@@ -1969,6 +1999,17 @@ struct AudioView: View {
         }
         .padding(18)
         .audioPanelStyle()
+        .fileImporter(
+            isPresented: $isPresentingAudioImporter,
+            allowedContentTypes: AudioFileImporter.supportedContentTypes
+        ) { result in
+            switch result {
+            case .success(let url):
+                captureLibrary.importFile(from: url)
+            case .failure(let error):
+                captureLibrary.lastErrorMessage = error.localizedDescription
+            }
+        }
     }
 
     private func shortcutRow(

--- a/Tests/NativTests/AudioFileImporterTests.swift
+++ b/Tests/NativTests/AudioFileImporterTests.swift
@@ -1,0 +1,285 @@
+import AVFoundation
+import Foundation
+import XCTest
+
+final class AudioFileImporterTests: XCTestCase {
+    private func temporaryURL(_ fileExtension: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(fileExtension)
+    }
+
+    private func makeBuffer(
+        seconds: Double,
+        sampleRate: Double,
+        channels: AVAudioChannelCount
+    ) throws -> AVAudioPCMBuffer {
+        let format = try XCTUnwrap(
+            AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: sampleRate,
+                channels: channels,
+                interleaved: false
+            )
+        )
+        let frames = AVAudioFrameCount(sampleRate * seconds)
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames))
+        buffer.frameLength = frames
+        let data = try XCTUnwrap(buffer.floatChannelData)
+        for channel in 0..<Int(channels) {
+            for frame in 0..<Int(frames) {
+                let phase = 2 * Double.pi * 440 * Double(frame) / sampleRate
+                data[channel][frame] = Float(sin(phase) * 0.5)
+            }
+        }
+        return buffer
+    }
+
+    private func makeWAV(
+        seconds: Double,
+        sampleRate: Double = 44_100,
+        channels: AVAudioChannelCount = 2
+    ) throws -> URL {
+        let url = temporaryURL("wav")
+        let buffer = try makeBuffer(seconds: seconds, sampleRate: sampleRate, channels: channels)
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: sampleRate,
+                AVNumberOfChannelsKey: Int(channels),
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false,
+            ]
+        )
+        if buffer.frameLength > 0 {
+            try file.write(from: buffer)
+        }
+        return url
+    }
+
+    private func makeM4A(
+        seconds: Double,
+        sampleRate: Double = 44_100,
+        channels: AVAudioChannelCount = 2
+    ) throws -> URL {
+        let url = temporaryURL("m4a")
+        let buffer = try makeBuffer(seconds: seconds, sampleRate: sampleRate, channels: channels)
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: sampleRate,
+                AVNumberOfChannelsKey: Int(channels),
+            ]
+        )
+        try file.write(from: buffer)
+        return url
+    }
+
+    private func makeFile(_ fileExtension: String, header: [UInt8]) throws -> URL {
+        let url = temporaryURL(fileExtension)
+        var bytes = header
+        bytes.append(contentsOf: [UInt8](repeating: 0, count: max(0, 128 - bytes.count)))
+        try Data(bytes).write(to: url)
+        return url
+    }
+
+    private func oggBytes(codec: [UInt8]) -> [UInt8] {
+        var bytes = Array("OggS".utf8)
+        bytes.append(contentsOf: [UInt8](repeating: 0, count: 22))
+        bytes.append(1)
+        bytes.append(UInt8(codec.count))
+        bytes.append(contentsOf: codec)
+        return bytes
+    }
+
+    func testPlanPassesThroughFormatsTheServerCanDecode() throws {
+        let wav = try makeWAV(seconds: 0.1)
+        let flac = try makeFile("flac", header: Array("fLaC".utf8))
+        let tagged = try makeFile("mp3", header: Array("ID3".utf8) + [0x04, 0x00])
+        let bare = try makeFile("mp3", header: [0xFF, 0xFB, 0x90, 0x00])
+        let vorbis = try makeFile("ogg", header: oggBytes(codec: [0x01] + Array("vorbis".utf8)))
+
+        XCTAssertEqual(AudioFileImporter.plan(for: wav), .passthrough(fileExtension: "wav"))
+        XCTAssertEqual(AudioFileImporter.plan(for: flac), .passthrough(fileExtension: "flac"))
+        XCTAssertEqual(AudioFileImporter.plan(for: tagged), .passthrough(fileExtension: "mp3"))
+        XCTAssertEqual(AudioFileImporter.plan(for: bare), .passthrough(fileExtension: "mp3"))
+        XCTAssertEqual(AudioFileImporter.plan(for: vorbis), .passthrough(fileExtension: "ogg"))
+    }
+
+    func testPlanTranscodesFormatsOnlyAVFoundationCanDecode() throws {
+        let m4a = try makeM4A(seconds: 0.1)
+        let caf = try makeFile("caf", header: Array("caff".utf8))
+        let aiff = try makeFile("aiff", header: Array("FORM".utf8) + [0, 0, 0, 0] + Array("AIFF".utf8))
+
+        XCTAssertEqual(AudioFileImporter.plan(for: m4a), .transcode)
+        XCTAssertEqual(AudioFileImporter.plan(for: caf), .transcode)
+        XCTAssertEqual(AudioFileImporter.plan(for: aiff), .transcode)
+    }
+
+    func testPlanRejectsFormatsNeitherSideCanDecode() throws {
+        let opus = try makeFile("opus", header: oggBytes(codec: Array("OpusHead".utf8)))
+        let webm = try makeFile("webm", header: [0x1A, 0x45, 0xDF, 0xA3])
+
+        XCTAssertEqual(AudioFileImporter.plan(for: opus), .reject(format: "Opus"))
+        XCTAssertEqual(AudioFileImporter.plan(for: webm), .reject(format: "WebM"))
+    }
+
+    func testPlanRejectsOpusCarryingAnOggExtension() throws {
+        let disguised = try makeFile("ogg", header: oggBytes(codec: Array("OpusHead".utf8)))
+        XCTAssertEqual(
+            AudioFileImporter.plan(for: disguised),
+            .reject(format: "Opus"),
+            "the .opus and .ogg extensions share one content type, so only the header can tell them apart"
+        )
+    }
+
+    func testPlanFollowsContentRatherThanFileExtension() throws {
+        let wav = try makeWAV(seconds: 0.1)
+        let mislabelled = wav.deletingPathExtension().appendingPathExtension("m4a")
+        try FileManager.default.moveItem(at: wav, to: mislabelled)
+        let aac = try makeM4A(seconds: 0.1)
+        let disguisedAAC = aac.deletingPathExtension().appendingPathExtension("wav")
+        try FileManager.default.moveItem(at: aac, to: disguisedAAC)
+
+        XCTAssertEqual(
+            AudioFileImporter.plan(for: mislabelled),
+            .passthrough(fileExtension: "wav"),
+            "a WAV named .m4a is still readable server-side"
+        )
+        XCTAssertEqual(
+            AudioFileImporter.plan(for: disguisedAAC),
+            .transcode,
+            "AAC named .wav would fail server-side, so it has to be transcoded"
+        )
+    }
+
+    func testMissingFileIsUnreadableRatherThanRejected() async throws {
+        let missing = URL(filePath: "/nonexistent/recording.opus")
+        XCTAssertEqual(AudioFileImporter.plan(for: missing), .transcode)
+        await assertImportFails(from: missing, with: .unreadable)
+    }
+
+    func testRejectedFormatFailsWithTheFormatName() async throws {
+        let opus = try makeFile("opus", header: oggBytes(codec: Array("OpusHead".utf8)))
+        await assertImportFails(from: opus, with: .unsupportedFormat("Opus"))
+    }
+
+    func testPassthroughCopiesWithoutReencoding() async throws {
+        let source = try makeWAV(seconds: 0.25)
+        let imported = try await AudioFileImporter().importFile(
+            from: source,
+            into: temporaryURL("import")
+        )
+
+        XCTAssertFalse(imported.wasTranscoded, "WAV is readable server-side, so it must not be re-encoded")
+        XCTAssertEqual(imported.url.pathExtension, "wav")
+        let copied = try AVAudioFile(forReading: imported.url)
+        XCTAssertEqual(copied.fileFormat.sampleRate, 44_100, "passthrough must not resample")
+        XCTAssertEqual(copied.fileFormat.channelCount, 2, "passthrough must not downmix")
+        XCTAssertEqual(imported.duration, 0.25, accuracy: 0.01)
+    }
+
+    func testTranscodeProducesMonoTranscriptionAudio() async throws {
+        let source = try makeM4A(seconds: 3, sampleRate: 44_100, channels: 2)
+        let imported = try await AudioFileImporter().importFile(
+            from: source,
+            into: temporaryURL("import")
+        )
+
+        XCTAssertTrue(imported.wasTranscoded)
+        XCTAssertEqual(imported.url.pathExtension, "wav")
+        let output = try AVAudioFile(forReading: imported.url)
+        XCTAssertEqual(output.fileFormat.sampleRate, AudioFileImporter.transcriptionSampleRate)
+        XCTAssertEqual(output.fileFormat.channelCount, 1)
+        XCTAssertEqual(
+            Double(output.length) / output.fileFormat.sampleRate,
+            3,
+            accuracy: 0.05,
+            "the resampled file must keep the original duration, not stop at the first chunk"
+        )
+    }
+
+    func testTranscodePreservesAudioRatherThanWritingSilence() async throws {
+        let source = try makeM4A(seconds: 0.5, sampleRate: 44_100, channels: 2)
+        let imported = try await AudioFileImporter().importFile(
+            from: source,
+            into: temporaryURL("import")
+        )
+
+        let output = try AVAudioFile(forReading: imported.url)
+        let buffer = try XCTUnwrap(
+            AVAudioPCMBuffer(
+                pcmFormat: output.processingFormat,
+                frameCapacity: AVAudioFrameCount(output.length)
+            )
+        )
+        try output.read(into: buffer)
+        let samples = try XCTUnwrap(buffer.floatChannelData)[0]
+        var peak: Float = 0
+        for frame in 0..<Int(buffer.frameLength) {
+            peak = max(peak, abs(samples[frame]))
+        }
+        XCTAssertGreaterThan(peak, 0.1, "a 440 Hz tone must survive the resample")
+    }
+
+    func testStagingFileIsNotLeftBehind() async throws {
+        let source = try makeM4A(seconds: 0.2)
+        let directory = temporaryURL("import")
+        let imported = try await AudioFileImporter().importFile(from: source, into: directory)
+
+        let contents = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        XCTAssertEqual(contents, [imported.url.lastPathComponent])
+    }
+
+    func testDurationLimitMatchesTheDocumentedMaximum() {
+        XCTAssertEqual(AudioFileImporter.maximumDuration, 50 * 60)
+        XCTAssertEqual(AudioFileImporter.transcriptionSampleRate, 16_000)
+    }
+
+    func testEmptyAudioIsRejected() async throws {
+        let source = try makeWAV(seconds: 0)
+        await assertImportFails(from: source, with: .empty)
+    }
+
+    func testImportIsCancellable() async throws {
+        let source = try makeM4A(seconds: 120)
+        let directory = temporaryURL("import")
+
+        let task = Task {
+            try await AudioFileImporter().importFile(from: source, into: directory)
+        }
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("a cancelled import must not produce a file")
+        } catch is CancellationError {
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: directory.path),
+                "cancellation must not leave a partial import behind"
+            )
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    private func assertImportFails(
+        from source: URL,
+        with expected: AudioFileImportError
+    ) async {
+        do {
+            _ = try await AudioFileImporter().importFile(
+                from: source,
+                into: FileManager.default.temporaryDirectory
+                    .appendingPathComponent(UUID().uuidString)
+            )
+            XCTFail("expected \(expected)")
+        } catch let error as AudioFileImportError {
+            XCTAssertEqual(error, expected)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -185,6 +185,7 @@ targets:
       - path: Sources/Nativ/Features/VoiceCapture/VoiceShortcut.swift
       - path: Sources/Nativ/Features/VoiceCapture/VoiceAnimationPreferences.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
+      - path: Sources/Nativ/Features/VoiceCapture/AudioFileImporter.swift
       - path: Sources/Nativ/Utilities/NativSystemPermissionController.swift
       - path: Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
       - path: Sources/Nativ/Features/MCP/MCPServerCatalog.swift


### PR DESCRIPTION
Adds an Import file action to the Recordings panel that copies or transcodes a chosen audio file into the library and runs the existing transcribe and summarize pipeline, redesigned from current main as a replacement for #253.