### PR TITLE
Allow slow local models to start

### DIFF
--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -542,9 +542,7 @@ public final class NativChatClient {
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
 
-    /// How long a response may go without delivering any bytes before the request
-    /// fails. Cold model loading happens before the first response bytes arrive,
-    /// so allow enough time for large local models to start.
+
     public static let defaultIdleTimeout: TimeInterval = 600
 
     /// Total budget for one request. Long generations legitimately run for many

--- a/Sources/NativServerKit/NativChatClient.swift
+++ b/Sources/NativServerKit/NativChatClient.swift
@@ -542,11 +542,10 @@ public final class NativChatClient {
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
 
-    /// How long a streaming response may go without delivering any bytes before
-    /// the request fails. `timeoutIntervalForRequest` is an inactivity timer that
-    /// URLSession resets whenever new data arrives, so this bounds a stalled
-    /// stream without limiting a healthy one.
-    public static let defaultIdleTimeout: TimeInterval = 120
+    /// How long a response may go without delivering any bytes before the request
+    /// fails. Cold model loading happens before the first response bytes arrive,
+    /// so allow enough time for large local models to start.
+    public static let defaultIdleTimeout: TimeInterval = 600
 
     /// Total budget for one request. Long generations legitimately run for many
     /// minutes, so this only exists to stop a connection leaking forever; stalls

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -392,7 +392,7 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
     }
 
-    func testChatClientAddsServerAuthorization() throws {
+    func testChatClientConfiguresRequest() throws {
         let client = NativChatClient(
             baseURL: URL(string: "http://127.0.0.1:8080")!,
             apiKey: "nativ_chat_token"
@@ -409,6 +409,7 @@ final class NativSettingsTests: XCTestCase {
 
         let request = try client.makeURLRequest(payload: payload, accepts: "application/json")
 
+        XCTAssertEqual(request.timeoutInterval, 600)
         XCTAssertEqual(
             request.value(forHTTPHeaderField: "Authorization"),
             "Bearer nativ_chat_token"


### PR DESCRIPTION
Fixes #379 by allowing slow local models enough time to load before chat requests expire.