### PR TITLE
Select drafter models in the chat picker to enable speculative decoding

### DIFF
--- a/Docs/features/models.md
+++ b/Docs/features/models.md
@@ -29,9 +29,10 @@ Each model carries a set of capabilities (`LocalModelCapability`):
 | `tools` | Supports tool calling. |
 | `drafter` | Usable as a speculative-decoding draft model. |
 
-Capability determines where a model is offered: only `text` (and non-image `vision`) models
-appear in the conversation model picker; image, speech, and embedding models are selected in
-their own slots.
+Capability determines where a model is offered: chat model pickers use
+`isEligibleForLanguageModelPicker` — `text` (and non-image `vision`) models qualify, while
+`drafter` and `reranking` models are always excluded. Image, speech, and embedding models are
+selected in their own slots.
 
 ## Downloading
 

--- a/Docs/features/models.md
+++ b/Docs/features/models.md
@@ -75,3 +75,12 @@ A draft model can accelerate a larger target model. Enable `speculativeDecodingE
 `draftModelID`; the draft must be capability-compatible with the target. Draft kind and block
 size are configurable (`draftKind`, `draftBlockSize`). Only `drafter`-eligible models are offered
 as drafts, and a mismatched hidden size is flagged as an incompatible target.
+
+Drafters are also listed in the chat composer's model menu, in their own section below the chat
+models. Selecting one does not load it as the main model — it enables speculative decoding with
+that drafter on its compatible target
+([`DrafterTargetResolver`](../../Sources/Nativ/Features/Models/LocalModelDiscovery.swift)): the
+current chat model when compatible, otherwise the name-derived pair (for example
+`Qwen3.8-27B-MTP-8bit` → `Qwen3.8-27B-8bit`), otherwise the first hidden-size-compatible chat
+model. When no compatible target is installed, the menu entry notes that a compatible chat model
+is needed and selecting it does nothing.

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		4CB31A9AACD344FA2CD1B6FD /* VoiceAnimationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632EB67BFAC2BCBE082A3E2B /* VoiceAnimationPreferences.swift */; };
 		4DB478CE9FB6079C7B55B097 /* DevHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E646A2A68BB20D0CD4933E2A /* DevHubView.swift */; };
 		4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */; };
+		D6A77E57C011AB1ED0000001 /* DrafterTargetResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A77E57C011AB1ED0000002 /* DrafterTargetResolverTests.swift */; };
 		4E81E2CBA8DBB61035A07C86 /* ChatDocumentExtractionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */; };
 		4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
 		4FC9EEEC4DFDE7766C2526E2 /* ChatDocumentContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */; };
@@ -520,6 +521,7 @@
 		BF65681C9FD920314BECC7D3 /* Tavily.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Tavily.png; sourceTree = "<group>"; };
 		C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentValidatorTests.swift; sourceTree = "<group>"; };
 		C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscoveryTests.swift; sourceTree = "<group>"; };
+		D6A77E57C011AB1ED0000002 /* DrafterTargetResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrafterTargetResolverTests.swift; sourceTree = "<group>"; };
 		C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSwitchModelTool.swift; sourceTree = "<group>"; };
 		C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTool.swift; sourceTree = "<group>"; };
 		C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolRegistryTests.swift; sourceTree = "<group>"; };
@@ -1097,6 +1099,7 @@
 				2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */,
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
+				D6A77E57C011AB1ED0000002 /* DrafterTargetResolverTests.swift */,
 				8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */,
 				A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */,
 				B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */,
@@ -1574,6 +1577,7 @@
 				F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */,
 				39DF704E9F1D23E2F8248F02 /* LocalModelDiscovery.swift in Sources */,
 				4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */,
+				D6A77E57C011AB1ED0000001 /* DrafterTargetResolverTests.swift in Sources */,
 				4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */,
 				9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */,
 				3583BC09DCAFC37BBB94749D /* MCPHostManager.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		197EBBED5CC651E6364617B5 /* VoiceCaptureOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C93856381B1D89C4DE61DCC /* VoiceCaptureOverlay.swift */; };
 		1A6F5207528E44EA9FF8F831 /* NativChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E6FD97A66F91B3B667B3FE /* NativChatClient.swift */; };
 		1A82A76742BFEEBE881659BD /* TavilyBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90AC464C5C04FB14A3C789 /* TavilyBrowsingProvider.swift */; };
+		1AD6097DBE84CD7647D59724 /* DrafterTargetResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D6160B6EA752DBA0083497 /* DrafterTargetResolverTests.swift */; };
 		1C6295D830FE941FDCE3ECCC /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
 		1CD847CE1BC2696D9306656D /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */; };
 		1DCBC70AA972310D3FBC22CC /* ChatSwitchModelTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */; };
@@ -104,7 +105,6 @@
 		4CB31A9AACD344FA2CD1B6FD /* VoiceAnimationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632EB67BFAC2BCBE082A3E2B /* VoiceAnimationPreferences.swift */; };
 		4DB478CE9FB6079C7B55B097 /* DevHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E646A2A68BB20D0CD4933E2A /* DevHubView.swift */; };
 		4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */; };
-		D6A77E57C011AB1ED0000001 /* DrafterTargetResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A77E57C011AB1ED0000002 /* DrafterTargetResolverTests.swift */; };
 		4E81E2CBA8DBB61035A07C86 /* ChatDocumentExtractionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */; };
 		4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
 		4FC9EEEC4DFDE7766C2526E2 /* ChatDocumentContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */; };
@@ -507,6 +507,7 @@
 		B059AF48F10F1B0502DC5E6F /* ChatConversationBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatConversationBranchTests.swift; sourceTree = "<group>"; };
 		B0E2EE61C1652C49ECC69658 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerCatalogTests.swift; sourceTree = "<group>"; };
+		B2D6160B6EA752DBA0083497 /* DrafterTargetResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrafterTargetResolverTests.swift; sourceTree = "<group>"; };
 		B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerCatalog.swift; sourceTree = "<group>"; };
 		B4E0214BE1D88EB4CDB66836 /* WebBrowsingProviderClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingProviderClient.swift; sourceTree = "<group>"; };
 		B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListModelsTool.swift; sourceTree = "<group>"; };
@@ -521,7 +522,6 @@
 		BF65681C9FD920314BECC7D3 /* Tavily.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Tavily.png; sourceTree = "<group>"; };
 		C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentValidatorTests.swift; sourceTree = "<group>"; };
 		C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscoveryTests.swift; sourceTree = "<group>"; };
-		D6A77E57C011AB1ED0000002 /* DrafterTargetResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrafterTargetResolverTests.swift; sourceTree = "<group>"; };
 		C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSwitchModelTool.swift; sourceTree = "<group>"; };
 		C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTool.swift; sourceTree = "<group>"; };
 		C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolRegistryTests.swift; sourceTree = "<group>"; };
@@ -1093,13 +1093,13 @@
 				83D56A7BC388C8D6DEAEFA18 /* ChatWebReadToolTests.swift */,
 				AFA5142DB692E378ADE8DFA0 /* ChatWebSearchToolTests.swift */,
 				DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */,
+				B2D6160B6EA752DBA0083497 /* DrafterTargetResolverTests.swift */,
 				711EAE65183E78E000DD3253 /* GitHubOAuthTests.swift */,
 				A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */,
 				908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */,
 				2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */,
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
-				D6A77E57C011AB1ED0000002 /* DrafterTargetResolverTests.swift */,
 				8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */,
 				A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */,
 				B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */,
@@ -1558,6 +1558,7 @@
 				1C6295D830FE941FDCE3ECCC /* CodexCLIProfile.swift in Sources */,
 				44F8A17BDE2610C6E90CE53F /* CustomTool.swift in Sources */,
 				AB4C49A5BFDAA9352BD257B7 /* CustomToolTests.swift in Sources */,
+				1AD6097DBE84CD7647D59724 /* DrafterTargetResolverTests.swift in Sources */,
 				9FC9DFAEC00710427FDD509C /* ExaBrowsingProvider.swift in Sources */,
 				CB0D232F71771BF7F3EE2B53 /* FirecrawlBrowsingProvider.swift in Sources */,
 				8E16504AFD5457AC965426F2 /* FnControlShortcutMonitor.swift in Sources */,
@@ -1577,7 +1578,6 @@
 				F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */,
 				39DF704E9F1D23E2F8248F02 /* LocalModelDiscovery.swift in Sources */,
 				4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */,
-				D6A77E57C011AB1ED0000001 /* DrafterTargetResolverTests.swift in Sources */,
 				4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */,
 				9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */,
 				3583BC09DCAFC37BBB94749D /* MCPHostManager.swift in Sources */,

--- a/PythonDistribution/Overlay/nativ_server.py
+++ b/PythonDistribution/Overlay/nativ_server.py
@@ -1302,6 +1302,41 @@ def install_metrics_overlay() -> None:
     async def metrics_endpoint():
         return TRACKER.snapshot()
 
+def reject_drafter_as_main_model(model_id: str) -> None:
+    """Reject speculative drafter checkpoints loaded as the main chat model.
+
+    Drafters (MTP/EAGLE-3/DFlash) are partial models that only work through the
+    speculative decoding path; loading one as the target model crashes the
+    generation thread with an opaque AttributeError. Fail fast with a clear
+    message instead. When the config cannot be read, defer to the normal
+    loading flow and its own error reporting.
+    """
+    try:
+        from mlx_vlm.speculative.drafters import DRAFTER_KIND_BY_MODEL_TYPE
+        from mlx_vlm.utils import get_model_path, load_config
+
+        config = load_config(get_model_path(model_id))
+    except Exception:
+        return
+    model_type = str(
+        config.get("model_type") or config.get("speculators_model_type") or ""
+    ).lower()
+    if not model_type:
+        return
+    is_drafter = model_type in DRAFTER_KIND_BY_MODEL_TYPE or any(
+        marker in model_type for marker in ("mtp", "dflash", "eagle")
+    )
+    if is_drafter:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"{model_id} is a speculative drafter (model_type={model_type!r}) "
+                "and cannot be used as the main model. "
+                "Select it as the draft model for speculative decoding instead."
+            ),
+        )
+
+
     @base.app.post("/models/load", include_in_schema=False)
     @base.app.post("/v1/models/load")
     def load_model_endpoint(request: Request, payload: dict[str, Any]):
@@ -1317,6 +1352,8 @@ def install_metrics_overlay() -> None:
         adapter = payload.get("adapter_path")
         if adapter is not None and not isinstance(adapter, str):
             raise HTTPException(status_code=400, detail="adapter_path must be a string or null.")
+
+        reject_drafter_as_main_model(model.strip())
 
         try:
             base.get_cached_model(model.strip(), adapter)

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -433,7 +433,7 @@ struct ChatComposer: View {
     }
 
     private var languageModels: [LocalModel] {
-        localLibrary.models.filter { $0.capabilities.contains(.text) }
+        localLibrary.models.filter { $0.isEligibleForLanguageModelPicker }
     }
 
     private var selectedModelID: String? {

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -119,6 +119,7 @@ struct ChatComposer: View {
     let onBackdropHeightChange: (CGFloat) -> Void
     @State private var editorContentHeight: CGFloat = 0
     @State private var didApplyInitialReasoningDefault = false
+    @State private var isApplyingDrafterSelection = false
     @State private var showsKits = false
     @State private var showsCapabilities = false
     @State private var showsAddPanel = false
@@ -302,6 +303,12 @@ struct ChatComposer: View {
             applyInitialReasoningDefaultIfNeeded(modelID: selectedModelID, models: models)
         }
         .onChange(of: selectedModelID) { oldModelID, newModelID in
+            // Drafter selection writes the switched model's full configuration itself;
+            // re-running the generic profile swap here would corrupt it.
+            if isApplyingDrafterSelection {
+                isApplyingDrafterSelection = false
+                return
+            }
             applyModelConfigOnSwitch(from: oldModelID, to: newModelID, models: localLibrary.models)
         }
         .onChange(of: model.settings.currentModelProfile) { _, _ in
@@ -428,12 +435,24 @@ struct ChatComposer: View {
             emptyStateActionTitle: nil,
             onEmptyStateAction: nil,
             onSelectModel: select,
-            onSwitchModel: { model.switchLanguageModel(to: $0) }
+            onSwitchModel: { model.switchLanguageModel(to: $0) },
+            drafters: drafterModels,
+            selectedDrafterID: selectedDrafterID,
+            onSelectDrafter: selectDrafter
         )
     }
 
     private var languageModels: [LocalModel] {
         localLibrary.models.filter { $0.isEligibleForLanguageModelPicker }
+    }
+
+    private var drafterModels: [LocalModel] {
+        localLibrary.models.filter { $0.drafterKind != nil }
+    }
+
+    private var selectedDrafterID: String? {
+        guard model.settings.speculativeDecodingActive else { return nil }
+        return model.settings.draftModelID
     }
 
     private var selectedModelID: String? {
@@ -659,6 +678,46 @@ struct ChatComposer: View {
             for: .language,
             availableModels: localLibrary.models
         ) {}
+    }
+
+    /// Picking a drafter from the model menu enables speculative decoding on its
+    /// compatible chat model instead of loading the drafter as the main model.
+    private func selectDrafter(_ drafter: LocalModel) {
+        let currentID = model.settings.normalized().languageModelID
+        guard let target = DrafterTargetResolver.compatibleTarget(
+            for: drafter,
+            currentModelID: currentID,
+            models: localLibrary.models
+        ) else { return }
+
+        var next = model.settings
+        if let currentID, !currentID.isEmpty, currentID != target.repoID {
+            next.rememberProfile(forModel: currentID)
+        }
+        if currentID != target.repoID, let existing = next.modelProfile(for: target.repoID) {
+            next.applyProfile(existing)
+        }
+        next.speculativeDecodingEnabled = true
+        next.draftModelID = drafter.repoID
+        next.draftKind = "auto"
+        next.rememberProfile(forModel: target.repoID)
+
+        if target.repoID == currentID {
+            model.settings = next.normalized()
+            model.restartServer()
+            return
+        }
+
+        model.requestPreloadedModelSwitch(
+            to: target,
+            for: .language,
+            availableModels: localLibrary.models
+        ) {
+            isApplyingDrafterSelection = true
+            var switched = next
+            switched.setModelID(target.repoID, for: .language)
+            model.settings = switched.normalized()
+        }
     }
 
     private var availableReasoningLevels: [ChatReasoningLevel] {
@@ -896,6 +955,9 @@ struct ComposerModelPicker: View {
     let onEmptyStateAction: (() -> Void)?
     let onSelectModel: (LocalModel) -> Void
     let onSwitchModel: (String) -> Void
+    let drafters: [LocalModel]
+    let selectedDrafterID: String?
+    let onSelectDrafter: (LocalModel) -> Void
 
     var body: some View {
         ZStack {
@@ -915,6 +977,9 @@ struct ComposerModelPicker: View {
                 onEmptyStateAction: onEmptyStateAction,
                 onSelectModel: onSelectModel,
                 onSwitchModel: onSwitchModel,
+                drafters: drafters,
+                selectedDrafterID: selectedDrafterID,
+                onSelectDrafter: onSelectDrafter,
                 onTrackingChanged: { isTracking in
                     isMenuOpen = isTracking
                     if !isTracking {
@@ -1000,6 +1065,9 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
     let onEmptyStateAction: (() -> Void)?
     let onSelectModel: (LocalModel) -> Void
     let onSwitchModel: (String) -> Void
+    let drafters: [LocalModel]
+    let selectedDrafterID: String?
+    let onSelectDrafter: (LocalModel) -> Void
     let onTrackingChanged: (Bool) -> Void
 
     func makeCoordinator() -> Coordinator {
@@ -1041,6 +1109,7 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
         private weak var modelSummaryItem: NSMenuItem?
         private weak var secondarySummaryItem: NSMenuItem?
         private var modelOptionViews = [PersistentMenuActionView]()
+        private var drafterOptionViews = [PersistentMenuActionView]()
         private var secondaryOptionViews = [PersistentMenuActionView]()
 
         init(parent: ComposerModelPickerMenuControl) {
@@ -1051,6 +1120,7 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
             // Build the entire tree before tracking begins. Keeping both submenus
             // alive for the whole session prevents hover-driven view replacement.
             modelOptionViews.removeAll()
+            drafterOptionViews.removeAll()
             secondaryOptionViews.removeAll()
             let menu = makeMenu()
             parent.onTrackingChanged(true)
@@ -1122,6 +1192,47 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
                     isSelected: model.repoID == parent.selectedModelID
                 )
                 menu.addItem(item)
+            }
+
+            if !parent.drafters.isEmpty {
+                menu.addItem(.separator())
+                let header = NSMenuItem(
+                    title: "Drafters — speculative decoding",
+                    action: nil,
+                    keyEquivalent: ""
+                )
+                header.isEnabled = false
+                menu.addItem(header)
+
+                for drafter in parent.drafters {
+                    var title = modelMenuLabel(drafter.repoID)
+                    if let kindLabel = drafter.drafterKindLabel {
+                        title += " (\(kindLabel))"
+                    }
+                    let target = DrafterTargetResolver.compatibleTarget(
+                        for: drafter,
+                        currentModelID: parent.selectedModelID,
+                        models: parent.models
+                    )
+                    if target == nil {
+                        title += " — needs a compatible chat model"
+                    }
+                    let item = persistentMenuItem(
+                        title: NSAttributedString(
+                            string: title,
+                            attributes: [.font: Self.menuFont]
+                        ),
+                        optionID: drafter.repoID,
+                        image: nil,
+                        isSelected: drafter.repoID == parent.selectedDrafterID
+                    ) { [weak self] in
+                        self?.selectModel(drafter.repoID)
+                    }
+                    if let itemView = item.view as? PersistentMenuActionView {
+                        drafterOptionViews.append(itemView)
+                    }
+                    menu.addItem(item)
+                }
             }
 
             if parent.models.isEmpty && parent.selectedModelID == nil {
@@ -1221,6 +1332,12 @@ private struct ComposerModelPickerMenuControl: NSViewRepresentable {
         }
 
         private func selectModel(_ repoID: String) {
+            if let drafter = parent.drafters.first(where: { $0.repoID == repoID }) {
+                drafterOptionViews.forEach { $0.isSelected = $0.optionID == repoID }
+                parent.onSelectDrafter(drafter)
+                return
+            }
+
             modelOptionViews.forEach { $0.isSelected = $0.optionID == repoID }
             modelSummaryItem?.title = "Model   \(modelMenuLabel(repoID))"
 

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
@@ -344,7 +344,10 @@ private struct ImageGenerationComposer: View {
             emptyStateActionTitle: "Browse Image Models…",
             onEmptyStateAction: onExploreImageModels,
             onSelectModel: selectImageModel,
-            onSwitchModel: selectImageModel
+            onSwitchModel: selectImageModel,
+            drafters: [],
+            selectedDrafterID: nil,
+            onSelectDrafter: { _ in }
         )
     }
 

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -47,6 +47,8 @@ final class IntegrationsViewModel: ObservableObject {
                         with: [.imageGeneration, .imageEditing]
                     )
                     && !$0.capabilities.contains(.embeddings)
+                    && !$0.capabilities.contains(.drafter)
+                    && !$0.capabilities.contains(.reranking)
             }
             .map(IntegrationModelDescriptor.init)
     }

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -209,6 +209,57 @@ struct LocalModel: Identifiable, Equatable, Sendable {
     }
 }
 
+/// Resolves which chat model a drafter model (MTP/EAGLE/DFlash) accelerates when the
+/// user picks the drafter from the chat model menu. Selecting a drafter enables
+/// speculative decoding on its compatible target instead of loading the drafter itself.
+enum DrafterTargetResolver {
+    static func compatibleTarget(
+        for drafter: LocalModel,
+        currentModelID: String?,
+        models: [LocalModel]
+    ) -> LocalModel? {
+        let chatModels = models.filter { $0.isEligibleForLanguageModelPicker }
+
+        if let currentModelID,
+           let current = chatModels.first(where: { $0.repoID == currentModelID }),
+           isCompatible(drafter: drafter, target: current) {
+            return current
+        }
+
+        for candidate in targetNameCandidates(from: drafter.repoID) {
+            if let match = chatModels.first(where: { $0.repoID == candidate }),
+               isCompatible(drafter: drafter, target: match) {
+                return match
+            }
+        }
+
+        return chatModels.first { isCompatible(drafter: drafter, target: $0) }
+    }
+
+    // Same rule as ChatConfigurationView.isDrafterIncompatible: a hidden-size
+    // mismatch is incompatible, missing metadata is treated as compatible.
+    static func isCompatible(drafter: LocalModel, target: LocalModel) -> Bool {
+        guard let drafterHiddenSize = drafter.hiddenSize,
+              let targetHiddenSize = target.hiddenSize else {
+            return true
+        }
+        return drafterHiddenSize == targetHiddenSize
+    }
+
+    /// "mlx-community/Qwen3.8-27B-MTP-8bit" → "mlx-community/Qwen3.8-27B-8bit".
+    /// Marker order matters: "eagle3" must be tried before "eagle".
+    static func targetNameCandidates(from repoID: String) -> [String] {
+        for marker in ["mtp", "eagle3", "eagle", "dflash"] {
+            if let range = repoID.range(of: "-" + marker, options: .caseInsensitive) {
+                var candidate = repoID
+                candidate.removeSubrange(range)
+                return [candidate]
+            }
+        }
+        return []
+    }
+}
+
 struct LocalModelMemoryEstimate: Equatable, Sendable {
     static let headroomFraction = 0.20
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -802,8 +802,7 @@ struct ModelsView: View {
 
     private func preloadSlots(for localModel: LocalModel) -> [ModelPreloadSlot] {
         var slots: [ModelPreloadSlot] = []
-        if localModel.capabilities.contains(.text)
-            && !localModel.capabilities.contains(.reranking) {
+        if localModel.isEligibleForLanguageModelPicker {
             slots.append(.language)
         }
         if localModel.capabilities.contains(.imageGeneration) {

--- a/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
@@ -245,7 +245,7 @@ struct ScheduledTasksView: View {
 
     @ViewBuilder
     private func editor(for draft: RoutineDraft) -> some View {
-        let textModels = modelLibrary.models.filter { $0.capabilities.contains(.text) }
+        let textModels = modelLibrary.models.filter { $0.isEligibleForLanguageModelPicker }
         let modelIDs = textModels.map(\.repoID)
         let selectedModelID = draft.routine.modelID
         let availableModelIDs = (

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -325,15 +325,23 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
         modelLoadingProgress = settings.normalized().languageModelID == nil ? nil : 0
         var launchArguments = settings.launchArguments
         if let languageModelID = settings.normalized().languageModelID,
-           isKnownNonGenerativeModel(languageModelID),
            let modelFlagIndex = launchArguments.firstIndex(of: "--model"),
            modelFlagIndex + 1 < launchArguments.count {
-            // A stale, non-chat selection (e.g. a BERT encoder) would make the
-            // server abort while pre-loading it. Start on-demand instead so it
-            // still comes up.
-            launchArguments.removeSubrange(modelFlagIndex...(modelFlagIndex + 1))
-            modelLoadingProgress = nil
-            appendLog("\n\(languageModelID) is not a text-generation model — starting the server without pre-loading it. Pick a chat model to load one.\n")
+            if isKnownNonGenerativeModel(languageModelID) {
+                // A stale, non-chat selection (e.g. a BERT encoder) would make the
+                // server abort while pre-loading it. Start on-demand instead so it
+                // still comes up.
+                launchArguments.removeSubrange(modelFlagIndex...(modelFlagIndex + 1))
+                modelLoadingProgress = nil
+                appendLog("\n\(languageModelID) is not a text-generation model — starting the server without pre-loading it. Pick a chat model to load one.\n")
+            } else if isKnownDrafterModel(languageModelID) {
+                // A stale speculative drafter selection (e.g. an MTP checkpoint)
+                // crashes the generation thread once a chat request arrives.
+                // Start on-demand instead so the server still comes up.
+                launchArguments.removeSubrange(modelFlagIndex...(modelFlagIndex + 1))
+                modelLoadingProgress = nil
+                appendLog("\n\(languageModelID) is a speculative drafter, not a chat model — starting the server without pre-loading it. Pick a chat model and set this one as the draft model instead.\n")
+            }
         }
         if let speechToTextModelID = settings.normalized().speechToTextModelID,
            let speechIssue = LocalModelDiscovery.speechToTextPreloadIssue(
@@ -413,6 +421,35 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
                     .map { $0.lowercased() }
                     .contains { arch in generativeMarkers.contains { arch.contains($0) } }
                 return !isGenerative
+            }
+        }
+        return false
+    }
+
+    private func isKnownDrafterModel(_ repoID: String) -> Bool {
+        let cacheName = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
+        let fileManager = FileManager.default
+
+        for root in settings.normalized().modelSearchRoots {
+            let snapshots = URL(fileURLWithPath: root)
+                .appendingPathComponent(cacheName)
+                .appendingPathComponent("snapshots")
+            guard let revisions = try? fileManager.contentsOfDirectory(
+                at: snapshots,
+                includingPropertiesForKeys: nil
+            ) else {
+                continue
+            }
+            for revision in revisions {
+                let configURL = revision.appendingPathComponent("config.json")
+                guard let data = try? Data(contentsOf: configURL),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                else {
+                    continue
+                }
+                let modelType = (json["model_type"] as? String)
+                    ?? (json["speculators_model_type"] as? String)
+                return LocalModelDiscovery.drafterKind(fromModelType: modelType) != nil
             }
         }
         return false

--- a/Tests/NativTests/DrafterTargetResolverTests.swift
+++ b/Tests/NativTests/DrafterTargetResolverTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import XCTest
+
+final class DrafterTargetResolverTests: XCTestCase {
+    func testPrefersCurrentModelWhenCompatible() {
+        let current = makeChatModel(repoID: "mlx-community/Qwen3.8-27B-8bit", hiddenSize: 5_120)
+        let other = makeChatModel(repoID: "mlx-community/Other-7B-8bit", hiddenSize: 5_120)
+        let drafter = makeDrafter(repoID: "mlx-community/Qwen3.8-27B-MTP-8bit", hiddenSize: 5_120)
+
+        let resolved = DrafterTargetResolver.compatibleTarget(
+            for: drafter,
+            currentModelID: current.repoID,
+            models: [current, other, drafter]
+        )
+
+        XCTAssertEqual(resolved?.repoID, current.repoID)
+    }
+
+    func testFallsBackToDerivedNameWhenCurrentModelIsIncompatible() {
+        let current = makeChatModel(repoID: "mlx-community/Unrelated-7B-8bit", hiddenSize: 2_048)
+        let paired = makeChatModel(repoID: "mlx-community/Qwen3.8-27B-8bit", hiddenSize: 5_120)
+        let drafter = makeDrafter(repoID: "mlx-community/Qwen3.8-27B-MTP-8bit", hiddenSize: 5_120)
+
+        let resolved = DrafterTargetResolver.compatibleTarget(
+            for: drafter,
+            currentModelID: current.repoID,
+            models: [current, paired, drafter]
+        )
+
+        XCTAssertEqual(resolved?.repoID, paired.repoID)
+    }
+
+    func testFallsBackToFirstCompatibleChatModelWhenNameDerivationMisses() {
+        let current = makeChatModel(repoID: "mlx-community/Unrelated-7B-8bit", hiddenSize: 2_048)
+        let compatible = makeChatModel(repoID: "mlx-community/SameHidden-9B-4bit", hiddenSize: 5_120)
+        let drafter = makeDrafter(repoID: "mlx-community/Qwen3.8-27B-MTP-8bit", hiddenSize: 5_120)
+
+        let resolved = DrafterTargetResolver.compatibleTarget(
+            for: drafter,
+            currentModelID: current.repoID,
+            models: [current, compatible, drafter]
+        )
+
+        XCTAssertEqual(resolved?.repoID, compatible.repoID)
+    }
+
+    func testReturnsNilWhenNoChatModelIsCompatible() {
+        let current = makeChatModel(repoID: "mlx-community/Unrelated-7B-8bit", hiddenSize: 2_048)
+        let drafter = makeDrafter(repoID: "mlx-community/Qwen3.8-27B-MTP-8bit", hiddenSize: 5_120)
+
+        let resolved = DrafterTargetResolver.compatibleTarget(
+            for: drafter,
+            currentModelID: current.repoID,
+            models: [current, drafter]
+        )
+
+        XCTAssertNil(resolved)
+    }
+
+    func testMissingHiddenSizeMetadataCountsAsCompatible() {
+        let target = makeChatModel(repoID: "mlx-community/Qwen3.8-27B-8bit", hiddenSize: nil)
+        let drafter = makeDrafter(repoID: "mlx-community/Qwen3.8-27B-MTP-8bit", hiddenSize: 5_120)
+
+        let resolved = DrafterTargetResolver.compatibleTarget(
+            for: drafter,
+            currentModelID: nil,
+            models: [drafter, target]
+        )
+
+        XCTAssertEqual(resolved?.repoID, target.repoID)
+    }
+
+    func testTargetNameCandidatesStripDrafterMarker() {
+        XCTAssertEqual(
+            DrafterTargetResolver.targetNameCandidates(from: "mlx-community/Qwen3.8-27B-MTP-8bit"),
+            ["mlx-community/Qwen3.8-27B-8bit"]
+        )
+        XCTAssertEqual(
+            DrafterTargetResolver.targetNameCandidates(from: "org/Foo-EAGLE3-8bit"),
+            ["org/Foo-8bit"]
+        )
+        XCTAssertEqual(
+            DrafterTargetResolver.targetNameCandidates(from: "org/Plain-8bit"),
+            []
+        )
+    }
+
+    private func makeChatModel(repoID: String, hiddenSize: Int?) -> LocalModel {
+        LocalModel(
+            repoID: repoID,
+            snapshotURL: nil,
+            modifiedAt: nil,
+            sizeBytes: nil,
+            parameterCount: nil,
+            quantizationBits: nil,
+            quantizationGroupSize: nil,
+            contextSize: nil,
+            provider: nil,
+            capabilities: [.text],
+            drafterKind: nil,
+            hiddenSize: hiddenSize
+        )
+    }
+
+    private func makeDrafter(repoID: String, hiddenSize: Int?) -> LocalModel {
+        LocalModel(
+            repoID: repoID,
+            snapshotURL: nil,
+            modifiedAt: nil,
+            sizeBytes: nil,
+            parameterCount: nil,
+            quantizationBits: nil,
+            quantizationGroupSize: nil,
+            contextSize: nil,
+            provider: nil,
+            capabilities: [.text, .drafter],
+            drafterKind: "mtp",
+            hiddenSize: hiddenSize
+        )
+    }
+}

--- a/Tests/NativTests/LocalModelDiscoveryTests.swift
+++ b/Tests/NativTests/LocalModelDiscoveryTests.swift
@@ -494,6 +494,25 @@ final class LocalModelDiscoveryTests: XCTestCase {
         XCTAssertTrue(chatModel.isEligibleForLanguageModelPicker)
     }
 
+    func testMTPSnapshotScansAsIneligibleDrafter() async throws {
+        // A real MTP checkpoint (model_type qwen3_5_mtp) must surface both the
+        // .text and .drafter capabilities: it is a language-model family member,
+        // but chat model pickers must keep it out via isEligibleForLanguageModelPicker.
+        try makeTextModelSnapshot(
+            repoID: "mlx-community/Qwen3.8-27B-MTP-8bit",
+            modelType: "qwen3_5_mtp",
+            architectures: ["Qwen3_5MTPDraftModel"],
+            sentenceTransformer: false
+        )
+
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+        let mtp = try XCTUnwrap(models.first)
+        XCTAssertTrue(mtp.capabilities.contains(.text))
+        XCTAssertTrue(mtp.capabilities.contains(.drafter))
+        XCTAssertEqual(mtp.drafterKind, "mtp")
+        XCTAssertFalse(mtp.isEligibleForLanguageModelPicker)
+    }
+
     func testRerankerIsClassifiedAndExcludedFromLanguageModelPicker() async throws {
         try makeTextModelSnapshot(
             repoID: "mlx-community/Qwen3-Reranker-0.6B-mxfp8",


### PR DESCRIPTION
## Problem

Drafter snapshots such as `mlx-community/Qwen3.8-27B-MTP-8bit` carry text-generation tags, so they showed up in chat model pickers. Selecting one loaded the MTP draft model as the main chat model, and the server crashed handling requests:

```
'Qwen3_5MTPDraftModel' object has no attribute 'language_model'
```

(raised by `BatchGenerator(self.model.language_model, ...)` in mlx-vlm's server generation path — a drafter can only run as `--draft-model` of a compatible target, never standalone).

But users who select an MTP model in the picker actually want the `--model Qwen3.8-27B-8bit --draft-model Qwen3.8-27B-MTP-8bit` speculative-decoding combo, not to load the drafter itself.

## What changed

**Drafters can no longer be loaded as chat models.**
- All language-model picker entry points (chat composer, scheduled tasks, model preloading, integrations) now filter with `isEligibleForLanguageModelPicker`, which excludes `drafter`/`reranking` capabilities.
- `NativModel.startServer` skips preloading a known drafter left over in stored settings; the server's `/models/load` rejects drafters as the main model with a 400.

**Selecting a drafter in the chat picker now enables speculative decoding on its target.**
- The chat composer model menu lists drafters in their own "Drafters — speculative decoding" section with a kind badge (e.g. `Qwen3.8-27B-MTP-8bit (MTP)`).
- Selecting one resolves its compatible chat model via `DrafterTargetResolver`: keep the current model when compatible (hidden-size match, missing metadata counts as compatible), then the name-derived pair (`X-27B-MTP-8bit` → `X-27B-8bit`; mtp/eagle3/eagle/dflash markers), then the first compatible chat model. Entries with no compatible target are annotated and inert.
- The selection writes `speculativeDecodingEnabled`/`draftModelID`/`draftKind=auto`, persists it into the target model's per-model profile, and restarts or switches the server with the drafter attached.

## Testing

- New `DrafterTargetResolverTests` (target resolution: current model, name derivation, hidden-size fallback, no-compatible → nil) and an MTP snapshot scanning test (`qwen3_5_mtp` classified as ineligible drafter).
- Full `NativTests` suite passes locally (443 tests, 0 failures).
- Verified end-to-end on device: selecting `Qwen3.8-27B-MTP-8bit (MTP)` in the composer menu restarts the server with `Drafter ready; speculative decoding enabled.` and responses report `draft_kind: mtp` in timings.
