### PR TITLE
Detect a busy server port before launch instead of reporting a crash

### DIFF
--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -373,6 +373,12 @@ final class NativModel: ChatModelSwitchingSurface {
             appendLog("\n\(speechIssue) Starting the server without it — dictation stays unavailable until that model is replaced or repaired.\n")
         }
         do {
+            if !server.isRunning {
+                let target = settings.normalized()
+                if ServerPortProbe.availability(host: target.serverHost, port: target.serverPort) == .addressInUse {
+                    throw NativError.portInUse(host: target.serverHost, port: target.serverPort)
+                }
+            }
             var launchEnvironment = settings.launchEnvironment
             launchEnvironment["MLX_PLATFORM_ANALYTICS_DB_PATH"] = currentAnalyticsDatabaseURL().path
             if let effectiveHuggingFaceToken {
@@ -393,6 +399,9 @@ final class NativModel: ChatModelSwitchingSurface {
             huggingFaceTokenAppliedAtServerStart = effectiveHuggingFaceToken
             appendLog("\nmlx-vlm-server is already running.\n")
             shouldStartMetrics = true
+        } catch NativError.portInUse(let host, let port) {
+            modelLoadingProgress = nil
+            appendLog("\nCan't start mlx-vlm-server: \(host):\(port) is already in use by another process. Stop that process or choose a different port in Settings, then try again.\n")
         } catch {
             modelLoadingProgress = nil
             appendLog("\nFailed to start mlx-vlm-server: \(error)\n")
@@ -842,6 +851,11 @@ final class NativModel: ChatModelSwitchingSurface {
                 if let stopReason {
                     self.appendLog(
                         "\nmlx-vlm-server stopped after Nativ requested \(stopReason.rawValue) (status \(status))\n"
+                    )
+                } else if NativServerErrorMessage.isPortConflictFailure(in: self.currentServerOutput) {
+                    let target = self.settingsAppliedAtServerStart ?? self.settings.normalized()
+                    self.appendLog(
+                        "\nmlx-vlm-server couldn't start: \(target.serverHost):\(target.serverPort) is already in use by another process. Stop that process or choose a different port in Settings, then start the server again.\n"
                     )
                 } else {
                     self.appendLog(

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -91,9 +91,7 @@ public enum NativServerErrorMessage {
         return nil
     }
 
-    /// True when the captured server output shows uvicorn/asyncio failing to
-    /// bind its socket because another process already holds the port —
-    /// distinct from a genuine crash, and worth naming explicitly.
+
     public static func isPortConflictFailure(in text: String) -> Bool {
         let lowered = text.lowercased()
         return lowered.contains("address already in use")

--- a/Sources/NativServerKit/NativServerKit.swift
+++ b/Sources/NativServerKit/NativServerKit.swift
@@ -91,6 +91,15 @@ public enum NativServerErrorMessage {
         return nil
     }
 
+    /// True when the captured server output shows uvicorn/asyncio failing to
+    /// bind its socket because another process already holds the port —
+    /// distinct from a genuine crash, and worth naming explicitly.
+    public static func isPortConflictFailure(in text: String) -> Bool {
+        let lowered = text.lowercased()
+        return lowered.contains("address already in use")
+            || lowered.contains("errno 48")
+    }
+
     private static func normalized(_ value: String?) -> String? {
         guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !value.isEmpty
@@ -109,6 +118,7 @@ public enum NativError: Error, CustomStringConvertible {
     case alreadyRunning
     case notRunning
     case launchFailed(Int32, String)
+    case portInUse(host: String, port: Int)
 
     public var description: String {
         switch self {
@@ -126,6 +136,8 @@ public enum NativError: Error, CustomStringConvertible {
             return "mlx-vlm-server is not running"
         case .launchFailed(let status, let output):
             return "mlx-vlm-server exited with status \(status):\n\(output)"
+        case .portInUse(let host, let port):
+            return "\(host):\(port) is already in use by another process"
         }
     }
 }

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -964,6 +964,21 @@ final class NativChatToolProtocolTests: XCTestCase {
             )
         )
     }
+
+    func testPortConflictFailureIsDetectedFromServerLogs() {
+        let output = """
+            INFO:     Application startup complete.
+            ERROR:    [Errno 48] error while attempting to bind on address ('127.0.0.1', 8080): [errno 48] address already in use
+            INFO:     Waiting for application shutdown.
+            """
+
+        XCTAssertTrue(NativServerErrorMessage.isPortConflictFailure(in: output))
+        XCTAssertFalse(
+            NativServerErrorMessage.isPortConflictFailure(
+                in: "ERROR: Application startup failed."
+            )
+        )
+    }
 }
 
 extension Array where Element == String {


### PR DESCRIPTION

This fixes #405 by allowing Nativ to name mlx-vlm's server error which refused to bind to a port already being used.