### PR TITLE
Make live resizing of the sidebar smooth and avoid truncating titles unnecessarily

### DIFF
--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarRows.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarRows.swift
@@ -56,7 +56,7 @@ struct ControlPanelRecentSessionRow: View {
                             if !focused, isRenaming { commitRename() }
                         }
                 }
-                .padding(.trailing, 52)
+                .padding(.trailing, isHovering && !isSelecting ? 52 : 0)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .sidebarRowSelectionStyle(isSelected: isSelecting ? isChecked : isSelected)
             } else {
@@ -95,7 +95,7 @@ struct ControlPanelRecentSessionRow: View {
 
                         Spacer(minLength: 0)
                     }
-                    .padding(.trailing, 52)
+                    .padding(.trailing, isHovering && !isSelecting ? 52 : 0)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .contentShape(.rect)
                     .sidebarRowSelectionStyle(isSelected: isSelecting ? isChecked : isSelected)

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
@@ -177,7 +177,7 @@ extension ControlPanelView {
             (isHovering ? NSCursor.resizeLeftRight : NSCursor.arrow).set()
         }
         .gesture(
-            DragGesture(minimumDistance: 0)
+            DragGesture(minimumDistance: 0, coordinateSpace: .global)
                 .onChanged { value in
                     if sidebarDragStartWidth == nil {
                         sidebarDragStartWidth = sidebarWidth

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSupportViews.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSupportViews.swift
@@ -15,7 +15,7 @@ enum FooterControl {
 enum ControlPanelLayout {
     static let sidebarMinimumWidth: CGFloat = 220
     static let sidebarIdealWidth: CGFloat = 260
-    static let sidebarMaximumWidth: CGFloat = 320
+    static let sidebarMaximumWidth: CGFloat = 480
     static let detailMinimumWidth: CGFloat = 720
     static let titlebarHeight: CGFloat = 52
     static let sidebarBrandTopClearance: CGFloat = 46


### PR DESCRIPTION
The coordinate system on the drag gesture wasn't set up correctly which was causing jitter when resizing. This also makes it so the titles occupy the visible space when the buttons aren't visible.

https://github.com/user-attachments/assets/33ee2127-f87a-4344-a0a1-e89a061b65de

