### PR TITLE
Fix non-disappearing button when creating a schedule

### DIFF
--- a/Sources/Nativ/Features/Routines/ScheduledTaskViews.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTaskViews.swift
@@ -200,6 +200,7 @@ struct ScheduledRunRow: View {
 
 struct ScheduledTasksEmptyState: View {
     let onCreate: () -> Void
+    let showsCreateAction: Bool
 
     var body: some View {
         ContentUnavailableView {
@@ -207,8 +208,10 @@ struct ScheduledTasksEmptyState: View {
         } description: {
             Text("Create a task to run a prompt automatically on a recurring schedule.")
         } actions: {
-            Button("New scheduled task", action: onCreate)
-                .buttonStyle(.borderedProminent)
+            if showsCreateAction {
+                Button("New scheduled task", action: onCreate)
+                    .buttonStyle(.borderedProminent)
+            }
         }
     }
 }

--- a/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
@@ -96,7 +96,10 @@ struct ScheduledTasksView: View {
             Divider()
 
             if orderedTasks.isEmpty {
-                ScheduledTasksEmptyState(onCreate: presentNewTask)
+                ScheduledTasksEmptyState(
+                    onCreate: presentNewTask,
+                    showsCreateAction: draft == nil
+                )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 taskList
@@ -116,17 +119,14 @@ struct ScheduledTasksView: View {
 
             Spacer()
 
-            Button(action: presentNewTask) {
-                if draft == nil {
+            if draft == nil {
+                Button(action: presentNewTask) {
                     Label("New scheduled task", systemImage: "plus")
-                } else {
-                    Image(systemName: "plus")
-                        .frame(width: 18, height: 18)
                 }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .help("New scheduled task")
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .help("New scheduled task")
         }
         .padding(.horizontal, 22)
         .padding(.leading, titleLeadingInset)


### PR DESCRIPTION
When a user clicks **New scheduled task**, the action remained visible while the editor was open, allowing another unfinished draft to be created. Hide the create actions until the current draft is saved or canceled.


<img width="1125" height="942" alt="Screenshot 2026-08-20 at 10 25 45 PM" src="https://github.com/user-attachments/assets/13a4823a-88aa-4f8f-ac38-c288e66f68fa" />
