### PR TITLE
Stabilize Kit definitions and additive activation

### DIFF
--- a/Docs/extending/kits.md
+++ b/Docs/extending/kits.md
@@ -1,37 +1,43 @@
 # Authoring a Kit
 
 A **Kit** is a ready-made setup — a curated bundle of MCP servers, their tools,
-skills, and extensions for a role or use-case (Engineering, Research, Sales,
-Operations…). Enabling a kit turns all of its pieces on at once; each piece
-stays individually manageable afterward.
+skills, and extensions for a role or use-case. Engineering and Research are
+built-in examples, not special cases the rest of the implementation depends on.
+Applying a Kit additively enables its missing components; each component stays
+individually manageable afterward.
 
 Kits are the layer above the [MCP catalog](mcp-catalog.md): the catalog is the
-parts bin, a kit is an assembled machine. Kits live in code so their skill text
-stays readable and type-checked. The registry is
+parts bin, a Kit is an assembled machine. Built-in Kits live in code so their
+skill text stays readable and type-checked. The validated registry is
 [`Sources/Nativ/Features/Extensions/NativKit.swift`](../../Sources/Nativ/Features/Extensions/NativKit.swift).
 
-## The four things a kit can bundle
+## The component format
 
-| Piece | How the kit references it |
+Every Kit uses one ordered `components` array. This is the canonical addition
+format and gives every component a stable, typed identity.
+
+| Piece | Component value |
 |---|---|
-| **MCP servers** (and their tools) | `mcpServerIDs` — the `id` of a [catalog](mcp-catalog.md) entry. Enabling the kit installs the server if missing; its tools then appear under **Tools**. |
-| **Skills** | `skills` — `NativSkill` values defined inline, each with a stable UUID. |
-| **Extensions** | `extensionIDs` — an extension manifest `id` (e.g. `com.nativ.voice-dictation`). |
+| **MCP servers** (and their tools) | `.mcpServer(catalogID:)` — the stable `id` of a [catalog](mcp-catalog.md) entry. |
+| **Skills** | `.skill(...)` — a `NativSkill` defined inline with a stable UUID. |
+| **Extensions** | `.extensionPackage(id:)` — a stable extension manifest `id`. |
 
 ## Add to an existing kit
 
 Whenever you add a new MCP server to the catalog, a new skill, or a new
-extension, you can fold it into a kit by editing that kit in `NativKit.all`:
+extension, you can fold it into a Kit's `components` array:
 
 ```swift
-mcpServerIDs: ["git", "github", "filesystem", "fetch", "your-new-server"],
-extensionIDs: ["com.nativ.your-extension"],
-skills: [ existingSkill, .kit("<new-uuid>", "Your skill", "…") ],
+components: [
+    .mcpServer(catalogID: "your-new-server"),
+    .skill(.kit("<new-uuid>", "Your skill", "…")),
+    .extensionPackage(id: "com.nativ.your-extension"),
+],
 ```
 
 ## Create a new kit
 
-Append an entry to `NativKit.all`:
+Append a definition to `NativKit.bundledDefinitions`:
 
 ```swift
 NativKit(
@@ -39,34 +45,42 @@ NativKit(
     name: "Finance",
     summary: "Pull filings, keep a working memory, and query the numbers.",
     symbol: "dollarsign.circle",
-    tint: .green,
-    mcpServerIDs: ["fetch", "memory", "sqlite"],
-    extensionIDs: [],
-    skills: [
-        .kit(
-            "B1000000-0000-4000-8000-000000000010",
-            "Financial analysis",
-            """
-            You're helping with finance. Ground every figure in a source or the \
-            user's own data, and never invent numbers.
-            …
-            """
-        )
+    tintName: "green",
+    components: [
+        .mcpServer(catalogID: "fetch"),
+        .mcpServer(catalogID: "memory"),
+        .mcpServer(catalogID: "sqlite"),
+        .skill(
+            .kit(
+                "B1000000-0000-4000-8000-000000000010",
+                "Financial analysis",
+                """
+                You're helping with finance. Ground every figure in a source or the \
+                user's own data, and never invent numbers.
+                …
+                """
+            )
+        ),
     ]
 )
 ```
 
 Rules of thumb:
 
-- **`id`** is unique, lowercase, and stable. A kit's Enabled/Partial state is
+- **`id`** is unique, lowercase, and stable. A Kit's Enabled/Partial state is
   derived live from whether its pieces are on, so it never drifts out of sync.
-- **`mcpServerIDs`** must match catalog entry `id`s. If your kit needs a server
+- **MCP catalog IDs** must match catalog entry `id`s. If your Kit needs a server
   that isn't in the catalog yet, add it there first — it has to pass the
   [`Verify MCP Catalog`](../../.github/workflows/verify-mcp-catalog.yml) check.
 - **Skill UUIDs** must be stable and unique, so enabling a kit twice never
   duplicates a skill. Generate one and keep it.
-- **`tint`** uses the shared names (`blue`, `green`, `indigo`, `teal`, `purple`,
+- **`tintName`** uses the shared names (`blue`, `green`, `indigo`, `teal`, `purple`,
   …); `symbol` is any SF Symbol.
 
-A new kit shows up automatically as a card at the top of the Extensions hub —
-no other wiring needed.
+The catalog rejects duplicate Kit IDs, duplicate components, conflicting skill
+UUIDs, and unknown MCP catalog IDs. A valid definition shows up automatically
+wherever Kits are offered; no consumer-specific wiring is needed.
+
+Kits never own global capability state. Applying a Kit only enables missing
+components. Removing or disabling a shared component remains an explicit action
+in that component's own management surface.

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		49D9B119A4F90BBE66343B5B /* WebBrowsingProviderClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E0214BE1D88EB4CDB66836 /* WebBrowsingProviderClient.swift */; };
 		4A72536E0D4FDE1D2E6174E3 /* MCPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D9C81870FB504D03D2A1D5 /* MCPClient.swift */; };
 		4B25C497C3E90EE13474F839 /* UISFXMinimalPlay.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 9FB275767AC2B912FA2FEDEE /* UISFXMinimalPlay.mp3 */; };
+		4B3B371072FF015C6CA2CA61 /* NativKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780A9582305FC184F6C68D12 /* NativKitTests.swift */; };
 		4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */; };
 		4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B965B701714787B0A85AE6B /* AudioTests.swift */; };
 		4BD354A4C41C62B7F11E1686 /* WebSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2580C52ECE6D40D71E44463F /* WebSearchProvider.swift */; };
@@ -277,6 +278,7 @@
 		D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */; };
 		D74F92EBE05FADCD813CD8B9 /* AudioAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0BD007DAD141D50E1BAA4 /* AudioAnalyticsStore.swift */; };
 		D76DC0072E523E6409DF1176 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 730B64747E8A780CD14AF88F /* Textual */; };
+		D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7F610FC8739BA80227DB26 /* NativKit.swift */; };
 		D8838254D03112C2EABE37AC /* ModelPrimaryTaskResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */; };
 		D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
 		D94A6B329A8D7D3285147914 /* MarkdownFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */; };
@@ -499,6 +501,7 @@
 		7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceShortcut.swift; sourceTree = "<group>"; };
 		769A36AA0753AB7F4CB1E371 /* ExaBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExaBrowsingProvider.swift; sourceTree = "<group>"; };
 		76F460CC6B734041A8C60AAE /* ControlPanelSidebarModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarModels.swift; sourceTree = "<group>"; };
+		780A9582305FC184F6C68D12 /* NativKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitTests.swift; sourceTree = "<group>"; };
 		7A1B88001E3E22C2E592C0BA /* WebBrowsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingError.swift; sourceTree = "<group>"; };
 		7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontScale.swift; sourceTree = "<group>"; };
 		7B0425C365C50DD040161226 /* FileReadAccessPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReadAccessPolicy.swift; sourceTree = "<group>"; };
@@ -1212,6 +1215,7 @@
 				3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */,
 				2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */,
 				E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */,
+				780A9582305FC184F6C68D12 /* NativKitTests.swift */,
 				982F3BB563023885587DC860 /* NativNotificationTests.swift */,
 				E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */,
 				8513AE482EB6C3113080826A /* PDFDocumentTextExtractorTests.swift */,
@@ -1733,6 +1737,8 @@
 				252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */,
 				ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */,
 				0E326825AE5A1A5EEA33D928 /* NativExtensionTests.swift in Sources */,
+				D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */,
+				4B3B371072FF015C6CA2CA61 /* NativKitTests.swift in Sources */,
 				025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */,
 				C98474155E01AF49957443C9 /* NativNotificationService.swift in Sources */,
 				87C7CE62B090DCE2F9CF0A4F /* NativNotificationTests.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
+++ b/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
@@ -296,7 +296,7 @@ struct ChatKitsPickerSheet: View {
                 .foregroundStyle(.secondary)
 
             VStack(spacing: 0) {
-                ForEach(Array(NativKit.all.enumerated()), id: \.element.id) { index, kit in
+                ForEach(Array(NativKitCatalog.bundled.kits.enumerated()), id: \.element.id) { index, kit in
                     if index > 0 { Divider() }
                     kitRow(kit)
                 }
@@ -306,47 +306,65 @@ struct ChatKitsPickerSheet: View {
         .frame(width: 480)
     }
 
+    @ViewBuilder
     private func kitRow(_ kit: NativKit) -> some View {
-        let state = NativKitActivation.state(of: kit, model: model, manager: manager)
-        return Button {
-            NativKitActivation.setEnabled(
-                state != .enabled,
-                kit: kit,
-                model: model,
-                manager: manager
-            )
-        } label: {
-            HStack(spacing: 12) {
-                Image(systemName: kit.symbol)
-                    .font(.system(size: 15))
-                    .foregroundStyle(kit.tint)
-                    .frame(width: 28, height: 28)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(kit.name)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.primary)
-                    Text(kit.summary)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                }
-
-                Spacer(minLength: 20)
-
-                if state == .enabled {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(Color.green)
-                        .frame(width: 18, height: 18)
-                        .accessibilityLabel("Enabled globally")
-                }
+        let state = NativKitActivation.state(
+            of: kit,
+            model: model,
+            isExtensionEnabled: manager.isEnabled(extensionID:)
+        )
+        if state == .enabled {
+            kitRowContent(kit, state: state)
+                .accessibilityElement(children: .combine)
+        } else {
+            Button {
+                NativKitActivation.enableMissing(
+                    in: kit,
+                    model: model,
+                    isExtensionEnabled: manager.isEnabled(extensionID:),
+                    enableExtension: { manager.setEnabled(true, extensionID: $0) }
+                )
+            } label: {
+                kitRowContent(kit, state: state)
             }
-            .padding(.vertical, 12)
-            .padding(.trailing, 8)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .accessibilityHint(
+                state == .partial
+                    ? "Enables the missing Kit capabilities"
+                    : "Enables this Kit"
+            )
         }
-        .buttonStyle(.plain)
+    }
+
+    private func kitRowContent(_ kit: NativKit, state: NativKitState) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: kit.symbol)
+                .font(.system(size: 15))
+                .foregroundStyle(Color.nativTint(kit.tintName))
+                .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(kit.name)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text(kit.summary)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 20)
+
+            Label(
+                state == .enabled ? "Enabled" : state == .partial ? "Enable missing" : "Enable",
+                systemImage: state == .enabled ? "checkmark.circle.fill" : "plus.circle"
+            )
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(state == .enabled ? Color.green : Color.accentColor)
+        }
+        .padding(.vertical, 12)
+        .padding(.trailing, 8)
+        .contentShape(Rectangle())
     }
 }
 

--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -35,13 +35,22 @@ struct KitsSectionView: View {
             EmptyView()
         } content: {
             LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
-                ForEach(NativKit.all) { kit in
+                ForEach(NativKitCatalog.bundled.kits) { kit in
                     KitCard(
                         kit: kit,
-                        state: NativKitActivation.state(of: kit, model: model, manager: manager),
-                        inactiveParts: NativKitActivation.inactivePartNames(of: kit, model: model, manager: manager),
+                        state: NativKitActivation.state(
+                            of: kit,
+                            model: model,
+                            isExtensionEnabled: manager.isEnabled(extensionID:)
+                        ),
+                        inactiveParts: NativKitActivation.inactivePartNames(
+                            of: kit,
+                            model: model,
+                            extensionName: extensionName,
+                            isExtensionEnabled: manager.isEnabled(extensionID:)
+                        ),
                         onOpen: { openKit = kit },
-                        onEnable: { NativKitActivation.setEnabled(true, kit: kit, model: model, manager: manager) }
+                        onEnable: { enableMissing(in: kit) }
                     )
                 }
             }
@@ -49,6 +58,19 @@ struct KitsSectionView: View {
         .sheet(item: $openKit) { kit in
             KitDetailView(kit: kit, manager: manager, host: host, model: model)
         }
+    }
+
+    private func extensionName(_ id: String) -> String {
+        manager.records.first { $0.id == id }?.manifest.displayName ?? id
+    }
+
+    private func enableMissing(in kit: NativKit) {
+        NativKitActivation.enableMissing(
+            in: kit,
+            model: model,
+            isExtensionEnabled: manager.isEnabled(extensionID:),
+            enableExtension: { manager.setEnabled(true, extensionID: $0) }
+        )
     }
 }
 
@@ -68,7 +90,7 @@ private struct KitCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 6) {
-                NativTintedIconTile(symbol: kit.symbol, tint: kit.tint)
+                NativTintedIconTile(symbol: kit.symbol, tint: .nativTint(kit.tintName))
                 Spacer(minLength: 0)
                 NativStatusBadge(text: "Built-in")
                     .help("Ships with Nativ")
@@ -95,10 +117,12 @@ private struct KitCard: View {
                     alignment: .topLeading
                 )
             HStack(spacing: 8) {
-                if state == .off {
-                    Button("Enable", action: onEnable)
+                if state != .enabled {
+                    Button(state == .partial ? "Enable missing" : "Enable", action: onEnable)
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
+                }
+                if state == .off {
                     Button("Details", action: onOpen)
                         .buttonStyle(.plain)
                         .controlSize(.small)
@@ -131,7 +155,7 @@ private struct KitCard: View {
         if state == .partial {
             return "Off: \(inactiveParts.joined(separator: " · "))"
         }
-        return "Includes: \(kit.capabilityNames.joined(separator: " · "))"
+        return "Includes: \(kit.capabilityNames(in: .bundled).joined(separator: " · "))"
     }
 }
 
@@ -142,7 +166,13 @@ private struct KitDetailView: View {
     var model: NativModel
     @Environment(\.dismiss) private var dismiss
 
-    private var state: NativKitState { NativKitActivation.state(of: kit, model: model, manager: manager) }
+    private var state: NativKitState {
+        NativKitActivation.state(
+            of: kit,
+            model: model,
+            isExtensionEnabled: manager.isEnabled(extensionID:)
+        )
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -160,7 +190,7 @@ private struct KitDetailView: View {
 
     private var header: some View {
         HStack(alignment: .top, spacing: 12) {
-            NativTintedIconTile(symbol: kit.symbol, tint: kit.tint, size: 40)
+            NativTintedIconTile(symbol: kit.symbol, tint: .nativTint(kit.tintName), size: 40)
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
                     Text(kit.name)
@@ -171,19 +201,19 @@ private struct KitDetailView: View {
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                HStack(spacing: 8) {
-                    Button("Enable all") {
-                        NativKitActivation.setEnabled(true, kit: kit, model: model, manager: manager)
+                if state != .enabled {
+                    Button(state == .partial ? "Enable missing" : "Enable all") {
+                        NativKitActivation.enableMissing(
+                            in: kit,
+                            model: model,
+                            isExtensionEnabled: manager.isEnabled(extensionID:),
+                            enableExtension: { manager.setEnabled(true, extensionID: $0) }
+                        )
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    Button("Disable all") {
-                        NativKitActivation.setEnabled(false, kit: kit, model: model, manager: manager)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                    .padding(.top, 4)
                 }
-                .padding(.top, 4)
             }
             Spacer(minLength: 12)
             NativHoverCloseButton { dismiss() }
@@ -195,7 +225,7 @@ private struct KitDetailView: View {
 
     private var mcpGroup: some View {
         KitGroup(title: "MCP servers & tools", caption: "Their tools become available in chat and appear under Tools.") {
-            ForEach(kit.mcpEntries) { entry in
+            ForEach(kit.mcpEntries(in: .bundled)) { entry in
                 KitPartRow(
                     symbol: entry.symbol,
                     tint: .nativTint(entry.tintName),
@@ -213,7 +243,7 @@ private struct KitDetailView: View {
             ForEach(kit.skills) { skill in
                 KitPartRow(
                     symbol: "sparkles",
-                    tint: kit.tint,
+                    tint: .nativTint(kit.tintName),
                     logoAssetName: nil,
                     title: skill.name,
                     subtitle: nil,
@@ -228,7 +258,7 @@ private struct KitDetailView: View {
             ForEach(kit.extensionIDs, id: \.self) { extensionID in
                 KitPartRow(
                     symbol: "puzzlepiece.extension",
-                    tint: kit.tint,
+                    tint: .nativTint(kit.tintName),
                     logoAssetName: nil,
                     title: extensionName(extensionID),
                     subtitle: nil,

--- a/Sources/Nativ/Features/Extensions/NativKit.swift
+++ b/Sources/Nativ/Features/Extensions/NativKit.swift
@@ -1,76 +1,201 @@
-import SwiftUI
+import Foundation
 
-// A Kit is a ready-made setup: a curated bundle of MCP servers, their tools,
-// skills, and extensions for a role or use-case. Enabling one fans out across
-// all four primitives at once; each part stays individually manageable after.
+/// A capability included in a Kit definition.
+enum NativKitComponent: Equatable, Identifiable, Sendable {
+    case mcpServer(catalogID: String)
+    case skill(NativSkill)
+    case extensionPackage(id: String)
 
-struct NativKit: Identifiable {
+    var id: String {
+        switch self {
+        case .mcpServer(let catalogID):
+            "mcp:\(catalogID)"
+        case .skill(let skill):
+            "skill:\(skill.id.uuidString)"
+        case .extensionPackage(let id):
+            "extension:\(id)"
+        }
+    }
+}
+
+/// A ready-made, additive bundle of capabilities for a role or workflow.
+struct NativKit: Equatable, Identifiable, Sendable {
     let id: String
     let name: String
     let summary: String
     let symbol: String
-    let tint: Color
-    let mcpServerIDs: [String]
-    let extensionIDs: [String]
-    let skills: [NativSkill]
+    let tintName: String
+    let components: [NativKitComponent]
 
-    /// Catalog MCP entries this kit references, in listed order.
-    var mcpEntries: [MCPCatalogEntry] {
-        mcpServerIDs.compactMap { MCPServerCatalog.bundled.entry(id: $0) }
+    var mcpServerIDs: [String] {
+        components.compactMap { component in
+            guard case .mcpServer(let catalogID) = component else { return nil }
+            return catalogID
+        }
     }
 
-    /// A one-line inventory of what the kit turns on.
+    var skills: [NativSkill] {
+        components.compactMap { component in
+            guard case .skill(let skill) = component else { return nil }
+            return skill
+        }
+    }
+
+    var extensionIDs: [String] {
+        components.compactMap { component in
+            guard case .extensionPackage(let id) = component else { return nil }
+            return id
+        }
+    }
+
+    /// Catalog MCP entries this Kit references, in definition order.
+    func mcpEntries(in catalog: MCPServerCatalog) -> [MCPCatalogEntry] {
+        mcpServerIDs.compactMap(catalog.entry(id:))
+    }
+
+    /// A one-line inventory of the components in this Kit definition.
     var inventory: String {
         var parts: [String] = []
-        let servers = mcpEntries.count
-        if servers > 0 { parts.append("\(servers) MCP server\(servers == 1 ? "" : "s")") }
-        if !skills.isEmpty { parts.append("\(skills.count) skill\(skills.count == 1 ? "" : "s")") }
-        if !extensionIDs.isEmpty { parts.append("\(extensionIDs.count) extension\(extensionIDs.count == 1 ? "" : "s")") }
+        let serverCount = mcpServerIDs.count
+        if serverCount > 0 {
+            parts.append("\(serverCount) MCP server\(serverCount == 1 ? "" : "s")")
+        }
+        if !skills.isEmpty {
+            parts.append("\(skills.count) skill\(skills.count == 1 ? "" : "s")")
+        }
+        if !extensionIDs.isEmpty {
+            parts.append("\(extensionIDs.count) extension\(extensionIDs.count == 1 ? "" : "s")")
+        }
         return parts.joined(separator: " · ")
     }
 
-    /// The abilities a person gets when every part of this kit is enabled.
-    var capabilityNames: [String] {
-        mcpEntries.map(\.name) + skills.map(\.name) + extensionIDs
+    /// Names the capabilities supplied by this Kit in definition order.
+    func capabilityNames(in catalog: MCPServerCatalog) -> [String] {
+        components.map { component in
+            switch component {
+            case .mcpServer(let catalogID):
+                catalog.entry(id: catalogID)?.name ?? catalogID
+            case .skill(let skill):
+                skill.name
+            case .extensionPackage(let id):
+                id
+            }
+        }
+    }
+}
+
+enum NativKitCatalogError: Error, Equatable {
+    case duplicateKitIdentifier(String)
+    case duplicateComponent(kitID: String, componentID: String)
+    case conflictingSkillIdentifier(UUID)
+    case unknownMCPServer(kitID: String, catalogID: String)
+}
+
+/// An immutable, validated collection of Kit definitions.
+struct NativKitCatalog: Sendable {
+    static let bundled: NativKitCatalog = {
+        do {
+            return try NativKitCatalog(
+                kits: NativKit.bundledDefinitions,
+                mcpCatalog: .bundled
+            )
+        } catch {
+            preconditionFailure("Invalid bundled Kit catalog: \(error)")
+        }
+    }()
+
+    let kits: [NativKit]
+    private let kitsByID: [String: NativKit]
+
+    init(kits: [NativKit], mcpCatalog: MCPServerCatalog) throws {
+        var kitsByID: [String: NativKit] = [:]
+        var skillsByID: [UUID: NativSkill] = [:]
+
+        for kit in kits {
+            guard kitsByID.updateValue(kit, forKey: kit.id) == nil else {
+                throw NativKitCatalogError.duplicateKitIdentifier(kit.id)
+            }
+
+            var componentIDs = Set<String>()
+            for component in kit.components {
+                guard componentIDs.insert(component.id).inserted else {
+                    throw NativKitCatalogError.duplicateComponent(
+                        kitID: kit.id,
+                        componentID: component.id
+                    )
+                }
+
+                switch component {
+                case .mcpServer(let catalogID):
+                    guard mcpCatalog.entry(id: catalogID) != nil else {
+                        throw NativKitCatalogError.unknownMCPServer(
+                            kitID: kit.id,
+                            catalogID: catalogID
+                        )
+                    }
+                case .skill(let skill):
+                    if let existing = skillsByID[skill.id], existing != skill {
+                        throw NativKitCatalogError.conflictingSkillIdentifier(skill.id)
+                    }
+                    skillsByID[skill.id] = skill
+                case .extensionPackage:
+                    break
+                }
+            }
+        }
+
+        self.kits = kits
+        self.kitsByID = kitsByID
+    }
+
+    func kit(id: String) -> NativKit? {
+        kitsByID[id]
     }
 }
 
 private extension NativSkill {
-    /// A kit skill with a stable identity so enabling a kit twice never duplicates it.
-    static func kit(_ uuid: String, _ name: String, _ instructions: String) -> NativSkill {
-        NativSkill(id: UUID(uuidString: uuid)!, name: name, instructions: instructions, isEnabled: true)
+    /// Creates a built-in Kit skill with a stable identity.
+    static func kit(_ identifier: String, _ name: String, _ instructions: String) -> NativSkill {
+        guard let id = UUID(uuidString: identifier) else {
+            preconditionFailure("Invalid built-in Kit skill identifier: \(identifier)")
+        }
+        return NativSkill(id: id, name: name, instructions: instructions, isEnabled: true)
     }
 }
 
-extension NativKit {
-    /// The curated kits shown at the top of the Extensions hub.
-    static let all: [NativKit] = [
+private extension NativKit {
+    /// Built-in examples that ship in Nativ's Kit catalog.
+    static let bundledDefinitions: [NativKit] = [
         NativKit(
             id: "engineering",
             name: "Engineering",
             summary: "Read code, work with Git and GitHub, and pull in docs while you build.",
             symbol: "chevron.left.forwardslash.chevron.right",
-            tint: .indigo,
-            mcpServerIDs: ["git", "github", "filesystem", "fetch"],
-            extensionIDs: [],
-            skills: [
-                .kit(
-                    "A1000000-0000-4000-8000-000000000001",
-                    "Working in a codebase",
-                    """
-                    You're helping with software. Ground every answer in the actual \
-                    repository, not assumptions.
+            tintName: "indigo",
+            components: [
+                .mcpServer(catalogID: "git"),
+                .mcpServer(catalogID: "github"),
+                .mcpServer(catalogID: "filesystem"),
+                .mcpServer(catalogID: "fetch"),
+                .skill(
+                    .kit(
+                        "A1000000-0000-4000-8000-000000000001",
+                        "Working in a codebase",
+                        """
+                        You're helping with software. Ground every answer in the actual \
+                        repository, not assumptions.
 
-                    - Use the Git and filesystem tools to read real files, history, and \
-                    diffs before proposing changes; cite concrete paths and symbols.
-                    - When you touch GitHub, prefer read-only queries (issues, PRs, code \
-                    search) and summarize findings precisely.
-                    - Match the project's existing style and conventions. Keep changes \
-                    minimal and explain the reasoning.
-                    - Fetch documentation when an API or library detail is uncertain \
-                    rather than guessing.
-                    """
-                )
+                        - Use the Git and filesystem tools to read real files, history, and \
+                        diffs before proposing changes; cite concrete paths and symbols.
+                        - When you touch GitHub, prefer read-only queries (issues, PRs, code \
+                        search) and summarize findings precisely.
+                        - Match the project's existing style and conventions. Keep changes \
+                        minimal and explain the reasoning.
+                        - Fetch documentation when an API or library detail is uncertain \
+                        rather than guessing.
+                        """
+                    )
+                ),
             ]
         ),
         NativKit(
@@ -78,26 +203,29 @@ extension NativKit {
             name: "Research",
             summary: "Gather sources from the web, keep notes, and query your own data.",
             symbol: "magnifyingglass",
-            tint: .purple,
-            mcpServerIDs: ["fetch", "memory", "sqlite"],
-            extensionIDs: [],
-            skills: [
-                .kit(
-                    "A2000000-0000-4000-8000-000000000002",
-                    "Researching with sources",
-                    """
-                    You're doing careful research. Prioritize accuracy and traceability.
+            tintName: "purple",
+            components: [
+                .mcpServer(catalogID: "fetch"),
+                .mcpServer(catalogID: "memory"),
+                .mcpServer(catalogID: "sqlite"),
+                .skill(
+                    .kit(
+                        "A2000000-0000-4000-8000-000000000002",
+                        "Researching with sources",
+                        """
+                        You're doing careful research. Prioritize accuracy and traceability.
 
-                    - Use the fetch tool to read primary sources; quote or paraphrase \
-                    with a link back to where each claim came from.
-                    - Record durable findings in the memory tool so they carry across \
-                    the conversation, and recall them before re-fetching.
-                    - Query the SQLite tool for anything in the user's own dataset \
-                    instead of estimating.
-                    - Separate what the sources say from your own inference, and flag \
-                    uncertainty plainly.
-                    """
-                )
+                        - Use the fetch tool to read primary sources; quote or paraphrase \
+                        with a link back to where each claim came from.
+                        - Record durable findings in the memory tool so they carry across \
+                        the conversation, and recall them before re-fetching.
+                        - Query the SQLite tool for anything in the user's own dataset \
+                        instead of estimating.
+                        - Separate what the sources say from your own inference, and flag \
+                        uncertainty plainly.
+                        """
+                    )
+                ),
             ]
         ),
     ]
@@ -105,75 +233,124 @@ extension NativKit {
 
 // MARK: - Activation
 
-/// How much of a kit is currently switched on, derived from its live pieces.
+/// How much of a Kit is currently active, derived from its live components.
 enum NativKitState: Equatable {
     case off
     case partial
     case enabled
 }
 
-/// Turns a kit's MCP servers, skills, and extensions on or off together, driving
-/// the same settings the individual sections do. Enabling appends any missing
-/// pieces; disabling switches them off without deleting the user's edits.
+/// Additively enables Kit components and derives status from their live state.
 @MainActor
 enum NativKitActivation {
-    static func setEnabled(
-        _ enabled: Bool,
-        kit: NativKit,
+    /// Enables every missing component without disabling or taking ownership of shared components.
+    static func enableMissing(
+        in kit: NativKit,
         model: NativModel,
-        manager: NativExtensionManager
+        mcpCatalog: MCPServerCatalog = .bundled,
+        isExtensionEnabled: (String) -> Bool,
+        enableExtension: (String) -> Void
     ) {
-        let catalog = MCPServerCatalog.bundled
-        var servers = model.settings.mcpServers
-        for entry in kit.mcpEntries {
-            catalog.setEnabled(enabled, for: entry, in: &servers)
+        var settings = model.settings
+        let extensionIDs = enableMissing(in: kit, settings: &settings, mcpCatalog: mcpCatalog)
+        if settings != model.settings {
+            model.settings = settings
         }
-        model.settings.mcpServers = servers
+
+        for extensionID in extensionIDs where !isExtensionEnabled(extensionID) {
+            enableExtension(extensionID)
+        }
+    }
+
+    /// Enables settings-backed components and returns extension identifiers to enable.
+    @discardableResult
+    static func enableMissing(
+        in kit: NativKit,
+        settings: inout NativSettings,
+        mcpCatalog: MCPServerCatalog
+    ) -> [String] {
+        for catalogID in kit.mcpServerIDs {
+            guard let entry = mcpCatalog.entry(id: catalogID) else { continue }
+            mcpCatalog.setEnabled(true, for: entry, in: &settings.mcpServers)
+        }
 
         for skill in kit.skills {
-            if let index = model.settings.skills.firstIndex(where: { $0.id == skill.id }) {
-                model.settings.skills[index].isEnabled = enabled
-            } else if enabled {
-                model.settings.skills.append(skill)
+            if let index = settings.skills.firstIndex(where: { $0.id == skill.id }) {
+                settings.skills[index].isEnabled = true
+            } else {
+                settings.skills.append(skill)
             }
         }
 
-        for extensionID in kit.extensionIDs {
-            manager.setEnabled(enabled, extensionID: extensionID)
-        }
+        return kit.extensionIDs
     }
 
-    /// The kit's activation derived from the actual state of its pieces, so the UI
-    /// cannot drift out of sync with the individual switches.
-    static func state(of kit: NativKit, model: NativModel, manager: NativExtensionManager) -> NativKitState {
-        let inactive = inactivePartNames(of: kit, model: model, manager: manager)
-        guard inactive.count < kit.capabilityNames.count else { return .off }
-        return inactive.isEmpty ? .enabled : .partial
+    static func state(
+        of kit: NativKit,
+        model: NativModel,
+        mcpCatalog: MCPServerCatalog = .bundled,
+        isExtensionEnabled: (String) -> Bool
+    ) -> NativKitState {
+        state(
+            of: kit,
+            settings: model.settings,
+            isExtensionEnabled: isExtensionEnabled,
+            mcpCatalog: mcpCatalog
+        )
     }
 
-    /// Names the parts a person still needs to turn on for this kit.
+    static func state(
+        of kit: NativKit,
+        settings: NativSettings,
+        isExtensionEnabled: (String) -> Bool,
+        mcpCatalog: MCPServerCatalog
+    ) -> NativKitState {
+        let inactiveCount = inactivePartNames(
+            of: kit,
+            settings: settings,
+            extensionName: { $0 },
+            isExtensionEnabled: isExtensionEnabled,
+            mcpCatalog: mcpCatalog
+        ).count
+        guard inactiveCount < kit.components.count else { return .off }
+        return inactiveCount == 0 ? .enabled : .partial
+    }
+
+    /// Names the components a person still needs to enable for this Kit.
     static func inactivePartNames(
         of kit: NativKit,
         model: NativModel,
-        manager: NativExtensionManager
+        mcpCatalog: MCPServerCatalog = .bundled,
+        extensionName: (String) -> String,
+        isExtensionEnabled: (String) -> Bool
     ) -> [String] {
-        var names: [String] = []
-
-        for entry in kit.mcpEntries where !isServerEnabled(entry, in: model) {
-            names.append(entry.name)
-        }
-        for skill in kit.skills where model.settings.skills.first(where: { $0.id == skill.id })?.isEnabled != true {
-            names.append(skill.name)
-        }
-        for extensionID in kit.extensionIDs where !manager.isEnabled(extensionID: extensionID) {
-            let name = manager.records.first { $0.id == extensionID }?.manifest.displayName ?? extensionID
-            names.append(name)
-        }
-
-        return names
+        inactivePartNames(
+            of: kit,
+            settings: model.settings,
+            extensionName: extensionName,
+            isExtensionEnabled: isExtensionEnabled,
+            mcpCatalog: mcpCatalog
+        )
     }
 
-    private static func isServerEnabled(_ entry: MCPCatalogEntry, in model: NativModel) -> Bool {
-        MCPServerCatalog.bundled.isEnabled(entry, in: model.settings.mcpServers)
+    static func inactivePartNames(
+        of kit: NativKit,
+        settings: NativSettings,
+        extensionName: (String) -> String,
+        isExtensionEnabled: (String) -> Bool,
+        mcpCatalog: MCPServerCatalog
+    ) -> [String] {
+        kit.components.compactMap { component in
+            switch component {
+            case .mcpServer(let catalogID):
+                guard let entry = mcpCatalog.entry(id: catalogID) else { return catalogID }
+                return mcpCatalog.isEnabled(entry, in: settings.mcpServers) ? nil : entry.name
+            case .skill(let skill):
+                let isEnabled = settings.skills.first(where: { $0.id == skill.id })?.isEnabled == true
+                return isEnabled ? nil : skill.name
+            case .extensionPackage(let id):
+                return isExtensionEnabled(id) ? nil : extensionName(id)
+            }
+        }
     }
 }

--- a/Sources/Nativ/Features/Routines/RoutineEditorView.swift
+++ b/Sources/Nativ/Features/Routines/RoutineEditorView.swift
@@ -67,7 +67,7 @@ struct RoutineEditor: View {
             case .skill:
                 return false
             case .kit(let id):
-                return NativKit.all.first(where: { $0.id == id })?.mcpServerIDs.isEmpty == false
+                return NativKitCatalog.bundled.kit(id: id)?.mcpServerIDs.isEmpty == false
             case .mcpServer, .tool:
                 return true
             }
@@ -75,7 +75,7 @@ struct RoutineEditor: View {
     }
 
     private var capabilityOptions: [ScheduledCapabilityOption] {
-        var options = NativKit.all.map { kit in
+        var options = NativKitCatalog.bundled.kits.map { kit in
             ScheduledCapabilityOption(
                 capability: .kit(kit.id),
                 section: .kits,

--- a/Sources/Nativ/Features/Routines/RoutineRunner.swift
+++ b/Sources/Nativ/Features/Routines/RoutineRunner.swift
@@ -449,8 +449,8 @@ final class RoutineRunner {
         for capability in routine.capabilities {
             switch capability {
             case .kit(let kitID):
-                guard let kit = NativKit.all.first(where: { $0.id == kitID }) else { continue }
-                for entry in kit.mcpEntries {
+                guard let kit = NativKitCatalog.bundled.kit(id: kitID) else { continue }
+                for entry in kit.mcpEntries(in: .bundled) {
                     if let server = settings.mcpServers.first(where: {
                         $0.command == entry.command && $0.arguments == entry.arguments
                     }) {
@@ -500,11 +500,11 @@ final class RoutineRunner {
         for capability in routine.capabilities {
             switch capability {
             case .kit(let kitID):
-                guard let kit = NativKit.all.first(where: { $0.id == kitID }) else {
+                guard let kit = NativKitCatalog.bundled.kit(id: kitID) else {
                     unavailable.append(kitID)
                     continue
                 }
-                for entry in kit.mcpEntries {
+                for entry in kit.mcpEntries(in: .bundled) {
                     if let server = settings.mcpServers.first(where: {
                         $0.command == entry.command
                             && $0.arguments == entry.arguments

--- a/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
@@ -298,13 +298,13 @@ struct ScheduledTasksView: View {
         for capability in task.capabilities {
             guard case .kit(let id) = capability,
                   !previousKitIDs.contains(id),
-                  let kit = NativKit.all.first(where: { $0.id == id })
+                  let kit = NativKitCatalog.bundled.kit(id: id)
             else { continue }
-            NativKitActivation.setEnabled(
-                true,
-                kit: kit,
+            NativKitActivation.enableMissing(
+                in: kit,
                 model: model,
-                manager: extensionManager
+                isExtensionEnabled: extensionManager.isEnabled(extensionID:),
+                enableExtension: { extensionManager.setEnabled(true, extensionID: $0) }
             )
         }
     }

--- a/Tests/NativTests/NativKitTests.swift
+++ b/Tests/NativTests/NativKitTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+
+@Suite("Kits")
+@MainActor
+struct NativKitTests {
+    @Test("Bundled Kits are validated catalog entries")
+    func bundledCatalog() throws {
+        let engineering = try #require(NativKitCatalog.bundled.kit(id: "engineering"))
+        let research = try #require(NativKitCatalog.bundled.kit(id: "research"))
+
+        #expect(engineering.name == "Engineering")
+        #expect(research.name == "Research")
+        #expect(engineering.mcpServerIDs.contains("fetch"))
+        #expect(research.mcpServerIDs.contains("fetch"))
+    }
+
+    @Test("Catalog rejects duplicate Kit identifiers")
+    func duplicateKitIdentifiers() {
+        let kit = makeKit(id: "example", components: [])
+
+        #expect(throws: NativKitCatalogError.duplicateKitIdentifier("example")) {
+            try NativKitCatalog(kits: [kit, kit], mcpCatalog: .empty)
+        }
+    }
+
+    @Test("Catalog rejects duplicate components within a Kit")
+    func duplicateComponents() {
+        let kit = makeKit(
+            id: "example",
+            components: [
+                .mcpServer(catalogID: "fetch"),
+                .mcpServer(catalogID: "fetch"),
+            ]
+        )
+
+        #expect(
+            throws: NativKitCatalogError.duplicateComponent(
+                kitID: "example",
+                componentID: "mcp:fetch"
+            )
+        ) {
+            try NativKitCatalog(kits: [kit], mcpCatalog: try makeMCPCatalog())
+        }
+    }
+
+    @Test("Catalog rejects unknown MCP server references")
+    func unknownMCPServer() {
+        let kit = makeKit(
+            id: "example",
+            components: [.mcpServer(catalogID: "missing")]
+        )
+
+        #expect(
+            throws: NativKitCatalogError.unknownMCPServer(
+                kitID: "example",
+                catalogID: "missing"
+            )
+        ) {
+            try NativKitCatalog(kits: [kit], mcpCatalog: try makeMCPCatalog())
+        }
+    }
+
+    @Test("Enabling overlapping Kits is additive and does not duplicate shared components")
+    func additiveActivation() throws {
+        let mcpCatalog = try makeMCPCatalog()
+        let skillID = try #require(UUID(uuidString: "AB000000-0000-4000-8000-000000000001"))
+        let skill = NativSkill(
+            id: skillID,
+            name: "Example skill",
+            instructions: "Use the example capability.",
+            isEnabled: true
+        )
+        let first = makeKit(
+            id: "first",
+            components: [.mcpServer(catalogID: "fetch")]
+        )
+        let second = makeKit(
+            id: "second",
+            components: [
+                .mcpServer(catalogID: "fetch"),
+                .skill(skill),
+            ]
+        )
+        var settings = NativSettings()
+
+        NativKitActivation.enableMissing(in: first, settings: &settings, mcpCatalog: mcpCatalog)
+        NativKitActivation.enableMissing(in: second, settings: &settings, mcpCatalog: mcpCatalog)
+
+        #expect(settings.mcpServers.count == 1)
+        #expect(settings.mcpServers.first?.catalogID == "fetch")
+        #expect(settings.mcpServers.first?.isEnabled == true)
+        #expect(settings.skills == [skill])
+        #expect(
+            NativKitActivation.state(
+                of: first,
+                settings: settings,
+                isExtensionEnabled: { _ in false },
+                mcpCatalog: mcpCatalog
+            ) == .enabled
+        )
+        #expect(
+            NativKitActivation.state(
+                of: second,
+                settings: settings,
+                isExtensionEnabled: { _ in false },
+                mcpCatalog: mcpCatalog
+            ) == .enabled
+        )
+    }
+
+    @Test("Activation preserves an existing skill while enabling it")
+    func preservesExistingSkill() throws {
+        let id = try #require(UUID(uuidString: "AB000000-0000-4000-8000-000000000002"))
+        let bundledSkill = NativSkill(
+            id: id,
+            name: "Bundled name",
+            instructions: "Bundled instructions",
+            isEnabled: true
+        )
+        let editedSkill = NativSkill(
+            id: id,
+            name: "My name",
+            instructions: "My instructions",
+            isEnabled: false
+        )
+        let kit = makeKit(id: "example", components: [.skill(bundledSkill)])
+        var settings = NativSettings(skills: [editedSkill])
+
+        NativKitActivation.enableMissing(in: kit, settings: &settings, mcpCatalog: .empty)
+
+        #expect(settings.skills == [
+            NativSkill(
+                id: id,
+                name: "My name",
+                instructions: "My instructions",
+                isEnabled: true
+            ),
+        ])
+    }
+
+    @Test("State is partial when only some components are enabled")
+    func partialState() throws {
+        let mcpCatalog = try makeMCPCatalog()
+        let skillID = try #require(UUID(uuidString: "AB000000-0000-4000-8000-000000000003"))
+        let skill = NativSkill(
+            id: skillID,
+            name: "Example skill",
+            instructions: "Example instructions",
+            isEnabled: true
+        )
+        let kit = makeKit(
+            id: "example",
+            components: [
+                .mcpServer(catalogID: "fetch"),
+                .skill(skill),
+            ]
+        )
+        var settings = NativSettings()
+        let entry = try #require(mcpCatalog.entry(id: "fetch"))
+        mcpCatalog.setEnabled(true, for: entry, in: &settings.mcpServers)
+
+        #expect(
+            NativKitActivation.state(
+                of: kit,
+                settings: settings,
+                isExtensionEnabled: { _ in false },
+                mcpCatalog: mcpCatalog
+            ) == .partial
+        )
+        #expect(
+            NativKitActivation.inactivePartNames(
+                of: kit,
+                settings: settings,
+                extensionName: { $0 },
+                isExtensionEnabled: { _ in false },
+                mcpCatalog: mcpCatalog
+            ) == ["Example skill"]
+        )
+    }
+
+    private func makeKit(
+        id: String,
+        components: [NativKitComponent]
+    ) -> NativKit {
+        NativKit(
+            id: id,
+            name: id.capitalized,
+            summary: "Example Kit",
+            symbol: "shippingbox",
+            tintName: "blue",
+            components: components
+        )
+    }
+
+    private func makeMCPCatalog() throws -> MCPServerCatalog {
+        try MCPServerCatalog(entries: [
+            MCPCatalogEntry(
+                id: "fetch",
+                name: "Fetch",
+                summary: "Fetch web content",
+                command: "fetch"
+            ),
+        ])
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -175,6 +175,7 @@ targets:
       - path: Tests/NativTests
       - path: Sources/Nativ/NativSettings.swift
       - path: Sources/Nativ/Features/Extensions/NativSkill.swift
+      - path: Sources/Nativ/Features/Extensions/NativKit.swift
       - path: Sources/Nativ/Features/Extensions/CustomTool.swift
       - path: Sources/Nativ/Features/Routines/Routine.swift
       - path: Sources/Nativ/Features/Routines/ScheduledTaskChatLinker.swift


### PR DESCRIPTION
Introduces a validated Kit catalog with stable component identities and reusable definitions. Changes Kit activation to enable missing capabilities while preserving settings and independently managed shared components. Adds focused tests for catalog validation, overlapping Kits, partial states, and additive activation behavior regressions.

Mainly helps by not having kits expose dead actions.

This is pre-cleaning for an upcoming pr to supercede #251