### PR TITLE
Show drafter models as drafters instead of Not supported

### DIFF
--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -801,6 +801,12 @@ struct ModelsView: View {
     }
 
     private func preloadSlots(for localModel: LocalModel) -> [ModelPreloadSlot] {
+        // Drafter models attach to a chat model via Chat settings and never
+        // take a preload slot, even when their model_type resolves as a
+        // language model (e.g. qwen3_5_mtp).
+        guard !localModel.capabilities.contains(.drafter) else {
+            return []
+        }
         var slots: [ModelPreloadSlot] = []
         if localModel.capabilities.contains(.text)
             && !localModel.capabilities.contains(.reranking) {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1524,11 +1524,20 @@ private struct InstalledModelRow: View, @MainActor Equatable {
                                     color: .accentColor
                                 )
                             } else if preloadSlots.isEmpty {
-                                ModelPill(
-                                    title: "Not supported",
-                                    systemImage: "exclamationmark.triangle",
-                                    color: .orange
-                                )
+                                if isDrafter {
+                                    ModelPill(
+                                        title: localModel.drafterKindLabel.map { "\($0) drafter" }
+                                            ?? "Drafter",
+                                        systemImage: "hare",
+                                        color: .purple
+                                    )
+                                } else {
+                                    ModelPill(
+                                        title: "Not supported",
+                                        systemImage: "exclamationmark.triangle",
+                                        color: .orange
+                                    )
+                                }
                             }
                             ForEach(
                                 preloadSlots.filter(selectedPreloadSlots.contains)
@@ -1596,13 +1605,14 @@ private struct InstalledModelRow: View, @MainActor Equatable {
         .padding(14)
         .contentShape(RoundedRectangle(cornerRadius: 12))
         .modelRowBackground(isHighlighted: isReadmeSelected)
-        .alert("Model isn’t supported", isPresented: $showsUnsupportedModelInformation) {
+        .alert(
+            isDrafter ? "Drafter model" : "Model isn’t supported",
+            isPresented: $showsUnsupportedModelInformation
+        ) {
             Button("OK", role: .cancel) {}
                 .keyboardShortcut(.defaultAction)
         } message: {
-            Text(
-                "\(localModel.repoID) is installed in your Hugging Face cache, but Nativ can’t use it for chat, image generation, text-to-speech, or speech-to-text."
-            )
+            Text(unsupportedModelMessage)
         }
         .alert("Delete \(modelName(localModel.repoID))?", isPresented: $showsDeleteConfirmation) {
             Button("Delete Model", role: .destructive, action: onDelete)
@@ -1683,7 +1693,10 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             Button {
                 showsUnsupportedModelInformation = true
             } label: {
-                Label("Unavailable", systemImage: "exclamationmark.triangle")
+                Label(
+                    isDrafter ? "Drafter" : "Unavailable",
+                    systemImage: isDrafter ? "hare" : "exclamationmark.triangle"
+                )
                     .font(.callout.weight(.medium))
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 10)
@@ -1708,7 +1721,25 @@ private struct InstalledModelRow: View, @MainActor Equatable {
         if let preferredPreloadSlot {
             return "Preload \(localModel.repoID) for \(preferredPreloadSlot.displayName)"
         }
+        if isDrafter {
+            return
+                "\(localModel.repoID) is a drafter for speculative decoding — enable it from Chat settings"
+        }
         return "\(localModel.repoID) has no supported preload role"
+    }
+
+    private var isDrafter: Bool {
+        localModel.capabilities.contains(.drafter)
+    }
+
+    private var unsupportedModelMessage: String {
+        if isDrafter {
+            let kindLabel = localModel.drafterKindLabel.map { " (\($0))" } ?? ""
+            return
+                "\(localModel.repoID) is a drafter model\(kindLabel) for speculative decoding. It doesn’t load on its own — enable it from Chat settings under “Enable drafter” to accelerate a compatible chat model."
+        }
+        return
+            "\(localModel.repoID) is installed in your Hugging Face cache, but Nativ can’t use it for chat, image generation, text-to-speech, or speech-to-text."
     }
 }
 


### PR DESCRIPTION
## Problem

MTP/EAGLE/DFlash drafter models (e.g. `mlx-community/Qwen3.8-27B-MTP-8bit`) aren't eligible for the language picker — they're attached to a compatible chat model via Chat settings → "Enable drafter" for speculative decoding instead. Their row in Models should say so, but the current treatment depends on the drafter's `model_type`:

- Drafters whose `model_type` isn't language-mapped fall into the `preloadSlots.isEmpty` branch and show an orange "Not supported" pill plus an "Unavailable" button.
- `qwen3_5_mtp` resolves as a language model type, so MTP checkpoints got a Language preload slot and a working preload button — bypassing the language picker's eligibility filter and offering to "preload" a drafter that can't run standalone.

## Fix

Render drafter-specific UI instead:

- `preloadSlots(for:)` now returns empty for models with the `.drafter` capability — drafters never take a preload slot, so the row treatment below applies to every drafter kind
- Title pill reads "MTP drafter" (falls back to "Drafter") in purple instead of "Not supported"
- Action button reads "Drafter" with the `hare` icon instead of "Unavailable"
- The info alert explains the model is a speculative-decoding drafter and points to Chat settings → "Enable drafter"
- Hover help text updated accordingly

Verified with `make xcode-build` (Debug, BUILD SUCCEEDED) and by checking the row, pill, and info alert render correctly with `mlx-community/Qwen3.8-27B-MTP-8bit` in the Hugging Face cache.