### PR TITLE
Migrate SystemMonitorStore to @Observable

### DIFF
--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
@@ -190,10 +190,10 @@ final class SystemMonitorStore {
     private let collector = SystemMetricsCollector()
     private let displayFPSSampler = SystemDisplayFPSSampler()
     private let aneSampler = SystemANEUtilizationSampler()
-    nonisolated(unsafe) private var samplingTask: Task<Void, Never>?
+    private var samplingTask: Task<Void, Never>?
     private let historyLimit = 300
 
-    deinit {
+    isolated deinit {
         samplingTask?.cancel()
     }
 

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
@@ -1,10 +1,10 @@
 import AppKit
-import Combine
 import CoreGraphics
 import Darwin
 import Foundation
 import IOKit
 import Metal
+import Observation
 import QuartzCore
 
 struct SystemHistorySample: Identifiable, Equatable, Sendable {
@@ -172,24 +172,25 @@ struct SystemMonitorSnapshot: Equatable, Sendable {
 }
 
 @MainActor
-final class SystemMonitorStore: ObservableObject {
-    @Published private(set) var snapshot = SystemMonitorSnapshot()
-    @Published private(set) var cpuHistory: [SystemHistorySample] = []
-    @Published private(set) var gpuHistory: [SystemHistorySample] = []
-    @Published private(set) var aneHistory: [SystemHistorySample] = []
-    @Published private(set) var fpsHistory: [SystemHistorySample] = []
-    @Published private(set) var memoryHistory: [SystemHistorySample] = []
-    @Published private(set) var swapHistory: [SystemHistorySample] = []
-    @Published private(set) var diskReadHistory: [SystemHistorySample] = []
-    @Published private(set) var diskWriteHistory: [SystemHistorySample] = []
-    @Published private(set) var temperatureHistory: [SystemHistorySample] = []
-    @Published private(set) var powerHistory: [SystemHistorySample] = []
-    @Published private(set) var isSampling = false
+@Observable
+final class SystemMonitorStore {
+    private(set) var snapshot = SystemMonitorSnapshot()
+    private(set) var cpuHistory: [SystemHistorySample] = []
+    private(set) var gpuHistory: [SystemHistorySample] = []
+    private(set) var aneHistory: [SystemHistorySample] = []
+    private(set) var fpsHistory: [SystemHistorySample] = []
+    private(set) var memoryHistory: [SystemHistorySample] = []
+    private(set) var swapHistory: [SystemHistorySample] = []
+    private(set) var diskReadHistory: [SystemHistorySample] = []
+    private(set) var diskWriteHistory: [SystemHistorySample] = []
+    private(set) var temperatureHistory: [SystemHistorySample] = []
+    private(set) var powerHistory: [SystemHistorySample] = []
+    private(set) var isSampling = false
 
     private let collector = SystemMetricsCollector()
     private let displayFPSSampler = SystemDisplayFPSSampler()
     private let aneSampler = SystemANEUtilizationSampler()
-    private var samplingTask: Task<Void, Never>?
+    nonisolated(unsafe) private var samplingTask: Task<Void, Never>?
     private let historyLimit = 300
 
     deinit {

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -48,7 +48,7 @@ private enum SystemMonitorDestination: String, CaseIterable, Identifiable {
 }
 
 struct SystemMonitorView: View {
-    @ObservedObject var store: SystemMonitorStore
+    var store: SystemMonitorStore
     @ObservedObject var menuBarPreferences: SystemMenuBarPreferences
     var titleLeadingInset: CGFloat = 0
     @State private var destination: SystemMonitorDestination = .overview


### PR DESCRIPTION
Another polish, the system monitor updated views it didn't need to, this makes observation proerty-level instead. 11 values are published every sec, under `ObservableObject`

With `@Observable`, views re-render only when a property they actually read changes

No API or behavior change: same `start/stop/refresh/collectSnapshot` surface, same sampling cadence.