### PR TITLE
Check for software updates only after app launch is complete

### DIFF
--- a/Configuration/Nativ-Info.plist
+++ b/Configuration/Nativ-Info.plist
@@ -46,6 +46,8 @@
 	<string>$(NATIV_GITHUB_APP_SLUG)</string>
 	<key>SUFeedURL</key>
 	<string>https://github.com/Blaizzy/nativ/releases/latest/download/appcast.xml</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
 	<key>SUPublicEDKey</key>
 	<string>$(NATIV_SPARKLE_PUBLIC_KEY)</string>
 	<key>UTExportedTypeDeclarations</key>

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -439,6 +439,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @MainA
         if WelcomePreferences.hasCompleted {
             model.startServer()
         }
+        DispatchQueue.main.async { [softwareUpdater] in
+            softwareUpdater.start()
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Sources/Nativ/SoftwareUpdater.swift
+++ b/Sources/Nativ/SoftwareUpdater.swift
@@ -34,10 +34,14 @@ final class SoftwareUpdater {
     init() {
         NativApplicationIcon.registerForInAppUse()
         updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
+            startingUpdater: false,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
+    }
+
+    func start() {
+        updaterController.startUpdater()
     }
 }
 


### PR DESCRIPTION
This prevents blocking app launch on the SU network calls. I also opted in automatic updates by default (the modern standard) to avoid the annoying dialog that otherwise runs on first app launch.