### PR TITLE
Add GLM-5.3-Flash (Z.ai) to partner models

### DIFF
--- a/website/assets/partners/zai.svg
+++ b/website/assets/partners/zai.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 640 640" fill="#000000" fill-rule="evenodd" xmlns="http://www.w3.org/2000/svg">
+  <path d="M78 55 H325 L273 133 H26 Z" />
+  <path d="M395 55 H620 L260 595 H35 Z" />
+  <path d="M367 517 H614 L562 595 H315 Z" />
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -135,7 +135,7 @@
           <article class="feature-card reveal">
             <span class="feature-number">01</span><span class="feature-tag">CURATED LIBRARY</span>
             <h3>Pick the right model for your Mac</h3>
-            <p>Run standout open models from Google, Cohere, and Liquid AI. Nativ recommends the right partner model for your hardware.</p>
+            <p>Run standout open models from Z.ai, Google, Cohere, and Liquid AI. Nativ recommends the right partner model for your hardware.</p>
             <div class="feature-visual model-stack" aria-hidden="true">
               <div><b><img src="assets/partners/google.svg" alt="" /></b><span>Gemma 4 E2B<small>Google · 10.28 GB</small></span><i>128K</i></div>
               <div><b><img src="assets/partners/cohere.svg" alt="" /></b><span>North Mini Code<small>Cohere · 19.38 GB</small></span><i>500K</i></div>
@@ -235,6 +235,7 @@
         <div class="library-header reveal">
           <div><p class="kicker">/ PARTNER MODELS</p><h2>Open models from<br /><em>teams we trust.</em></h2></div>
           <div class="partner-lockup" aria-label="Nativ model partners">
+            <span><img src="assets/partners/zai.svg" alt="" />Z.ai</span>
             <span><img src="assets/partners/google.svg" alt="" />Google</span>
             <span><img src="assets/partners/cohere.svg" alt="" />Cohere</span>
             <span><img src="assets/partners/liquid.svg" alt="" />Liquid AI</span>
@@ -242,6 +243,7 @@
         </div>
         <div class="model-table reveal" role="table" aria-label="Featured models">
           <div class="model-row model-table-head" role="row"><span>MODEL</span><span>CREATOR</span><span>CONTEXT</span><span>SIZE</span><span>TYPE</span><span></span></div>
+          <a class="model-row" href="https://huggingface.co/zai-org/GLM-5.3-Flash" role="row"><strong class="partner-model"><img src="assets/partners/zai.svg" alt="" />GLM-5.3-Flash</strong><span>Z.ai</span><span>1M</span><span>320B</span><i>VISION + LANGUAGE</i><b>↗</b></a>
           <a class="model-row" href="https://huggingface.co/google/gemma-4-E2B-it" role="row"><strong class="partner-model"><img src="assets/partners/google.svg" alt="" />Gemma 4 E2B Instruct</strong><span>Google</span><span>128k</span><span>10.28 GB</span><i>VISION + AUDIO</i><b>↗</b></a>
           <a class="model-row" href="https://huggingface.co/CohereLabs/North-Mini-Code-1.0-w4a16" role="row"><strong class="partner-model"><img src="assets/partners/cohere.svg" alt="" />North Mini Code</strong><span>Cohere</span><span>500k</span><span>19.38 GB</span><i>CODE + TOOLS</i><b>↗</b></a>
           <a class="model-row" href="https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B" role="row"><strong class="partner-model"><img src="assets/partners/liquid.svg" alt="" />LFM2.5-VL 1.6B</strong><span>Liquid AI</span><span>128k</span><span>3.20 GB</span><i>VISION + LANGUAGE</i><b>↗</b></a>


### PR DESCRIPTION
Adds **Z.ai** as a partner on the marketing site, featuring **GLM-5.3-Flash** (the `glm5_next` architecture landed in mlx-vlm #2030).
