### PR TITLE
Reconcile routine launchctl jobs off the main thread to avoid blocking app startup

### DIFF
--- a/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
+++ b/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
@@ -3,11 +3,23 @@ import Foundation
 
 enum RoutineLaunchAgent {
     private static let labelPrefix = "dev.local.Nativ.routine."
+    private static let reconciliationQueue = DispatchQueue(
+        label: "dev.local.Nativ.routine-launch-agent",
+        qos: .utility
+    )
 
     static func refresh(routines: [Routine]) {
-        guard let directory = launchAgentsDirectory,
-              let executablePath = Bundle.main.executablePath
-        else {
+        guard let executablePath = Bundle.main.executablePath else {
+            return
+        }
+
+        reconciliationQueue.async {
+            reconcile(routines: routines, executablePath: executablePath)
+        }
+    }
+
+    private static func reconcile(routines: [Routine], executablePath: String) {
+        guard let directory = launchAgentsDirectory else {
             return
         }
 
@@ -43,8 +55,22 @@ enum RoutineLaunchAgent {
             ) else {
                 continue
             }
-            unload(url)
-            try? data.write(to: url, options: .atomic)
+
+            let fileExists = FileManager.default.fileExists(atPath: url.path)
+            if fileExists,
+               let existingData = try? Data(contentsOf: url),
+               existingData == data {
+                continue
+            }
+
+            if fileExists {
+                unload(url)
+            }
+            do {
+                try data.write(to: url, options: .atomic)
+            } catch {
+                continue
+            }
             load(url)
         }
     }
@@ -96,8 +122,12 @@ enum RoutineLaunchAgent {
         process.arguments = arguments
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
-        try? process.run()
-        process.waitUntilExit()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return
+        }
     }
 }
 

--- a/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
+++ b/Sources/Nativ/Features/Routines/RoutineLaunchAgent.swift
@@ -66,11 +66,7 @@ enum RoutineLaunchAgent {
             if fileExists {
                 unload(url)
             }
-            do {
-                try data.write(to: url, options: .atomic)
-            } catch {
-                continue
-            }
+            try? data.write(to: url, options: .atomic)
             load(url)
         }
     }


### PR DESCRIPTION
This was calling out to `launchctl` and waiting for it to exit on the main thread even though there was nothing to wait for. It also avoids any disk I/O if the routine is already up to date on disk.