### PR TITLE
Fix multi-key audio shortcut capture

### DIFF
--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -3096,7 +3096,9 @@ private final class ShortcutRecorderNSView: NSView {
     override var acceptsFirstResponder: Bool { true }
 
     override func flagsChanged(with event: NSEvent) {
-        let modifiers = VoiceShortcutModifiers(eventFlags: event.modifierFlags)
+        let modifiers = VoiceShortcutModifiers(
+            cgEventFlags: CGEventSource.flagsState(.combinedSessionState)
+        )
         if modifiers.isEmpty {
             if !pendingModifiers.isEmpty {
                 onCapture?(


### PR DESCRIPTION
Fixes #339 

Audio shortcut recorder replaced the pending modifier set with the flags from the latest `flagsChanged` event. On macOS 27, that event can report only the modifier that changed, so pressing Control + Option saved only the last key.

It now reads the complete session modifier state with `CGEventSource.flagsState(.combinedSessionState)` before updating the recorder. This preserves every held modifier until the shortcut is captured.