### PR TITLE
Improve gated model download errors

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1013,7 +1013,7 @@ private struct ChatImageModelOptionRow: View {
             }
 
             if let error = downloadManager.errorByModelID[model.modelID] {
-                Label(error, systemImage: "exclamationmark.triangle.fill")
+                Label(error.localizedDescription, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -461,7 +461,6 @@ enum HuggingFaceHubError: LocalizedError {
     case invalidResponse
     case requestFailed(Int, String)
     case pythonUnavailable
-    case downloadFailed(String)
     case downloadStalled
     case anotherDownloadInProgress(String)
 
@@ -473,12 +472,42 @@ enum HuggingFaceHubError: LocalizedError {
             message.isEmpty ? "Hugging Face request failed (HTTP \(status))." : message
         case .pythonUnavailable:
             "The bundled model downloader is unavailable."
-        case .downloadFailed(let message):
-            message.isEmpty ? "The model download failed." : message
         case .downloadStalled:
             "The model download stopped responding after multiple automatic retries. Check your connection and try again."
         case .anotherDownloadInProgress(let modelID):
             "Wait for \(modelID) to finish downloading before starting another model download."
+        }
+    }
+}
+
+enum HuggingFaceDownloadFailure: LocalizedError, Equatable {
+    case gatedRepository
+    case message(String)
+
+    init(processOutput: String) {
+        let normalizedOutput = processOutput.lowercased()
+        if normalizedOutput.contains("gatedrepoerror")
+            || normalizedOutput.contains("cannot access gated repo")
+            || normalizedOutput.contains("is restricted and you are not in the authorized list") {
+            self = .gatedRepository
+            return
+        }
+
+        let usefulMessage = processOutput
+            .split(whereSeparator: { $0.isNewline || $0 == "\r" })
+            .suffix(4)
+            .joined(separator: "\n")
+        self = .message(
+            usefulMessage.isEmpty ? "The model download failed. Try again." : usefulMessage
+        )
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .gatedRepository:
+            "This gated model requires access approval from its publisher."
+        case .message(let message):
+            message
         }
     }
 }
@@ -992,7 +1021,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
         let isDownloading: Bool
         let progress: Double
         let isPaused: Bool
-        let error: String?
+        let error: HuggingFaceDownloadFailure?
     }
 
     struct ActiveDownload: Identifiable, Equatable {
@@ -1024,7 +1053,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     }
 
     @Published private(set) var downloads: [ActiveDownload] = []
-    @Published private(set) var errorByModelID: [String: String] = [:]
+    @Published private(set) var errorByModelID: [String: HuggingFaceDownloadFailure] = [:]
     /// Emits the affected model ID for progress/state changes. `nil` denotes
     /// a structural change that can affect capacity for every download row.
     let rowUpdates = PassthroughSubject<String?, Never>()
@@ -1078,7 +1107,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     }
 
     func reportError(_ message: String, for modelID: String) {
-        errorByModelID[modelID] = message
+        errorByModelID[modelID] = .message(message)
     }
 
     func capacityBlocker(sizeBytes: Int64?, cachePath: String) -> String? {
@@ -1101,7 +1130,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     ) {
         guard contexts[repoID] == nil else { return }
         if let blocker = capacityBlocker(sizeBytes: sizeBytes, cachePath: cachePath) {
-            errorByModelID[repoID] = blocker
+            errorByModelID[repoID] = .message(blocker)
             rowUpdates.send(repoID)
             return
         }
@@ -1114,8 +1143,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
                 onCompletion: onCompletion
             )
         } catch {
-            errorByModelID[repoID] =
-                (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            errorByModelID[repoID] = downloadFailure(for: error)
             rowUpdates.send(repoID)
         }
     }
@@ -1141,8 +1169,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
                     onCompletion: nil
                 )
             } catch {
-                errorByModelID[repoID] =
-                    (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                errorByModelID[repoID] = downloadFailure(for: error)
                 rowUpdates.send(repoID)
                 throw error
             }
@@ -1300,8 +1327,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
         let completion = context.onCompletion
         let waiters = Array(context.waiters.values)
         if let error {
-            errorByModelID[repoID] =
-                (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            errorByModelID[repoID] = downloadFailure(for: error)
         }
         removeContext(repoID)
 
@@ -1404,6 +1430,15 @@ final class HuggingFaceDownloadManager: ObservableObject {
         progressLimiters.removeValue(forKey: modelID)
         downloads.removeAll { $0.modelID == modelID }
         rowUpdates.send(nil)
+    }
+
+    private func downloadFailure(for error: Error) -> HuggingFaceDownloadFailure {
+        if let failure = error as? HuggingFaceDownloadFailure {
+            return failure
+        }
+        return .message(
+            (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        )
     }
 
     private func cancelWaiter(_ waiterID: UUID, modelID: String) {
@@ -2040,11 +2075,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         }
         guard process.terminationStatus == 0 else {
             let message = String(decoding: output.snapshot(), as: UTF8.self)
-            let usefulMessage = message
-                .split(whereSeparator: { $0.isNewline || $0 == "\r" })
-                .suffix(4)
-                .joined(separator: "\n")
-            throw HuggingFaceHubError.downloadFailed(usefulMessage)
+            throw HuggingFaceDownloadFailure(processOutput: message)
         }
     }
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -413,6 +413,7 @@ struct ModelsView: View {
                             onClose: { self.readmeSelection = nil }
                         )
                         .frame(width: geometry.size.width * 0.4)
+                        .frame(maxHeight: .infinity, alignment: .top)
                         .transition(.move(edge: .trailing).combined(with: .opacity))
                     }
                 }
@@ -1891,7 +1892,7 @@ private struct HubModelRow: View, @MainActor Equatable {
     let isDownloading: Bool
     let downloadProgress: Double
     let isDownloadPaused: Bool
-    let downloadError: String?
+    let downloadError: HuggingFaceDownloadFailure?
     let onShowReadme: () -> Void
     let onDownload: () -> Void
     let onPauseResume: () -> Void
@@ -2034,10 +2035,7 @@ private struct HubModelRow: View, @MainActor Equatable {
             }
 
             if let downloadError {
-                Label(downloadError, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-                    .textSelection(.enabled)
+                downloadErrorView(downloadError)
             }
         }
         .padding(14)
@@ -2048,6 +2046,38 @@ private struct HubModelRow: View, @MainActor Equatable {
         return model.isGated
             ? "Gated models require Hugging Face authentication."
             : "Download to the configured cache"
+    }
+
+    @ViewBuilder
+    private func downloadErrorView(_ error: HuggingFaceDownloadFailure) -> some View {
+        switch error {
+        case .gatedRepository:
+            VStack(alignment: .leading, spacing: 6) {
+                Label(error.localizedDescription, systemImage: "lock.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                Text("Request access, then add or update the approved account’s token in Developer and retry.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Link(destination: modelHubURL) {
+                    Label("Request access on Hugging Face", systemImage: "arrow.up.right")
+                        .font(.caption.weight(.semibold))
+                }
+            }
+        case .message:
+            Label(error.localizedDescription, systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var modelHubURL: URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/\(model.id)"
+        return components.url ?? URL(string: "https://huggingface.co/")!
     }
 }
 

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -469,7 +469,7 @@ private struct WelcomeView: View {
                 sizeBytes: hubModel.sizeBytes,
                 cachePath: model.settings.modelSearchPath
             ),
-            downloadError: downloadManager.errorByModelID[hubModel.id],
+            downloadError: downloadManager.errorByModelID[hubModel.id]?.localizedDescription,
             onSelect: { selectedModelID = hubModel.id },
             onDownload: { downloadRecommendedModel(hubModel) },
             onCancel: { downloadManager.removeDownload(hubModel.id) }

--- a/Tests/NativTests/LocalModelProviderTests.swift
+++ b/Tests/NativTests/LocalModelProviderTests.swift
@@ -418,6 +418,31 @@ final class HuggingFaceDownloadOutputTests: XCTestCase {
         XCTAssertNil(HuggingFaceDownloadOutput(line: "__NATIV_PROGRESS__:34:0"))
         XCTAssertNil(HuggingFaceDownloadOutput(line: "ordinary log output"))
     }
+
+    func testClassifiesGatedRepositoryFailure() {
+        let failure = HuggingFaceDownloadFailure(processOutput: """
+        huggingface_hub.errors.GatedRepoError: 403 Client Error.
+        Cannot access gated repo for url https://huggingface.co/org/model/resolve/main/config.json.
+        Access to model org/model is restricted and you are not in the authorized list.
+        """)
+
+        XCTAssertEqual(failure, .gatedRepository)
+    }
+
+    func testKeepsUsefulLinesForUnknownDownloadFailure() {
+        let failure = HuggingFaceDownloadFailure(processOutput: """
+        first line
+        second line
+        third line
+        fourth line
+        fifth line
+        """)
+
+        XCTAssertEqual(
+            failure,
+            .message("second line\nthird line\nfourth line\nfifth line")
+        )
+    }
 }
 
 final class HuggingFaceDownloadProgressStateTests: XCTestCase {


### PR DESCRIPTION
currently this is what i see when I try downloading a model I shouln't be able to:

<img width="636" height="253" alt="Screenshot 2026-08-20 at 9 59 56 AM" src="https://github.com/user-attachments/assets/ec0bd0cc-813a-42cb-b00c-57af21c7a868" />


also fixes the readme, by pinning it when gated model is selected:

<img width="1107" height="906" alt="clipboard-2026-08-20-093707-E67E9B39" src="https://github.com/user-attachments/assets/2ce6f4dc-f1a8-46ac-bb24-36b5222af701" />
