### PR TITLE
Adjust detail header padding for sidebar/fullscreen states

### DIFF
--- a/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
@@ -730,7 +730,7 @@ struct ArtifactsView: View {
         }
         .padding(.horizontal, 24)
         .padding(.leading, titleLeadingInset)
-        .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+        .controlPanelDetailHeaderTopPadding()
         .padding(.bottom, 12)
     }
 

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
@@ -11,7 +11,7 @@ extension ControlPanelView {
             Color.clear
                 .frame(
                     height: isFullScreen
-                        ? ControlPanelLayout.fullScreenSidebarTopClearance
+                        ? ControlPanelLayout.fullScreenTopClearance
                         : 0
                 )
 

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSupportViews.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSupportViews.swift
@@ -21,8 +21,10 @@ enum ControlPanelLayout {
     static let sidebarBrandHeight: CGFloat = 40
     static let sidebarBrandIconSize: CGFloat = 24
     static let sidebarBrandBottomClearance: CGFloat = 8
-    static let fullScreenSidebarTopClearance: CGFloat = 32
-    static let detailHeaderTopInset = (sidebarBrandHeight - sidebarBrandIconSize) / 2
+    static let fullScreenTopClearance: CGFloat = 32
+    static let detailHeaderTopInset: CGFloat = 16
+    static let hiddenSidebarDetailHeaderTopInset =
+        (sidebarBrandHeight - sidebarBrandIconSize) / 2
     static let topControlSize: CGFloat = 30
     static let topControlsLeadingPadding: CGFloat = 80
     static let topControlsLeadingPaddingFullScreen: CGFloat = 12
@@ -39,10 +41,47 @@ private struct ControlPanelFullScreenKey: EnvironmentKey {
     static let defaultValue = false
 }
 
+private struct ControlPanelSidebarVisibleKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
 extension EnvironmentValues {
     var controlPanelIsFullScreen: Bool {
         get { self[ControlPanelFullScreenKey.self] }
         set { self[ControlPanelFullScreenKey.self] = newValue }
+    }
+
+    var controlPanelIsSidebarVisible: Bool {
+        get { self[ControlPanelSidebarVisibleKey.self] }
+        set { self[ControlPanelSidebarVisibleKey.self] = newValue }
+    }
+}
+
+private struct ControlPanelDetailHeaderTopPadding: ViewModifier {
+    @Environment(\.controlPanelIsFullScreen) private var isFullScreen
+    @Environment(\.controlPanelIsSidebarVisible) private var isSidebarVisible
+
+    func body(content: Content) -> some View {
+        content.padding(.top, topInset)
+    }
+
+    private var topInset: CGFloat {
+        if isSidebarVisible {
+            return ControlPanelLayout.detailHeaderTopInset
+        }
+
+        if isFullScreen {
+            return ControlPanelLayout.hiddenSidebarDetailHeaderTopInset
+                + ControlPanelLayout.fullScreenTopClearance
+        }
+
+        return ControlPanelLayout.hiddenSidebarDetailHeaderTopInset
+    }
+}
+
+extension View {
+    func controlPanelDetailHeaderTopPadding() -> some View {
+        modifier(ControlPanelDetailHeaderTopPadding())
     }
 }
 

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelView.swift
@@ -109,6 +109,10 @@ struct ControlPanelView: View {
                         maxWidth: .infinity,
                         maxHeight: .infinity
                     )
+                    .ignoresSafeArea(
+                        .container,
+                        edges: isSidebarVisible ? .top : []
+                    )
             }
 
             resizableSidebar
@@ -128,6 +132,7 @@ struct ControlPanelView: View {
         .toolbar(removing: .title)
         .frame(minWidth: 1040, minHeight: 600)
         .environment(\.controlPanelIsFullScreen, isFullScreen)
+        .environment(\.controlPanelIsSidebarVisible, isSidebarVisible)
         .environment(\.openExtensionsHubSection) { section in
             selectedExtensionsHubSection = section
             Task { @MainActor in

--- a/Sources/Nativ/Features/Dashboard/StatsView.swift
+++ b/Sources/Nativ/Features/Dashboard/StatsView.swift
@@ -122,7 +122,7 @@ private struct DashboardContentView: View, @MainActor Equatable {
             VStack(spacing: 0) {
                 pageHeader
                     .padding(.horizontal, 22)
-                    .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+                    .controlPanelDetailHeaderTopPadding()
                     .padding(.bottom, 16)
 
                 Divider()

--- a/Sources/Nativ/Features/Developer/DevHubView.swift
+++ b/Sources/Nativ/Features/Developer/DevHubView.swift
@@ -59,7 +59,7 @@ struct DevHubView: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 12)
-        .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+        .controlPanelDetailHeaderTopPadding()
         .padding(.bottom, 12)
         .frame(width: 188)
     }

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -37,7 +37,7 @@ struct DeveloperView: View {
                 VStack(spacing: 0) {
                     pageHeader
                         .padding(.horizontal, 22)
-                        .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+                        .controlPanelDetailHeaderTopPadding()
                         .padding(.bottom, 16)
 
                     Divider()

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -75,7 +75,7 @@ struct ExtensionsHubView: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 12)
-        .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+        .controlPanelDetailHeaderTopPadding()
         .padding(.bottom, 12)
         .frame(width: 188)
     }
@@ -137,7 +137,7 @@ struct HubSectionScaffold<Content: View, Action: View>: View {
                 content()
             }
             .padding(.horizontal, 28)
-            .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+            .controlPanelDetailHeaderTopPadding()
             .padding(.bottom, 24)
             .frame(maxWidth: 720, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -440,7 +440,7 @@ private struct IntegrationCatalogView: View {
             }
             .padding(.horizontal, 22)
             .padding(.leading, titleLeadingInset)
-            .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+            .controlPanelDetailHeaderTopPadding()
             .padding(.bottom, 16)
 
             Divider()
@@ -561,7 +561,7 @@ private struct IntegrationDetailView: View {
             }
             .padding(.horizontal, 24)
             .padding(.leading, titleLeadingInset)
-            .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+            .controlPanelDetailHeaderTopPadding()
             .padding(.bottom, 18)
 
             Divider()

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -383,7 +383,7 @@ struct ModelsView: View {
         }
         .padding(.horizontal, 22)
         .padding(.leading, titleLeadingInset)
-        .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+        .controlPanelDetailHeaderTopPadding()
         .padding(.bottom, 16)
     }
 

--- a/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
@@ -131,7 +131,7 @@ struct ScheduledTasksView: View {
         }
         .padding(.horizontal, 22)
         .padding(.leading, titleLeadingInset)
-        .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+        .controlPanelDetailHeaderTopPadding()
         .padding(.bottom, 16)
     }
 

--- a/Sources/Nativ/Features/Settings/SettingsView.swift
+++ b/Sources/Nativ/Features/Settings/SettingsView.swift
@@ -62,7 +62,7 @@ struct SettingsView: View {
             .frame(maxWidth: 760, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.horizontal, 28)
-            .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+            .controlPanelDetailHeaderTopPadding()
             .padding(.bottom, 26)
         }
         .background(Color.nativMainContentBackground)

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -119,7 +119,7 @@ struct SystemMonitorView: View {
         }
         .padding(.horizontal, 22)
         .padding(.leading, titleLeadingInset)
-        .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+        .controlPanelDetailHeaderTopPadding()
         .padding(.bottom, 16)
     }
 

--- a/Sources/Nativ/Features/VoiceCapture/AudioView.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioView.swift
@@ -243,7 +243,7 @@ struct AudioView: View {
         }
         .padding(.horizontal, 22)
         .padding(.leading, titleLeadingInset)
-        .padding(.top, ControlPanelLayout.detailHeaderTopInset)
+        .controlPanelDetailHeaderTopPadding()
         .padding(.bottom, 16)
     }
 


### PR DESCRIPTION
This avoids the excess padding when the sidebar is open for the detail view headers.

https://github.com/user-attachments/assets/d6c9cac0-68fd-4ad5-b355-067c9e7793e4

