### PR TITLE
Make Kits scalable and accessible

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
+++ b/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
@@ -283,27 +283,35 @@ struct ChatKitsPickerSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
+        let kits = NativKitCatalog.bundled.kits
         VStack(alignment: .leading, spacing: 16) {
             HStack {
                 Text("Kits")
-                    .font(.system(size: 18, weight: .semibold))
+                    .font(.title3.weight(.semibold))
                 Spacer()
                 NativHoverCloseButton { dismiss() }
             }
 
             Text("Enable a ready-made set of capabilities for every chat.")
-                .font(.system(size: 12))
+                .font(.body)
                 .foregroundStyle(.secondary)
 
-            VStack(spacing: 0) {
-                ForEach(Array(NativKitCatalog.bundled.kits.enumerated()), id: \.element.id) { index, kit in
-                    if index > 0 { Divider() }
-                    kitRow(kit)
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(kits) { kit in
+                        VStack(spacing: 0) {
+                            kitRow(kit)
+                            if kit.id != kits.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
                 }
             }
+            .scrollBounceBehavior(.basedOnSize)
         }
         .padding(20)
-        .frame(width: 480)
+        .presentationSizing(.form)
     }
 
     @ViewBuilder
@@ -328,39 +336,39 @@ struct ChatKitsPickerSheet: View {
                 kitRowContent(kit, state: state)
             }
             .buttonStyle(.plain)
-            .accessibilityHint(
-                state == .partial
-                    ? "Enables the missing Kit capabilities"
-                    : "Enables this Kit"
-            )
+            .accessibilityHint(state == .partial ? "Enables the missing Kit capabilities" : "Enables this Kit")
         }
     }
 
     private func kitRowContent(_ kit: NativKit, state: NativKitState) -> some View {
-        HStack(spacing: 12) {
+        let actionTitle = switch state {
+        case .off: "Enable"
+        case .partial: "Enable missing"
+        case .enabled: "Enabled"
+        }
+        return HStack(spacing: 12) {
             Image(systemName: kit.symbol)
-                .font(.system(size: 15))
+                .font(.headline)
                 .foregroundStyle(Color.nativTint(kit.tintName))
-                .frame(width: 28, height: 28)
+                .frame(minWidth: 28, minHeight: 28)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(kit.name)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.headline)
                     .foregroundStyle(.primary)
                 Text(kit.summary)
-                    .font(.system(size: 11))
+                    .font(.caption)
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                Label(
+                    actionTitle,
+                    systemImage: state == .enabled ? "checkmark.circle.fill" : "plus.circle"
+                )
+                .font(.caption)
+                .foregroundStyle(state == .enabled ? Color.green : Color.accentColor)
             }
-
-            Spacer(minLength: 20)
-
-            Label(
-                state == .enabled ? "Enabled" : state == .partial ? "Enable missing" : "Enable",
-                systemImage: state == .enabled ? "checkmark.circle.fill" : "plus.circle"
-            )
-            .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(state == .enabled ? Color.green : Color.accentColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 12)
         .padding(.trailing, 8)

--- a/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
+++ b/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
@@ -343,7 +343,7 @@ struct ChatKitsPickerSheet: View {
     private func kitRowContent(_ kit: NativKit, state: NativKitState) -> some View {
         let actionTitle = switch state {
         case .off: "Enable"
-        case .partial: "Enable missing"
+        case .partial: "Enable All"
         case .enabled: "Enabled"
         }
         return HStack(spacing: 12) {

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -84,7 +84,7 @@ struct ExtensionsHubView: View {
     private var detail: some View {
         switch section {
         case .kits:
-            KitsSectionView(manager: manager, host: host, model: model)
+            KitsSectionView(manager: manager, model: model)
         case .extensions:
             ExtensionsSectionView(manager: manager)
         case .mcp:
@@ -126,9 +126,9 @@ struct HubSectionScaffold<Content: View, Action: View>: View {
                 HStack(alignment: .firstTextBaseline) {
                     VStack(alignment: .leading, spacing: 3) {
                         Text(title)
-                            .font(.system(size: 20, weight: .semibold))
+                            .font(.title3.weight(.semibold))
                         Text(subtitle)
-                            .font(.system(size: 12))
+                            .font(.subheadline)
                             .foregroundStyle(.secondary)
                     }
                     Spacer(minLength: 12)

--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -155,7 +155,7 @@ private struct KitCard: View {
     @ViewBuilder
     private var actions: some View {
         if snapshot.state != .enabled {
-            Button(snapshot.state == .partial ? "Enable missing" : "Enable", action: onEnable)
+            Button(snapshot.state == .partial ? "Enable All" : "Enable", action: onEnable)
                 .buttonStyle(.borderedProminent)
         }
         Button(snapshot.state == .off ? "Details" : "Manage", action: onOpen)
@@ -216,7 +216,7 @@ private struct KitDetailView: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 if snapshot.state != .enabled {
-                    Button(snapshot.state == .partial ? "Enable missing" : "Enable all") {
+                    Button("Enable All") {
                         NativKitActivation.enableMissing(
                             in: kit,
                             model: model,

--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -2,30 +2,48 @@ import NativExtensionSDK
 import NativServerKit
 import SwiftUI
 
-@ViewBuilder
-private func kitCompletionIndicator(_ state: NativKitState) -> some View {
-    ZStack {
-        if state == .enabled {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(Color.green)
-                .help("Enabled")
-                .accessibilityLabel("Enabled")
+private struct KitStateIcon: View {
+    let state: NativKitState
+
+    var body: some View {
+        Image(systemName: symbol)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(color)
+            .accessibilityLabel("Kit status: \(title)")
+            .help(title)
+    }
+
+    private var title: String {
+        switch state {
+        case .off: "Not enabled"
+        case .partial: "Partially enabled"
+        case .enabled: "Enabled"
         }
     }
-    .frame(width: 16, height: 16)
+
+    private var symbol: String {
+        switch state {
+        case .off: "circle"
+        case .partial: "circle.lefthalf.filled"
+        case .enabled: "circle.fill"
+        }
+    }
+
+    private var color: Color {
+        switch state {
+        case .off: .secondary
+        case .partial: .orange
+        case .enabled: .green
+        }
+    }
 }
 
 struct KitsSectionView: View {
     @ObservedObject var manager: NativExtensionManager
-    @ObservedObject var host: MCPHostManager
     var model: NativModel
     @State private var openKit: NativKit?
 
-    private let columns = [
-        GridItem(.flexible(minimum: 240, maximum: 340), spacing: 14),
-        GridItem(.flexible(minimum: 240, maximum: 340)),
-    ]
+    private static let columns = [GridItem(.adaptive(minimum: 260, maximum: 360), spacing: 14)]
 
     var body: some View {
         HubSectionScaffold(
@@ -34,30 +52,30 @@ struct KitsSectionView: View {
         ) {
             EmptyView()
         } content: {
-            LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
+            LazyVGrid(columns: Self.columns, alignment: .leading, spacing: 14) {
                 ForEach(NativKitCatalog.bundled.kits) { kit in
-                    KitCard(
-                        kit: kit,
-                        state: NativKitActivation.state(
-                            of: kit,
-                            model: model,
-                            isExtensionEnabled: manager.isEnabled(extensionID:)
-                        ),
-                        inactiveParts: NativKitActivation.inactivePartNames(
-                            of: kit,
-                            model: model,
-                            extensionName: extensionName,
-                            isExtensionEnabled: manager.isEnabled(extensionID:)
-                        ),
-                        onOpen: { openKit = kit },
-                        onEnable: { enableMissing(in: kit) }
-                    )
+                    kitCard(for: kit)
                 }
             }
         }
         .sheet(item: $openKit) { kit in
-            KitDetailView(kit: kit, manager: manager, host: host, model: model)
+            KitDetailView(kit: kit, manager: manager, model: model)
         }
+    }
+
+    private func kitCard(for kit: NativKit) -> some View {
+        let snapshot = NativKitActivation.snapshot(
+            of: kit,
+            model: model,
+            extensionName: extensionName,
+            isExtensionEnabled: manager.isEnabled(extensionID:)
+        )
+        return KitCard(
+            kit: kit,
+            snapshot: snapshot,
+            onOpen: { openKit = kit },
+            onEnable: { enableMissing(in: kit) }
+        )
     }
 
     private func extensionName(_ id: String) -> String {
@@ -75,15 +93,8 @@ struct KitsSectionView: View {
 }
 
 private struct KitCard: View {
-    private enum Layout {
-        static let summaryHeight: CGFloat = 50
-        static let capabilitiesHeight: CGFloat = 28
-        static let actionsHeight: CGFloat = 24
-    }
-
     let kit: NativKit
-    let state: NativKitState
-    let inactiveParts: [String]
+    let snapshot: NativKitActivationSnapshot
     let onOpen: () -> Void
     let onEnable: () -> Void
 
@@ -91,51 +102,34 @@ private struct KitCard: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 6) {
                 NativTintedIconTile(symbol: kit.symbol, tint: .nativTint(kit.tintName))
+                    .accessibilityHidden(true)
                 Spacer(minLength: 0)
                 NativStatusBadge(text: "Built-in")
                     .help("Ships with Nativ")
-                kitCompletionIndicator(state)
+                KitStateIcon(state: snapshot.state)
             }
-            .frame(height: 44)
             VStack(alignment: .leading, spacing: 3) {
                 Text(kit.name)
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.headline)
                 Text(kit.summary)
-                    .font(.system(size: 12))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .frame(height: Layout.summaryHeight, alignment: .topLeading)
             Text(capabilitiesText)
-                .font(.system(size: 11))
-                .foregroundStyle(.tertiary)
-                .lineLimit(2)
-                .frame(
-                    maxWidth: .infinity,
-                    minHeight: Layout.capabilitiesHeight,
-                    maxHeight: Layout.capabilitiesHeight,
-                    alignment: .topLeading
-                )
-            HStack(spacing: 8) {
-                if state != .enabled {
-                    Button(state == .partial ? "Enable missing" : "Enable", action: onEnable)
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.small)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    actions
                 }
-                if state == .off {
-                    Button("Details", action: onOpen)
-                        .buttonStyle(.plain)
-                        .controlSize(.small)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Button("Manage", action: onOpen)
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
+                .fixedSize(horizontal: true, vertical: false)
+                VStack(alignment: .leading, spacing: 8) {
+                    actions
                 }
-                Spacer(minLength: 0)
             }
-            .font(.system(size: 12))
-            .frame(height: Layout.actionsHeight)
+            .controlSize(.regular)
         }
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -147,62 +141,82 @@ private struct KitCard: View {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
         )
-        .contentShape(.rect)
-        .onTapGesture(perform: onOpen)
+        .accessibilityElement(children: .contain)
     }
 
     private var capabilitiesText: String {
-        if state == .partial {
-            return "Off: \(inactiveParts.joined(separator: " · "))"
+        if snapshot.state == .partial {
+            "Needs: \(snapshot.inactivePartNames.joined(separator: " · "))"
+        } else {
+            "Includes: \(kit.capabilityNames(in: .bundled).joined(separator: " · "))"
         }
-        return "Includes: \(kit.capabilityNames(in: .bundled).joined(separator: " · "))"
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        if snapshot.state != .enabled {
+            Button(snapshot.state == .partial ? "Enable missing" : "Enable", action: onEnable)
+                .buttonStyle(.borderedProminent)
+        }
+        Button(snapshot.state == .off ? "Details" : "Manage", action: onOpen)
+            .buttonStyle(.bordered)
     }
 }
 
 private struct KitDetailView: View {
     let kit: NativKit
     @ObservedObject var manager: NativExtensionManager
-    @ObservedObject var host: MCPHostManager
     var model: NativModel
     @Environment(\.dismiss) private var dismiss
-
-    private var state: NativKitState {
-        NativKitActivation.state(
-            of: kit,
-            model: model,
-            isExtensionEnabled: manager.isEnabled(extensionID:)
-        )
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
             Divider()
-            VStack(alignment: .leading, spacing: 22) {
-                mcpGroup
-                if !kit.skills.isEmpty { skillsGroup }
-                if !kit.extensionIDs.isEmpty { extensionsGroup }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    mcpGroup
+                    if !kit.skills.isEmpty { skillsGroup }
+                    if !kit.extensionIDs.isEmpty { extensionsGroup }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(20)
             }
-            .padding(20)
+            .scrollBounceBehavior(.basedOnSize)
         }
-        .frame(width: 560)
+        .presentationSizing(.fitted)
+        .frame(
+            minWidth: 600,
+            idealWidth: 680,
+            maxWidth: 920,
+            minHeight: 480,
+            idealHeight: 620,
+            maxHeight: 800
+        )
     }
 
     private var header: some View {
-        HStack(alignment: .top, spacing: 12) {
+        let snapshot = NativKitActivation.snapshot(
+            of: kit,
+            model: model,
+            extensionName: extensionName,
+            isExtensionEnabled: manager.isEnabled(extensionID:)
+        )
+        return HStack(alignment: .top, spacing: 12) {
             NativTintedIconTile(symbol: kit.symbol, tint: .nativTint(kit.tintName), size: 40)
+                .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
                     Text(kit.name)
-                        .font(.system(size: 17, weight: .semibold))
-                    kitCompletionIndicator(state)
+                        .font(.title3.weight(.semibold))
+                    KitStateIcon(state: snapshot.state)
                 }
                 Text(kit.summary)
-                    .font(.system(size: 12))
+                    .font(.body)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
-                if state != .enabled {
-                    Button(state == .partial ? "Enable missing" : "Enable all") {
+                if snapshot.state != .enabled {
+                    Button(snapshot.state == .partial ? "Enable missing" : "Enable all") {
                         NativKitActivation.enableMissing(
                             in: kit,
                             model: model,
@@ -211,7 +225,7 @@ private struct KitDetailView: View {
                         )
                     }
                     .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
+                    .controlSize(.regular)
                     .padding(.top, 4)
                 }
             }
@@ -318,11 +332,12 @@ private struct KitGroup<Content: View>: View {
         VStack(alignment: .leading, spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.headline)
                 if let caption {
                     Text(caption)
-                        .font(.system(size: 11))
+                        .font(.caption)
                         .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             VStack(spacing: 0) {
@@ -341,24 +356,30 @@ private struct KitPartRow: View {
     @Binding var isOn: Bool
 
     var body: some View {
-        HStack(spacing: 10) {
-            NativTintedIconTile(symbol: symbol, tint: tint, logoAssetName: logoAssetName, size: 30)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(title)
-                    .font(.system(size: 13, weight: .medium))
-                if let subtitle {
-                    Text(subtitle)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+        Toggle(isOn: $isOn) {
+            HStack(spacing: 10) {
+                NativTintedIconTile(
+                    symbol: symbol,
+                    tint: tint,
+                    logoAssetName: logoAssetName,
+                    size: 30
+                )
+                .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(.body.weight(.medium))
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
+                Spacer(minLength: 12)
             }
-            Spacer(minLength: 12)
-            Toggle("", isOn: $isOn)
-                .labelsHidden()
-                .toggleStyle(.switch)
-                .controlSize(.small)
         }
+        .toggleStyle(.switch)
+        .controlSize(.regular)
         .padding(.vertical, 8)
     }
 }

--- a/Sources/Nativ/Features/Extensions/NativKit.swift
+++ b/Sources/Nativ/Features/Extensions/NativKit.swift
@@ -240,6 +240,11 @@ enum NativKitState: Equatable {
     case enabled
 }
 
+struct NativKitActivationSnapshot: Equatable {
+    let state: NativKitState
+    let inactivePartNames: [String]
+}
+
 /// Additively enables Kit components and derives status from their live state.
 @MainActor
 enum NativKitActivation {
@@ -291,12 +296,13 @@ enum NativKitActivation {
         mcpCatalog: MCPServerCatalog = .bundled,
         isExtensionEnabled: (String) -> Bool
     ) -> NativKitState {
-        state(
+        snapshot(
             of: kit,
             settings: model.settings,
+            extensionName: { $0 },
             isExtensionEnabled: isExtensionEnabled,
             mcpCatalog: mcpCatalog
-        )
+        ).state
     }
 
     static func state(
@@ -305,26 +311,23 @@ enum NativKitActivation {
         isExtensionEnabled: (String) -> Bool,
         mcpCatalog: MCPServerCatalog
     ) -> NativKitState {
-        let inactiveCount = inactivePartNames(
+        snapshot(
             of: kit,
             settings: settings,
             extensionName: { $0 },
             isExtensionEnabled: isExtensionEnabled,
             mcpCatalog: mcpCatalog
-        ).count
-        guard inactiveCount < kit.components.count else { return .off }
-        return inactiveCount == 0 ? .enabled : .partial
+        ).state
     }
 
-    /// Names the components a person still needs to enable for this Kit.
-    static func inactivePartNames(
+    static func snapshot(
         of kit: NativKit,
         model: NativModel,
         mcpCatalog: MCPServerCatalog = .bundled,
         extensionName: (String) -> String,
         isExtensionEnabled: (String) -> Bool
-    ) -> [String] {
-        inactivePartNames(
+    ) -> NativKitActivationSnapshot {
+        snapshot(
             of: kit,
             settings: model.settings,
             extensionName: extensionName,
@@ -333,14 +336,14 @@ enum NativKitActivation {
         )
     }
 
-    static func inactivePartNames(
+    static func snapshot(
         of kit: NativKit,
         settings: NativSettings,
         extensionName: (String) -> String,
         isExtensionEnabled: (String) -> Bool,
         mcpCatalog: MCPServerCatalog
-    ) -> [String] {
-        kit.components.compactMap { component in
+    ) -> NativKitActivationSnapshot {
+        let inactivePartNames = kit.components.compactMap { component in
             switch component {
             case .mcpServer(let catalogID):
                 guard let entry = mcpCatalog.entry(id: catalogID) else { return catalogID }
@@ -352,5 +355,19 @@ enum NativKitActivation {
                 return isExtensionEnabled(id) ? nil : extensionName(id)
             }
         }
+        let state: NativKitState
+        if kit.components.isEmpty {
+            state = .off
+        } else if inactivePartNames.isEmpty {
+            state = .enabled
+        } else if inactivePartNames.count == kit.components.count {
+            state = .off
+        } else {
+            state = .partial
+        }
+        return NativKitActivationSnapshot(
+            state: state,
+            inactivePartNames: inactivePartNames
+        )
     }
 }

--- a/Sources/Nativ/Features/Shared/NativComponents.swift
+++ b/Sources/Nativ/Features/Shared/NativComponents.swift
@@ -247,11 +247,10 @@ struct NativStatusBadge: View {
         HStack(spacing: 4) {
             if let symbol {
                 Image(systemName: symbol)
-                    .font(.system(size: 9, weight: .semibold))
             }
             Text(text)
         }
-        .font(.system(size: 10, weight: .semibold))
+        .font(.caption2.weight(.semibold))
         .foregroundStyle(tone.color)
         .padding(.horizontal, 7)
         .padding(.vertical, 2)

--- a/Tests/NativTests/NativKitTests.swift
+++ b/Tests/NativTests/NativKitTests.swift
@@ -160,23 +160,16 @@ struct NativKitTests {
         let entry = try #require(mcpCatalog.entry(id: "fetch"))
         mcpCatalog.setEnabled(true, for: entry, in: &settings.mcpServers)
 
-        #expect(
-            NativKitActivation.state(
-                of: kit,
-                settings: settings,
-                isExtensionEnabled: { _ in false },
-                mcpCatalog: mcpCatalog
-            ) == .partial
+        let snapshot = NativKitActivation.snapshot(
+            of: kit,
+            settings: settings,
+            extensionName: { $0 },
+            isExtensionEnabled: { _ in false },
+            mcpCatalog: mcpCatalog
         )
-        #expect(
-            NativKitActivation.inactivePartNames(
-                of: kit,
-                settings: settings,
-                extensionName: { $0 },
-                isExtensionEnabled: { _ in false },
-                mcpCatalog: mcpCatalog
-            ) == ["Example skill"]
-        )
+
+        #expect(snapshot.state == .partial)
+        #expect(snapshot.inactivePartNames == ["Example skill"])
     }
 
     @Test("Runtime resolution reports disabled and missing Kit components")


### PR DESCRIPTION
Makes Kit cards and management sheets adapt cleanly across window sizes and expanding catalogs naturally.

Replaces gesture-only interactions and fixed typography with explicit controls, semantic styles, and compact status indicators.

Removes redundant activation helpers while resolving each Kit snapshot once per rendered interface surface update.

Mainly helps by keeping Kits usable as their catalog and component counts grow.

This is pre-cleaning for an upcoming pr to supercede #251