### PR TITLE
Move server logs into a dedicated observable store

### DIFF
--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -173,7 +173,7 @@ struct DeveloperView: View {
 
     private var logPanel: some View {
         let output = LogOutput.filtered(
-            model.logText,
+            model.serverLogs.text,
             query: logQuery,
             level: logLevelFilter
         )
@@ -186,7 +186,7 @@ struct DeveloperView: View {
             ZStack {
                 LogTextView(text: output.text, searchQuery: logQuery)
 
-                if model.logText.isEmpty {
+                if model.serverLogs.text.isEmpty {
                     ContentUnavailableView(
                         "No server output",
                         systemImage: "terminal",
@@ -541,7 +541,7 @@ struct DeveloperView: View {
                 title: "Clear logs",
                 systemImage: "trash",
                 hoverTint: .red,
-                isDisabled: model.logText.isEmpty
+                isDisabled: model.serverLogs.text.isEmpty
             ) {
                 model.clearLogs()
             }
@@ -560,7 +560,7 @@ struct DeveloperView: View {
     }
 
     private func logSummary(_ output: LogOutput) -> String {
-        if model.logText.isEmpty {
+        if model.serverLogs.text.isEmpty {
             return "No output yet"
         }
         if !logQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || logLevelFilter != .all {

--- a/Sources/Nativ/Features/IssueReport/IssueReport.swift
+++ b/Sources/Nativ/Features/IssueReport/IssueReport.swift
@@ -82,7 +82,7 @@ enum IssueDiagnostics {
     }
 
     static func serverOutputTail(model: NativModel, maxLines: Int = 60) -> [String] {
-        let lines = model.logText
+        let lines = model.serverLogs.text
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map(String.init)
             .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import NativServerKit
+import Observation
 
 struct SessionTokenActivitySample: Equatable, Sendable {
     let recordedAt: Date
@@ -33,9 +34,28 @@ struct ModelLoadFailure: Equatable, Identifiable, Sendable {
 }
 
 @MainActor
+@Observable
+final class ServerLogStore {
+    private(set) var text = ""
+
+    private let maxLogCharacters = 250_000
+
+    func append(_ newOutput: String) {
+        text.append(newOutput)
+        if text.count > maxLogCharacters {
+            text.removeFirst(text.count - maxLogCharacters)
+        }
+    }
+
+    func clear() {
+        text = ""
+    }
+}
+
+@MainActor
 final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     @Published private(set) var isRunning = false
-    @Published private(set) var logText = ""
+    let serverLogs = ServerLogStore()
     @Published private(set) var metrics: NativMetrics?
     @Published private(set) var lastMetricsError: String?
     @Published private(set) var lastMetricsFetchAt: Date?
@@ -81,7 +101,6 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     private var serverRestartTask: Task<Void, Never>?
     private var currentServerOutput = ""
 
-    private let maxLogCharacters = 250_000
     private let maxCurrentServerOutputCharacters = 50_000
     private let maxSessionActivitySamples = 120
 
@@ -707,7 +726,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     }
 
     func clearLogs() {
-        logText = ""
+        serverLogs.clear()
     }
 
     func reportModelLoadFailure(modelID: String?, error: Error) {
@@ -918,10 +937,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     }
 
     private func appendLog(_ text: String) {
-        logText.append(text)
-        if logText.count > maxLogCharacters {
-            logText.removeFirst(logText.count - maxLogCharacters)
-        }
+        serverLogs.append(text)
     }
 
     private func handleServerOutput(_ text: String) {


### PR DESCRIPTION
Incoming server logs re-rendered unrelated screens. Now they update only the developer log views.

Accumulation now lives in a dedicated `@MainActor @Observable ServerLogStore`; only the developer log panel and issue reports read it, so log traffic invalidates just those views.


