### PR TITLE
Resolve Kit capabilities at routine runtime

### DIFF
--- a/Docs/extending/kits.md
+++ b/Docs/extending/kits.md
@@ -84,3 +84,18 @@ wherever Kits are offered; no consumer-specific wiring is needed.
 Kits never own global capability state. Applying a Kit only enables missing
 components. Removing or disabling a shared component remains an explicit action
 in that component's own management surface.
+
+## Runtime resolution
+
+Routines resolve a Kit from its stable ID each time they run. The resolver uses
+the current settings snapshot and fails the run with named unavailable
+capabilities when a required MCP server or skill is missing or disabled. It does
+not silently substitute a partial Kit.
+
+Known settings failures are reported before the model server starts. Shared MCP
+servers and skills are resolved once when multiple selected Kits reference them.
+
+Extensions are activation-only prerequisites today: applying the Kit enables
+them globally, but the routine runtime does not derive tools directly from an
+extension package. A future extension-to-capability contract should replace
+that boundary before extension-provided tools are scoped to individual runs.

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */; };
 		060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */; };
+		06C8B891576DC3051282D367 /* NativKitRuntimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */; };
 		07E17841B388FBBD8C8A28EF /* NativSystemPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E2A903D604A57696674510 /* NativSystemPermissionController.swift */; };
 		086BC5B6FF02F0305536333B /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
 		086BDF7ECBBC6CF5F63C63CB /* TavilyBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90AC464C5C04FB14A3C789 /* TavilyBrowsingProvider.swift */; };
@@ -150,6 +151,7 @@
 		66745D5BB4D1454479FF6C9C /* RoutineScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C1220F03EC60874920E0CE /* RoutineScheduler.swift */; };
 		67560D2323090F583CCC39C6 /* NotificationAppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 6ABC782FB29B8C76EC8B60E6 /* NotificationAppIcon.icns */; };
 		686A83AD1E07A381F56F6D05 /* ChatDocumentContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */; };
+		690202C6E092ABA0A086955F /* NativKitRuntimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */; };
 		692EA024371CB249BE53DB86 /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
 		6B5A139573E38850CE9C1E3F /* AudioInputDevicePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */; };
 		6B75126FADAA6F8B2016DBDF /* ChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE817B51A37BDB25AD26A11 /* ChatViewModelTests.swift */; };
@@ -456,6 +458,7 @@
 		3D2AACD0A419316AD0099E20 /* ChatCapabilitiesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCapabilitiesSheet.swift; sourceTree = "<group>"; };
 		3D5C104E12EEB90C4108DD86 /* ScheduledTasksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTasksView.swift; sourceTree = "<group>"; };
 		3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorStore.swift; sourceTree = "<group>"; };
+		3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitRuntimeResolver.swift; sourceTree = "<group>"; };
 		3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXImageModelResolverTests.swift; sourceTree = "<group>"; };
 		41417C210BF817681A8C6D87 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
 		4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperView.swift; sourceTree = "<group>"; };
@@ -1083,6 +1086,7 @@
 				7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */,
 				27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */,
 				AA7F610FC8739BA80227DB26 /* NativKit.swift */,
+				3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */,
 				CDDB4C89F8DD338E9209E7FF /* NativSkill.swift */,
 				E902D6BB4117C3F240832FA3 /* ToolsSectionView.swift */,
 				49B4556627CCB5BD1D3DE5F8 /* VoiceDictationExtension.swift */,
@@ -1597,6 +1601,7 @@
 				F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */,
 				2B988CEEF0FD7FCCD3862AF6 /* NativExtensionStateStore.swift in Sources */,
 				C03E948D1C7E27B27838C4C6 /* NativKit.swift in Sources */,
+				690202C6E092ABA0A086955F /* NativKitRuntimeResolver.swift in Sources */,
 				4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */,
 				751C105813095FEC67349FBB /* NativNotificationService.swift in Sources */,
 				7C9ADF2438B155D639E6A6F2 /* NativPermissionsCard.swift in Sources */,
@@ -1738,6 +1743,7 @@
 				ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */,
 				0E326825AE5A1A5EEA33D928 /* NativExtensionTests.swift in Sources */,
 				D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */,
+				06C8B891576DC3051282D367 /* NativKitRuntimeResolver.swift in Sources */,
 				4B3B371072FF015C6CA2CA61 /* NativKitTests.swift in Sources */,
 				025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */,
 				C98474155E01AF49957443C9 /* NativNotificationService.swift in Sources */,

--- a/Sources/Nativ/Features/Extensions/NativKitRuntimeResolver.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitRuntimeResolver.swift
@@ -1,0 +1,77 @@
+import Foundation
+import NativServerKit
+
+/// The settings-backed capabilities selected Kits can supply to a routine.
+struct NativKitRuntimeResolution: Equatable, Sendable {
+    let mcpServers: [MCPServerConfig]
+    let skills: [NativSkill]
+    let unavailableCapabilities: [String]
+}
+
+/// Resolves selected Kit identities and deduplicates their shared capabilities.
+enum NativKitRuntimeResolver {
+    static func resolve(
+        kitIDs: [String],
+        settings: NativSettings,
+        kitCatalog: NativKitCatalog = .bundled,
+        mcpCatalog: MCPServerCatalog = .bundled
+    ) -> NativKitRuntimeResolution {
+        var serverIDs = Set<UUID>()
+        var servers: [MCPServerConfig] = []
+        var skillIDs = Set<UUID>()
+        var skills: [NativSkill] = []
+        var unavailable = Set<String>()
+
+        for kitID in kitIDs {
+            guard let kit = kitCatalog.kit(id: kitID) else {
+                unavailable.insert("Kit \(kitID) (unavailable)")
+                continue
+            }
+
+            for component in kit.components {
+                switch component {
+                case .mcpServer(let catalogID):
+                    guard let entry = mcpCatalog.entry(id: catalogID) else {
+                        unavailable.insert("\(kit.name): \(catalogID) (unavailable)")
+                        continue
+                    }
+                    guard let server = mcpCatalog.configuredServer(
+                        for: entry,
+                        in: settings.mcpServers
+                    ) else {
+                        unavailable.insert("\(kit.name): \(entry.name) (not configured)")
+                        continue
+                    }
+                    guard server.isEnabled else {
+                        unavailable.insert("\(kit.name): \(entry.name) (disabled)")
+                        continue
+                    }
+                    guard serverIDs.insert(server.id).inserted else { continue }
+                    servers.append(server)
+
+                case .skill(let definition):
+                    guard let skill = settings.skills.first(where: { $0.id == definition.id }) else {
+                        unavailable.insert("\(kit.name): \(definition.name) (not configured)")
+                        continue
+                    }
+                    guard skill.isEnabled else {
+                        let name = skill.name.isEmpty ? definition.name : skill.name
+                        unavailable.insert("\(kit.name): \(name) (disabled)")
+                        continue
+                    }
+                    guard skillIDs.insert(skill.id).inserted else { continue }
+                    skills.append(skill)
+
+                case .extensionPackage:
+                    break
+                }
+            }
+        }
+
+        return NativKitRuntimeResolution(
+            mcpServers: servers,
+            skills: skills,
+            unavailableCapabilities: unavailable.sorted()
+        )
+    }
+}

--- a/Sources/Nativ/Features/Routines/RoutineRunner.swift
+++ b/Sources/Nativ/Features/Routines/RoutineRunner.swift
@@ -78,6 +78,26 @@ final class RoutineRunner {
         )
         store.recordRun(run)
 
+        let settings = model.settings.normalized()
+        let kitResolution = NativKitRuntimeResolver.resolve(
+            kitIDs: routine.capabilities.compactMap { capability in
+                guard case .kit(let id) = capability else { return nil }
+                return id
+            },
+            settings: settings
+        )
+        guard kitResolution.unavailableCapabilities.isEmpty else {
+            finishUnavailableCapabilities(
+                kitResolution.unavailableCapabilities,
+                run: &run,
+                routine: routine,
+                sessionID: sessionID,
+                startedAt: startedAt,
+                initialTranscript: initialTranscript
+            )
+            return
+        }
+
         if !model.isRunning {
             model.startServer()
         }
@@ -96,28 +116,27 @@ final class RoutineRunner {
             return
         }
 
-        let settings = model.settings.normalized()
-        let selectedServers = Self.selectedMCPServers(for: routine, settings: settings)
+        let selectedServers = Self.selectedMCPServers(
+            for: routine,
+            settings: settings,
+            kitMCPServers: kitResolution.mcpServers
+        )
         await mcpHost.prepare(servers: selectedServers)
         guard shouldContinue(routine) else { return }
         let capabilities = Self.resolveCapabilities(
             for: routine,
             settings: settings,
-            mcpHost: mcpHost
+            mcpHost: mcpHost,
+            kitResolution: kitResolution
         )
         guard capabilities.unavailable.isEmpty else {
-            let message = "Unavailable tools: \(capabilities.unavailable.joined(separator: ", "))."
-            saveRunChat(
+            finishUnavailableCapabilities(
+                capabilities.unavailable,
+                run: &run,
                 routine: routine,
                 sessionID: sessionID,
-                createdAt: startedAt,
-                messages: initialTranscript + [ChatTranscriptMessage(role: .error, content: message)]
-            )
-            finish(
-                &run,
-                routine: routine,
-                status: .failed,
-                summary: message
+                startedAt: startedAt,
+                initialTranscript: initialTranscript
             )
             return
         }
@@ -443,20 +462,14 @@ final class RoutineRunner {
 
     private static func selectedMCPServers(
         for routine: Routine,
-        settings: NativSettings
+        settings: NativSettings,
+        kitMCPServers: [MCPServerConfig]
     ) -> [MCPServerConfig] {
-        var ids = Set<UUID>()
+        var ids = Set(kitMCPServers.map(\.id))
         for capability in routine.capabilities {
             switch capability {
-            case .kit(let kitID):
-                guard let kit = NativKitCatalog.bundled.kit(id: kitID) else { continue }
-                for entry in kit.mcpEntries(in: .bundled) {
-                    if let server = settings.mcpServers.first(where: {
-                        $0.command == entry.command && $0.arguments == entry.arguments
-                    }) {
-                        ids.insert(server.id)
-                    }
-                }
+            case .kit:
+                break
             case .mcpServer(let id):
                 ids.insert(id)
             case .tool(let tool):
@@ -473,14 +486,19 @@ final class RoutineRunner {
     private static func resolveCapabilities(
         for routine: Routine,
         settings: NativSettings,
-        mcpHost: MCPHostManager
+        mcpHost: MCPHostManager,
+        kitResolution: NativKitRuntimeResolution
     ) -> ResolvedCapabilities {
         var toolsByName: [String: ResolvedTool] = [:]
         var conflictingToolNames = Set<String>()
         var skillsByID: [UUID: NativSkill] = [:]
-        var unavailable: [String] = []
-        var wholeMCPServers = Set<UUID>()
+        var unavailable = kitResolution.unavailableCapabilities
+        var wholeMCPServers = Set(kitResolution.mcpServers.map(\.id))
         var selectedTools: [ScheduledTool] = []
+
+        for skill in kitResolution.skills {
+            skillsByID[skill.id] = skill
+        }
 
         func registerTool(
             _ definition: MLXChatToolDefinition,
@@ -499,29 +517,8 @@ final class RoutineRunner {
 
         for capability in routine.capabilities {
             switch capability {
-            case .kit(let kitID):
-                guard let kit = NativKitCatalog.bundled.kit(id: kitID) else {
-                    unavailable.append(kitID)
-                    continue
-                }
-                for entry in kit.mcpEntries(in: .bundled) {
-                    if let server = settings.mcpServers.first(where: {
-                        $0.command == entry.command
-                            && $0.arguments == entry.arguments
-                            && $0.isEnabled
-                    }) {
-                        wholeMCPServers.insert(server.id)
-                    }
-                }
-                for skill in kit.skills {
-                    if let configured = settings.skills.first(where: { $0.id == skill.id }) {
-                        if configured.isEnabled {
-                            skillsByID[skill.id] = configured
-                        }
-                    } else {
-                        skillsByID[skill.id] = skill
-                    }
-                }
+            case .kit:
+                break
             case .mcpServer(let id):
                 wholeMCPServers.insert(id)
             case .tool(let tool):
@@ -607,6 +604,24 @@ final class RoutineRunner {
             skills: skillsByID.values.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending },
             unavailable: Array(Set(unavailable)).sorted()
         )
+    }
+
+    private func finishUnavailableCapabilities(
+        _ unavailable: [String],
+        run: inout RoutineRun,
+        routine: Routine,
+        sessionID: UUID,
+        startedAt: Date,
+        initialTranscript: [ChatTranscriptMessage]
+    ) {
+        let message = "Unavailable capabilities: \(unavailable.joined(separator: ", "))."
+        saveRunChat(
+            routine: routine,
+            sessionID: sessionID,
+            createdAt: startedAt,
+            messages: initialTranscript + [ChatTranscriptMessage(role: .error, content: message)]
+        )
+        finish(&run, routine: routine, status: .failed, summary: message)
     }
 
     private static func normalizedToolCalls(_ calls: [MLXChatToolCall]) -> [MLXChatToolCall] {

--- a/Tests/NativTests/NativKitTests.swift
+++ b/Tests/NativTests/NativKitTests.swift
@@ -179,6 +179,114 @@ struct NativKitTests {
         )
     }
 
+    @Test("Runtime resolution reports disabled and missing Kit components")
+    func runtimeResolutionReportsUnavailableComponents() throws {
+        let mcpCatalog = try makeMCPCatalog()
+        let skillID = try #require(UUID(uuidString: "AB000000-0000-4000-8000-000000000004"))
+        let skill = NativSkill(
+            id: skillID,
+            name: "Example skill",
+            instructions: "Example instructions",
+            isEnabled: true
+        )
+        let kit = makeKit(
+            id: "example",
+            components: [
+                .mcpServer(catalogID: "fetch"),
+                .skill(skill),
+                .extensionPackage(id: "com.nativ.example"),
+            ]
+        )
+        let kitCatalog = try NativKitCatalog(kits: [kit], mcpCatalog: mcpCatalog)
+        let entry = try #require(mcpCatalog.entry(id: "fetch"))
+        var settings = NativSettings(
+            mcpServers: [entry.makeConfiguration(isEnabled: false)]
+        )
+
+        var resolution = NativKitRuntimeResolver.resolve(
+            kitIDs: [kit.id],
+            settings: settings,
+            kitCatalog: kitCatalog,
+            mcpCatalog: mcpCatalog
+        )
+
+        #expect(resolution.mcpServers.isEmpty)
+        #expect(resolution.skills.isEmpty)
+        #expect(resolution.unavailableCapabilities == [
+            "Example: Example skill (not configured)",
+            "Example: Fetch (disabled)",
+        ])
+
+        var disabledSkill = skill
+        disabledSkill.isEnabled = false
+        settings = NativSettings(skills: [disabledSkill])
+        resolution = NativKitRuntimeResolver.resolve(
+            kitIDs: [kit.id],
+            settings: settings,
+            kitCatalog: kitCatalog,
+            mcpCatalog: mcpCatalog
+        )
+
+        #expect(resolution.unavailableCapabilities == [
+            "Example: Example skill (disabled)",
+            "Example: Fetch (not configured)",
+        ])
+
+        NativKitActivation.enableMissing(
+            in: kit,
+            settings: &settings,
+            mcpCatalog: mcpCatalog
+        )
+        resolution = NativKitRuntimeResolver.resolve(
+            kitIDs: [kit.id],
+            settings: settings,
+            kitCatalog: kitCatalog,
+            mcpCatalog: mcpCatalog
+        )
+
+        #expect(resolution.mcpServers.count == 1)
+        #expect(resolution.skills == [skill])
+        #expect(resolution.unavailableCapabilities.isEmpty)
+    }
+
+    @Test("Routine resolution deduplicates shared capabilities and reports unknown Kits")
+    func routineResolutionDeduplicatesSharedCapabilities() throws {
+        let mcpCatalog = try makeMCPCatalog()
+        let entry = try #require(mcpCatalog.entry(id: "fetch"))
+        let skillID = try #require(UUID(uuidString: "AB000000-0000-4000-8000-000000000006"))
+        let skill = NativSkill(
+            id: skillID,
+            name: "Shared skill",
+            instructions: "Example instructions",
+            isEnabled: true
+        )
+        let first = makeKit(
+            id: "first",
+            components: [.mcpServer(catalogID: "fetch"), .skill(skill)]
+        )
+        let second = makeKit(
+            id: "second",
+            components: [.mcpServer(catalogID: "fetch"), .skill(skill)]
+        )
+        let kitCatalog = try NativKitCatalog(
+            kits: [first, second],
+            mcpCatalog: mcpCatalog
+        )
+        let server = entry.makeConfiguration()
+        let settings = NativSettings(mcpServers: [server], skills: [skill])
+
+        let resolution = NativKitRuntimeResolver.resolve(
+            kitIDs: ["first", "missing", "second"],
+            settings: settings,
+            kitCatalog: kitCatalog,
+            mcpCatalog: mcpCatalog
+        )
+
+        #expect(resolution.mcpServers == [server])
+        #expect(resolution.skills == [skill])
+        #expect(resolution.unavailableCapabilities == ["Kit missing (unavailable)"])
+    }
+
     private func makeKit(
         id: String,
         components: [NativKitComponent]

--- a/project.yml
+++ b/project.yml
@@ -176,6 +176,7 @@ targets:
       - path: Sources/Nativ/NativSettings.swift
       - path: Sources/Nativ/Features/Extensions/NativSkill.swift
       - path: Sources/Nativ/Features/Extensions/NativKit.swift
+      - path: Sources/Nativ/Features/Extensions/NativKitRuntimeResolver.swift
       - path: Sources/Nativ/Features/Extensions/CustomTool.swift
       - path: Sources/Nativ/Features/Routines/Routine.swift
       - path: Sources/Nativ/Features/Routines/ScheduledTaskChatLinker.swift


### PR DESCRIPTION
Resolves selected Kits against current settings while preserving stable identities and deduplicating shared runtime capabilities. Fails routines early with named unavailable components instead of silently executing partially configured Kit selections. Adds focused coverage for disabled skills, missing servers, unknown Kits, and shared capability deduplication behavior.

Mainly helps by preventing routines from silently running incomplete Kits.

This is pre-cleaning for an upcoming pr to supercede #251