### PR TITLE
Keep models whose shard index describes another build

### DIFF
--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -736,6 +736,11 @@ enum LocalModelDiscovery {
             return true
         case .incomplete:
             return false
+        case .stale:
+            // The index describes a different build of the model, so fall back
+            // to the shards on disk — but only accept a set that is complete on
+            // its own, so a partially downloaded snapshot stays hidden.
+            return safetensorsShardsLookComplete(at: snapshotURL, fileManager: fileManager)
         case .absent:
             break
         }
@@ -766,6 +771,10 @@ enum LocalModelDiscovery {
         case absent
         case complete
         case incomplete
+        /// The index references shards, none of whose filenames exist in the
+        /// snapshot. The index describes a different build of the model rather
+        /// than a download that is still in flight.
+        case stale
     }
 
     private struct SafetensorsShardIndex: Decodable {
@@ -776,9 +785,77 @@ enum LocalModelDiscovery {
         }
     }
 
+    /// Decides whether the `.safetensors` files in a snapshot form a complete
+    /// set on their own, without consulting a shard index. A snapshot qualifies
+    /// when it holds a single unsharded file, or every shard of one
+    /// `model-0000N-of-0000M` series.
+    private static func safetensorsShardsLookComplete(
+        at snapshotURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: snapshotURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        var shardTotals: Set<Int> = []
+        var shardNumbers: Set<Int> = []
+        var hasUnshardedWeights = false
+
+        for fileURL in contents where fileURL.pathExtension == "safetensors" {
+            guard let values = try? fileURL.resolvingSymlinksInPath().resourceValues(
+                    forKeys: [.isRegularFileKey, .fileSizeKey]
+                  ),
+                  values.isRegularFile == true,
+                  let fileSize = values.fileSize,
+                  fileSize > 0
+            else {
+                continue
+            }
+
+            if let numbering = shardNumbering(forFilename: fileURL.lastPathComponent) {
+                shardTotals.insert(numbering.total)
+                shardNumbers.insert(numbering.index)
+            } else {
+                hasUnshardedWeights = true
+            }
+        }
+
+        // Shards from more than one series mean the snapshot holds leftovers of
+        // another build, which is not a set this check can vouch for.
+        if let total = shardTotals.first, shardTotals.count == 1 {
+            return shardNumbers == Set(1...total)
+        }
+        return shardTotals.isEmpty && hasUnshardedWeights
+    }
+
+    /// Parses the `model-00001-of-00004.safetensors` shard naming convention.
+    private static func shardNumbering(forFilename filename: String) -> (index: Int, total: Int)? {
+        let components = (filename as NSString).deletingPathExtension.components(separatedBy: "-")
+        guard components.count >= 4,
+              components[components.count - 2] == "of",
+              let index = Int(components[components.count - 3]),
+              let total = Int(components[components.count - 1]),
+              index >= 1,
+              total >= 1,
+              index <= total
+        else {
+            return nil
+        }
+        return (index, total)
+    }
+
     /// A shard index is downloaded before the weight shards it describes. Treat
     /// the snapshot as usable only after every referenced shard is a non-empty
     /// regular file inside the snapshot directory.
+    ///
+    /// When none of the referenced filenames are present the index is reporting
+    /// on a different build of the model, so it says nothing about whether this
+    /// snapshot finished downloading; that case is reported as `.stale` and the
+    /// shards themselves are inspected instead.
     private static func safetensorsShardIndexStatus(
         at snapshotURL: URL,
         fileManager: FileManager
@@ -801,7 +878,7 @@ enum LocalModelDiscovery {
 
         let snapshotPath = snapshotURL.standardizedFileURL.path
         let snapshotPrefix = snapshotPath.hasSuffix("/") ? snapshotPath : snapshotPath + "/"
-        let allShardsAreAvailable = shardFilenames.allSatisfy { filename in
+        let availableShardCount = shardFilenames.filter { filename in
             guard !filename.isEmpty,
                   !(filename as NSString).isAbsolutePath
             else {
@@ -820,8 +897,12 @@ enum LocalModelDiscovery {
                 return false
             }
             return true
+        }.count
+
+        if availableShardCount == shardFilenames.count {
+            return .complete
         }
-        return allShardsAreAvailable ? .complete : .incomplete
+        return availableShardCount == 0 ? .stale : .incomplete
     }
 
     private static func snapshotSize(at snapshotURL: URL, fileManager: FileManager) -> Int64? {

--- a/Tests/NativTests/LocalModelDiscoveryTests.swift
+++ b/Tests/NativTests/LocalModelDiscoveryTests.swift
@@ -209,6 +209,53 @@ final class LocalModelDiscoveryTests: XCTestCase {
         XCTAssertTrue(models.contains { $0.repoID == repoID })
     }
 
+    func testDiscoversCompleteSnapshotWhoseIndexDescribesAnotherBuild() async throws {
+        try makeSnapshotWithIndependentShardIndex(
+            repoID: "org/stale-index-complete",
+            indexedShardFilenames: (1...13).map {
+                String(format: "model-%05d-of-00013.safetensors", $0)
+            },
+            onDiskShardFilenames: (1...4).map {
+                String(format: "model-%05d-of-00004.safetensors", $0)
+            }
+        )
+
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+
+        XCTAssertTrue(models.contains { $0.repoID == "org/stale-index-complete" })
+    }
+
+    func testHidesPartialDownloadWhoseIndexDescribesAnotherBuild() async throws {
+        try makeSnapshotWithIndependentShardIndex(
+            repoID: "org/stale-index-partial",
+            indexedShardFilenames: (1...13).map {
+                String(format: "model-%05d-of-00013.safetensors", $0)
+            },
+            onDiskShardFilenames: (1...2).map {
+                String(format: "model-%05d-of-00004.safetensors", $0)
+            }
+        )
+
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+
+        XCTAssertFalse(models.contains { $0.repoID == "org/stale-index-partial" })
+    }
+
+    func testHidesSnapshotWithShardIndexButNoWeightsYet() async throws {
+        try makeSnapshotWithIndependentShardIndex(
+            repoID: "org/index-without-weights",
+            indexedShardFilenames: [
+                "model-00001-of-00002.safetensors",
+                "model-00002-of-00002.safetensors",
+            ],
+            onDiskShardFilenames: []
+        )
+
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+
+        XCTAssertFalse(models.contains { $0.repoID == "org/index-without-weights" })
+    }
+
     func testSelectsAnyInstalledSpeechToTextModelWithoutKnownModelNames() {
         let models = [
             makeModel(repoID: "owner/text-only", capabilities: [.text]),
@@ -446,6 +493,40 @@ final class LocalModelDiscoveryTests: XCTestCase {
             ["weight_map": weightMap],
             to: snapshot.appendingPathComponent("model.safetensors.index.json")
         )
+    }
+
+    /// Builds a snapshot whose shard index and on-disk shards are unrelated,
+    /// which is what a quantized repo looks like when it ships the source
+    /// model's `model.safetensors.index.json`.
+    private func makeSnapshotWithIndependentShardIndex(
+        repoID: String,
+        indexedShardFilenames: [String],
+        onDiskShardFilenames: [String]
+    ) throws {
+        let snapshot = snapshotURL(repoID: repoID)
+        let repository = snapshot
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let revision = snapshot.lastPathComponent
+
+        try write(revision, to: repository.appendingPathComponent("refs/main"))
+        try writeJSON(
+            ["model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]],
+            to: snapshot.appendingPathComponent("config.json")
+        )
+
+        var weightMap: [String: String] = [:]
+        for (index, filename) in indexedShardFilenames.enumerated() {
+            weightMap["model.layers.\(index).weight"] = filename
+        }
+        try writeJSON(
+            ["weight_map": weightMap],
+            to: snapshot.appendingPathComponent("model.safetensors.index.json")
+        )
+
+        for filename in onDiskShardFilenames {
+            try write("weights", to: snapshot.appendingPathComponent(filename))
+        }
     }
 
     private func snapshotURL(repoID: String) -> URL {


### PR DESCRIPTION
### Summary

A fully downloaded, loadable model is silently dropped from the model list when its
`model.safetensors.index.json` is stale — that is, when it references shard filenames
that are not in the snapshot at all. No error, no warning; the model simply never
appears.

This affected all six `mlx-community` Qwen3-VL repos I tested, so it is not a one-off
bad upload. The bundled `mlx-vlm` runtime loads these models fine, so today the
pre-flight check is stricter than the loader it is guarding.

This PR teaches the check to tell "download still in progress" apart from "this index
describes a different build of the model", while keeping partially downloaded snapshots
hidden.

### Reproduction

1. `hf download mlx-community/Qwen3-VL-30B-A3B-Instruct-4bit`
2. Open Nativ → the model does not appear in the model list.

Snapshot contents are complete (4 shards totalling 18.3 GB / 17 GiB, no `.incomplete`
files), but the repo's index references 13 shards from the original bf16 model:

| | index.json claims | actually on disk |
|---|---|---|
| shards | 13 (`model-0000N-of-00013`) | 4 (`model-0000N-of-00004`) |
| total_size | 62.1 GB | 18.3 GB (17 GiB) |
| overlap | **0 files** | |

The local file is byte-identical to the one served by the Hub
(sha256 `4fa496bd4b4aace60623070379297c7c0c78b5aa4924b39e1174a0e9e1aeae5e`), so this is
not local cache corruption.

### Root cause

`safetensorsShardIndexStatus()` requires *every* shard named in `weight_map` to exist,
so 0-of-13 present collapses to the same `.incomplete` verdict as 12-of-13 present.
`isLikelyMLXModelSnapshot()` then returns `false` at the `case .incomplete:` arm, before
reaching the `.safetensors` fallback, and `scanSynchronously()`'s `compactMap` drops the
model with no diagnostic.

The two situations are genuinely different, though. A partial download has *some* of the
referenced shards on disk. An index describing another build has **none** of them, and
therefore says nothing at all about whether this snapshot finished downloading.

### What this changes

- Adds a `.stale` case to `SafetensorsShardIndexStatus`, returned when the index
  references shards and none of those filenames exist in the snapshot.
- Routes `.stale` to a new `safetensorsShardsLookComplete(at:fileManager:)`, which
  accepts the snapshot only if the `.safetensors` files form a complete set on their own:
  a single unsharded file, or every shard of one `model-0000N-of-0000M` series. Mixed
  series (leftovers of another build) are rejected.
- `.absent`, `.complete` and `.incomplete` behave exactly as before.

The weak "any `.safetensors` exists" fallback is deliberately *not* reused for `.stale`,
since that would list a snapshot that had only downloaded 2 of its 4 shards.

### Tests

Three tests added to `LocalModelDiscoveryTests`:

| test | expectation |
|---|---|
| `testDiscoversCompleteSnapshotWhoseIndexDescribesAnotherBuild` | stale index + all 4 real shards → listed |
| `testHidesPartialDownloadWhoseIndexDescribesAnotherBuild` | stale index + 2 of 4 shards → hidden |
| `testHidesSnapshotWithShardIndexButNoWeightsYet` | index present, no weights yet → hidden |

The existing shard-index tests are unaffected by design:
`testRequiresEveryShardReferencedBySafetensorsIndex` keeps its incomplete fixture hidden
(1 of 2 referenced shards present → still `.incomplete`, not `.stale`), and
`testRejectsMalformedOrEmptySafetensorsIndex` is untouched because the empty-`weight_map`
guard still returns `.incomplete` before the new branch is reached.

### Verification

I could not run the Xcode test suite locally — the checked-in project fails to resolve
its SPM module graph without regenerating via `xcodegen`, and `NativTests` pulls in
`NativServerKit`, whose post-build phase rebuilds the Python resource. Both are
pre-existing to this change.

Instead I extracted the modified functions verbatim from the patched source into a
standalone harness and ran the fixtures through them, including ones that replicate the
existing XCTest expectations:

```
✅ indexed 2 of 2 present                          listed    [complete]
✅ indexed 1 of 2 present (downloading)            hidden    [incomplete]
✅ malformed JSON index                            hidden    [incomplete]
✅ empty weight_map                                hidden    [incomplete]
✅ completed shard via HF blob symlink             listed    [complete]
✅ stale index + all 4 real shards                 listed    [stale]
✅ stale index + 2 of 4 shards                     hidden    [stale]
✅ index present, no weights yet                   hidden    [stale]
✅ stale index + single unsharded file             listed    [stale]
✅ stale index + two different shard series        hidden    [stale]
```

Against the real Hugging Face cache entry from the report, the patched logic reports
`stale` and lists the model, with no change to the files on disk.

Please do run the suite in CI — a local confirmation would be better than my harness.

### Scope of the upstream problem

All six checked `mlx-community` Qwen3-VL repos carry a stale index (`total_size` is the
bf16 figure in every case):

| repo | index refs | actual | total_size |
|---|---|---|---|
| Qwen3-VL-4B-Instruct-4bit | 2 | 1 | 8.9 GB |
| Qwen3-VL-8B-Instruct-4bit | 4 | 2 | 17.5 GB |
| Qwen3-VL-30B-A3B-Instruct-4bit | 13 | 4 | 62.1 GB |
| Qwen3-VL-30B-A3B-Thinking-4bit | 13 | 4 | 62.1 GB |
| Qwen3-VL-30B-A3B-Instruct-8bit | 13 | 7 | 62.1 GB |
| Qwen3-VL-235B-A22B-Instruct-4bit | 96 | 26 | 471.3 GB |

These were converted/uploaded between 2025-10-09 and 2025-10-16, before
`Blaizzy/mlx-vlm` commit `c4ea290e` (2025-12-18, #638 "Skip index.json in file copy to
prevent overwrite"), where the `*.json` copy step used `shutil.copy` and overwrote the
correct index produced by `save_weights()`. The converter is fixed, but the already
published repos still carry the bad file — so Nativ will keep meeting these snapshots
for as long as they stay up.

### Follow-up worth considering

Separately from this fix, surfacing *why* a snapshot was skipped (a log line at minimum)
would make this class of problem self-diagnosable. Right now a skipped model leaves no
trace anywhere, which is what made this take a while to pin down.

### Environment

- Reported against Nativ v0.3.3 (build 202608182002), installed from release
- macOS 26.6 (Darwin 25.6.0), Apple silicon
- `modelSearchPath`: `~/.cache/huggingface/hub` (default)
- `LocalModelDiscovery.swift` is unchanged between tag `v0.3.3` and current `main`
