### PR TITLE
Surface MCP connection failures

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */; };
 		02571B1CDC31A5D168247CCD /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
 		025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
+		0394DEE40DF5A06244F72794 /* MCPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F373627C4A522AF78E2A17 /* MCPClientTests.swift */; };
 		03B0228F483C7F76742D5245 /* PerplexityBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F316824C4C3D36A94717A62 /* PerplexityBrowsingProvider.swift */; };
 		04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */; };
@@ -435,6 +436,7 @@
 		4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperView.swift; sourceTree = "<group>"; };
 		42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		44FCFAB2E7C5BC1AC0A5D9BB /* ControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelView.swift; sourceTree = "<group>"; };
+		45F373627C4A522AF78E2A17 /* MCPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPClientTests.swift; sourceTree = "<group>"; };
 		46B469F1D62E2DB0DE8CFAF1 /* NativPermissionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativPermissionsCard.swift; sourceTree = "<group>"; };
 		46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSemanticSearch.swift; sourceTree = "<group>"; };
 		49B4556627CCB5BD1D3DE5F8 /* VoiceDictationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtension.swift; sourceTree = "<group>"; };
@@ -1150,6 +1152,7 @@
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
 				8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */,
 				A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */,
+				45F373627C4A522AF78E2A17 /* MCPClientTests.swift */,
 				B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */,
 				3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */,
 				2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */,
@@ -1644,6 +1647,7 @@
 				9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */,
 				3583BC09DCAFC37BBB94749D /* MCPHostManager.swift in Sources */,
 				2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */,
+				0394DEE40DF5A06244F72794 /* MCPClientTests.swift in Sources */,
 				D9CA77A603AF02C2C70BC9FF /* MCPServerCatalogTests.swift in Sources */,
 				B2B154008527C6291C17AC93 /* MLXImageModelResolver.swift in Sources */,
 				EF3678F684519D8ADC625B20 /* MLXImageModelResolverTests.swift in Sources */,

--- a/Sources/Nativ/Features/Extensions/MCPSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/MCPSectionView.swift
@@ -171,7 +171,7 @@ private struct MCPServerRow: View {
     @State private var copiedAuthorizationCode = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: showsGitHubSetup ? 10 : 0) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 12) {
                 NativStatusDot(tone: statusTone, pulsing: isConnecting)
                 VStack(alignment: .leading, spacing: 2) {
@@ -254,15 +254,14 @@ private struct MCPServerRow: View {
                     destination: installationURL
                 )
                 .padding(.leading, 20)
+            } else if case .failed(let failure) = state,
+                      let details = failure.details,
+                      !details.isEmpty {
+                MCPConnectionFailureCallout(details: details)
+                    .padding(.leading, 20)
             }
         }
         .padding(.vertical, 11)
-    }
-
-    private var showsGitHubSetup: Bool {
-        if case .authorizingGitHub = state { return true }
-        if case .installingGitHub = state { return true }
-        return false
     }
 
     private var isConnecting: Bool {
@@ -287,7 +286,7 @@ private struct MCPServerRow: View {
         case .connecting: "Connecting\u{2026}"
         case .authorizingGitHub: "Authorization required"
         case .installingGitHub: "Repository access required"
-        case .failed(let message): message.isEmpty ? "Failed to connect" : message
+        case .failed(let failure): failure.message.isEmpty ? "Failed to connect" : failure.message
         case .disabled: "Off"
         case .none: server.isEnabled ? "Not connected" : "Off"
         }
@@ -297,6 +296,31 @@ private struct MCPServerRow: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(code, forType: .string)
         copiedAuthorizationCode = true
+    }
+}
+
+private struct MCPConnectionFailureCallout: View {
+    let details: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+                .accessibilityHidden(true)
+
+            Text(details)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
+        .frame(maxWidth: 650, alignment: .leading)
+        .background(Color.red.opacity(0.05), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.red.opacity(0.16), lineWidth: 1)
+        }
     }
 }
 

--- a/Sources/Nativ/Features/MCP/MCPHostManager.swift
+++ b/Sources/Nativ/Features/MCP/MCPHostManager.swift
@@ -8,7 +8,7 @@ enum MCPServerConnectionState: Equatable {
     case authorizingGitHub(code: String, verificationURL: URL)
     case installingGitHub(URL)
     case connected(toolCount: Int)
-    case failed(String)
+    case failed(MCPConnectionFailure)
 }
 
 @MainActor
@@ -144,7 +144,9 @@ final class MCPHostManager: ObservableObject {
         var githubPending: [(config: MCPServerConfig, executable: URL)] = []
         for config in toConnect where connections[config.id] == nil {
             guard let executable = Self.resolveExecutable(config.command, searchPath: searchPath) else {
-                states[config.id] = .failed("Couldn’t find “\(config.command)”")
+                states[config.id] = .failed(
+                    MCPConnectionFailure(message: "Couldn’t find “\(config.command)”")
+                )
                 continue
             }
             let catalogEntry = MCPServerCatalog.bundled.entry(matching: config)
@@ -206,7 +208,7 @@ final class MCPHostManager: ObservableObject {
                         return ConnectOutcome(
                             config: item.config,
                             tools: nil,
-                            error: error.localizedDescription,
+                            error: Self.connectionFailure(from: error),
                             client: item.client
                         )
                     }
@@ -234,7 +236,7 @@ final class MCPHostManager: ObservableObject {
                 } else {
                     await outcome.client.disconnect()
                     states[outcome.config.id] = .failed(
-                        outcome.error ?? "Failed to connect"
+                        outcome.error ?? MCPConnectionFailure(message: "Failed to connect")
                     )
                 }
             }
@@ -249,7 +251,7 @@ final class MCPHostManager: ObservableObject {
     ) async {
         guard let githubOAuth else {
             states[config.id] = .failed(
-                GitHubOAuthError.notConfigured.localizedDescription
+                MCPConnectionFailure(message: GitHubOAuthError.notConfigured.localizedDescription)
             )
             return
         }
@@ -318,19 +320,26 @@ final class MCPHostManager: ObservableObject {
                 states[config.id] = .connected(toolCount: tools.count)
             } catch {
                 await client.disconnect()
-                states[config.id] = .failed(error.localizedDescription)
+                states[config.id] = .failed(Self.connectionFailure(from: error))
             }
         } catch {
             guard generation == reloadGeneration else { return }
-            states[config.id] = .failed(error.localizedDescription)
+            states[config.id] = .failed(Self.connectionFailure(from: error))
         }
     }
 
     private struct ConnectOutcome: Sendable {
         let config: MCPServerConfig
         let tools: [MCPToolInfo]?
-        let error: String?
+        let error: MCPConnectionFailure?
         let client: MCPClient
+    }
+
+    nonisolated private static func connectionFailure(from error: Error) -> MCPConnectionFailure {
+        if let failure = error as? MCPConnectionFailure {
+            return failure
+        }
+        return MCPConnectionFailure(message: error.localizedDescription)
     }
 
     private static func toolDefinitions(for connection: Connection) -> [MLXChatToolDefinition] {

--- a/Sources/NativServerKit/MCPClient.swift
+++ b/Sources/NativServerKit/MCPClient.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import Synchronization
 
 #if canImport(System)
 import System
@@ -19,6 +20,18 @@ public struct MCPToolInfo: Sendable, Equatable {
     }
 }
 
+public struct MCPConnectionFailure: LocalizedError, Equatable, Sendable {
+    public let message: String
+    public let details: String?
+
+    public init(message: String, details: String? = nil) {
+        self.message = message
+        self.details = details
+    }
+
+    public var errorDescription: String? { message }
+}
+
 public enum MCPClientError: LocalizedError {
     case notConnected
     case timedOut
@@ -36,7 +49,51 @@ public enum MCPClientError: LocalizedError {
     }
 }
 
+private final class MCPStderrCapture: Sendable {
+    private struct State: Sendable {
+        var data = Data()
+        var wasTruncated = false
+    }
+
+    private let limit: Int
+    private let state = Mutex(State())
+
+    init(limit: Int) {
+        self.limit = limit
+    }
+
+    func append(_ chunk: Data) {
+        guard !chunk.isEmpty else { return }
+        state.withLock { state in
+            state.data.append(chunk)
+            guard state.data.count > limit else { return }
+            state.data.removeFirst(state.data.count - limit)
+            state.wasTruncated = true
+        }
+    }
+
+    func snapshot() -> (text: String, wasTruncated: Bool) {
+        state.withLock { state in
+            (String(decoding: state.data, as: UTF8.self), state.wasTruncated)
+        }
+    }
+}
+
 public actor MCPClient {
+    private struct Connection {
+        let id: UUID
+        let process: Process
+        let inputPipe: Pipe
+        let outputPipe: Pipe
+        let errorPipe: Pipe
+        let stderr: MCPStderrCapture
+        let transport: StdioTransport
+        let client: Client
+    }
+
+    private static let stderrLimit = 16_384
+    private static let diagnosticLineLimit = 12
+
     private let executableURL: URL
     private let arguments: [String]
     private let environment: [String: String]
@@ -44,11 +101,9 @@ public actor MCPClient {
     private let clientName: String
     private let clientVersion: String
 
-    private var process: Process?
-    private var inputPipe: Pipe?
-    private var outputPipe: Pipe?
-    private var transport: StdioTransport?
-    private var client: Client?
+    private var connection: Connection?
+    private var isReady = false
+    private var startupFailure: MCPConnectionFailure?
 
     public init(
         executableURL: URL,
@@ -67,15 +122,81 @@ public actor MCPClient {
     }
 
     public var isConnected: Bool {
-        client != nil
+        connection != nil && isReady
     }
 
     public func connect() async throws {
-        guard client == nil else { return }
+        guard !isReady else { return }
+        do {
+            try await startConnection()
+            isReady = true
+            startupFailure = nil
+        } catch {
+            let failure = startupFailure ?? connectionFailure(for: error)
+            await tearDownConnection()
+            throw failure
+        }
+    }
+
+    /// Connects and lists tools under a single deadline, so a server that hangs
+    /// during startup or the handshake fails fast instead of blocking forever.
+    public func connectAndListTools(timeout: TimeInterval = 60) async throws -> [MCPToolInfo] {
+        if isReady {
+            return try await listTools()
+        }
+
+        return try await withTaskCancellationHandler {
+            do {
+                let tools = try await withThrowingTaskGroup(of: [MCPToolInfo].self) { group in
+                    group.addTask {
+                        try await self.startConnection()
+                        return try await self.listTools()
+                    }
+                    group.addTask {
+                        let nanoseconds = UInt64(max(0, timeout) * 1_000_000_000)
+                        try await Task.sleep(nanoseconds: nanoseconds)
+                        let failure = await self.failStartupAfterTimeout(timeout)
+                        throw failure
+                    }
+                    defer { group.cancelAll() }
+                    guard let result = try await group.next() else {
+                        throw MCPConnectionFailure(message: "Failed to connect to the MCP server.")
+                    }
+                    return result
+                }
+
+                guard connection != nil else {
+                    throw startupFailure ?? MCPConnectionFailure(
+                        message: "Failed to connect to the MCP server."
+                    )
+                }
+                isReady = true
+                startupFailure = nil
+                return tools
+            } catch {
+                if Task.isCancelled {
+                    await tearDownConnection()
+                    throw CancellationError()
+                }
+
+                let failure = startupFailure ?? connectionFailure(for: error)
+                await tearDownConnection()
+                throw failure
+            }
+        } onCancel: {
+            Task { await self.tearDownConnection() }
+        }
+    }
+
+    private func startConnection() async throws {
+        guard connection == nil else { return }
 
         let inputPipe = Pipe()
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        let stderrCapture = MCPStderrCapture(limit: Self.stderrLimit)
         let process = Process()
+        let connectionID = UUID()
         process.executableURL = executableURL
         process.arguments = arguments
         process.environment = environment
@@ -88,8 +209,7 @@ public actor MCPClient {
         }
         process.standardInput = inputPipe
         process.standardOutput = outputPipe
-        process.standardError = FileHandle.nullDevice
-        try process.run()
+        process.standardError = errorPipe
 
         let transport = StdioTransport(
             input: FileDescriptor(rawValue: outputPipe.fileHandleForReading.fileDescriptor),
@@ -97,33 +217,49 @@ public actor MCPClient {
         )
         let client = Client(name: clientName, version: clientVersion)
 
-        do {
-            try await client.connect(transport: transport)
-        } catch {
-            if process.isRunning {
-                process.terminate()
+        errorPipe.fileHandleForReading.readabilityHandler = { handle in
+            stderrCapture.append(handle.availableData)
+        }
+        process.terminationHandler = { [weak self, errorPipe, stderrCapture] process in
+            let handle = errorPipe.fileHandleForReading
+            handle.readabilityHandler = nil
+            stderrCapture.append(handle.readDataToEndOfFile())
+            let processSummary: String
+            switch process.terminationReason {
+            case .exit:
+                processSummary = "Process exited with status \(process.terminationStatus)."
+            case .uncaughtSignal:
+                processSummary = "Process ended from signal \(process.terminationStatus)."
+            @unknown default:
+                processSummary = "Process ended with status \(process.terminationStatus)."
             }
-            throw error
+            Task {
+                await self?.processDidTerminate(
+                    connectionID: connectionID,
+                    processSummary: processSummary
+                )
+            }
         }
 
-        self.inputPipe = inputPipe
-        self.outputPipe = outputPipe
-        self.process = process
-        self.transport = transport
-        self.client = client
-    }
+        connection = Connection(
+            id: connectionID,
+            process: process,
+            inputPipe: inputPipe,
+            outputPipe: outputPipe,
+            errorPipe: errorPipe,
+            stderr: stderrCapture,
+            transport: transport,
+            client: client
+        )
+        isReady = false
+        startupFailure = nil
 
-    /// Connects and lists tools under a single deadline, so a server that hangs
-    /// during startup or the handshake fails fast instead of blocking forever.
-    public func connectAndListTools(timeout: TimeInterval = 60) async throws -> [MCPToolInfo] {
-        try await Self.withTimeout(timeout) {
-            try await self.connect()
-            return try await self.listTools()
-        }
+        try process.run()
+        try await client.connect(transport: transport)
     }
 
     public func listTools() async throws -> [MCPToolInfo] {
-        guard let client else { throw MCPClientError.notConnected }
+        guard let client = connection?.client else { throw MCPClientError.notConnected }
 
         var infos: [MCPToolInfo] = []
         var cursor: String?
@@ -149,7 +285,7 @@ public actor MCPClient {
         argumentsJSON: String?,
         timeout: TimeInterval = 120
     ) async throws -> String {
-        guard let client else { throw MCPClientError.notConnected }
+        guard let client = connection?.client else { throw MCPClientError.notConnected }
 
         let arguments = try Self.arguments(from: argumentsJSON)
         return try await Self.withTimeout(timeout) {
@@ -163,17 +299,7 @@ public actor MCPClient {
     }
 
     public func disconnect() async {
-        if let client {
-            await client.disconnect()
-        }
-        client = nil
-        transport = nil
-        if let process, process.isRunning {
-            process.terminate()
-        }
-        process = nil
-        inputPipe = nil
-        outputPipe = nil
+        await tearDownConnection()
     }
 
     private static func withTimeout<T: Sendable>(
@@ -192,6 +318,131 @@ public actor MCPClient {
             }
             return result
         }
+    }
+
+    private func failStartupAfterTimeout(_ timeout: TimeInterval) async -> MCPConnectionFailure {
+        let seconds = max(0, Int(timeout.rounded(.up)))
+        let failure = MCPConnectionFailure(
+            message: "MCP server didn’t connect within \(seconds) second\(seconds == 1 ? "" : "s").",
+            details: diagnosticDetails()
+        )
+        startupFailure = failure
+        await tearDownConnection(preservingFailure: true)
+        return failure
+    }
+
+    private func processDidTerminate(
+        connectionID: UUID,
+        processSummary: String
+    ) async {
+        guard connection?.id == connectionID else { return }
+
+        if !isReady {
+            startupFailure = MCPConnectionFailure(
+                message: "MCP server exited before connecting.",
+                details: diagnosticDetails(processSummary: processSummary)
+            )
+        }
+        await tearDownConnection(preservingFailure: !isReady)
+    }
+
+    private func connectionFailure(for error: Error) -> MCPConnectionFailure {
+        if let failure = error as? MCPConnectionFailure {
+            return failure
+        }
+
+        let description = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        return MCPConnectionFailure(
+            message: "Failed to connect to the MCP server.",
+            details: diagnosticDetails(leading: description.isEmpty ? nil : description)
+        )
+    }
+
+    private func diagnosticDetails(
+        leading: String? = nil,
+        processSummary: String? = nil
+    ) -> String? {
+        var sections = [leading, processSummary].compactMap { output -> String? in
+            guard let output, !output.isEmpty else { return nil }
+            let redacted = Self.redactedDiagnosticOutput(
+                output,
+                arguments: arguments,
+                environment: environment
+            )
+            return redacted.isEmpty ? nil : redacted
+        }
+
+        if let capture = connection?.stderr {
+            let snapshot = capture.snapshot()
+            let output = Self.redactedDiagnosticOutput(
+                snapshot.text,
+                arguments: arguments,
+                environment: environment
+            )
+            if !output.isEmpty {
+                let prefix = snapshot.wasTruncated ? "Earlier server output was truncated.\n" : ""
+                sections.append(prefix + output)
+            }
+        }
+
+        let details = sections.joined(separator: "\n\n")
+        return details.isEmpty ? nil : details
+    }
+
+    static func redactedDiagnosticOutput(
+        _ output: String,
+        arguments: [String],
+        environment: [String: String]
+    ) -> String {
+        var result = output
+        let sensitiveKeyFragments = [
+            "TOKEN", "KEY", "SECRET", "PASSWORD", "AUTH", "CREDENTIAL", "PRIVATE",
+        ]
+        var secretValues = environment.compactMap { key, value -> String? in
+            guard value.count >= 4 else { return nil }
+            let normalized = key.uppercased()
+            return sensitiveKeyFragments.contains(where: normalized.contains) ? value : nil
+        }
+
+        for argument in arguments {
+            let lowercased = argument.lowercased()
+            guard let bearerRange = lowercased.range(of: "bearer ") else { continue }
+            if let value = argument[bearerRange.upperBound...]
+                .split(whereSeparator: { $0.isWhitespace || $0 == "\"" || $0 == "'" })
+                .first,
+                value.count >= 4 {
+                secretValues.append(String(value))
+            }
+        }
+
+        for secret in Set(secretValues).sorted(by: { $0.count > $1.count }) {
+            result = result.replacingOccurrences(of: secret, with: "<redacted>")
+        }
+
+        let lines = result
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        result = lines.suffix(Self.diagnosticLineLimit).joined(separator: "\n")
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func tearDownConnection(preservingFailure: Bool = false) async {
+        let connection = self.connection
+        self.connection = nil
+        isReady = false
+        if !preservingFailure {
+            startupFailure = nil
+        }
+
+        connection?.process.terminationHandler = nil
+        connection?.errorPipe.fileHandleForReading.readabilityHandler = nil
+        if let process = connection?.process, process.isRunning {
+            process.terminate()
+        }
+        try? connection?.inputPipe.fileHandleForWriting.close()
+        await connection?.client.disconnect()
+        try? connection?.outputPipe.fileHandleForReading.close()
+        try? connection?.errorPipe.fileHandleForReading.close()
     }
 
     private static func schema(from value: Value?) throws -> MLXJSONValue {

--- a/Tests/NativTests/MCPClientTests.swift
+++ b/Tests/NativTests/MCPClientTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import NativServerKit
+
+final class MCPClientTests: XCTestCase {
+    func testProcessExitSurfacesStderrStatusAndRedactsSecrets() async {
+        let secret = "issue-366-secret"
+        let client = makeClient(
+            script: "i=0; while [ $i -lt 3000 ]; do echo beginning-$i >&2; i=$((i + 1)); done; echo 'Authorization: Bearer \(secret)' >&2; echo 'Invalid MCP header' >&2; exit 23"
+        )
+        let start = Date()
+
+        let failure = await connectionFailure(from: client, timeout: 5)
+
+        XCTAssertLessThan(Date().timeIntervalSince(start), 2)
+        XCTAssertEqual(failure.message, "MCP server exited before connecting.")
+        XCTAssertEqual(failure.details?.contains("Process exited with status 23."), true)
+        XCTAssertEqual(failure.details?.contains("Earlier server output was truncated."), true)
+        XCTAssertEqual(failure.details?.contains("beginning-0\n"), false)
+        XCTAssertEqual(failure.details?.contains("Invalid MCP header"), true)
+        XCTAssertEqual(failure.details?.contains("<redacted>"), true)
+        XCTAssertNotEqual(failure.details?.contains(secret), true)
+    }
+
+    func testConnectionDeadlineStopsStalledHandshake() async {
+        let client = makeClient(script: "while IFS= read -r line; do :; done")
+        let start = Date()
+
+        let failure = await connectionFailure(from: client, timeout: 0.2)
+        let isConnected = await client.isConnected
+
+        XCTAssertLessThan(Date().timeIntervalSince(start), 2)
+        XCTAssertEqual(failure.message, "MCP server didn’t connect within 1 second.")
+        XCTAssertFalse(isConnected)
+    }
+
+    private func makeClient(script: String) -> MCPClient {
+        MCPClient(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", script],
+            environment: [:]
+        )
+    }
+
+    private func connectionFailure(
+        from client: MCPClient,
+        timeout: TimeInterval
+    ) async -> MCPConnectionFailure {
+        do {
+            _ = try await client.connectAndListTools(timeout: timeout)
+            XCTFail("Expected the MCP connection to fail")
+            await client.disconnect()
+            return MCPConnectionFailure(message: "Unexpected success")
+        } catch let failure as MCPConnectionFailure {
+            await client.disconnect()
+            return failure
+        } catch {
+            XCTFail("Expected MCPConnectionFailure, got \(error)")
+            await client.disconnect()
+            return MCPConnectionFailure(message: error.localizedDescription)
+        }
+    }
+}


### PR DESCRIPTION

Closes #366

Issue #366 made light a problem where stderr's from a mcp child precess didn't get captured, so it would incorrectly say "Connecting" when infact there was an error connecting to mcp server. It surfaces a concise, redacted connection diagnostics on the failed mcp 

<img width="1440" height="452" alt="Image 8-23-26 at 3 12 PM" src="https://github.com/user-attachments/assets/3833310e-932d-4f6c-83b7-9048c4543049" />

