### PR TITLE
Secure local server access

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -16,7 +16,7 @@ For running Nativ, building from source, and the project layout, see the
 | [Voice](features/voice.md) | Voice dictation, global shortcuts, hands-free and push-to-talk capture, transcription, and permissions. |
 | [Scheduled](features/routines.md) | Saved prompts that run on a schedule with task-specific capabilities. |
 | [Integrations](features/integrations.md) | Serving local models over OpenAI- and Anthropic-compatible APIs, MCP host usage, and per-tool coding-agent and editor setup. |
-| [Developer](features/developer.md) | Server host and port, local API endpoints, logs, performance analytics, and the system monitor. |
+| [Developer](features/developer.md) | Local server port and authentication, API endpoints, logs, performance analytics, and the system monitor. |
 
 ## Extending Nativ
 

--- a/Docs/features/developer.md
+++ b/Docs/features/developer.md
@@ -8,14 +8,15 @@ observe it. Sources:
 
 ## Server and endpoints
 
-The bundled server listens on `http://127.0.0.1:8080` by default. Host and port are set in the
-Developer page (`serverHost` / `serverPort`); the page lists every endpoint and copies URLs
-directly. An optional server API key (`serverAPIKey`) is sent as a bearer token.
+The bundled server listens only on this Mac at `http://127.0.0.1:8080`. The port is set in the
+Developer page (`serverPort`); the host is permanently restricted to loopback. The page lists
+every endpoint and copies URLs directly. A generated server API key (`serverAPIKey`) is required
+as a bearer token for every HTTP and WebSocket request and is stored in Keychain.
 
 ```sh
 curl http://127.0.0.1:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer nativ' \
+  -H 'Authorization: Bearer <server-api-key>' \
   -d '{"model":"<model-id>","messages":[{"role":"user","content":"Hi"}],"stream":false}'
 ```
 

--- a/Docs/features/integrations.md
+++ b/Docs/features/integrations.md
@@ -8,10 +8,11 @@ automatically; the per-tool sections below document what each one needs for manu
 
 - OpenAI-compatible base URL: `http://127.0.0.1:8080/v1`
 - Anthropic-compatible base URL: `http://127.0.0.1:8080`
-- API key: `nativ` by default, or the server API key set on the Welcome screen.
+- API key: the generated server API key shown on the Welcome and Developer pages.
 - Model: the repository ID of a loaded model (for example `mlx-community/Qwen3.5-9B-MLX-4bit`).
 
-A different host or port (set in the [Developer](developer.md) page) substitutes everywhere below.
+A different port set in the [Developer](developer.md) page substitutes everywhere below. The host
+is always `127.0.0.1`, so clients must run on the same Mac.
 
 ## MCP host
 
@@ -32,7 +33,7 @@ pieces via [Kits](../extending/kits.md).
 ### Pi
 Minimal, extensible coding agent.
 - Config: `~/.pi/agent/models.json` — a `nativ` provider (`api: openai-completions`,
-  `baseUrl: http://127.0.0.1:8080/v1`, `apiKey: nativ`) with the loaded models.
+  `baseUrl: http://127.0.0.1:8080/v1`, `apiKey: <server-api-key>`) with the loaded models.
 - Run: `pi --provider nativ --model <model-id>`
 
 ### Codex
@@ -46,53 +47,53 @@ OpenAI coding agent for the terminal.
   env_key = "NATIV_API_KEY"
   wire_api = "responses"
   ```
-- Run: `NATIV_API_KEY=nativ codex --profile nativ --model <model-id>`
+- Run: `NATIV_API_KEY=<server-api-key> codex --profile nativ --model <model-id>`
 
 ### Claude Code
 Anthropic's agentic coding tool. Points at the Anthropic-compatible endpoint.
-- Environment: `ANTHROPIC_BASE_URL=http://127.0.0.1:8080`, `ANTHROPIC_AUTH_TOKEN=nativ`,
+- Environment: `ANTHROPIC_BASE_URL=http://127.0.0.1:8080`, `ANTHROPIC_AUTH_TOKEN=<server-api-key>`,
   `ANTHROPIC_API_KEY=` (empty), `ANTHROPIC_MODEL=<model-id>`, `ANTHROPIC_SMALL_FAST_MODEL=<model-id>`
 - Run: `claude --model <model-id>` with the environment above.
 
 ### Hermes
 Open agent with tools, skills, and memory.
 - Config: `~/.hermes/profiles/nativ/config.yaml` — a `custom` provider with
-  `base_url: http://127.0.0.1:8080/v1`, `api_key: nativ`, `api_mode: chat_completions`.
+  `base_url: http://127.0.0.1:8080/v1`, `api_key: <server-api-key>`, `api_mode: chat_completions`.
 - Run: `hermes -p nativ chat --provider custom --model <model-id>`
 
 ### OpenCode
 Open-source coding agent.
 - Config: an `opencode.json` using the `@ai-sdk/openai-compatible` provider `nativ`
-  (`baseURL: http://127.0.0.1:8080/v1`, `apiKey: nativ`).
+  (`baseURL: http://127.0.0.1:8080/v1`, `apiKey: <server-api-key>`).
 - Run: `OPENCODE_CONFIG=<path> opencode --model nativ/<model-id>`
 
 ### Aider
 AI pair programming in the terminal.
-- Config (env file): `OPENAI_API_BASE=http://127.0.0.1:8080/v1`, `OPENAI_API_KEY=nativ`
+- Config (env file): `OPENAI_API_BASE=http://127.0.0.1:8080/v1`, `OPENAI_API_KEY=<server-api-key>`
 - Run: `aider --env-file <path> --model openai/<model-id>`
 
 ### Goose
 Extensible on-machine AI agent.
 - Config: `~/.config/goose/custom_providers/nativ.json` — an `openai` engine provider with
   `base_url: http://127.0.0.1:8080/v1/chat/completions` and `api_key_env: NATIV_API_KEY`.
-- Run: `NATIV_API_KEY=nativ GOOSE_MODEL=<model-id> goose session start --provider nativ`
+- Run: `NATIV_API_KEY=<server-api-key> GOOSE_MODEL=<model-id> goose session start --provider nativ`
 
 ### Crush
 Terminal coding agent.
 - Config: a `crush.json` with an `openai-compat` provider `nativ`
-  (`base_url: http://127.0.0.1:8080/v1`, `api_key: nativ`); large and small models set to `nativ`.
+  (`base_url: http://127.0.0.1:8080/v1`, `api_key: <server-api-key>`); large and small models set to `nativ`.
 - Run: `CRUSH_GLOBAL_CONFIG=<path> crush`
 
 ### Qwen Code
 Agentic coding CLI; works with any served model.
-- Environment: `OPENAI_BASE_URL=http://127.0.0.1:8080/v1`, `OPENAI_API_KEY=nativ`,
+- Environment: `OPENAI_BASE_URL=http://127.0.0.1:8080/v1`, `OPENAI_API_KEY=<server-api-key>`,
   `OPENAI_MODEL=<model-id>`
 - Run: `qwen` with the environment above.
 
 ### OpenClaw
 Open personal AI agent and gateway.
 - Config: `~/.openclaw/openclaw.json` — adds `models.providers.nativ` (`api: openai-completions`,
-  `baseUrl: http://127.0.0.1:8080/v1`, `apiKey: nativ`).
+  `baseUrl: http://127.0.0.1:8080/v1`, `apiKey: <server-api-key>`).
 - Run: `openclaw agent --model nativ/<model-id>`
 
 ## Editors
@@ -100,34 +101,34 @@ Open personal AI agent and gateway.
 ### Zed
 - Config: `~/.config/zed/settings.json` — `language_models.openai_compatible.nativ` with
   `api_url: http://127.0.0.1:8080/v1` and the available models.
-- Run: `NATIV_API_KEY=nativ zed .`
+- Run: `NATIV_API_KEY=<server-api-key> zed .`
 
 ### Continue
 - Config: a `continue-config.yaml` with `provider: openai`, `apiBase: http://127.0.0.1:8080/v1`,
-  `apiKey: nativ`, and roles `chat`, `edit`, `apply`.
+  `apiKey: <server-api-key>`, and roles `chat`, `edit`, `apply`.
 - Run: `cn --config <path>`
 
 ### VS Code (Copilot BYOK)
 1. Start the server and load a model from the Models page.
 2. Command Palette → "Chat: Manage Language Models".
-3. Choose "OpenAI Compatible", set base URL `http://127.0.0.1:8080/v1` and key `nativ`, then pick
+3. Choose "OpenAI Compatible", set base URL `http://127.0.0.1:8080/v1` and the server API key, then pick
    the model. Requires the GitHub Copilot extension, signed in.
 
 ### Cline
 1. Install the Cline extension in VS Code (or a compatible editor).
 2. Add an API Provider of type "OpenAI Compatible".
-3. Set base URL `http://127.0.0.1:8080/v1` and key `nativ`, then select the model.
+3. Set base URL `http://127.0.0.1:8080/v1` and the server API key, then select the model.
 
 ### Cursor
 1. Settings → Models.
-2. Enable "Override OpenAI Base URL" and set `http://127.0.0.1:8080/v1` with key `nativ`.
+2. Enable "Override OpenAI Base URL" and set `http://127.0.0.1:8080/v1` with the server API key.
 3. Add the model name, then select it in the chat model picker. Only the chat/AI panel honors a
    custom OpenAI endpoint — Tab and inline edits stay on Cursor's own models.
 
 ### JetBrains AI Assistant
 1. Settings → Tools → AI Assistant → Models.
 2. Under Providers & API keys, add an "OpenAI Compatible" provider with base URL
-   `http://127.0.0.1:8080/v1` and key `nativ`.
+   `http://127.0.0.1:8080/v1` and the server API key.
 3. Select the model. Requires the AI Assistant plugin.
 
 ## Buzz
@@ -135,7 +136,7 @@ Open personal AI agent and gateway.
 A self-hostable workspace where people and AI agents share rooms; its agent runtime selects a
 provider from environment variables.
 - Environment: `BUZZ_AGENT_PROVIDER=openai`, `OPENAI_COMPAT_BASE_URL=http://127.0.0.1:8080/v1`,
-  `OPENAI_COMPAT_API_KEY=nativ`, `OPENAI_COMPAT_MODEL=<model-id>` (or `BUZZ_AGENT_MODEL`);
+  `OPENAI_COMPAT_API_KEY=<server-api-key>`, `OPENAI_COMPAT_MODEL=<model-id>` (or `BUZZ_AGENT_MODEL`);
   optional `OPENAI_COMPAT_API=chat` to force Chat Completions.
 - Anthropic instead: `BUZZ_AGENT_PROVIDER=anthropic`, `ANTHROPIC_BASE_URL=http://127.0.0.1:8080`,
-  `ANTHROPIC_API_KEY=nativ`, `ANTHROPIC_MODEL=<model-id>`.
+  `ANTHROPIC_API_KEY=<server-api-key>`, `ANTHROPIC_MODEL=<model-id>`.

--- a/PythonDistribution/Overlay/nativ_server.py
+++ b/PythonDistribution/Overlay/nativ_server.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sqlite3
+import sys
 import time
 import uuid
 from contextvars import ContextVar
@@ -18,11 +19,18 @@ import mlx.core as mx
 from fastapi import HTTPException, Request
 from fastapi.responses import Response
 from mlx.utils import tree_flatten
+from starlette.middleware.cors import CORSMiddleware
 
 import mlx_vlm.server as base
 import mlx_vlm.server.cli as base_cli
 import mlx_vlm.server.generation as base_generation
 import mlx_vlm.server.openai as base_openai
+from nativ_server_security import (
+    LOOPBACK_SERVER_HOST,
+    ServerAuthenticationMiddleware,
+    remove_middleware,
+    validate_server_start,
+)
 
 
 BACKEND_NAME = f"mlx_vlm/{base.__version__}"
@@ -1304,12 +1312,8 @@ def install_metrics_overlay() -> None:
 
     @base.app.post("/models/load", include_in_schema=False)
     @base.app.post("/v1/models/load")
-    def load_model_endpoint(request: Request, payload: dict[str, Any]):
+    def load_model_endpoint(payload: dict[str, Any]):
         """Load or hot-swap the text model without restarting the server."""
-        require_api_key = getattr(base, "_require_management_api_key", None)
-        if require_api_key is not None:
-            require_api_key(request)
-
         model = payload.get("model")
         if not isinstance(model, str) or not model.strip():
             raise HTTPException(status_code=400, detail="A non-empty model is required.")
@@ -1334,12 +1338,8 @@ def install_metrics_overlay() -> None:
 
     @base.app.post("/routines/{routine_id}/run", include_in_schema=False)
     @base.app.post("/v1/routines/{routine_id}/run")
-    def run_routine_endpoint(routine_id: str, request: Request):
+    def run_routine_endpoint(routine_id: str):
         """Queue a routine for the Nativ app to run."""
-        require_api_key = getattr(base, "_require_management_api_key", None)
-        if require_api_key is not None:
-            require_api_key(request)
-
         if not routine_id.strip():
             raise HTTPException(status_code=400, detail="A routine id is required.")
 
@@ -1354,16 +1354,41 @@ def install_metrics_overlay() -> None:
         return {"status": "queued", "routine_id": routine_id}
 
 
+def install_security_overlay() -> None:
+    if getattr(base.app.state, "nativ_security_installed", False):
+        return
+    remove_middleware(base.app, CORSMiddleware)
+    base.app.add_middleware(ServerAuthenticationMiddleware)
+    base.app.state.nativ_security_installed = True
+
+
 def main() -> None:
+    validate_server_start(sys.argv[1:])
     install_metrics_overlay()
+    install_security_overlay()
     install_metrics_access_log_filter()
     original_argparse = base_cli.argparse
 
-    def nativ_argument_parser(*args: Any, **kwargs: Any):
-        kwargs["description"] = "Nativ."
-        return original_argparse.ArgumentParser(*args, **kwargs)
+    class NativArgumentParser(original_argparse.ArgumentParser):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["description"] = "Nativ."
+            super().__init__(*args, **kwargs)
 
-    base_cli.argparse = SimpleNamespace(ArgumentParser=nativ_argument_parser)
+        def add_argument(self, *names: str, **kwargs: Any):
+            if "--host" in names:
+                kwargs["default"] = LOOPBACK_SERVER_HOST
+                kwargs["help"] = (
+                    "Host for the HTTP server; loopback addresses only "
+                    f"(default: {LOOPBACK_SERVER_HOST})."
+                )
+            elif "--api-key" in names:
+                kwargs["help"] = (
+                    "Required bearer token for every endpoint. May also be set "
+                    "with MLX_VLM_SERVER_API_KEY."
+                )
+            return super().add_argument(*names, **kwargs)
+
+    base_cli.argparse = SimpleNamespace(ArgumentParser=NativArgumentParser)
     try:
         base.main()
     finally:
@@ -1372,6 +1397,7 @@ def main() -> None:
 
 install_model_load_progress()
 install_metrics_overlay()
+install_security_overlay()
 
 
 if __name__ == "__main__":

--- a/PythonDistribution/Overlay/nativ_server_security.py
+++ b/PythonDistribution/Overlay/nativ_server_security.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import ipaddress
+import os
+import secrets
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+API_KEY_ENVIRONMENT_VARIABLE = "MLX_VLM_SERVER_API_KEY"
+LOOPBACK_SERVER_HOST = "127.0.0.1"
+DEFAULT_SERVER_HOST = LOOPBACK_SERVER_HOST
+HELP_ARGUMENTS = frozenset({"-h", "--help", "--version"})
+
+
+class ServerSecurityConfigurationError(ValueError):
+    pass
+
+
+def normalized_api_key(value: str | None) -> str | None:
+    if value is None:
+        return None
+    token = value.strip()
+    return token if token else None
+
+
+def requested_host(
+    arguments: Sequence[str],
+    default: str = DEFAULT_SERVER_HOST,
+) -> str:
+    host = default
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--host":
+            if index + 1 >= len(arguments):
+                raise ServerSecurityConfigurationError("--host requires a value")
+            host = arguments[index + 1]
+            index += 2
+            continue
+        if argument.startswith("--host="):
+            host = argument.partition("=")[2]
+        index += 1
+    return host.strip()
+
+
+def requested_api_key(
+    arguments: Sequence[str],
+    environment: Mapping[str, str],
+) -> str | None:
+    api_key = environment.get(API_KEY_ENVIRONMENT_VARIABLE)
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--api-key":
+            if index + 1 >= len(arguments):
+                raise ServerSecurityConfigurationError("--api-key requires a value")
+            api_key = arguments[index + 1]
+            index += 2
+            continue
+        if argument.startswith("--api-key="):
+            api_key = argument.partition("=")[2]
+        index += 1
+    return normalized_api_key(api_key)
+
+
+def is_loopback_host(host: str) -> bool:
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_server_start(
+    arguments: Sequence[str],
+    environment: Mapping[str, str] | None = None,
+    default_host: str = DEFAULT_SERVER_HOST,
+) -> None:
+    if any(argument in HELP_ARGUMENTS for argument in arguments):
+        return
+    values = os.environ if environment is None else environment
+    if requested_api_key(arguments, values) is None:
+        raise ServerSecurityConfigurationError("A server API key is required")
+    host = requested_host(arguments, default=default_host)
+    if not is_loopback_host(host):
+        raise ServerSecurityConfigurationError(
+            f"Server host {host!r} is not a loopback address"
+        )
+
+
+def remove_middleware(application: Any, middleware_type: type[Any]) -> None:
+    middleware = application.user_middleware
+    retained = [item for item in middleware if item.cls is not middleware_type]
+    if len(retained) == len(middleware):
+        return
+    application.user_middleware = retained
+    application.middleware_stack = None
+
+
+class ServerAuthenticationMiddleware:
+    def __init__(self, application: Any, api_key: str | None = None) -> None:
+        token = normalized_api_key(
+            os.environ.get(API_KEY_ENVIRONMENT_VARIABLE) if api_key is None else api_key
+        )
+        if token is None:
+            raise ServerSecurityConfigurationError("A server API key is required")
+        self.application = application
+        self.expected_authorization = f"Bearer {token}".encode("utf-8")
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope["type"] not in {"http", "websocket"}:
+            await self.application(scope, receive, send)
+            return
+        authorization = [
+            value
+            for name, value in scope.get("headers", [])
+            if name.lower() == b"authorization"
+        ]
+        if len(authorization) == 1 and secrets.compare_digest(
+            authorization[0], self.expected_authorization
+        ):
+            await self.application(scope, receive, send)
+            return
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": 1008})
+            return
+        body = b'{"detail":"Not authenticated"}'
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                    (b"www-authenticate", b"Bearer"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})

--- a/PythonDistribution/Scripts/build_mlx_vlm_server.py
+++ b/PythonDistribution/Scripts/build_mlx_vlm_server.py
@@ -29,6 +29,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PYTHON_DISTRIBUTION_ROOT = REPO_ROOT / "PythonDistribution"
 LAUNCHER_SOURCE = PYTHON_DISTRIBUTION_ROOT / "Launcher" / "mlx_vlm_server_launcher.c"
 OVERLAY_SERVER = PYTHON_DISTRIBUTION_ROOT / "Overlay" / "nativ_server.py"
+OVERLAY_SECURITY = PYTHON_DISTRIBUTION_ROOT / "Overlay" / "nativ_server_security.py"
 IMAGE_MODEL_MANIFEST_GENERATOR = Path(__file__).with_name(
     "generate_image_model_manifest.py"
 )
@@ -310,6 +311,7 @@ def build_signature(
         ),
         "launcher_sha256": file_sha256(LAUNCHER_SOURCE),
         "overlay_server_sha256": file_sha256(OVERLAY_SERVER),
+        "overlay_security_sha256": file_sha256(OVERLAY_SECURITY),
         "image_model_manifest_generator_sha256": file_sha256(
             IMAGE_MODEL_MANIFEST_GENERATOR
         ),
@@ -614,9 +616,10 @@ def site_packages_dir(output: Path) -> Path:
 
 
 def install_overlay(output: Path) -> None:
-    destination = site_packages_dir(output) / OVERLAY_SERVER.name
-    log(f"Installing metrics overlay {OVERLAY_SERVER.name}")
-    shutil.copy2(OVERLAY_SERVER, destination)
+    destination = site_packages_dir(output)
+    for source in (OVERLAY_SERVER, OVERLAY_SECURITY):
+        log(f"Installing server overlay {source.name}")
+        shutil.copy2(source, destination / source.name)
 
 
 def install_image_model_manifest(output: Path) -> None:
@@ -645,6 +648,14 @@ def verify_distribution(output: Path, *, expect_mlx_vlm: bool) -> None:
                 "-c",
                 "import importlib.util; "
                 "raise SystemExit(0 if importlib.util.find_spec('nativ_server') else 1)",
+            ]
+        )
+        run(
+            [
+                str(python),
+                "-c",
+                "import importlib.util; "
+                "raise SystemExit(0 if importlib.util.find_spec('nativ_server_security') else 1)",
             ]
         )
         manifest_path = output / IMAGE_MODEL_MANIFEST_FILENAME

--- a/PythonDistribution/Tests/test_nativ_server_security.py
+++ b/PythonDistribution/Tests/test_nativ_server_security.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "Overlay"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "Scripts"))
+
+import build_mlx_vlm_server
+from nativ_server_security import API_KEY_ENVIRONMENT_VARIABLE
+from nativ_server_security import ServerAuthenticationMiddleware
+from nativ_server_security import ServerSecurityConfigurationError
+from nativ_server_security import remove_middleware
+from nativ_server_security import requested_api_key
+from nativ_server_security import requested_host
+from nativ_server_security import validate_server_start
+
+
+class ServerStartPolicyTests(unittest.TestCase):
+    def test_loopback_requires_api_key(self) -> None:
+        with self.assertRaisesRegex(
+            ServerSecurityConfigurationError,
+            "API key is required",
+        ):
+            validate_server_start(["--host", "127.0.0.1"], {})
+
+    def test_non_loopback_is_rejected_with_api_key(self) -> None:
+        with self.assertRaisesRegex(
+            ServerSecurityConfigurationError,
+            "not a loopback address",
+        ):
+            validate_server_start(
+                ["--host", "0.0.0.0"],
+                {API_KEY_ENVIRONMENT_VARIABLE: "nativ_test"},
+            )
+
+    def test_ipv4_and_ipv6_loopback_are_accepted(self) -> None:
+        environment = {API_KEY_ENVIRONMENT_VARIABLE: "nativ_test"}
+        validate_server_start(["--host=127.0.0.1"], environment)
+        validate_server_start(["--host", "::1"], environment)
+
+    def test_default_host_is_loopback(self) -> None:
+        validate_server_start(
+            [],
+            {API_KEY_ENVIRONMENT_VARIABLE: "nativ_test"},
+        )
+
+    def test_help_does_not_require_runtime_security_configuration(self) -> None:
+        validate_server_start(["--help"], {})
+
+    def test_last_host_argument_wins(self) -> None:
+        self.assertEqual(
+            requested_host(["--host", "0.0.0.0", "--host=127.0.0.1"]),
+            "127.0.0.1",
+        )
+
+    def test_command_line_api_key_is_accepted(self) -> None:
+        validate_server_start(
+            ["--host", "127.0.0.1", "--api-key", "nativ_test"],
+            {},
+        )
+        self.assertEqual(
+            requested_api_key(["--api-key=nativ_test"], {}),
+            "nativ_test",
+        )
+
+    def test_blank_command_line_api_key_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ServerSecurityConfigurationError,
+            "API key is required",
+        ):
+            validate_server_start(["--api-key", " "], {})
+
+    def test_missing_command_line_api_key_value_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ServerSecurityConfigurationError,
+            "--api-key requires a value",
+        ):
+            validate_server_start(["--api-key"], {})
+
+
+class ServerAuthenticationMiddlewareTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.downstream_calls = 0
+        self.messages: list[dict[str, object]] = []
+
+        async def application(scope, receive, send) -> None:
+            self.downstream_calls += 1
+            if scope["type"] == "http":
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 204,
+                        "headers": [],
+                    }
+                )
+                await send({"type": "http.response.body", "body": b""})
+
+        self.middleware = ServerAuthenticationMiddleware(
+            application,
+            api_key="nativ_test",
+        )
+
+    async def receive(self) -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(self, message: dict[str, object]) -> None:
+        self.messages.append(message)
+
+    async def test_http_request_without_credentials_is_rejected(self) -> None:
+        await self.middleware(
+            {"type": "http", "headers": []},
+            self.receive,
+            self.send,
+        )
+        self.assertEqual(self.downstream_calls, 0)
+        self.assertEqual(self.messages[0]["status"], 401)
+        self.assertIn(
+            (b"www-authenticate", b"Bearer"),
+            self.messages[0]["headers"],
+        )
+
+    async def test_http_request_with_credentials_is_allowed(self) -> None:
+        await self.middleware(
+            {
+                "type": "http",
+                "headers": [(b"authorization", b"Bearer nativ_test")],
+            },
+            self.receive,
+            self.send,
+        )
+        self.assertEqual(self.downstream_calls, 1)
+        self.assertEqual(self.messages[0]["status"], 204)
+
+    async def test_duplicate_authorization_headers_are_rejected(self) -> None:
+        await self.middleware(
+            {
+                "type": "http",
+                "headers": [
+                    (b"authorization", b"Bearer nativ_test"),
+                    (b"authorization", b"Bearer nativ_test"),
+                ],
+            },
+            self.receive,
+            self.send,
+        )
+        self.assertEqual(self.downstream_calls, 0)
+        self.assertEqual(self.messages[0]["status"], 401)
+
+    async def test_websocket_without_credentials_is_closed(self) -> None:
+        await self.middleware(
+            {"type": "websocket", "headers": []},
+            self.receive,
+            self.send,
+        )
+        self.assertEqual(self.downstream_calls, 0)
+        self.assertEqual(
+            self.messages,
+            [{"type": "websocket.close", "code": 1008}],
+        )
+
+
+class MiddlewareConfigurationTests(unittest.TestCase):
+    def test_removes_every_matching_middleware_and_resets_stack(self) -> None:
+        class RemovedMiddleware:
+            pass
+
+        class RetainedMiddleware:
+            pass
+
+        application = SimpleNamespace(
+            user_middleware=[
+                SimpleNamespace(cls=RemovedMiddleware),
+                SimpleNamespace(cls=RetainedMiddleware),
+                SimpleNamespace(cls=RemovedMiddleware),
+            ],
+            middleware_stack=object(),
+        )
+        remove_middleware(application, RemovedMiddleware)
+        self.assertEqual(
+            [item.cls for item in application.user_middleware],
+            [RetainedMiddleware],
+        )
+        self.assertIsNone(application.middleware_stack)
+
+
+class DistributionPackagingTests(unittest.TestCase):
+    def test_installs_both_server_overlay_modules(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            destination = output / "python/lib/python3.12/site-packages"
+            destination.mkdir(parents=True)
+
+            build_mlx_vlm_server.install_overlay(output)
+
+            for source in (
+                build_mlx_vlm_server.OVERLAY_SERVER,
+                build_mlx_vlm_server.OVERLAY_SECURITY,
+            ):
+                installed = destination / source.name
+                self.assertEqual(installed.read_bytes(), source.read_bytes())
+
+    def test_security_overlay_changes_invalidate_distribution_cache(self) -> None:
+        signature = build_mlx_vlm_server.build_signature(
+            asset=build_mlx_vlm_server.Asset("python.tar.gz", "https://example.test"),
+            python_version="3.12",
+            pbs_release="test",
+            target="aarch64-apple-darwin",
+            requirements=None,
+            mlx_vlm_source=None,
+            mlx_audio_source=None,
+            skip_install=False,
+        )
+
+        self.assertEqual(
+            signature["overlay_security_sha256"],
+            build_mlx_vlm_server.file_sha256(
+                build_mlx_vlm_server.OVERLAY_SECURITY
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Full feature and contributor documentation lives in **[`Docs/`](Docs/README.md)*
 | **System monitor** | Inspect live per-core CPU load, GPU utilization, unified memory and swap pressure, disk throughput, capacity, SMART health, and thermal and power sensors. |
 | **Local APIs** | OpenAI-compatible chat, Responses, image, audio, embeddings, and model endpoints, plus Anthropic Messages endpoints. |
 | **Coding-tool integrations** | Configure and launch terminal coding agents — Codex, Claude Code, Pi, Hermes, OpenCode, Aider, Goose, Crush, Qwen Code, OpenClaw — and set up editors — VS Code, Cursor, Zed, JetBrains, Cline, Continue — against models served by Nativ. See [Docs/features/integrations.md](Docs/features/integrations.md) for per-tool setup. |
-| **Developer workspace** | Set the server host and port, add a Hugging Face token for gated models, inspect runtime details, copy endpoint URLs, search and filter live server logs, and monitor server health. |
+| **Developer workspace** | Set the local server port, rotate its required API key, add a Hugging Face token for gated models, inspect runtime details, copy endpoint URLs, search and filter live server logs, and monitor server health. |
 | **Menu bar controls** | Start or stop the server, change the loaded model, check serving statistics, open the main app without breaking focus, or pin multiple live CPU, GPU, and RAM percentages and mini graphs. |
 | **Extension platform** | Install, disable, remove, and restore independently versioned capabilities. Audio ships as the first included extension and contributes its own pages, commands, shortcuts, settings, and permission declarations. |
 | **Audio extension** | Use private local audio capabilities, including voice dictation in any app with either a pointer-following waveform or a camera-cutout pill with a reactive gradient orb and timer. Review transcript history, track words per minute, total words, time saved, and streaks, choose an installed speech model, and customize the record and retry shortcuts. |
@@ -93,7 +93,7 @@ Download the latest DMG from [GitHub Releases](https://github.com/Blaizzy/nativ/
 On first launch:
 
 1. Choose an installed language model, download a recommended one, or continue with load-on-demand.
-2. Optionally generate an API key to protect the server's management endpoints.
+2. Save the generated API key. Nativ requires it for every server endpoint and stores it in Keychain.
 3. Grant microphone, accessibility, and screen recording permissions up front, or change them later in Settings.
 4. Open **Models** to download or select a compatible model.
 5. Start chatting, inspect analytics, or connect one of the supported coding tools.
@@ -138,13 +138,14 @@ branch is detected automatically, matching the existing local `mlx-vlm` behavior
 
 ## Use Nativ as a local API server
 
-By default, the app exposes its server at `http://127.0.0.1:8080`. You can change the host and port in the Developer page, which also lists every available endpoint and lets you copy URLs directly.
+The app serves only on this Mac at `http://127.0.0.1:8080`. You can change the port in the Developer page, which also lets you rotate or copy the required API key, lists every available endpoint, and lets you copy URLs directly.
 
 For example, with a model selected:
 
 ```sh
 curl http://127.0.0.1:8080/v1/chat/completions \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer your-api-key' \
   -d '{
     "model": "your-model-id",
     "messages": [{"role": "user", "content": "Why is the sky blue?"}],
@@ -152,11 +153,7 @@ curl http://127.0.0.1:8080/v1/chat/completions \
   }'
 ```
 
-If you enabled a server API key, also send it as a Bearer token:
-
-```sh
--H 'Authorization: Bearer your-api-key'
-```
+Copy the API key from the Developer page and send it as a Bearer token with every request.
 
 The server includes:
 

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -256,7 +256,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
         NSApplication.shared.activate(ignoringOtherApps: true)
     }
 
-    private func completeWelcome(modelID: String?, serverAPIKey: String?) {
+    private func completeWelcome(modelID: String?, serverAPIKey: String) {
         var settings = model.settings
         settings.languageModelID = modelID
         settings.serverAPIKey = serverAPIKey

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -5,7 +5,6 @@ import NativServerKit
 import SwiftUI
 
 private enum EndpointEditorField: Hashable {
-    case host
     case port
 }
 
@@ -256,7 +255,7 @@ struct DeveloperView: View {
                     endpointCategoryPicker
                         .frame(width: 300, alignment: .leading)
 
-                    serverHostField
+                    serverHostDisplay
 
                     serverPortField
                 }
@@ -269,7 +268,7 @@ struct DeveloperView: View {
                         endpointCategoryPicker
                             .frame(width: 320)
 
-                        serverHostField
+                        serverHostDisplay
 
                         serverPortField
 
@@ -284,7 +283,7 @@ struct DeveloperView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     HStack(spacing: 10) {
-                        serverHostField
+                        serverHostDisplay
                         serverPortField
                         Spacer(minLength: 0)
                     }
@@ -401,25 +400,18 @@ struct DeveloperView: View {
         }
     }
 
-    private var serverHostField: some View {
+    private var serverHostDisplay: some View {
         HStack(spacing: 6) {
             Text("Host")
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.primary)
-            TextField("", text: $model.settings.serverHost)
-                .textFieldStyle(.plain)
+            Text(model.settings.serverHost)
                 .font(.callout.monospaced())
-                .focused($focusedEndpointField, equals: .host)
-                .editableFieldChrome(
-                    isFocused: focusedEndpointField == .host
-                )
+                .foregroundStyle(.secondary)
                 .frame(width: 144)
                 .accessibilityLabel("Server host")
-                .onSubmit {
-                    model.settings.serverHost = model.settings.normalized().serverHost
-                }
         }
-        .help("The host or IP address the local server binds to. Changes restart a running server after 3 seconds.")
+        .help("The server is restricted to this Mac.")
     }
 
     private var serverEndpointProbeID: String {
@@ -643,11 +635,10 @@ private extension View {
 }
 
 private struct ServerAPIAuthenticationPanel: View {
-    let token: String?
-    let onSetToken: (String?) -> Void
+    let token: String
+    let onSetToken: (String) -> Void
     @State private var tokenEntry = ""
     @State private var isEditingToken = false
-    @State private var showsRemovalConfirmation = false
     @FocusState private var tokenFieldIsFocused: Bool
 
     private var activeToken: String? {
@@ -682,21 +673,6 @@ private struct ServerAPIAuthenticationPanel: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
-        .alert(
-            "Remove the server API token?",
-            isPresented: $showsRemovalConfirmation
-        ) {
-            Button("Remove Token") {
-                onSetToken(nil)
-            }
-            .keyboardShortcut(.defaultAction)
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text(
-                "API requests will no longer require this token. "
-                    + "The running server restarts automatically."
-            )
-        }
     }
 
     private var authenticationHeader: some View {
@@ -725,7 +701,7 @@ private struct ServerAPIAuthenticationPanel: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text("Server API Authentication")
                     .font(.callout.weight(.semibold))
-                Text("Protect API requests with a custom Bearer token.")
+                Text("Every API request requires this Bearer token.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
@@ -747,15 +723,15 @@ private struct ServerAPIAuthenticationPanel: View {
     }
 
     private var authenticationStatus: String {
-        activeToken == nil ? "Not Configured" : "Configured"
+        "Configured"
     }
 
     private var authenticationStatusImage: String {
-        activeToken == nil ? "circle.dashed" : "checkmark.circle.fill"
+        "checkmark.circle.fill"
     }
 
     private var authenticationStatusColor: Color {
-        activeToken == nil ? .secondary : .green
+        .green
     }
 
     private var credentialOverview: some View {
@@ -827,33 +803,24 @@ private struct ServerAPIAuthenticationPanel: View {
     }
 
     private var credentialStatus: some View {
-        Label(
-            activeToken == nil ? "No Active Credential" : "Active Credential",
-            systemImage: activeToken == nil ? "key" : "key.fill"
-        )
+        Label("Active Credential", systemImage: "key.fill")
         .font(.caption.weight(.semibold))
-        .foregroundStyle(activeToken == nil ? .secondary : .primary)
+        .foregroundStyle(.primary)
         .fixedSize()
     }
 
     @ViewBuilder
     private var credentialActions: some View {
-        if activeToken != nil {
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 8) {
-                    copyTokenButton
-                    changeTokenButton
-                    removeTokenButton
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    copyTokenButton
-                    changeTokenButton
-                    removeTokenButton
-                }
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                copyTokenButton
+                changeTokenButton
             }
-        } else {
-            addTokenButton
+
+            VStack(alignment: .leading, spacing: 8) {
+                copyTokenButton
+                changeTokenButton
+            }
         }
     }
 
@@ -874,24 +841,6 @@ private struct ServerAPIAuthenticationPanel: View {
             Label("Change", systemImage: "pencil")
         }
         .buttonStyle(.bordered)
-    }
-
-    private var removeTokenButton: some View {
-        Button(role: .destructive) {
-            showsRemovalConfirmation = true
-        } label: {
-            Label("Remove", systemImage: "trash")
-        }
-        .buttonStyle(.bordered)
-    }
-
-    private var addTokenButton: some View {
-        Button {
-            beginEditingToken()
-        } label: {
-            Label("Add Token", systemImage: "plus")
-        }
-        .buttonStyle(.borderedProminent)
     }
 
     private var tokenEditor: some View {
@@ -942,7 +891,7 @@ private struct ServerAPIAuthenticationPanel: View {
 
     private var tokenEditorTitle: some View {
         Label(
-            activeToken == nil ? "Add Server API Token" : "Replace Server API Token",
+            "Replace Server API Token",
             systemImage: "key.fill"
         )
         .font(.caption.weight(.semibold))

--- a/Sources/Nativ/Features/Integrations/IntegrationServices.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationServices.swift
@@ -20,7 +20,7 @@ struct IntegrationProfileManager {
 
     init(
         serverBaseURL: URL,
-        serverAPIKey: String? = nil,
+        serverAPIKey: String,
         fileManager: FileManager = .default,
         homeDirectory: URL? = nil,
         applicationSupportDirectory: URL? = nil
@@ -29,12 +29,9 @@ struct IntegrationProfileManager {
         self.fileManager = fileManager
         self.homeDirectory = resolvedHomeDirectory
         self.serverBaseURL = serverBaseURL
-        let normalizedAPIKey = serverAPIKey?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let normalizedAPIKey, !normalizedAPIKey.isEmpty {
-            self.apiKey = normalizedAPIKey
-        } else {
-            self.apiKey = "nativ"
-        }
+        let normalizedAPIKey = serverAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        precondition(!normalizedAPIKey.isEmpty)
+        self.apiKey = normalizedAPIKey
         self.applicationSupportDirectory = applicationSupportDirectory
             ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? resolvedHomeDirectory

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -66,6 +66,10 @@ final class IntegrationsViewModel: ObservableObject {
         profiles.openAIBaseURL
     }
 
+    var integrationAPIKey: String {
+        profiles.apiKey
+    }
+
     var modelSearchPaths: LocalModelSearchPaths {
         serverModel.settings.localModelSearchPaths
     }
@@ -74,7 +78,7 @@ final class IntegrationsViewModel: ObservableObject {
         serverModel.activeServerBaseURL ?? serverModel.settings.serverBaseURL
     }
 
-    private var serverAPIKey: String? {
+    private var serverAPIKey: String {
         serverModel.settings.normalized().serverAPIKey
     }
 
@@ -596,7 +600,7 @@ private struct IntegrationDetailView: View {
         IntegrationPanel(title: "Guided setup", systemImage: "sparkles") {
             Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 8) {
                 IntegrationConfigurationRow(label: "Endpoint", value: viewModel.integrationEndpoint)
-                IntegrationConfigurationRow(label: "API key", value: "nativ")
+                IntegrationConfigurationRow(label: "API key", value: viewModel.integrationAPIKey)
             }
 
             VStack(alignment: .leading, spacing: 8) {

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -46,12 +46,20 @@ enum Main {
             do {
                 let smokeHost = ProcessInfo.processInfo.environment["NATIV_SMOKE_HOST"] ?? "127.0.0.1"
                 let smokePort = ProcessInfo.processInfo.environment["NATIV_SMOKE_PORT"] ?? "18080"
-                try server.start(arguments: ["--host", smokeHost, "--port", smokePort])
+                let smokeAPIKey = ServerAPIAuthentication.generateToken()
+                try server.start(
+                    arguments: ["--host", smokeHost, "--port", smokePort],
+                    environment: ["MLX_VLM_SERVER_API_KEY": smokeAPIKey]
+                )
                 guard server.isRunning else {
                     fputs("mlx-vlm-server exited before stop was requested\n", stderr)
                     exit(EXIT_FAILURE)
                 }
-                guard waitForMetricsEndpoint(host: smokeHost, port: smokePort) else {
+                guard waitForMetricsEndpoint(
+                    host: smokeHost,
+                    port: smokePort,
+                    apiKey: smokeAPIKey
+                ) else {
                     fputs("mlx-vlm-server did not expose /metrics at \(smokeHost):\(smokePort)\n", stderr)
                     try? server.stop()
                     exit(EXIT_FAILURE)
@@ -80,11 +88,12 @@ enum Main {
     private static func waitForMetricsEndpoint(
         host: String,
         port: String,
+        apiKey: String,
         timeout: TimeInterval = 5
     ) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if checkMetricsEndpoint(host: host, port: port) {
+            if checkMetricsEndpoint(host: host, port: port, apiKey: apiKey) {
                 return true
             }
             Thread.sleep(forTimeInterval: 0.2)
@@ -92,7 +101,7 @@ enum Main {
         return false
     }
 
-    private static func checkMetricsEndpoint(host: String, port: String) -> Bool {
+    private static func checkMetricsEndpoint(host: String, port: String, apiKey: String) -> Bool {
         let urlHost = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
         guard let url = URL(string: "http://\(urlHost):\(port)/metrics") else {
             return false
@@ -100,7 +109,9 @@ enum Main {
 
         let semaphore = DispatchSemaphore(value: 0)
         let result = MetricsProbeResult()
-        let task = URLSession.shared.dataTask(with: url) { _, response, _ in
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        let task = URLSession.shared.dataTask(with: request) { _, response, _ in
             if let httpResponse = response as? HTTPURLResponse,
                (200..<300).contains(httpResponse.statusCode) {
                 result.markSucceeded()

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -205,6 +205,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
 
     func setServerAPIKey(_ token: String?) {
         let normalizedToken = ServerAPIAuthentication.normalizedToken(token)
+            ?? ServerAPIAuthentication.generateToken()
         guard normalizedToken != settings.normalized().serverAPIKey else {
             return
         }
@@ -345,6 +346,7 @@ final class NativModel: ObservableObject, ChatModelSwitchingSurface {
     }
 
     func startServer() {
+        settings = settings.normalized()
         var shouldStartMetrics = false
         clearModelLoadFailure()
         currentServerOutput = ""

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -333,9 +333,11 @@ struct NativSettings: Codable, Equatable {
     var textToSpeechModelID: String?
     var speechToTextModelID: String?
     var embeddingModelID: String?
-    var serverAPIKey: String?
+    var serverAPIKey: String
     var huggingFaceToken: String?
-    var serverHost: String
+    var serverHost: String {
+        Self.defaultServerHost
+    }
     var serverPort: Int
     var maxTokens: Int
     var maxKVSize: Int
@@ -386,7 +388,6 @@ struct NativSettings: Codable, Equatable {
         embeddingModelID: String? = nil,
         serverAPIKey: String? = nil,
         huggingFaceToken: String? = nil,
-        serverHost: String = Self.defaultServerHost,
         serverPort: Int = 8080,
         maxTokens: Int = 2048,
         maxKVSize: Int = 0,
@@ -434,9 +435,9 @@ struct NativSettings: Codable, Equatable {
         self.textToSpeechModelID = textToSpeechModelID
         self.speechToTextModelID = speechToTextModelID
         self.embeddingModelID = embeddingModelID
-        self.serverAPIKey = serverAPIKey
+        self.serverAPIKey = ServerAPIAuthentication.normalizedToken(serverAPIKey)
+            ?? ServerAPIAuthentication.generateToken()
         self.huggingFaceToken = huggingFaceToken
-        self.serverHost = serverHost
         self.serverPort = serverPort
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
@@ -543,9 +544,11 @@ struct NativSettings: Codable, Equatable {
         textToSpeechModelID = try container.decodeIfPresent(String.self, forKey: .textToSpeechModelID) ?? defaults.textToSpeechModelID
         speechToTextModelID = try container.decodeIfPresent(String.self, forKey: .speechToTextModelID) ?? defaults.speechToTextModelID
         embeddingModelID = try container.decodeIfPresent(String.self, forKey: .embeddingModelID) ?? defaults.embeddingModelID
-        serverAPIKey = try container.decodeIfPresent(String.self, forKey: .serverAPIKey) ?? defaults.serverAPIKey
+        serverAPIKey = ServerAPIAuthentication.normalizedToken(
+            try container.decodeIfPresent(String.self, forKey: .serverAPIKey)
+        ) ?? defaults.serverAPIKey
         huggingFaceToken = try container.decodeIfPresent(String.self, forKey: .huggingFaceToken) ?? defaults.huggingFaceToken
-        serverHost = try container.decodeIfPresent(String.self, forKey: .serverHost) ?? defaults.serverHost
+        _ = try container.decodeIfPresent(String.self, forKey: .serverHost)
         serverPort = try container.decodeIfPresent(Int.self, forKey: .serverPort) ?? defaults.serverPort
         maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens) ?? defaults.maxTokens
         maxKVSize = try container.decodeIfPresent(Int.self, forKey: .maxKVSize) ?? defaults.maxKVSize
@@ -597,7 +600,6 @@ struct NativSettings: Codable, Equatable {
         try container.encodeIfPresent(speechToTextModelID, forKey: .speechToTextModelID)
         try container.encodeIfPresent(embeddingModelID, forKey: .embeddingModelID)
         try container.encodeIfPresent(huggingFaceToken, forKey: .huggingFaceToken)
-        try container.encode(serverHost, forKey: .serverHost)
         try container.encode(serverPort, forKey: .serverPort)
         try container.encode(maxTokens, forKey: .maxTokens)
         try container.encode(maxKVSize, forKey: .maxKVSize)
@@ -679,14 +681,12 @@ struct NativSettings: Codable, Equatable {
         }
 
         var settings = storedSettings
-        let legacyToken = ServerAPIAuthentication.normalizedToken(
-            storedSettings.serverAPIKey
-        )
+        let legacyToken = legacyServerAPIKey(from: url)
 
         do {
             if let keychainToken = try credentialStore.load() {
                 settings.serverAPIKey = keychainToken
-                if storedSettings.serverAPIKey != nil {
+                if legacyToken != nil {
                     try? settings.writePropertyList(to: url)
                 }
             } else if let legacyToken {
@@ -694,15 +694,13 @@ struct NativSettings: Codable, Equatable {
                 settings.serverAPIKey = legacyToken
                 try? settings.writePropertyList(to: url)
             } else {
-                settings.serverAPIKey = nil
-                if storedSettings.serverAPIKey != nil {
-                    try? settings.writePropertyList(to: url)
-                }
+                try credentialStore.save(settings.serverAPIKey)
             }
         } catch {
-            // Keep the legacy value until it can be migrated without data loss.
-            settings.serverAPIKey = legacyToken
+            settings.serverAPIKey = legacyToken ?? settings.serverAPIKey
         }
+
+        removeLegacyServerHost(from: url)
 
         if MCPServerCatalog.bundled.migrateConfigurations(in: &settings.mcpServers) {
             try? settings.writePropertyList(to: url)
@@ -729,6 +727,43 @@ struct NativSettings: Codable, Equatable {
         try data.write(to: url, options: .atomic)
     }
 
+    private static func legacyServerAPIKey(from url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url),
+              let propertyList = try? PropertyListSerialization.propertyList(
+                  from: data,
+                  options: [],
+                  format: nil
+              ) as? [String: Any]
+        else {
+            return nil
+        }
+        return ServerAPIAuthentication.normalizedToken(
+            propertyList[CodingKeys.serverAPIKey.rawValue] as? String
+        )
+    }
+
+    private static func removeLegacyServerHost(from url: URL) {
+        guard let data = try? Data(contentsOf: url) else {
+            return
+        }
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        guard var propertyList = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: &format
+        ) as? [String: Any],
+            propertyList.removeValue(forKey: CodingKeys.serverHost.rawValue) != nil,
+            let migratedData = try? PropertyListSerialization.data(
+                fromPropertyList: propertyList,
+                format: format,
+                options: 0
+            )
+        else {
+            return
+        }
+        try? migratedData.write(to: url, options: .atomic)
+    }
+
     func normalized() -> Self {
         var settings = self
         let trimmedPath = settings.modelSearchPath.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -747,8 +782,8 @@ struct NativSettings: Codable, Equatable {
         settings.speechToTextModelID = Self.normalizedModelID(settings.speechToTextModelID)
         settings.embeddingModelID = Self.normalizedModelID(settings.embeddingModelID)
         settings.serverAPIKey = ServerAPIAuthentication.normalizedToken(settings.serverAPIKey)
+            ?? ServerAPIAuthentication.generateToken()
         settings.huggingFaceToken = HuggingFaceAuthentication.normalizedToken(settings.huggingFaceToken)
-        settings.serverHost = Self.normalizedServerHost(settings.serverHost)
         settings.serverPort = min(max(settings.serverPort, 1), 65_535)
         settings.maxTokens = min(max(settings.maxTokens, 1), 262_144)
         settings.maxKVSize = min(max(settings.maxKVSize, 0), 1_048_576)
@@ -835,7 +870,6 @@ struct NativSettings: Codable, Equatable {
             && lhs.embeddingModelID == rhs.embeddingModelID
             && lhs.serverAPIKey == rhs.serverAPIKey
             && lhs.huggingFaceToken == rhs.huggingFaceToken
-            && lhs.serverHost == rhs.serverHost
             && lhs.serverPort == rhs.serverPort
             && lhs.maxTokens == rhs.maxTokens
             && lhs.maxKVSize == rhs.maxKVSize
@@ -861,8 +895,7 @@ struct NativSettings: Codable, Equatable {
 
     var serverBaseURL: URL {
         let settings = normalized()
-        let host = Self.urlHost(settings.serverHost)
-        return URL(string: "http://\(host):\(settings.serverPort)")!
+        return URL(string: "http://\(settings.serverHost):\(settings.serverPort)")!
     }
 
     var launchEnvironment: [String: String] {
@@ -872,9 +905,7 @@ struct NativSettings: Codable, Equatable {
         ]
 
         environment["APC_ENABLED"] = settings.prefixCachingEnabled ? "1" : "0"
-        if let serverAPIKey = settings.serverAPIKey {
-            environment["MLX_VLM_SERVER_API_KEY"] = serverAPIKey
-        }
+        environment["MLX_VLM_SERVER_API_KEY"] = settings.serverAPIKey
         if let huggingFaceToken = settings.huggingFaceToken {
             environment[HuggingFaceAuthentication.environmentVariableName] = huggingFaceToken
         }
@@ -1041,38 +1072,6 @@ struct NativSettings: Codable, Equatable {
     private static func normalizedModelID(_ value: String?) -> String? {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
-    }
-
-    private static func normalizedServerHost(_ value: String) -> String {
-        var host = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if host.hasPrefix("["), host.hasSuffix("]") {
-            host.removeFirst()
-            host.removeLast()
-        }
-        guard !host.isEmpty else {
-            return defaultServerHost
-        }
-
-        let candidate = "http://\(urlHost(host)):8080"
-        guard let components = URLComponents(string: candidate),
-              components.host != nil,
-              components.port == 8080,
-              components.path.isEmpty,
-              components.user == nil,
-              components.password == nil,
-              components.query == nil,
-              components.fragment == nil
-        else {
-            return defaultServerHost
-        }
-        return host
-    }
-
-    private static func urlHost(_ host: String) -> String {
-        guard host.contains(":") else {
-            return host
-        }
-        return "[\(host.replacingOccurrences(of: "%", with: "%25"))]"
     }
 
     private static func nonEmpty(_ value: String, fallback: String) -> String {

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -22,7 +22,7 @@ struct WelcomeGateView: View {
     let runtime: SystemRuntimeMonitor
     let extensionManager: NativExtensionManager
     let softwareUpdater: SoftwareUpdater
-    let onComplete: (_ modelID: String?, _ serverAPIKey: String?) -> Void
+    let onComplete: (_ modelID: String?, _ serverAPIKey: String) -> Void
 
     var body: some View {
         Group {
@@ -134,23 +134,21 @@ private struct WelcomeView: View {
     @State private var didRequestRecommendedModels = false
     @State private var showsAPIKeyEditor = false
     @State private var serverAPIKey: String
-    @State private var configuredServerAPIKey: String?
+    @State private var configuredServerAPIKey: String
     @StateObject private var permissions = NativPermissionStore()
     @FocusState private var isAPIKeyFieldFocused: Bool
 
-    let onComplete: (_ modelID: String?, _ serverAPIKey: String?) -> Void
+    let onComplete: (_ modelID: String?, _ serverAPIKey: String) -> Void
 
     init(
         model: NativModel,
-        onComplete: @escaping (_ modelID: String?, _ serverAPIKey: String?) -> Void
+        onComplete: @escaping (_ modelID: String?, _ serverAPIKey: String) -> Void
     ) {
         self.model = model
         self.onComplete = onComplete
         let settings = model.settings.normalized()
         _selectedModelID = State(initialValue: settings.languageModelID)
-        _serverAPIKey = State(
-            initialValue: settings.serverAPIKey ?? ServerAPIAuthentication.generateToken()
-        )
+        _serverAPIKey = State(initialValue: settings.serverAPIKey)
         _configuredServerAPIKey = State(initialValue: settings.serverAPIKey)
     }
 
@@ -490,7 +488,7 @@ private struct WelcomeView: View {
                         VStack(alignment: .leading, spacing: 5) {
                             Text("Protect management access")
                                 .font(.headline)
-                            Text("An API key provides basic security if you're running Nativ on a shared network.")
+                            Text("Nativ requires an API key for every server request and stores it in Keychain.")
                                 .font(.callout)
                                 .foregroundStyle(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
@@ -516,12 +514,6 @@ private struct WelcomeView: View {
                             .buttonStyle(.borderedProminent)
                             .controlSize(.large)
 
-                            Button("Skip") {
-                                skipAPIKey()
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.large)
-                            .frame(maxWidth: .infinity)
                         }
                     }
                 }
@@ -541,12 +533,6 @@ private struct WelcomeView: View {
                 Spacer()
 
                 if showsAPIKeyEditor {
-                    Button("Skip") {
-                        skipAPIKey()
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.large)
-
                     Button("Save & Continue") {
                         continueFromAPIKey()
                     }
@@ -556,7 +542,7 @@ private struct WelcomeView: View {
                     .disabled(normalizedAPIKey == nil)
                 } else {
                     Button("Continue") {
-                        skipAPIKey()
+                        continueFromAPIKey()
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
@@ -637,13 +623,6 @@ private struct WelcomeView: View {
     private func continueFromAPIKey() {
         guard let normalizedAPIKey else { return }
         configuredServerAPIKey = normalizedAPIKey
-        withAnimation(.easeInOut(duration: 0.2)) {
-            step = .permissions
-        }
-    }
-
-    private func skipAPIKey() {
-        configuredServerAPIKey = nil
         withAnimation(.easeInOut(duration: 0.2)) {
             step = .permissions
         }
@@ -763,7 +742,7 @@ private struct WelcomeView: View {
         return nil
     }
 
-    private func finish(serverAPIKey: String?) {
+    private func finish(serverAPIKey: String) {
         onComplete(selectedModelID, serverAPIKey)
     }
 

--- a/Tests/NativTests/IntegrationServicesTests.swift
+++ b/Tests/NativTests/IntegrationServicesTests.swift
@@ -53,6 +53,7 @@ final class IntegrationServicesTests: XCTestCase {
         try FileManager.default.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
         manager = IntegrationProfileManager(
             serverBaseURL: serverBaseURL,
+            serverAPIKey: "nativ_test_token",
             homeDirectory: homeDirectory,
             applicationSupportDirectory: applicationSupportDirectory
         )
@@ -112,6 +113,7 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertNotNil(providers["existing"])
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["baseUrl"] as? String, "http://nativ.test:49152/v1")
+        XCTAssertEqual(provider["apiKey"] as? String, "nativ_test_token")
         XCTAssertEqual(provider["api"] as? String, "openai-completions")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
@@ -155,7 +157,7 @@ final class IntegrationServicesTests: XCTestCase {
             launchCommand(for: .codex),
             """
             cd '/tmp/Nativ Project'
-            export NATIV_API_KEY='nativ'
+            export NATIV_API_KEY='nativ_test_token'
             '/tools/codex' '--profile' 'nativ' '--model' 'org/local-model'
             """
         )
@@ -167,7 +169,7 @@ final class IntegrationServicesTests: XCTestCase {
         let configurationURL = manager.configurationURL(for: .claudeCode)
         let root = try json(at: configurationURL)
         let environment = try XCTUnwrap(root["env"] as? [String: Any])
-        XCTAssertEqual(environment["ANTHROPIC_AUTH_TOKEN"] as? String, "nativ")
+        XCTAssertEqual(environment["ANTHROPIC_AUTH_TOKEN"] as? String, "nativ_test_token")
         XCTAssertEqual(environment["ANTHROPIC_API_KEY"] as? String, "")
         XCTAssertEqual(environment["ANTHROPIC_BASE_URL"] as? String, "http://nativ.test:49152")
         XCTAssertEqual(environment["ANTHROPIC_MODEL"] as? String, selectedModel.id)
@@ -177,7 +179,7 @@ final class IntegrationServicesTests: XCTestCase {
             """
             cd '/tmp/Nativ Project'
             export ANTHROPIC_API_KEY=''
-            export ANTHROPIC_AUTH_TOKEN='nativ'
+            export ANTHROPIC_AUTH_TOKEN='nativ_test_token'
             export ANTHROPIC_BASE_URL='http://nativ.test:49152'
             '/tools/claude' '--settings' '\(configurationURL.path)' '--model' 'org/local-model'
             """
@@ -191,6 +193,7 @@ final class IntegrationServicesTests: XCTestCase {
         let configuration = try String(contentsOf: configurationURL, encoding: .utf8)
         XCTAssertTrue(configuration.contains("default: \"org/local-model\""))
         XCTAssertTrue(configuration.contains("base_url: \"http://nativ.test:49152/v1\""))
+        XCTAssertTrue(configuration.contains("api_key: \"nativ_test_token\""))
         XCTAssertTrue(configuration.contains("\"org/local-model\":\n        context_length: 32768\n        supports_vision: true"))
         XCTAssertTrue(configuration.contains("\"org/basic-model\":\n        context_length: 131072"))
         XCTAssertEqual(
@@ -217,6 +220,7 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertEqual(provider["npm"] as? String, "@ai-sdk/openai-compatible")
         let options = try XCTUnwrap(provider["options"] as? [String: Any])
         XCTAssertEqual(options["baseURL"] as? String, "http://nativ.test:49152/v1")
+        XCTAssertEqual(options["apiKey"] as? String, "nativ_test_token")
         let models = try XCTUnwrap(provider["models"] as? [String: Any])
         let selected = try XCTUnwrap(models[selectedModel.id] as? [String: Any])
         XCTAssertEqual(selected["attachment"] as? Bool, true)
@@ -243,7 +247,7 @@ final class IntegrationServicesTests: XCTestCase {
         let configurationURL = manager.configurationURL(for: .aider)
         let contents = try String(contentsOf: configurationURL, encoding: .utf8)
         XCTAssertTrue(contents.contains("OPENAI_API_BASE=http://nativ.test:49152/v1"))
-        XCTAssertTrue(contents.contains("OPENAI_API_KEY=nativ"))
+        XCTAssertTrue(contents.contains("OPENAI_API_KEY=nativ_test_token"))
         XCTAssertEqual(
             launchCommand(for: .aider),
             "cd '/tmp/Nativ Project'\n'/tools/aider' '--env-file' '\(configurationURL.path)' '--model' 'openai/org/local-model'"
@@ -269,7 +273,7 @@ final class IntegrationServicesTests: XCTestCase {
             """
             cd '/tmp/Nativ Project'
             export GOOSE_MODEL='org/local-model'
-            export NATIV_API_KEY='nativ'
+            export NATIV_API_KEY='nativ_test_token'
             '/tools/goose' 'session' 'start' '--provider' 'nativ'
             """
         )
@@ -284,7 +288,7 @@ final class IntegrationServicesTests: XCTestCase {
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["type"] as? String, "openai-compat")
         XCTAssertEqual(provider["base_url"] as? String, "http://nativ.test:49152/v1")
-        XCTAssertEqual(provider["api_key"] as? String, "nativ")
+        XCTAssertEqual(provider["api_key"] as? String, "nativ_test_token")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
         XCTAssertEqual(models[0]["id"] as? String, selectedModel.id)
@@ -310,14 +314,14 @@ final class IntegrationServicesTests: XCTestCase {
 
         let configurationURL = manager.configurationURL(for: .qwenCode)
         let contents = try String(contentsOf: configurationURL, encoding: .utf8)
-        XCTAssertTrue(contents.contains("OPENAI_API_KEY=nativ"))
+        XCTAssertTrue(contents.contains("OPENAI_API_KEY=nativ_test_token"))
         XCTAssertTrue(contents.contains("OPENAI_BASE_URL=http://nativ.test:49152/v1"))
         XCTAssertTrue(contents.contains("OPENAI_MODEL=org/local-model"))
         XCTAssertEqual(
             launchCommand(for: .qwenCode),
             """
             cd '/tmp/Nativ Project'
-            export OPENAI_API_KEY='nativ'
+            export OPENAI_API_KEY='nativ_test_token'
             export OPENAI_BASE_URL='http://nativ.test:49152/v1'
             export OPENAI_MODEL='org/local-model'
             '/tools/qwen'
@@ -335,7 +339,7 @@ final class IntegrationServicesTests: XCTestCase {
         let provider = try XCTUnwrap(providers["nativ"] as? [String: Any])
         XCTAssertEqual(provider["baseUrl"] as? String, "http://nativ.test:49152/v1")
         XCTAssertEqual(provider["api"] as? String, "openai-completions")
-        XCTAssertEqual(provider["apiKey"] as? String, "nativ")
+        XCTAssertEqual(provider["apiKey"] as? String, "nativ_test_token")
         let models = try XCTUnwrap(provider["models"] as? [[String: Any]])
         XCTAssertEqual(models.count, 2)
         XCTAssertEqual(models[0]["id"] as? String, selectedModel.id)
@@ -366,7 +370,7 @@ final class IntegrationServicesTests: XCTestCase {
             launchCommand(for: .zed),
             """
             cd '/tmp/Nativ Project'
-            export NATIV_API_KEY='nativ'
+            export NATIV_API_KEY='nativ_test_token'
             '/tools/zed' '.'
             """
         )
@@ -380,7 +384,7 @@ final class IntegrationServicesTests: XCTestCase {
         XCTAssertTrue(contents.contains("provider: openai"))
         XCTAssertTrue(contents.contains("apiBase: \"http://nativ.test:49152/v1\""))
         XCTAssertTrue(contents.contains("model: \"org/local-model\""))
-        XCTAssertTrue(contents.contains("apiKey: \"nativ\""))
+        XCTAssertTrue(contents.contains("apiKey: \"nativ_test_token\""))
         XCTAssertEqual(
             launchCommand(for: .continueDev),
             "cd '/tmp/Nativ Project'\n'/tools/cn' '--config' '\(configurationURL.path)'"
@@ -416,7 +420,7 @@ final class IntegrationServicesTests: XCTestCase {
         let home = configurationURL.deletingLastPathComponent().path
         XCTAssertEqual(
             launchCommand(for: .openInterpreter),
-            "cd '/tmp/Nativ Project'\nexport CODEX_HOME='\(home)'\nexport NATIV_API_KEY='nativ'\n'/tools/interpreter' '--provider' 'nativ' '--model' 'org/local-model'"
+            "cd '/tmp/Nativ Project'\nexport CODEX_HOME='\(home)'\nexport NATIV_API_KEY='nativ_test_token'\n'/tools/interpreter' '--provider' 'nativ' '--model' 'org/local-model'"
         )
     }
 

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Testing
 @testable import NativServerKit
 
 final class NativSettingsTests: XCTestCase {
@@ -123,34 +124,63 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertFalse(settings.launchArguments.contains("--image-model"))
     }
 
-    func testServerHostIsNormalizedAndPassedToServer() {
-        let settings = NativSettings(serverHost: "  0.0.0.0  ", serverPort: 9_001)
+    func testLegacyNonLoopbackServerHostIsReplacedWithLoopback() throws {
+        let data = Data(#"{"serverHost":"0.0.0.0","serverPort":9001}"#.utf8)
+        let settings = try JSONDecoder().decode(NativSettings.self, from: data)
 
-        XCTAssertEqual(settings.normalized().serverHost, "0.0.0.0")
-        XCTAssertEqual(settings.serverBaseURL.absoluteString, "http://0.0.0.0:9001")
-        XCTAssertTrue(settings.launchArguments.containsAdjacent("--host", "0.0.0.0"))
+        XCTAssertEqual(settings.serverHost, "127.0.0.1")
+        XCTAssertEqual(settings.serverBaseURL.absoluteString, "http://127.0.0.1:9001")
+        XCTAssertTrue(settings.launchArguments.containsAdjacent("--host", "127.0.0.1"))
     }
 
-    func testIPv6ServerHostProducesValidBaseURL() {
-        let settings = NativSettings(serverHost: "[::1]", serverPort: 9_002)
+    func testServerHostIsNotPersisted() throws {
+        let data = try PropertyListEncoder().encode(NativSettings())
+        let propertyList = try XCTUnwrap(
+            PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+            ) as? [String: Any]
+        )
 
-        XCTAssertEqual(settings.normalized().serverHost, "::1")
-        XCTAssertEqual(settings.serverBaseURL.absoluteString, "http://[::1]:9002")
-        XCTAssertTrue(settings.launchArguments.containsAdjacent("--host", "::1"))
+        XCTAssertNil(propertyList["serverHost"])
+    }
+
+    func testPythonServerSecuritySuitePasses() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [
+            "-m", "unittest", "discover",
+            "-s", "PythonDistribution/Tests",
+            "-p", "test_*.py",
+            "-v"
+        ]
+        process.currentDirectoryURL = repositoryRoot
+        process.standardOutput = output
+        process.standardError = output
+
+        try process.run()
+        let outputData = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        let result = String(decoding: outputData, as: UTF8.self)
+
+        XCTAssertEqual(process.terminationStatus, 0, result)
+        XCTAssertNotNil(
+            result.range(of: #"Ran [1-9][0-9]* tests"#, options: .regularExpression),
+            result
+        )
+        XCTAssertTrue(result.contains("OK"), result)
     }
 
     func testMissingServerHostUsesLoopbackDefault() throws {
         let settings = try JSONDecoder().decode(NativSettings.self, from: Data("{}".utf8))
 
         XCTAssertEqual(settings.serverHost, "127.0.0.1")
-    }
-
-    func testServerHostRequiresServerRestart() {
-        let original = NativSettings()
-        var changed = original
-        changed.serverHost = "0.0.0.0"
-
-        XCTAssertFalse(original.hasSameLaunchConfiguration(as: changed))
     }
 
     func testServerAPITokenIsNormalizedMaskedAndPassedToServer() {
@@ -171,11 +201,14 @@ final class NativSettingsTests: XCTestCase {
         )
     }
 
-    func testBlankServerAPITokenIsOmitted() {
+    func testBlankServerAPITokenIsReplaced() {
         let settings = NativSettings(serverAPIKey: " \n ").normalized()
 
-        XCTAssertNil(settings.serverAPIKey)
-        XCTAssertNil(settings.launchEnvironment["MLX_VLM_SERVER_API_KEY"])
+        XCTAssertTrue(settings.serverAPIKey.hasPrefix("nativ_"))
+        XCTAssertEqual(
+            settings.launchEnvironment["MLX_VLM_SERVER_API_KEY"],
+            settings.serverAPIKey
+        )
     }
 
     func testGeneratedServerAPITokenHasNativPrefix() {
@@ -266,6 +299,26 @@ final class NativSettingsTests: XCTestCase {
             try propertyList(at: url)["serverAPIKey"] as? String,
             "nativ_legacy"
         )
+    }
+
+    func testLoadingRemovesLegacyServerHostWithoutDroppingRecoverableCredential() throws {
+        let url = temporarySettingsURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        try writeLegacySettings(
+            serverAPIKey: "nativ_legacy",
+            serverHost: "0.0.0.0",
+            to: url
+        )
+        let credentialStore = TestServerAPICredentialStore(
+            saveError: TestCredentialStoreError.unavailable
+        )
+
+        let settings = NativSettings.load(from: url, credentialStore: credentialStore)
+        let storedPropertyList = try propertyList(at: url)
+
+        XCTAssertEqual(settings.serverHost, NativSettings.defaultServerHost)
+        XCTAssertNil(storedPropertyList["serverHost"])
+        XCTAssertEqual(storedPropertyList["serverAPIKey"] as? String, "nativ_legacy")
     }
 
     func testKeychainCredentialTakesPrecedenceOverLegacyCredential() throws {
@@ -598,7 +651,11 @@ final class NativSettingsTests: XCTestCase {
         )
     }
 
-    private func writeLegacySettings(serverAPIKey: String, to url: URL) throws {
+    private func writeLegacySettings(
+        serverAPIKey: String,
+        serverHost: String? = nil,
+        to url: URL
+    ) throws {
         let encoded = try PropertyListEncoder().encode(NativSettings())
         var propertyList = try XCTUnwrap(
             PropertyListSerialization.propertyList(
@@ -608,6 +665,7 @@ final class NativSettingsTests: XCTestCase {
             ) as? [String: Any]
         )
         propertyList["serverAPIKey"] = serverAPIKey
+        propertyList["serverHost"] = serverHost
         let data = try PropertyListSerialization.data(
             fromPropertyList: propertyList,
             format: .binary,
@@ -820,6 +878,53 @@ final class NativChatToolProtocolTests: XCTestCase {
             NativServerErrorMessage.modelLoadFailure(
                 in: "Chat endpoint returned HTTP 400: Prompt is too long."
             )
+        )
+    }
+}
+
+@Suite("Server security policy")
+struct ServerSecurityPolicyTests {
+    @Test("Loading without a credential creates and persists one")
+    func loadingWithoutCredentialCreatesCredential() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = directory.appendingPathComponent("settings.plist")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let credentialStore = TestServerAPICredentialStore()
+
+        let settings = NativSettings.load(from: url, credentialStore: credentialStore)
+
+        #expect(settings.serverAPIKey.hasPrefix("nativ_"))
+        #expect(credentialStore.token == settings.serverAPIKey)
+        #expect(
+            settings.launchEnvironment["MLX_VLM_SERVER_API_KEY"]
+                == settings.serverAPIKey
+        )
+    }
+
+    @Test("Legacy network exposure cannot survive decoding")
+    func legacyNetworkExposureCannotSurviveDecoding() throws {
+        let data = Data(#"{"serverHost":"0.0.0.0","serverPort":8080}"#.utf8)
+
+        let settings = try JSONDecoder().decode(NativSettings.self, from: data)
+
+        #expect(settings.serverHost == NativSettings.defaultServerHost)
+        #expect(
+            settings.launchArguments.containsAdjacent(
+                "--host",
+                NativSettings.defaultServerHost
+            )
+        )
+    }
+
+    @Test("Blank credentials are replaced before launch")
+    func blankCredentialsAreReplacedBeforeLaunch() {
+        let settings = NativSettings(serverAPIKey: " \n ").normalized()
+
+        #expect(settings.serverAPIKey.hasPrefix("nativ_"))
+        #expect(
+            settings.launchEnvironment["MLX_VLM_SERVER_API_KEY"]
+                == settings.serverAPIKey
         )
     }
 }


### PR DESCRIPTION
Restrict the bundled server to loopback addresses and require a token for every supported request.

Generate a token automatically, store it in Keychain, and migrate legacy settings without exposing secrets.

Update integration profiles to use the generated token instead of the previous hardcoded fallback value.

Add regression coverage for startup policy, middleware behavior, credential migration, packaging, and integration configuration correctness.

