### PR TITLE
Add audio upload to the library

### DIFF
--- a/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
@@ -239,7 +239,8 @@ final class AudioAnalyticsStore: ObservableObject {
         recordingURL: URL,
         kind: AudioRecordKind,
         title: String,
-        durationSeconds: TimeInterval?
+        durationSeconds: TimeInterval?,
+        recordedAt: Date? = nil
     ) {
         upsertTranscription(
             recordingURL: recordingURL,
@@ -249,7 +250,8 @@ final class AudioAnalyticsStore: ObservableObject {
             applicationName: nil,
             kind: kind,
             title: title,
-            persistAudioReference: true
+            persistAudioReference: true,
+            recordedAt: recordedAt
         )
     }
 
@@ -440,6 +442,40 @@ final class AudioAnalyticsStore: ObservableObject {
         return values?.contentModificationDate ?? values?.creationDate
     }
 
+    private static func importedAt(from audioFileName: String?) -> Date? {
+        let prefix = "Imported Audio "
+        guard let audioFileName,
+              audioFileName.hasPrefix(prefix)
+        else {
+            return nil
+        }
+
+        let timestamp = String(audioFileName.dropFirst(prefix.count).prefix(26))
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd 'at' HH.mm.ss.SSS"
+        return formatter.date(from: timestamp)
+    }
+
+    private static func replacingRecordedAt(
+        _ recordedAt: Date,
+        in record: AudioTranscriptionRecord
+    ) -> AudioTranscriptionRecord {
+        AudioTranscriptionRecord(
+            id: record.id,
+            recordedAt: recordedAt,
+            updatedAt: record.updatedAt,
+            durationSeconds: record.durationSeconds,
+            transcript: record.transcript,
+            modelID: record.modelID,
+            applicationName: record.applicationName,
+            kind: record.kind,
+            title: record.title,
+            audioFileName: record.audioFileName,
+            summary: record.summary
+        )
+    }
+
     private static func deleteDictationFiles(
         withID recordID: String,
         in directory: URL,
@@ -464,8 +500,21 @@ final class AudioAnalyticsStore: ObservableObject {
             rebuildDerivedMetrics()
             return
         }
-        records = decoded.sorted { $0.recordedAt > $1.recordedAt }
+        var migratedImportedDates = false
+        records = decoded.map { record in
+            guard let importedAt = Self.importedAt(from: record.audioFileName),
+                  importedAt != record.recordedAt
+            else {
+                return record
+            }
+            migratedImportedDates = true
+            return Self.replacingRecordedAt(importedAt, in: record)
+        }
+        .sorted { $0.recordedAt > $1.recordedAt }
         rebuildDerivedMetrics()
+        if migratedImportedDates {
+            save()
+        }
     }
 
     private func save() {

--- a/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
@@ -453,6 +453,7 @@ final class AudioAnalyticsStore: ObservableObject {
         let timestamp = String(audioFileName.dropFirst(prefix.count).prefix(26))
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd 'at' HH.mm.ss.SSS"
         return formatter.date(from: timestamp)
     }

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -51,6 +51,7 @@ enum AudioCaptureLibraryError: LocalizedError {
     case missingSpeechModel
     case missingLanguageModel
     case recordingUnavailable
+    case invalidAudioFile
     case emptyTranscript
 
     var errorDescription: String? {
@@ -67,6 +68,8 @@ enum AudioCaptureLibraryError: LocalizedError {
             "Select a language model before generating a summary."
         case .recordingUnavailable:
             "The saved audio file is no longer available."
+        case .invalidAudioFile:
+            "The selected file does not contain a readable audio track."
         case .emptyTranscript:
             "The recording was saved, but the speech model did not produce a transcript."
         }
@@ -418,6 +421,52 @@ final class AudioCaptureLibrary: ObservableObject {
                 duration: record.durationSeconds ?? 0,
                 automaticallySummarize: false
             )
+        }
+    }
+
+    func importAudio(from sourceURL: URL) async {
+        clearLastError()
+        let isAccessingSecurityScopedResource = sourceURL.startAccessingSecurityScopedResource()
+        defer {
+            if isAccessingSecurityScopedResource {
+                sourceURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        do {
+            let asset = AVURLAsset(url: sourceURL)
+            let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+            guard !audioTracks.isEmpty else {
+                throw AudioCaptureLibraryError.invalidAudioFile
+            }
+
+            let duration = try await asset.load(.duration).seconds
+            guard duration.isFinite, duration > 0 else {
+                throw AudioCaptureLibraryError.invalidAudioFile
+            }
+
+            let recordingURL = try Self.copyImportedAudio(from: sourceURL)
+            let title = sourceURL.deletingPathExtension().lastPathComponent
+            let importedAt = Date()
+            analytics.addCapture(
+                recordingURL: recordingURL,
+                kind: .voiceNote,
+                title: title.isEmpty ? "Imported audio" : title,
+                durationSeconds: duration,
+                recordedAt: importedAt
+            )
+
+            let recordID = recordingURL.deletingPathExtension().lastPathComponent
+            processingRecordIDs.insert(recordID)
+            await processRecording(
+                recordingURL,
+                kind: .voiceNote,
+                title: title.isEmpty ? "Imported audio" : title,
+                duration: duration,
+                automaticallySummarize: true
+            )
+        } catch {
+            lastErrorMessage = "The audio could not be imported: \(error.localizedDescription)"
         }
     }
 
@@ -836,6 +885,18 @@ final class AudioCaptureLibrary: ObservableObject {
         return try recordingsDirectory
             .appendingPathComponent("\(prefix) \(formatter.string(from: Date()))")
             .appendingPathExtension("wav")
+    }
+
+    private static func copyImportedAudio(from sourceURL: URL) throws -> URL {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd 'at' HH.mm.ss.SSS"
+        let fileName = "Imported Audio \(formatter.string(from: Date())) \(UUID().uuidString.prefix(8))"
+        let destinationURL = try recordingsDirectory
+            .appendingPathComponent(fileName)
+            .appendingPathExtension(sourceURL.pathExtension.lowercased())
+        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        return destinationURL
     }
 
     private static func defaultTitle(for kind: AudioRecordKind, date: Date) -> String {

--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -890,6 +890,7 @@ final class AudioCaptureLibrary: ObservableObject {
     private static func copyImportedAudio(from sourceURL: URL) throws -> URL {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd 'at' HH.mm.ss.SSS"
         let fileName = "Imported Audio \(formatter.string(from: Date())) \(UUID().uuidString.prefix(8))"
         let destinationURL = try recordingsDirectory

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -1925,7 +1925,7 @@ struct AudioView: View {
                 }
                 Spacer()
                 Button(action: chooseAudioToImport) {
-                    Label("Upload audio", systemImage: "square.and.arrow.up")
+                    Label("Add Recording", systemImage: "plus")
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
@@ -1980,9 +1980,9 @@ struct AudioView: View {
 
     private func chooseAudioToImport() {
         let panel = NSOpenPanel()
-        panel.title = "Upload audio"
-        panel.message = "Choose an audio file to transcribe and summarize locally."
-        panel.prompt = "Upload"
+        panel.title = "Add Recording"
+        panel.message = "Choose a recording to transcribe and summarize locally."
+        panel.prompt = "Add"
         panel.allowedContentTypes = [.audio]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -3,6 +3,7 @@ import Carbon.HIToolbox
 import Charts
 import SwiftUI
 import Textual
+import UniformTypeIdentifiers
 
 private enum AudioDestination: String, CaseIterable, Identifiable {
     case overview
@@ -1923,6 +1924,12 @@ struct AudioView: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
+                Button(action: chooseAudioToImport) {
+                    Label("Upload audio", systemImage: "square.and.arrow.up")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+
                 Button {
                     destination = .record
                 } label: {
@@ -1969,6 +1976,24 @@ struct AudioView: View {
         }
         .padding(18)
         .audioPanelStyle()
+    }
+
+    private func chooseAudioToImport() {
+        let panel = NSOpenPanel()
+        panel.title = "Upload audio"
+        panel.message = "Choose an audio file to transcribe and summarize locally."
+        panel.prompt = "Upload"
+        panel.allowedContentTypes = [.audio]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.begin { response in
+            guard response == .OK, let sourceURL = panel.url else {
+                return
+            }
+            Task { @MainActor in
+                await captureLibrary.importAudio(from: sourceURL)
+            }
+        }
     }
 
     private func shortcutRow(

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -326,7 +326,7 @@ final class AudioAnalyticsStoreTests: XCTestCase {
         XCTAssertEqual(store.records.first?.recordedAt, importedAt)
     }
 
-    func testMigratesExistingImportedCaptureDateFromManagedFileName() throws {
+    func testMigratesExistingImportedCaptureDateFromUTCManagedFileName() throws {
         let legacyDate = Date(timeIntervalSince1970: 1_700_000_000)
         let importedAudioURL = temporaryDirectory.appendingPathComponent(
             "Imported Audio 2026-08-20 at 02.18.18.000 ABCD1234.m4a"
@@ -343,7 +343,9 @@ final class AudioAnalyticsStoreTests: XCTestCase {
             storageURL: temporaryDirectory.appendingPathComponent("analytics.json")
         )
         let migratedDate = try XCTUnwrap(reloaded.records.first?.recordedAt)
-        let components = Calendar.current.dateComponents(
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        let components = calendar.dateComponents(
             [.year, .month, .day, .hour, .minute, .second],
             from: migratedDate
         )

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -287,6 +287,74 @@ final class AudioAnalyticsStoreTests: XCTestCase {
         )
         XCTAssertEqual(reloaded.records.first?.displayTitle, "Product launch idea")
     }
+
+    func testImportedCaptureUsesImportDateAndPreservesItAfterTranscription() throws {
+        let earlierRecordingURL = temporaryDirectory.appendingPathComponent("earlier.wav")
+        let uploadedAudioURL = temporaryDirectory.appendingPathComponent("uploaded.m4a")
+        let earlierDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let importedAt = earlierDate.addingTimeInterval(3_600)
+
+        store.addCapture(
+            recordingURL: earlierRecordingURL,
+            kind: .voiceNote,
+            title: "Earlier recording",
+            durationSeconds: 30,
+            recordedAt: earlierDate
+        )
+        store.addCapture(
+            recordingURL: uploadedAudioURL,
+            kind: .voiceNote,
+            title: "Uploaded audio",
+            durationSeconds: 60,
+            recordedAt: importedAt
+        )
+
+        XCTAssertEqual(store.records.map(\.id), ["uploaded", "earlier"])
+
+        store.upsertTranscription(
+            recordingURL: uploadedAudioURL,
+            transcript: "A completed uploaded audio transcript.",
+            durationSeconds: 60,
+            modelID: "local-asr",
+            applicationName: nil,
+            kind: .voiceNote,
+            title: "Uploaded audio",
+            persistAudioReference: true
+        )
+
+        XCTAssertEqual(store.records.map(\.id), ["uploaded", "earlier"])
+        XCTAssertEqual(store.records.first?.recordedAt, importedAt)
+    }
+
+    func testMigratesExistingImportedCaptureDateFromManagedFileName() throws {
+        let legacyDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let importedAudioURL = temporaryDirectory.appendingPathComponent(
+            "Imported Audio 2026-08-20 at 02.18.18.000 ABCD1234.m4a"
+        )
+        store.addCapture(
+            recordingURL: importedAudioURL,
+            kind: .voiceNote,
+            title: "Existing upload",
+            durationSeconds: 60,
+            recordedAt: legacyDate
+        )
+
+        let reloaded = AudioAnalyticsStore(
+            storageURL: temporaryDirectory.appendingPathComponent("analytics.json")
+        )
+        let migratedDate = try XCTUnwrap(reloaded.records.first?.recordedAt)
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: migratedDate
+        )
+
+        XCTAssertEqual(components.year, 2026)
+        XCTAssertEqual(components.month, 8)
+        XCTAssertEqual(components.day, 20)
+        XCTAssertEqual(components.hour, 2)
+        XCTAssertEqual(components.minute, 18)
+        XCTAssertEqual(components.second, 18)
+    }
 }
 
 final class FnControlShortcutStateTests: XCTestCase {


### PR DESCRIPTION
## Summary
- add an Upload audio button to the Audio Library recordings panel
- import, transcribe, and automatically summarize selected audio files
- date uploaded items by import time so they appear at the top of the library
- migrate existing imported items without using `updatedAt` for ordering

## Testing
- focused AudioAnalyticsStore import-date regression tests
- unsigned Xcode build, recursive Apple Development signing, signature verification, and app launch

## Screenshot

<img width="1240" height="823" alt="Audio library upload UI" src="https://github.com/user-attachments/assets/60cd1ed0-66af-4314-9c4d-e81ba86e8ddf" />
