### PR TITLE
Move audio meter capture off the main thread

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -65,11 +65,13 @@
 		2C98514AA04F1488DE40A8A9 /* ControlPanelSidebarToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5339FA572796FC1E328494 /* ControlPanelSidebarToolbar.swift */; };
 		2C9930764FCB1AF6B4C66363 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
 		2C9DFB15B06C56CB650FC9A6 /* WebBrowsingTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB497800D0F8B237A1891EE1 /* WebBrowsingTransport.swift */; };
+		2CA1076EA0874C55E7BB14B2 /* RealtimeAudioMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5682AEE2C7DF8C9A3AFAC3DF /* RealtimeAudioMeter.swift */; };
 		2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */; };
 		2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		31D67AFE2E2CD864C37D6CFA /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		326C969CB7D0F41F38467DFE /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
 		32E3DD03D61C201E783539AF /* ChatServerStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */; };
+		330070AC18DC9F0752EB7138 /* RealtimeAudioMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5682AEE2C7DF8C9A3AFAC3DF /* RealtimeAudioMeter.swift */; };
 		33ADC132B82225C5E233F440 /* ChatSwitchModelTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */; };
 		351B2202E8690FC608A32AEF /* IntegrationServicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */; };
 		3545A0F2A3E0FE78FE7D501E /* WebBrowsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B88001E3E22C2E592C0BA /* WebBrowsingError.swift */; };
@@ -80,6 +82,7 @@
 		37019E4FD7ED9989CBB910F5 /* ControlPanelSidebarSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4EB9D6C2EB387FABD552B2 /* ControlPanelSidebarSections.swift */; };
 		37733336E268AC8DFE5AEC6C /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
 		388F4BD381D9732C614162C4 /* WebBrowsingRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254FDFBF7C5F7C8019E9E03F /* WebBrowsingRuntime.swift */; };
+		393DC62E524B83E0216268B8 /* AudioInputLevelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DDA5274474AC8D54DFDF71 /* AudioInputLevelMonitor.swift */; };
 		39ADE4524CF22ED36D505546 /* NativExtensionHostBroker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */; };
 		39DF704E9F1D23E2F8248F02 /* LocalModelDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */; };
 		39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
@@ -249,6 +252,7 @@
 		C98474155E01AF49957443C9 /* NativNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577B24B3B022E78F7664C76E /* NativNotificationService.swift */; };
 		CB0D232F71771BF7F3EE2B53 /* FirecrawlBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195075F70CCB0E7DE02934DF /* FirecrawlBrowsingProvider.swift */; };
 		CEE42CCB57866B76CE85E588 /* MCPServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A7ACB288953FD476C47E8 /* MCPServerConfig.swift */; };
+		D2D5168B1A4243EB55EB1D68 /* RealtimeAudioMeterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01D6D1C8C321F16B5FD31F8 /* RealtimeAudioMeterTests.swift */; };
 		D4F073244DE11FD98AD708E2 /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */; };
 		D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EF3E0B4A9EEC293EFD5F8A /* ChatImageTool.swift */; };
 		D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */; };
@@ -444,6 +448,7 @@
 		530CA8743FEBF843F79321A7 /* Parallel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Parallel.png; sourceTree = "<group>"; };
 		530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionStore.swift; sourceTree = "<group>"; };
 		5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDocumentExtractionCache.swift; sourceTree = "<group>"; };
+		5682AEE2C7DF8C9A3AFAC3DF /* RealtimeAudioMeter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeAudioMeter.swift; sourceTree = "<group>"; };
 		577B24B3B022E78F7664C76E /* NativNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativNotificationService.swift; sourceTree = "<group>"; };
 		586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionHostBroker.swift; sourceTree = "<group>"; };
 		5919AB4E9488642C73886266 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
@@ -541,6 +546,7 @@
 		BE5FF4A08C2B33756121EE2C /* ChatConversationBranch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatConversationBranch.swift; sourceTree = "<group>"; };
 		BEC8347D15B2595FF7819F7C /* ParallelBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParallelBrowsingProvider.swift; sourceTree = "<group>"; };
 		BF65681C9FD920314BECC7D3 /* Tavily.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Tavily.png; sourceTree = "<group>"; };
+		C01D6D1C8C321F16B5FD31F8 /* RealtimeAudioMeterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeAudioMeterTests.swift; sourceTree = "<group>"; };
 		C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentValidatorTests.swift; sourceTree = "<group>"; };
 		C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscoveryTests.swift; sourceTree = "<group>"; };
 		C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSwitchModelTool.swift; sourceTree = "<group>"; };
@@ -782,6 +788,7 @@
 				A118DF27AE0EF852DC458BB7 /* AudioInputVolumeController.swift */,
 				7E012B6E98DF6B992CDA591F /* AudioView.swift */,
 				27D63523BA62CC95FDD8D51E /* FnControlShortcutMonitor.swift */,
+				5682AEE2C7DF8C9A3AFAC3DF /* RealtimeAudioMeter.swift */,
 				EF7AE3F3DB48E640950CCDB4 /* SystemAudioMeetingRecorder.swift */,
 				632EB67BFAC2BCBE082A3E2B /* VoiceAnimationPreferences.swift */,
 				D0952EC469768D8775A2D188 /* VoiceAudioRecorder.swift */,
@@ -1150,6 +1157,7 @@
 				982F3BB563023885587DC860 /* NativNotificationTests.swift */,
 				E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */,
 				8513AE482EB6C3113080826A /* PDFDocumentTextExtractorTests.swift */,
+				C01D6D1C8C321F16B5FD31F8 /* RealtimeAudioMeterTests.swift */,
 				FB10CC03A96A3EA80EF9343B /* ScheduledCapabilityTests.swift */,
 				0DBC23C0369758C056A8182D /* ScheduledTaskChatLinkerTests.swift */,
 				3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */,
@@ -1528,6 +1536,7 @@
 				C4A766A43FD62815D056BD93 /* ParallelBrowsingProvider.swift in Sources */,
 				03B0228F483C7F76742D5245 /* PerplexityBrowsingProvider.swift in Sources */,
 				E407C7F9CE883C978DE7D716 /* PersistentMenuActionView.swift in Sources */,
+				330070AC18DC9F0752EB7138 /* RealtimeAudioMeter.swift in Sources */,
 				1EBCB9482DABA02FD039A795 /* Routine.swift in Sources */,
 				759391363423D786EF850BE3 /* RoutineEditorView.swift in Sources */,
 				98086CE0CF71463BDF07F8A8 /* RoutineLaunchAgent.swift in Sources */,
@@ -1581,6 +1590,7 @@
 				145464A2B098437667795AFB /* Artifact.swift in Sources */,
 				AB1C4B8494B46754E6E8BE24 /* AudioAnalyticsStore.swift in Sources */,
 				01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */,
+				393DC62E524B83E0216268B8 /* AudioInputLevelMonitor.swift in Sources */,
 				4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */,
 				B3DE35DF177BB2B7A9D7690B /* BraveBrowsingProvider.swift in Sources */,
 				7ACEF87EDC19CB862FCF8840 /* ChatAttachmentKind.swift in Sources */,
@@ -1656,6 +1666,8 @@
 				0B5170A046C3C587DE077072 /* PDFDocumentTextExtractorTests.swift in Sources */,
 				E0B07216A3D3638AA5FAA059 /* ParallelBrowsingProvider.swift in Sources */,
 				95711758521BCF469B48481E /* PerplexityBrowsingProvider.swift in Sources */,
+				2CA1076EA0874C55E7BB14B2 /* RealtimeAudioMeter.swift in Sources */,
+				D2D5168B1A4243EB55EB1D68 /* RealtimeAudioMeterTests.swift in Sources */,
 				56B6A9EF8A305C95F9E81D06 /* Routine.swift in Sources */,
 				02571B1CDC31A5D168247CCD /* RoutineStore.swift in Sources */,
 				E6696BECCF805C7262526F08 /* ScheduledCapabilityTests.swift in Sources */,

--- a/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
@@ -12,15 +12,13 @@ final class AudioInputLevelState: ObservableObject {
 
 @MainActor
 final class AudioInputLevelMonitor: ObservableObject {
-    private static let publishInterval: TimeInterval = 1.0 / 15.0
-
     let meterState = AudioInputLevelState()
     @Published private(set) var isMonitoring = false
     @Published private(set) var errorMessage: String?
 
     private var audioEngine: AVAudioEngine?
-    private var smoothedLevel: Float = 0
-    private var lastPublishedAt = Date.distantPast
+    private var realtimeMeter: RealtimeAudioMeter?
+    private var meterPublisherTask: Task<Void, Never>?
 
     func start(deviceUniqueID: String?) async {
         stop()
@@ -48,13 +46,8 @@ final class AudioInputLevelMonitor: ObservableObject {
                 throw VoiceAudioRecorderError.couldNotStart
             }
 
-            let tap: @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void = {
-                [weak self] buffer, _ in
-                let level = Self.normalizedLevel(from: buffer)
-                Task { @MainActor [weak self] in
-                    self?.update(level: level)
-                }
-            }
+            let realtimeMeter = RealtimeAudioMeter(profile: .inputMonitor)
+            let tap = Self.makeTap(realtimeMeter: realtimeMeter)
             inputNode.installTap(
                 onBus: 0,
                 bufferSize: 1_024,
@@ -65,6 +58,7 @@ final class AudioInputLevelMonitor: ObservableObject {
             try engine.start()
             audioEngine = engine
             isMonitoring = true
+            startMeterPublisher(realtimeMeter: realtimeMeter)
         } catch {
             errorMessage = error.localizedDescription
             stop(resetError: false)
@@ -89,25 +83,45 @@ final class AudioInputLevelMonitor: ObservableObject {
         }
         audioEngine = nil
         isMonitoring = false
-        smoothedLevel = 0
-        lastPublishedAt = .distantPast
+        stopMeterPublisher()
         meterState.update(0)
         if resetError {
             errorMessage = nil
         }
     }
 
-    private func update(level newLevel: Float) {
-        guard isMonitoring else {
-            return
+    private func startMeterPublisher(realtimeMeter: RealtimeAudioMeter) {
+        self.realtimeMeter = realtimeMeter
+        meterPublisherTask = Task { [weak self, realtimeMeter] in
+            await RealtimeAudioMeterPublisher.run(meter: realtimeMeter) {
+                [weak self, realtimeMeter] snapshot in
+                guard
+                    let self,
+                    self.realtimeMeter === realtimeMeter,
+                    self.isMonitoring
+                else {
+                    return
+                }
+                self.meterState.update(snapshot.level)
+            }
         }
-        smoothedLevel = (smoothedLevel * 0.65) + (newLevel * 0.35)
-        let now = Date()
-        guard now.timeIntervalSince(lastPublishedAt) >= Self.publishInterval else {
-            return
+    }
+
+    private func stopMeterPublisher() {
+        realtimeMeter = nil
+        meterPublisherTask?.cancel()
+        meterPublisherTask = nil
+    }
+
+    nonisolated static func makeTap(
+        realtimeMeter: RealtimeAudioMeter
+    ) -> @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void {
+        { buffer, _ in
+            realtimeMeter.submit(
+                level: normalizedLevel(from: buffer),
+                elapsed: 0
+            )
         }
-        lastPublishedAt = now
-        meterState.update(smoothedLevel)
     }
 
     private nonisolated static func normalizedLevel(

--- a/Sources/Nativ/Features/VoiceCapture/RealtimeAudioMeter.swift
+++ b/Sources/Nativ/Features/VoiceCapture/RealtimeAudioMeter.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Synchronization
+
+struct RealtimeAudioMeterSnapshot: Equatable, Sendable {
+    let level: Float
+    let elapsed: TimeInterval
+    let revision: UInt64
+}
+
+enum RealtimeAudioMeterProfile: Sendable {
+    case inputMonitor
+    case recording
+
+    func smoothedLevel(previous: Float, input: Float) -> Float {
+        let clamped = max(0, min(1, input))
+        switch self {
+        case .inputMonitor:
+            return (previous * 0.65) + (clamped * 0.35)
+        case .recording:
+            let shaped = pow(clamped, 0.72)
+            return (previous * 0.68) + (shaped * 0.32)
+        }
+    }
+}
+
+final class RealtimeAudioMeter: Sendable {
+    private let profile: RealtimeAudioMeterProfile
+    private let smoothedLevelBits = Atomic<UInt32>(0)
+    private let latestElapsedBits = Atomic<UInt64>(0)
+    private let sequence = Atomic<UInt64>(0)
+
+    init(profile: RealtimeAudioMeterProfile) {
+        self.profile = profile
+    }
+
+    func submit(level: Float, elapsed: TimeInterval) {
+        let previous = Float(
+            bitPattern: smoothedLevelBits.load(ordering: .relaxed)
+        )
+        let smoothed = profile.smoothedLevel(previous: previous, input: level)
+
+        // Odd sequence values identify a write in progress. The release on the
+        // final increment publishes both value stores to the consumer.
+        _ = sequence.add(1, ordering: .acquiringAndReleasing)
+        smoothedLevelBits.store(smoothed.bitPattern, ordering: .relaxed)
+        latestElapsedBits.store(elapsed.bitPattern, ordering: .relaxed)
+        _ = sequence.add(1, ordering: .releasing)
+    }
+
+    func snapshot(after lastRevision: UInt64) -> RealtimeAudioMeterSnapshot? {
+        let startingSequence = sequence.load(ordering: .acquiring)
+        guard startingSequence != lastRevision,
+            startingSequence.isMultiple(of: 2)
+        else {
+            return nil
+        }
+
+        let level = Float(
+            bitPattern: smoothedLevelBits.load(ordering: .relaxed)
+        )
+        let elapsed = TimeInterval(
+            bitPattern: latestElapsedBits.load(ordering: .relaxed)
+        )
+        let endingSequence = sequence.load(ordering: .acquiring)
+        guard startingSequence == endingSequence else {
+            return nil
+        }
+
+        return RealtimeAudioMeterSnapshot(
+            level: level,
+            elapsed: elapsed,
+            revision: endingSequence
+        )
+    }
+}
+
+enum RealtimeAudioMeterPublisher {
+    static let publishInterval: Duration = .nanoseconds(66_666_667)
+
+    @concurrent
+    static func run(
+        meter: RealtimeAudioMeter,
+        interval: Duration = publishInterval,
+        deliver: @escaping @MainActor @Sendable (RealtimeAudioMeterSnapshot) -> Void
+    ) async {
+        var deliveredRevision: UInt64 = 0
+
+        while !Task.isCancelled {
+            if let snapshot = meter.snapshot(after: deliveredRevision) {
+                deliveredRevision = snapshot.revision
+                await deliver(snapshot)
+            }
+
+            do {
+                try await Task.sleep(for: interval)
+            } catch {
+                return
+            }
+        }
+    }
+}

--- a/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
@@ -119,19 +119,26 @@ enum VoiceAudioRetention {
     }
 }
 
+struct VoiceAudioBufferMeasurement: Sendable {
+    let level: Float
+    let duration: TimeInterval
+}
+
+protocol VoiceAudioBufferWriting: Sendable {
+    func append(_ buffer: AVAudioPCMBuffer) -> VoiceAudioBufferMeasurement
+}
+
 @MainActor
 final class VoiceAudioRecorder {
-    private static let meterPublishInterval: TimeInterval = 1.0 / 15.0
-
-    var onMeterUpdate: ((Float, TimeInterval) -> Void)?
+    var onMeterUpdate: (@MainActor @Sendable (Float, TimeInterval) -> Void)?
 
     private(set) var isRecording = false
     private(set) var lastRecordingDuration: TimeInterval?
     private var audioEngine: AVAudioEngine?
     private var recordingWriter: VoiceAudioRecordingWriter?
     private var recordingURL: URL?
-    private var smoothedLevel: Float = 0
-    private var lastMeterUpdateElapsed = -Double.infinity
+    private var realtimeMeter: RealtimeAudioMeter?
+    private var meterPublisherTask: Task<Void, Never>?
 
     static var recordingsDirectory: URL {
         get throws {
@@ -193,16 +200,8 @@ final class VoiceAudioRecorder {
             audioFile: audioFile,
             sampleRate: inputFormat.sampleRate
         )
-        let tap: @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void = {
-            [weak self, writer] buffer, _ in
-            let measurement = writer.append(buffer)
-            Task { @MainActor [weak self] in
-                self?.updateMeter(
-                    level: measurement.level,
-                    elapsed: measurement.duration
-                )
-            }
-        }
+        let realtimeMeter = RealtimeAudioMeter(profile: .recording)
+        let tap = Self.makeTap(writer: writer, realtimeMeter: realtimeMeter)
         inputNode.installTap(
             onBus: 0,
             bufferSize: 1_024,
@@ -224,8 +223,7 @@ final class VoiceAudioRecorder {
         recordingURL = outputURL
         isRecording = true
         lastRecordingDuration = nil
-        smoothedLevel = 0
-        lastMeterUpdateElapsed = -Double.infinity
+        startMeterPublisher(realtimeMeter: realtimeMeter)
         return outputURL
     }
 
@@ -238,13 +236,12 @@ final class VoiceAudioRecorder {
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()
         let duration = recordingWriter.duration
+        stopMeterPublisher()
         self.audioEngine = nil
         self.recordingWriter = nil
         self.recordingURL = nil
         isRecording = false
         lastRecordingDuration = duration
-        smoothedLevel = 0
-        lastMeterUpdateElapsed = -Double.infinity
         onMeterUpdate?(0, duration)
 
         guard duration > 0 else {
@@ -262,17 +259,40 @@ final class VoiceAudioRecorder {
         lastRecordingDuration = nil
     }
 
-    private func updateMeter(level: Float, elapsed: TimeInterval) {
-        guard isRecording else {
-            return
+    private func startMeterPublisher(realtimeMeter: RealtimeAudioMeter) {
+        self.realtimeMeter = realtimeMeter
+        meterPublisherTask = Task { [weak self, realtimeMeter] in
+            await RealtimeAudioMeterPublisher.run(meter: realtimeMeter) {
+                [weak self, realtimeMeter] snapshot in
+                guard
+                    let self,
+                    self.realtimeMeter === realtimeMeter,
+                    self.isRecording
+                else {
+                    return
+                }
+                self.onMeterUpdate?(snapshot.level, snapshot.elapsed)
+            }
         }
-        let shapedLevel = pow(max(0, min(1, level)), 0.72)
-        smoothedLevel = (smoothedLevel * 0.68) + (shapedLevel * 0.32)
-        guard elapsed - lastMeterUpdateElapsed >= Self.meterPublishInterval else {
-            return
+    }
+
+    private func stopMeterPublisher() {
+        realtimeMeter = nil
+        meterPublisherTask?.cancel()
+        meterPublisherTask = nil
+    }
+
+    nonisolated static func makeTap(
+        writer: any VoiceAudioBufferWriting,
+        realtimeMeter: RealtimeAudioMeter
+    ) -> @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void {
+        { buffer, _ in
+            let measurement = writer.append(buffer)
+            realtimeMeter.submit(
+                level: measurement.level,
+                elapsed: measurement.duration
+            )
         }
-        lastMeterUpdateElapsed = elapsed
-        onMeterUpdate?(smoothedLevel, elapsed)
     }
 
     private static func makeOutputURL() throws -> URL {
@@ -284,7 +304,7 @@ final class VoiceAudioRecorder {
     }
 }
 
-private final class VoiceAudioRecordingWriter: @unchecked Sendable {
+final class VoiceAudioRecordingWriter: VoiceAudioBufferWriting, @unchecked Sendable {
     private let audioFile: AVAudioFile
     private let sampleRate: Double
     private let lock = NSLock()
@@ -304,7 +324,7 @@ private final class VoiceAudioRecordingWriter: @unchecked Sendable {
         }
     }
 
-    func append(_ buffer: AVAudioPCMBuffer) -> (level: Float, duration: TimeInterval) {
+    func append(_ buffer: AVAudioPCMBuffer) -> VoiceAudioBufferMeasurement {
         lock.withLock {
             do {
                 try audioFile.write(from: buffer)
@@ -325,7 +345,10 @@ private final class VoiceAudioRecordingWriter: @unchecked Sendable {
                 }
             }
             let elapsed = sampleRate > 0 ? Double(writtenFrames) / sampleRate : 0
-            return (min(1, peak * 3.5), elapsed)
+            return VoiceAudioBufferMeasurement(
+                level: min(1, peak * 3.5),
+                duration: elapsed
+            )
         }
     }
 }

--- a/Tests/NativTests/RealtimeAudioMeterTests.swift
+++ b/Tests/NativTests/RealtimeAudioMeterTests.swift
@@ -1,0 +1,245 @@
+import AVFoundation
+import Foundation
+import XCTest
+
+final class RealtimeAudioMeterTests: XCTestCase {
+    func testInputMonitorProfilePreservesPerBufferSmoothing() throws {
+        let meter = RealtimeAudioMeter(profile: .inputMonitor)
+
+        meter.submit(level: 1, elapsed: 0)
+        let first = try XCTUnwrap(meter.snapshot(after: 0))
+        XCTAssertEqual(first.level, 0.35, accuracy: 0.0001)
+
+        meter.submit(level: 1, elapsed: 0)
+        let second = try XCTUnwrap(meter.snapshot(after: first.revision))
+        XCTAssertEqual(second.level, 0.5775, accuracy: 0.0001)
+    }
+
+    func testRecordingProfilePreservesShapingAndSmoothing() throws {
+        let meter = RealtimeAudioMeter(profile: .recording)
+
+        meter.submit(level: 0.5, elapsed: 0.1)
+        let snapshot = try XCTUnwrap(meter.snapshot(after: 0))
+        let expected = pow(Float(0.5), 0.72) * 0.32
+
+        XCTAssertEqual(snapshot.level, expected, accuracy: 0.0001)
+        XCTAssertEqual(snapshot.elapsed, 0.1, accuracy: 0.0001)
+    }
+
+    func testLatestReadingReplacesIntermediateReadings() throws {
+        let meter = RealtimeAudioMeter(profile: .inputMonitor)
+
+        for index in 1 ... 100 {
+            meter.submit(
+                level: Float(index) / 100,
+                elapsed: TimeInterval(index) / 100
+            )
+        }
+
+        let snapshot = try XCTUnwrap(meter.snapshot(after: 0))
+        XCTAssertEqual(snapshot.elapsed, 1, accuracy: 0.0001)
+        XCTAssertNil(meter.snapshot(after: snapshot.revision))
+    }
+
+    func testInputMonitorTapRunsFromNonMainQueue() async throws {
+        let meter = RealtimeAudioMeter(profile: .inputMonitor)
+        let tap = AudioInputLevelMonitor.makeTap(realtimeMeter: meter)
+
+        let ranOnMainThread = await invokeOffMain(tap, amplitude: 0.1)
+
+        XCTAssertFalse(ranOnMainThread)
+        XCTAssertGreaterThan(try XCTUnwrap(meter.snapshot(after: 0)).level, 0)
+    }
+
+    func testRecorderTapWritesFromNonMainQueue() async throws {
+        let writer = VoiceAudioWriterProbe()
+        let meter = RealtimeAudioMeter(profile: .recording)
+        let tap = VoiceAudioRecorder.makeTap(
+            writer: writer,
+            realtimeMeter: meter
+        )
+
+        let ranOnMainThread = await invokeOffMain(tap, amplitude: 0.25)
+
+        XCTAssertFalse(ranOnMainThread)
+        XCTAssertEqual(writer.wasCalledOnMainThread, false)
+        let snapshot = try XCTUnwrap(meter.snapshot(after: 0))
+        XCTAssertGreaterThan(snapshot.level, 0)
+        XCTAssertEqual(snapshot.elapsed, 0.25, accuracy: 0.0001)
+    }
+
+    func testRecordingWriterPersistsFramesFromNonMainQueue() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let outputURL = directory.appendingPathComponent("recording.wav")
+        let format = Self.makeFormat()
+        let audioFile = try AVAudioFile(
+            forWriting: outputURL,
+            settings: format.settings,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
+        let writer = VoiceAudioRecordingWriter(
+            audioFile: audioFile,
+            sampleRate: format.sampleRate
+        )
+        let meter = RealtimeAudioMeter(profile: .recording)
+        let tap = VoiceAudioRecorder.makeTap(
+            writer: writer,
+            realtimeMeter: meter
+        )
+
+        let ranOnMainThread = await invokeOffMain(tap, amplitude: 0.25)
+
+        XCTAssertFalse(ranOnMainThread)
+        XCTAssertEqual(writer.duration, 1_024.0 / 48_000.0, accuracy: 0.0001)
+        let snapshot = try XCTUnwrap(meter.snapshot(after: 0))
+        XCTAssertEqual(snapshot.elapsed, writer.duration, accuracy: 0.0001)
+        let fileSize = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: outputURL.path)[.size]
+                as? NSNumber
+        )
+        XCTAssertGreaterThan(fileSize.intValue, 44)
+    }
+
+    private func invokeOffMain(
+        _ tap: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void,
+        amplitude: Float
+    ) async -> Bool {
+        await withCheckedContinuation { continuation in
+            DispatchQueue(label: "com.nativ.tests.audio-tap").async {
+                let ranOnMainThread = Thread.isMainThread
+                let buffer = Self.makeBuffer(amplitude: amplitude)
+                tap(buffer, AVAudioTime(hostTime: 0))
+                continuation.resume(returning: ranOnMainThread)
+            }
+        }
+    }
+
+    private static func makeBuffer(amplitude: Float) -> AVAudioPCMBuffer {
+        let buffer = AVAudioPCMBuffer(
+            pcmFormat: makeFormat(),
+            frameCapacity: 1_024
+        )!
+        buffer.frameLength = 1_024
+        for frame in 0 ..< Int(buffer.frameLength) {
+            buffer.floatChannelData![0][frame] = amplitude
+        }
+        return buffer
+    }
+
+    private static func makeFormat() -> AVAudioFormat {
+        AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        )!
+    }
+}
+
+@MainActor
+final class RealtimeAudioMeterPublisherTests: XCTestCase {
+    func testPublisherCoalescesAndDeliversOnlyOnMainActor() async throws {
+        let meter = RealtimeAudioMeter(profile: .inputMonitor)
+        var deliveries: [RealtimeAudioMeterSnapshot] = []
+        var deliveredOffMain = false
+        let publisher = Task {
+            await RealtimeAudioMeterPublisher.run(
+                meter: meter,
+                interval: .milliseconds(20)
+            ) { snapshot in
+                deliveredOffMain = deliveredOffMain || !Thread.isMainThread
+                deliveries.append(snapshot)
+            }
+        }
+
+        await Task.detached {
+            for index in 1 ... 100 {
+                meter.submit(
+                    level: Float(index) / 100,
+                    elapsed: TimeInterval(index) / 100
+                )
+            }
+        }.value
+        try await Task.sleep(for: .milliseconds(75))
+        publisher.cancel()
+        await publisher.value
+
+        XCTAssertFalse(deliveredOffMain)
+        XCTAssertFalse(deliveries.isEmpty)
+        XCTAssertLessThanOrEqual(deliveries.count, 4)
+        XCTAssertEqual(deliveries.last?.elapsed ?? 0, 1, accuracy: 0.0001)
+    }
+
+    func testCancelledPublisherDoesNotDeliverLateReadings() async throws {
+        let meter = RealtimeAudioMeter(profile: .recording)
+        var deliveryCount = 0
+        let publisher = Task {
+            await RealtimeAudioMeterPublisher.run(
+                meter: meter,
+                interval: .milliseconds(5)
+            ) { _ in
+                deliveryCount += 1
+            }
+        }
+
+        publisher.cancel()
+        await publisher.value
+        meter.submit(level: 1, elapsed: 1)
+        try await Task.sleep(for: .milliseconds(20))
+
+        XCTAssertEqual(deliveryCount, 0)
+    }
+
+    func testRepeatedPublisherStartStopDropsLateReadings() async throws {
+        var deliveryCount = 0
+
+        for _ in 0 ..< 25 {
+            let meter = RealtimeAudioMeter(profile: .inputMonitor)
+            let publisher = Task {
+                await RealtimeAudioMeterPublisher.run(
+                    meter: meter,
+                    interval: .milliseconds(2)
+                ) { _ in
+                    deliveryCount += 1
+                }
+            }
+            publisher.cancel()
+            await publisher.value
+            meter.submit(level: 1, elapsed: 1)
+        }
+
+        try await Task.sleep(for: .milliseconds(10))
+        XCTAssertEqual(deliveryCount, 0)
+    }
+
+    func testProductionPublishIntervalCapsUpdatesAtFifteenHertz() {
+        XCTAssertEqual(
+            RealtimeAudioMeterPublisher.publishInterval,
+            .nanoseconds(66_666_667)
+        )
+    }
+}
+
+private final class VoiceAudioWriterProbe: VoiceAudioBufferWriting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var calledOnMainThread: Bool?
+
+    var wasCalledOnMainThread: Bool? {
+        lock.withLock { calledOnMainThread }
+    }
+
+    func append(_ buffer: AVAudioPCMBuffer) -> VoiceAudioBufferMeasurement {
+        lock.withLock {
+            calledOnMainThread = Thread.isMainThread
+        }
+        return VoiceAudioBufferMeasurement(level: 0.75, duration: 0.25)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -171,6 +171,8 @@ targets:
       - path: Sources/Nativ/Features/Routines/ScheduledTaskNotification.swift
       - path: Sources/Nativ/Utilities/NativNotificationService.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioInputDevicePreferences.swift
+      - path: Sources/Nativ/Features/VoiceCapture/RealtimeAudioMeter.swift
+      - path: Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
       - path: Sources/Nativ/Features/Models/HubModelSizeResolver.swift
       - path: Sources/Nativ/Features/Models/LocalModelDiscovery.swift


### PR DESCRIPTION
This adds a publisher which computes the meter levels off the main thread and delivers them to the main thread on a 15Hz timer to coalesce UI updates.

https://github.com/Blaizzy/nativ/issues/325