### PR TITLE
Discover third-party server tools installed by Homebrew

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		727CB29E8D7346C29E0DBB3F /* ServerProcessEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055942EF0A544CE88654E7F6 /* ServerProcessEnvironmentTests.swift */; };
 		000EAB97CDF74A172ED79748 /* ChatWebReadTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8158351DC9E135F30DA83A01 /* ChatWebReadTool.swift */; };
 		01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */; };
 		02571B1CDC31A5D168247CCD /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
@@ -125,6 +126,7 @@
 		4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
 		4FC9EEEC4DFDE7766C2526E2 /* ChatDocumentContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */; };
 		506A12DCE5B56E53208A8BA2 /* NativServerKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1651E057CC5D05857CF1595 /* NativServerKit.swift */; };
+		E0A20B5A8E804C60B8CF06A7 /* ServerProcessEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8C02FD662848C7AAE73808 /* ServerProcessEnvironment.swift */; };
 		5196EA3B5CC4CE166899FE19 /* ControlPanelActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD296E4B5897E7E46606B697 /* ControlPanelActions.swift */; };
 		52927A9A78C07E5E649AFDF6 /* FilePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C9FECAED1FB3E2D43716FF /* FilePreview.swift */; };
 		52E78D326199C2BF37D16F66 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = 8DD1E187A7659D46CDC76CF9 /* MCP */; };
@@ -410,6 +412,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		055942EF0A544CE88654E7F6 /* ServerProcessEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessEnvironmentTests.swift; sourceTree = "<group>"; };
 		028A6EB95776995CFF6F82A9 /* ControlPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelState.swift; sourceTree = "<group>"; };
 		03496D30CE58F138CA30EB0D /* ControlPanelDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelDetail.swift; sourceTree = "<group>"; };
 		068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatServerStatsTool.swift; sourceTree = "<group>"; };
@@ -590,6 +593,7 @@
 		CFA5C785716081D2811DFD2D /* TextShimmerWave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextShimmerWave.swift; sourceTree = "<group>"; };
 		D0952EC469768D8775A2D188 /* VoiceAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioRecorder.swift; sourceTree = "<group>"; };
 		D1651E057CC5D05857CF1595 /* NativServerKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativServerKit.swift; sourceTree = "<group>"; };
+		5A8C02FD662848C7AAE73808 /* ServerProcessEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessEnvironment.swift; sourceTree = "<group>"; };
 		D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputDevicePreferences.swift; sourceTree = "<group>"; };
 		D34FBE730C051EFF28B1323B /* RoutineLaunchAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineLaunchAgent.swift; sourceTree = "<group>"; };
 		D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineEditorView.swift; sourceTree = "<group>"; };
@@ -783,6 +787,7 @@
 				96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */,
 				9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */,
 				D1651E057CC5D05857CF1595 /* NativServerKit.swift */,
+				5A8C02FD662848C7AAE73808 /* ServerProcessEnvironment.swift */,
 			);
 			path = NativServerKit;
 			sourceTree = "<group>";
@@ -1189,6 +1194,7 @@
 			isa = PBXGroup;
 			children = (
 				3B965B701714787B0A85AE6B /* AudioTests.swift */,
+				055942EF0A544CE88654E7F6 /* ServerProcessEnvironmentTests.swift */,
 				C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */,
 				B059AF48F10F1B0502DC5E6F /* ChatConversationBranchTests.swift */,
 				F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */,
@@ -1487,6 +1493,7 @@
 				732D29870D9B330A520DF15C /* NativEmbeddingsClient.swift in Sources */,
 				DC1ED6C1A11081FB70F1F019 /* NativImageClient.swift in Sources */,
 				506A12DCE5B56E53208A8BA2 /* NativServerKit.swift in Sources */,
+				E0A20B5A8E804C60B8CF06A7 /* ServerProcessEnvironment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1664,6 +1671,7 @@
 				01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */,
 				393DC62E524B83E0216268B8 /* AudioInputLevelMonitor.swift in Sources */,
 				4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */,
+				727CB29E8D7346C29E0DBB3F /* ServerProcessEnvironmentTests.swift in Sources */,
 				B3DE35DF177BB2B7A9D7690B /* BraveBrowsingProvider.swift in Sources */,
 				7ACEF87EDC19CB862FCF8840 /* ChatAttachmentKind.swift in Sources */,
 				6128B35157BF004E8A9E73F0 /* ChatAttachmentValidator.swift in Sources */,

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -176,10 +176,29 @@ public enum Nativ {
         let process = Process()
         process.executableURL = try executableURL()
         process.arguments = arguments
-        process.environment = ServerProcessEnvironment.make(
-            inherited: ProcessInfo.processInfo.environment,
-            overrides: environment
+        var processEnvironment = ProcessInfo.processInfo.environment
+        processEnvironment["PATH"] = ServerProcessEnvironment.augmentedSearchPath(
+            inheriting: processEnvironment["PATH"]
         )
+        processEnvironment.merge(environment) { _, newValue in newValue }
+        // Xcode enables Metal API validation for the app process and exports
+        // these variables to children. The inference server creates and
+        // releases many Metal buffers during chunked prefill; running that
+        // workload through MetalTools can make cache cleanup take minutes.
+        // Keep debugger validation scoped to Nativ itself, not the server.
+        for key in [
+            "MTL_DEBUG_LAYER",
+            "METAL_DEVICE_WRAPPER_TYPE",
+            "METAL_DEBUG_ERROR_MODE",
+            "METAL_DEBUG_ENFORCE_VALIDATION",
+            "METAL_CAPTURE_ENABLED",
+            "MTL_CAPTURE_ENABLED"
+        ] {
+            processEnvironment.removeValue(forKey: key)
+        }
+        processEnvironment["PYTHONNOUSERSITE"] = "1"
+        processEnvironment["PYTHONUNBUFFERED"] = "1"
+        process.environment = processEnvironment
         return process
     }
 

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -176,26 +176,10 @@ public enum Nativ {
         let process = Process()
         process.executableURL = try executableURL()
         process.arguments = arguments
-        var processEnvironment = ProcessInfo.processInfo.environment
-        processEnvironment.merge(environment) { _, newValue in newValue }
-        // Xcode enables Metal API validation for the app process and exports
-        // these variables to children. The inference server creates and
-        // releases many Metal buffers during chunked prefill; running that
-        // workload through MetalTools can make cache cleanup take minutes.
-        // Keep debugger validation scoped to Nativ itself, not the server.
-        for key in [
-            "MTL_DEBUG_LAYER",
-            "METAL_DEVICE_WRAPPER_TYPE",
-            "METAL_DEBUG_ERROR_MODE",
-            "METAL_DEBUG_ENFORCE_VALIDATION",
-            "METAL_CAPTURE_ENABLED",
-            "MTL_CAPTURE_ENABLED"
-        ] {
-            processEnvironment.removeValue(forKey: key)
-        }
-        processEnvironment["PYTHONNOUSERSITE"] = "1"
-        processEnvironment["PYTHONUNBUFFERED"] = "1"
-        process.environment = processEnvironment
+        process.environment = ServerProcessEnvironment.make(
+            inherited: ProcessInfo.processInfo.environment,
+            overrides: environment
+        )
         return process
     }
 

--- a/Sources/NativServerKit/ServerProcessEnvironment.swift
+++ b/Sources/NativServerKit/ServerProcessEnvironment.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+struct ExternalToolBundle: Sendable {
+    let name: String
+    let executableNames: [String]
+    let searchDirectories: [String]
+}
+
+enum ServerProcessEnvironment {
+    static let externalToolBundles = [
+        ExternalToolBundle(
+            name: "FFmpeg",
+            executableNames: ["ffmpeg", "ffprobe"],
+            searchDirectories: ["/opt/homebrew/bin", "/usr/local/bin"]
+        )
+    ]
+
+    private static let defaultSearchPath = "/usr/bin:/bin:/usr/sbin:/sbin"
+    private static let excludedVariables = [
+        "MTL_DEBUG_LAYER",
+        "METAL_DEVICE_WRAPPER_TYPE",
+        "METAL_DEBUG_ERROR_MODE",
+        "METAL_DEBUG_ENFORCE_VALIDATION",
+        "METAL_CAPTURE_ENABLED",
+        "MTL_CAPTURE_ENABLED"
+    ]
+
+    static func make(
+        inherited: [String: String],
+        overrides: [String: String],
+        toolBundles: [ExternalToolBundle] = externalToolBundles,
+        isExecutable: (String) -> Bool = FileManager.default.isExecutableFile(atPath:)
+    ) -> [String: String] {
+        var environment = inherited
+        environment["PATH"] = augmentedSearchPath(
+            inherited["PATH"] ?? defaultSearchPath,
+            toolBundles: toolBundles,
+            isExecutable: isExecutable
+        )
+        environment.merge(overrides) { _, newValue in newValue }
+
+        // Xcode enables Metal API validation for the app process and exports
+        // these variables to children. Keep validation scoped to Nativ itself.
+        for key in excludedVariables {
+            environment.removeValue(forKey: key)
+        }
+        environment["PYTHONNOUSERSITE"] = "1"
+        environment["PYTHONUNBUFFERED"] = "1"
+        return environment
+    }
+
+    private static func augmentedSearchPath(
+        _ searchPath: String,
+        toolBundles: [ExternalToolBundle],
+        isExecutable: (String) -> Bool
+    ) -> String {
+        var result = searchPath
+        var includedDirectories = Set(
+            searchPath.split(separator: ":").map(String.init)
+        )
+
+        for toolBundle in toolBundles {
+            guard let directory = toolBundle.searchDirectories.first(where: { directory in
+                toolBundle.executableNames.allSatisfy { executableName in
+                    let executable = URL(fileURLWithPath: directory, isDirectory: true)
+                        .appendingPathComponent(executableName)
+                    return isExecutable(executable.path)
+                }
+            }) else {
+                continue
+            }
+            guard includedDirectories.insert(directory).inserted else {
+                continue
+            }
+            result += result.isEmpty ? directory : ":\(directory)"
+        }
+        return result
+    }
+}

--- a/Sources/NativServerKit/ServerProcessEnvironment.swift
+++ b/Sources/NativServerKit/ServerProcessEnvironment.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-struct ExternalToolBundle: Sendable {
+struct ExternalToolRequirement: Sendable {
     let name: String
     let executableNames: [String]
     let searchDirectories: [String]
 }
 
 enum ServerProcessEnvironment {
-    static let externalToolBundles = [
-        ExternalToolBundle(
+    static let externalToolRequirements = [
+        ExternalToolRequirement(
             name: "FFmpeg",
             executableNames: ["ffmpeg", "ffprobe"],
             searchDirectories: ["/opt/homebrew/bin", "/usr/local/bin"]
@@ -16,55 +16,23 @@ enum ServerProcessEnvironment {
     ]
 
     private static let defaultSearchPath = "/usr/bin:/bin:/usr/sbin:/sbin"
-    private static let excludedVariables = [
-        "MTL_DEBUG_LAYER",
-        "METAL_DEVICE_WRAPPER_TYPE",
-        "METAL_DEBUG_ERROR_MODE",
-        "METAL_DEBUG_ENFORCE_VALIDATION",
-        "METAL_CAPTURE_ENABLED",
-        "MTL_CAPTURE_ENABLED"
-    ]
 
-    static func make(
-        inherited: [String: String],
-        overrides: [String: String],
-        toolBundles: [ExternalToolBundle] = externalToolBundles,
-        isExecutable: (String) -> Bool = FileManager.default.isExecutableFile(atPath:)
-    ) -> [String: String] {
-        var environment = inherited
-        environment["PATH"] = augmentedSearchPath(
-            inherited["PATH"] ?? defaultSearchPath,
-            toolBundles: toolBundles,
-            isExecutable: isExecutable
-        )
-        environment.merge(overrides) { _, newValue in newValue }
-
-        // Xcode enables Metal API validation for the app process and exports
-        // these variables to children. Keep validation scoped to Nativ itself.
-        for key in excludedVariables {
-            environment.removeValue(forKey: key)
-        }
-        environment["PYTHONNOUSERSITE"] = "1"
-        environment["PYTHONUNBUFFERED"] = "1"
-        return environment
-    }
-
-    private static func augmentedSearchPath(
-        _ searchPath: String,
-        toolBundles: [ExternalToolBundle],
-        isExecutable: (String) -> Bool
+    static func augmentedSearchPath(
+        inheriting searchPath: String?,
+        requirements: [ExternalToolRequirement] = externalToolRequirements,
+        isExecutableFile: (String) -> Bool = FileManager.default.isExecutableFile(atPath:)
     ) -> String {
+        let searchPath = searchPath ?? defaultSearchPath
         var result = searchPath
         var includedDirectories = Set(
             searchPath.split(separator: ":").map(String.init)
         )
 
-        for toolBundle in toolBundles {
-            guard let directory = toolBundle.searchDirectories.first(where: { directory in
-                toolBundle.executableNames.allSatisfy { executableName in
-                    let executable = URL(fileURLWithPath: directory, isDirectory: true)
-                        .appendingPathComponent(executableName)
-                    return isExecutable(executable.path)
+        for requirement in requirements {
+            guard let directory = requirement.searchDirectories.first(where: { directory in
+                let directoryURL = URL(filePath: directory, directoryHint: .isDirectory)
+                return requirement.executableNames.allSatisfy { executableName in
+                    isExecutableFile(directoryURL.appending(path: executableName).path)
                 }
             }) else {
                 continue

--- a/Tests/NativTests/ServerProcessEnvironmentTests.swift
+++ b/Tests/NativTests/ServerProcessEnvironmentTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import NativServerKit
+
+@Suite("Server process environment")
+struct ServerProcessEnvironmentTests {
+    @Test(
+        "Discovers every declared external tool bundle",
+        arguments: ServerProcessEnvironment.externalToolBundles
+    )
+    func discoversDeclaredToolBundle(_ toolBundle: ExternalToolBundle) throws {
+        let directory = try #require(toolBundle.searchDirectories.first)
+        let installedExecutables = Set(toolBundle.executableNames.map { name in
+            URL(fileURLWithPath: directory, isDirectory: true)
+                .appendingPathComponent(name)
+                .path
+        })
+
+        let environment = ServerProcessEnvironment.make(
+            inherited: ["PATH": "/usr/bin:/bin"],
+            overrides: [:],
+            toolBundles: [toolBundle],
+            isExecutable: installedExecutables.contains
+        )
+
+        #expect(environment["PATH"] == "/usr/bin:/bin:\(directory)")
+    }
+
+    @Test("Requires every executable in an external tool bundle")
+    func rejectsIncompleteToolBundle() throws {
+        let toolBundle = try #require(ServerProcessEnvironment.externalToolBundles.first)
+        let directory = try #require(toolBundle.searchDirectories.first)
+        let oneExecutable = try #require(toolBundle.executableNames.first)
+        let installedExecutables = [
+            URL(fileURLWithPath: directory, isDirectory: true)
+                .appendingPathComponent(oneExecutable)
+                .path
+        ]
+
+        let environment = ServerProcessEnvironment.make(
+            inherited: ["PATH": "/usr/bin:/bin"],
+            overrides: [:],
+            toolBundles: [toolBundle],
+            isExecutable: Set(installedExecutables).contains
+        )
+
+        #expect(environment["PATH"] == "/usr/bin:/bin")
+    }
+
+    @Test("Does not duplicate an existing external tool directory")
+    func avoidsDuplicateDirectory() throws {
+        let toolBundle = try #require(ServerProcessEnvironment.externalToolBundles.first)
+        let directory = try #require(toolBundle.searchDirectories.first)
+        let installedExecutables = Set(toolBundle.executableNames.map { name in
+            URL(fileURLWithPath: directory, isDirectory: true)
+                .appendingPathComponent(name)
+                .path
+        })
+
+        let environment = ServerProcessEnvironment.make(
+            inherited: ["PATH": "/usr/bin:\(directory):/bin"],
+            overrides: [:],
+            toolBundles: [toolBundle],
+            isExecutable: installedExecutables.contains
+        )
+
+        #expect(environment["PATH"] == "/usr/bin:\(directory):/bin")
+    }
+
+    @Test("Preserves an explicit caller search path")
+    func preservesSearchPathOverride() throws {
+        let toolBundle = try #require(ServerProcessEnvironment.externalToolBundles.first)
+        let directory = try #require(toolBundle.searchDirectories.first)
+        let installedExecutables = Set(toolBundle.executableNames.map { name in
+            URL(fileURLWithPath: directory, isDirectory: true)
+                .appendingPathComponent(name)
+                .path
+        })
+
+        let environment = ServerProcessEnvironment.make(
+            inherited: ["PATH": "/usr/bin:/bin"],
+            overrides: ["PATH": "/custom/bin"],
+            toolBundles: [toolBundle],
+            isExecutable: installedExecutables.contains
+        )
+
+        #expect(environment["PATH"] == "/custom/bin")
+    }
+
+    @Test("Keeps the bundled Python runtime isolated from app debugging settings")
+    func keepsServerSafeguards() {
+        let environment = ServerProcessEnvironment.make(
+            inherited: [
+                "MTL_DEBUG_LAYER": "1",
+                "METAL_CAPTURE_ENABLED": "1"
+            ],
+            overrides: [:],
+            toolBundles: [],
+            isExecutable: { _ in false }
+        )
+
+        #expect(environment["MTL_DEBUG_LAYER"] == nil)
+        #expect(environment["METAL_CAPTURE_ENABLED"] == nil)
+        #expect(environment["PYTHONNOUSERSITE"] == "1")
+        #expect(environment["PYTHONUNBUFFERED"] == "1")
+    }
+}

--- a/Tests/NativTests/ServerProcessEnvironmentTests.swift
+++ b/Tests/NativTests/ServerProcessEnvironmentTests.swift
@@ -5,103 +5,44 @@ import Testing
 @Suite("Server process environment")
 struct ServerProcessEnvironmentTests {
     @Test(
-        "Discovers every declared external tool bundle",
-        arguments: ServerProcessEnvironment.externalToolBundles
+        "Discovers every declared external tool requirement",
+        arguments: ServerProcessEnvironment.externalToolRequirements
     )
-    func discoversDeclaredToolBundle(_ toolBundle: ExternalToolBundle) throws {
-        let directory = try #require(toolBundle.searchDirectories.first)
-        let installedExecutables = Set(toolBundle.executableNames.map { name in
-            URL(fileURLWithPath: directory, isDirectory: true)
-                .appendingPathComponent(name)
-                .path
-        })
+    func discoversDeclaredTool(_ requirement: ExternalToolRequirement) throws {
+        #expect(requirement.name.isEmpty == false)
+        #expect(requirement.executableNames.isEmpty == false)
+        #expect(requirement.searchDirectories.isEmpty == false)
 
-        let environment = ServerProcessEnvironment.make(
-            inherited: ["PATH": "/usr/bin:/bin"],
-            overrides: [:],
-            toolBundles: [toolBundle],
-            isExecutable: installedExecutables.contains
-        )
+        for directory in requirement.searchDirectories {
+            let directoryURL = URL(filePath: directory, directoryHint: .isDirectory)
+            var executablePaths = Set(requirement.executableNames.map {
+                directoryURL.appending(path: $0).path
+            })
+            let baseSearchPath = "/usr/bin:/bin"
 
-        #expect(environment["PATH"] == "/usr/bin:/bin:\(directory)")
-    }
+            #expect(
+                ServerProcessEnvironment.augmentedSearchPath(
+                    inheriting: baseSearchPath,
+                    requirements: [requirement],
+                    isExecutableFile: executablePaths.contains
+                ) == "\(baseSearchPath):\(directory)"
+            )
+            #expect(
+                ServerProcessEnvironment.augmentedSearchPath(
+                    inheriting: "\(baseSearchPath):\(directory)",
+                    requirements: [requirement],
+                    isExecutableFile: executablePaths.contains
+                ) == "\(baseSearchPath):\(directory)"
+            )
 
-    @Test("Requires every executable in an external tool bundle")
-    func rejectsIncompleteToolBundle() throws {
-        let toolBundle = try #require(ServerProcessEnvironment.externalToolBundles.first)
-        let directory = try #require(toolBundle.searchDirectories.first)
-        let oneExecutable = try #require(toolBundle.executableNames.first)
-        let installedExecutables = [
-            URL(fileURLWithPath: directory, isDirectory: true)
-                .appendingPathComponent(oneExecutable)
-                .path
-        ]
-
-        let environment = ServerProcessEnvironment.make(
-            inherited: ["PATH": "/usr/bin:/bin"],
-            overrides: [:],
-            toolBundles: [toolBundle],
-            isExecutable: Set(installedExecutables).contains
-        )
-
-        #expect(environment["PATH"] == "/usr/bin:/bin")
-    }
-
-    @Test("Does not duplicate an existing external tool directory")
-    func avoidsDuplicateDirectory() throws {
-        let toolBundle = try #require(ServerProcessEnvironment.externalToolBundles.first)
-        let directory = try #require(toolBundle.searchDirectories.first)
-        let installedExecutables = Set(toolBundle.executableNames.map { name in
-            URL(fileURLWithPath: directory, isDirectory: true)
-                .appendingPathComponent(name)
-                .path
-        })
-
-        let environment = ServerProcessEnvironment.make(
-            inherited: ["PATH": "/usr/bin:\(directory):/bin"],
-            overrides: [:],
-            toolBundles: [toolBundle],
-            isExecutable: installedExecutables.contains
-        )
-
-        #expect(environment["PATH"] == "/usr/bin:\(directory):/bin")
-    }
-
-    @Test("Preserves an explicit caller search path")
-    func preservesSearchPathOverride() throws {
-        let toolBundle = try #require(ServerProcessEnvironment.externalToolBundles.first)
-        let directory = try #require(toolBundle.searchDirectories.first)
-        let installedExecutables = Set(toolBundle.executableNames.map { name in
-            URL(fileURLWithPath: directory, isDirectory: true)
-                .appendingPathComponent(name)
-                .path
-        })
-
-        let environment = ServerProcessEnvironment.make(
-            inherited: ["PATH": "/usr/bin:/bin"],
-            overrides: ["PATH": "/custom/bin"],
-            toolBundles: [toolBundle],
-            isExecutable: installedExecutables.contains
-        )
-
-        #expect(environment["PATH"] == "/custom/bin")
-    }
-
-    @Test("Keeps the bundled Python runtime isolated from app debugging settings")
-    func keepsServerSafeguards() {
-        let environment = ServerProcessEnvironment.make(
-            inherited: [
-                "MTL_DEBUG_LAYER": "1",
-                "METAL_CAPTURE_ENABLED": "1"
-            ],
-            overrides: [:],
-            toolBundles: [],
-            isExecutable: { _ in false }
-        )
-
-        #expect(environment["MTL_DEBUG_LAYER"] == nil)
-        #expect(environment["METAL_CAPTURE_ENABLED"] == nil)
-        #expect(environment["PYTHONNOUSERSITE"] == "1")
-        #expect(environment["PYTHONUNBUFFERED"] == "1")
+            executablePaths.remove(try #require(executablePaths.first))
+            #expect(
+                ServerProcessEnvironment.augmentedSearchPath(
+                    inheriting: baseSearchPath,
+                    requirements: [requirement],
+                    isExecutableFile: executablePaths.contains
+                ) == baseSearchPath
+            )
+        }
     }
 }


### PR DESCRIPTION
Teach Nativ’s server environment to safely discover complete Homebrew tool requirements through reusable dependency declarations.

Add parameterized FFmpeg coverage preventing M4A regressions and future tool failures; this fixes #390 reliably.