### PR TITLE
Improve server termination logging

### DIFF
--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -478,7 +478,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
             return
         }
 
-        stopServer(reason: .configurationRestart)
+        stopServer(preserveSessionStats: false, reason: .configurationRestart)
         guard !server.isRunning else {
             appendLog("\nCould not stop the current server to apply the configuration change.\n")
             return

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -18,6 +18,13 @@ private struct PendingModelPreloadSwitch {
     let onSelectionAccepted: () -> Void
 }
 
+private enum RequestedServerStopReason: String {
+    case stopRequest = "a stop request"
+    case modelSwitch = "a model switch"
+    case configurationRestart = "a configuration restart"
+    case appTermination = "app termination"
+}
+
 struct ModelLoadFailure: Equatable, Identifiable, Sendable {
     let id = UUID()
     let modelID: String?
@@ -76,6 +83,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     private var preservedSessionMetrics: NativMetrics?
     private var preservedSessionTokenActivity: [SessionTokenActivitySample] = []
     private var isStoppingForModelSwitch = false
+    private var requestedServerStopReason: RequestedServerStopReason?
     private var pendingModelPreloadSwitch: PendingModelPreloadSwitch?
     private var pendingServerRestartID: UUID?
     private var serverRestartTask: Task<Void, Never>?
@@ -419,6 +427,13 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     }
 
     func stopServer(preserveSessionStats: Bool = false) {
+        stopServer(preserveSessionStats: preserveSessionStats, reason: .stopRequest)
+    }
+
+    private func stopServer(
+        preserveSessionStats: Bool,
+        reason: RequestedServerStopReason
+    ) {
         cancelPendingServerRestart()
         modelLoadingProgress = nil
         if preserveSessionStats {
@@ -431,10 +446,13 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
         do {
             appendLog("\nStopping mlx-vlm-server...\n")
+            requestedServerStopReason = reason
             try server.stop()
         } catch NativError.notRunning {
+            requestedServerStopReason = nil
             appendLog("\nmlx-vlm-server is not running.\n")
         } catch {
+            requestedServerStopReason = nil
             appendLog("\nFailed to stop mlx-vlm-server: \(error)\n")
         }
 
@@ -460,7 +478,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
             return
         }
 
-        stopServer()
+        stopServer(reason: .configurationRestart)
         guard !server.isRunning else {
             appendLog("\nCould not stop the current server to apply the configuration change.\n")
             return
@@ -626,7 +644,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
             if self.server.isRunning {
                 self.isStoppingForModelSwitch = true
-                self.stopServer(preserveSessionStats: true)
+                self.stopServer(preserveSessionStats: true, reason: .modelSwitch)
                 await Task.yield()
                 self.isStoppingForModelSwitch = false
             }
@@ -695,6 +713,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
         allTimeStatsLoadTask = nil
         stopMetricsPolling(clearSession: true)
         if server.isRunning {
+            requestedServerStopReason = .appTermination
             try? server.stop(timeout: 2)
         }
         isRunning = false
@@ -779,7 +798,12 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
         }
         server.onTermination = { [weak self] status in
             Task { @MainActor [weak self] in
-                guard let self, !self.server.isRunning else {
+                guard let self else {
+                    return
+                }
+                let stopReason = self.requestedServerStopReason
+                self.requestedServerStopReason = nil
+                guard !self.server.isRunning else {
                     return
                 }
                 let wasLoadingModel = self.modelSwitchInProgress
@@ -796,7 +820,15 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
                         message: message
                     )
                 }
-                self.appendLog("\nmlx-vlm-server stopped with status \(status)\n")
+                if let stopReason {
+                    self.appendLog(
+                        "\nmlx-vlm-server stopped after Nativ requested \(stopReason.rawValue) (status \(status))\n"
+                    )
+                } else {
+                    self.appendLog(
+                        "\nmlx-vlm-server stopped unexpectedly (status \(status); Nativ did not request a stop)\n"
+                    )
+                }
                 self.isRunning = false
                 self.settingsAppliedAtServerStart = nil
                 self.huggingFaceTokenAppliedAtServerStart = nil


### PR DESCRIPTION
Logs now distinguish Nativ-requested server stops from unexpected terminations while preserving raw mlx-vlm failure details.

Lifecycle context remains local to Nativ, clarifying diagnostics without changing engine behavior or error handling.

Edit:

Before:

```
mlx-vlm-server stopped with status 143
```
After:

After Nativ stops it for a model switch:

```
mlx-vlm-server stopped after Nativ requested a model switch (status 143)
```


After an unrequested engine or external termination:
```
mlx-vlm-server stopped unexpectedly (status 143; Nativ did not request a stop)
```

also because I wasn't able to verify errors like this: https://github.com/Blaizzy/nativ/issues/338