### PR TITLE
Standardize built-in MCP terminology

### DIFF
--- a/Sources/Nativ/Features/Extensions/MCPSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/MCPSectionView.swift
@@ -29,7 +29,7 @@ struct MCPSectionView: View {
             } else {
                 VStack(alignment: .leading, spacing: 22) {
                     if !catalog.entries.isEmpty {
-                        serverGroup(title: "Built in") {
+                        serverGroup(title: "Built-in") {
                             ForEach(Array(catalog.entries.enumerated()), id: \.element.id) { index, entry in
                                 if index > 0 { Divider() }
                                 builtInServerRow(entry)


### PR DESCRIPTION
Standardizes the built-in MCP section label to match terminology used elsewhere throughout the Nativ interface.