### PR TITLE
Fix scrolling performance for long user prompts

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1568,10 +1568,9 @@ private struct ChatMessageText: View {
     @ViewBuilder
     var body: some View {
         if isUserPrompt {
-            ChatSelectablePromptText(
-                content: content,
-                fontScale: chatFontScale
-            )
+            Text(verbatim: content)
+                .textSelection(.enabled)
+                .font(ChatFontMetrics.bodyFont(scale: chatFontScale))
         } else if rendersMarkdown && isStreaming {
             ChatStreamingMarkdownText(
                 content: content,
@@ -1651,73 +1650,6 @@ private struct ChatStreamingMarkdownChunk: View, Equatable {
             syntaxExtensions: [.math]
         )
         .fixedSize(horizontal: false, vertical: true)
-    }
-}
-
-private struct ChatSelectablePromptText: NSViewRepresentable {
-    let content: String
-    let fontScale: Double
-
-    func makeNSView(context: Context) -> NSTextView {
-        let textView = NSTextView()
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.isRichText = false
-        textView.drawsBackground = false
-        textView.textContainerInset = .zero
-        textView.textContainer?.lineFragmentPadding = 0
-        textView.textContainer?.lineBreakMode = .byWordWrapping
-        textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.heightTracksTextView = false
-        textView.isHorizontallyResizable = false
-        textView.isVerticallyResizable = true
-        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        textView.setContentHuggingPriority(.defaultHigh, for: .vertical)
-        update(textView)
-        return textView
-    }
-
-    func updateNSView(_ textView: NSTextView, context: Context) {
-        update(textView)
-    }
-
-    func sizeThatFits(
-        _ proposal: ProposedViewSize,
-        nsView textView: NSTextView,
-        context: Context
-    ) -> CGSize? {
-        let font = ChatFontMetrics.bodyNSFont(scale: fontScale)
-        let availableWidth = proposal.width ?? .greatestFiniteMagnitude
-        let bounds = (content as NSString).boundingRect(
-            with: CGSize(width: availableWidth, height: .greatestFiniteMagnitude),
-            options: [.usesLineFragmentOrigin, .usesFontLeading],
-            attributes: textAttributes(font: font)
-        )
-        let measuredWidth = max(1, ceil(bounds.width))
-        let width = proposal.width.map { min($0, measuredWidth) } ?? measuredWidth
-        return CGSize(width: width, height: max(1, ceil(bounds.height)))
-    }
-
-    private func update(_ textView: NSTextView) {
-        let font = ChatFontMetrics.bodyNSFont(scale: fontScale)
-        if textView.string != content || textView.font != font {
-            textView.textStorage?.setAttributedString(NSAttributedString(
-                string: content,
-                attributes: textAttributes(font: font)
-            ))
-        }
-        textView.setAccessibilityLabel(content)
-    }
-
-    private func textAttributes(font: NSFont) -> [NSAttributedString.Key: Any] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineBreakMode = .byWordWrapping
-        paragraphStyle.lineSpacing = 2
-        return [
-            .font: font,
-            .foregroundColor: NSColor.white,
-            .paragraphStyle: paragraphStyle
-        ]
     }
 }
 


### PR DESCRIPTION
Use a native SwiftUI text view instead of the bridged AppKit view for user prompts, which has equivalent behavior but significantly improved layout performance.