### PR TITLE
Render the chat transcript lazily

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -117,7 +117,7 @@ private struct ChatTranscriptView: View {
         let latestUserMessageID = chat.latestUserMessageID
 
         ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+            LazyVStack(alignment: .leading, spacing: 12) {
                 if chat.visibleMessages.isEmpty {
                     if chat.messages.isEmpty {
                         ChatEmptyTranscriptView(


### PR DESCRIPTION
Transcript rows were all built upfront even off-screen; LazyVStack now builds them on demand, keeping long chats scrolling smoothly with identical behavior.