### PR TITLE
Fix the scroll indicator overlapping with the composer gradient

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -89,6 +89,7 @@ private enum ChatTranscriptLayout {
     static let messageHorizontalInset: CGFloat = 32
     static let composerClearance: CGFloat = 48
     static let composerFadeExtension: CGFloat = 40
+    static let scrollIndicatorClearance: CGFloat = 17
 }
 
 private struct ChatTranscriptView: View {
@@ -259,6 +260,7 @@ private struct ChatTranscriptView: View {
             Color.nativMainContentBackground
                 .frame(height: max(72, composerBackdropHeight))
         }
+        .padding(.trailing, ChatTranscriptLayout.scrollIndicatorClearance)
         .allowsHitTesting(false)
         .accessibilityHidden(true)
     }


### PR DESCRIPTION
Allow a small margin for the scroll indicator on the right in the chat view, so the composer's gradient underlay doesn't clip the indicator.