### PR TITLE
Pick MacBook Pro artwork from the built-in display size

### DIFF
--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -677,16 +677,7 @@ private enum SystemDeviceArtworkProvider {
         let machineName = identity.computerName.lowercased()
 
         if machineName.contains("macbook pro") {
-            let sixteenInchModels: Set<String> = [
-                "MacBookPro16,1", "MacBookPro16,4",
-                "MacBookPro18,1", "MacBookPro18,2",
-                "Mac14,6", "Mac14,10",
-                "Mac15,7", "Mac15,9", "Mac15,11",
-            ]
-            let size = sixteenInchModels.contains(identity.modelIdentifier)
-                ? "16"
-                : "14"
-            return "com.apple.macbookpro-\(size)-2021-space-gray"
+            return "com.apple.macbookpro-\(laptopScreenSize(for: identity))-2021-space-gray"
         }
         if machineName.contains("macbook air") {
             return "com.apple.macbookair-13-2022-midnight"
@@ -702,6 +693,31 @@ private enum SystemDeviceArtworkProvider {
         }
         if machineName.contains("mac pro") {
             return "com.apple.macpro-2019"
+        }
+        return nil
+    }
+
+    private static func laptopScreenSize(for identity: SystemMonitorIdentity) -> String {
+        if let diagonal = builtInDisplayDiagonalInches() {
+            return diagonal >= 15 ? "16" : "14"
+        }
+        let sixteenInchModels: Set<String> = [
+            "MacBookPro16,1", "MacBookPro16,4",
+            "MacBookPro18,1", "MacBookPro18,2",
+            "Mac14,6", "Mac14,10",
+            "Mac15,7", "Mac15,9", "Mac15,11",
+        ]
+        return sixteenInchModels.contains(identity.modelIdentifier) ? "16" : "14"
+    }
+
+    private static func builtInDisplayDiagonalInches() -> Double? {
+        var displays = [CGDirectDisplayID](repeating: 0, count: 8)
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(8, &displays, &count) == .success else { return nil }
+        for display in displays.prefix(Int(count)) where CGDisplayIsBuiltin(display) != 0 {
+            let size = CGDisplayScreenSize(display)
+            guard size.width > 0, size.height > 0 else { continue }
+            return (size.width * size.width + size.height * size.height).squareRoot() / 25.4
         }
         return nil
     }


### PR DESCRIPTION
## Problem

The system page picks its device artwork by mapping the reported hardware model to an icon that ships with macOS. For MacBook Pros it also has to choose between the 14-inch and 16-inch image, and that choice came from a hardcoded set of model identifiers:

```
"MacBookPro16,1", "MacBookPro16,4",
"MacBookPro18,1", "MacBookPro18,2",
"Mac14,6", "Mac14,10",
"Mac15,7", "Mac15,9", "Mac15,11",
```

The set stops at the M3 generation, and anything missing from it silently falls through to the 14-inch artwork. So every MacBook Pro newer than that renders at the wrong size, and the list needs another entry every time Apple ships a laptop.

Reproduced on an M5 Max 16-inch (`Mac17,6`): not in the set, so the page drew a 14-inch.

## Change

Measure the built-in display instead of consulting a list. A 14-inch panel reports a ~14.2 in diagonal and a 16-inch reports ~16.1 in, so a single threshold separates them and no maintenance is required for future models.

The identifier set is kept as a fallback for the case where no built-in display is online, such as clamshell mode with an external display. That path behaves exactly as it does today, so this is never worse than current behaviour.

No new assets. The artwork already ships with macOS in `CoreTypes.bundle` and both the 14-inch and 16-inch variants are present — this only changes which existing file is loaded.

## Verification

The replacement logic was compiled and run standalone on an M5 Max 16-inch:

```
built-in diagonal: 16.14 in
Mac17,6 -> 16      (previously 14)
```

`swiftc -parse` is clean on the edited file. I do not have Xcode locally, so this has not been built as part of the app target — worth a build check before merge.

## Follow-ups, not included here

Same lookup has other fixed choices that could use existing macOS artwork:

- MacBook Pro and MacBook Air are always Space Gray and Midnight, though `-silver`, `-space-gray` and `-stardust` variants all ship
- Mac Pro always draws the tower, though `macpro-2019-rackmount` ships
- Mac mini always draws the 2020 model; macOS ships nothing newer, so a current mini would need bundled art

Happy to split those into a separate PR if wanted.
