### PR TITLE
Standardize shared panel surfaces in Nativ

### DIFF
--- a/Sources/Nativ/Features/Dashboard/StatsView.swift
+++ b/Sources/Nativ/Features/Dashboard/StatsView.swift
@@ -223,7 +223,7 @@ private struct DashboardContentView: View, @MainActor Equatable {
             }
         }
         .padding(12)
-        .dashboardPanelStyle(cornerRadius: 12)
+        .nativPanelStyle()
     }
 
     private var overviewCards: some View {
@@ -516,7 +516,7 @@ private struct AnalyticsMetricCard: View {
             }
             .padding(16)
             .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .dashboardPanelStyle(cornerRadius: 14)
+            .nativPanelStyle(cornerRadius: .large)
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(isHovered ? tint.opacity(0.045) : Color.clear)
@@ -655,7 +655,7 @@ private struct UserActivityPanel: View {
             periodBreakdown
         }
         .padding(18)
-        .dashboardPanelStyle(cornerRadius: 14)
+        .nativPanelStyle(cornerRadius: .large)
         .animation(.snappy(duration: 0.24), value: isExpanded)
     }
 
@@ -1408,7 +1408,7 @@ private struct TokenUsagePanel: View {
             }
         }
         .padding(18)
-        .dashboardPanelStyle(cornerRadius: 14)
+        .nativPanelStyle(cornerRadius: .large)
     }
 
     private var chartTitle: String {
@@ -3443,7 +3443,7 @@ private struct RequestHealthPanel: View {
         }
         .padding(18)
         .frame(minHeight: minimumHeight, alignment: .top)
-        .dashboardPanelStyle(cornerRadius: 14)
+        .nativPanelStyle(cornerRadius: .large)
     }
 
     private var total: Int { completed + failed }
@@ -3671,7 +3671,7 @@ private struct ModelPerformanceTable: View {
             }
         }
         .padding(.horizontal, 16)
-        .dashboardPanelStyle(cornerRadius: 14)
+        .nativPanelStyle(cornerRadius: .large)
     }
 
     private var tableContent: some View {
@@ -3912,7 +3912,7 @@ private struct SessionMetricCard: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
-        .dashboardPanelStyle()
+        .nativPanelStyle()
         .help(card.help ?? card.value)
     }
 }
@@ -3936,7 +3936,7 @@ private struct DashboardPickerContainer<Content: View>: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
-        .dashboardPanelStyle(cornerRadius: 10)
+        .nativPanelStyle(cornerRadius: .compact)
     }
 }
 
@@ -3996,7 +3996,7 @@ private struct SummaryPill: View {
         .font(.callout)
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
-        .dashboardPanelStyle(cornerRadius: 10)
+        .nativPanelStyle(cornerRadius: .compact)
         .help(value)
     }
 }
@@ -4023,7 +4023,7 @@ private struct HistoricalChartCard<Content: View>: View {
             content
         }
         .padding(16)
-        .dashboardPanelStyle(cornerRadius: 14)
+        .nativPanelStyle(cornerRadius: .large)
     }
 }
 
@@ -4148,7 +4148,7 @@ private struct DashboardRecentRequestsTable: View {
             }
         }
         .padding(16)
-        .dashboardPanelStyle(cornerRadius: 14)
+        .nativPanelStyle(cornerRadius: .large)
         .sheet(item: $selectedRequest) { request in
             RequestDetailView(request: request)
         }
@@ -4271,7 +4271,7 @@ private struct RequestDetailMetric: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(12)
-        .dashboardPanelStyle(cornerRadius: 10)
+        .nativPanelStyle(cornerRadius: .compact)
     }
 }
 
@@ -4889,7 +4889,6 @@ private enum DashboardPalette {
     static let primaryBar = Color(red: 73 / 255, green: 163 / 255, blue: 176 / 255)
     static let successBar = Color(red: 68 / 255, green: 157 / 255, blue: 187 / 255)
     static let failureBar = Color(red: 181 / 255, green: 51 / 255, blue: 63 / 255)
-    static let panelFill = Color(nsColor: .controlBackgroundColor)
     static let panelStroke = Color(nsColor: .separatorColor).opacity(0.6)
     static let axisLabel = Color(nsColor: .tertiaryLabelColor)
     static let axisText = Color(nsColor: .secondaryLabelColor)
@@ -4966,26 +4965,4 @@ private enum DashboardFormatters {
         formatter.setLocalizedDateFormatFromTemplate("MMM d")
         return formatter
     }()
-}
-
-private struct DashboardPanelModifier: ViewModifier {
-    let cornerRadius: CGFloat
-
-    func body(content: Content) -> some View {
-        content
-            .background(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(DashboardPalette.panelFill)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .stroke(DashboardPalette.panelStroke, lineWidth: 0.75)
-            )
-    }
-}
-
-private extension View {
-    func dashboardPanelStyle(cornerRadius: CGFloat = 12) -> some View {
-        modifier(DashboardPanelModifier(cornerRadius: cornerRadius))
-    }
 }

--- a/Sources/Nativ/Features/Routines/ScheduledTaskViews.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTaskViews.swift
@@ -102,7 +102,7 @@ struct ScheduledTaskCard: View {
             .fixedSize()
             .padding(.trailing, 16)
         }
-        .scheduledPanelStyle(isHighlighted: isHovering)
+        .nativPanelStyle(isHighlighted: isHovering)
         .contextMenu {
             taskActions
         }
@@ -254,30 +254,6 @@ extension RoutineRunSource {
         case .scheduled: "Scheduled"
         case .manual: "Manual"
         case .api: "API"
-        }
-    }
-}
-
-extension View {
-    func scheduledPanelStyle(isHighlighted: Bool = false) -> some View {
-        background {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color(nsColor: .controlBackgroundColor))
-                .overlay {
-                    if isHighlighted {
-                        Color.primary.opacity(0.045)
-                    }
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        }
-        .overlay {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(
-                    isHighlighted
-                        ? Color.primary.opacity(0.16)
-                        : Color(nsColor: .separatorColor),
-                    lineWidth: 0.5
-                )
         }
     }
 }

--- a/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
@@ -182,7 +182,7 @@ struct ScheduledTasksView: View {
                                 }
                             }
                         }
-                        .scheduledPanelStyle()
+                        .nativPanelStyle()
                     }
                 }
             }

--- a/Sources/Nativ/Features/Shared/NativComponents.swift
+++ b/Sources/Nativ/Features/Shared/NativComponents.swift
@@ -197,6 +197,68 @@ extension Color {
 // single tint over nested filled tiles, so a surface reads as one calm plane
 // rather than a stack of boxes. Prefer these over re-rolling a pill/badge/dot.
 
+/// The supported corner-radius roles for shared panel surfaces.
+enum NativPanelCornerRadius {
+    case compact
+    case standard
+    case large
+
+    fileprivate var value: CGFloat {
+        switch self {
+        case .compact: 10
+        case .standard: 12
+        case .large: 14
+        }
+    }
+}
+
+private struct NativPanelSurfaceModifier: ViewModifier {
+    let cornerRadius: NativPanelCornerRadius
+    let isHighlighted: Bool
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(
+            cornerRadius: cornerRadius.value,
+            style: .continuous
+        )
+
+        content
+            .background {
+                shape
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .overlay {
+                        if isHighlighted {
+                            Color.primary.opacity(0.045)
+                        }
+                    }
+                    .clipShape(shape)
+            }
+            .overlay {
+                shape.stroke(
+                    isHighlighted
+                        ? Color.primary.opacity(0.16)
+                        : Color(nsColor: .separatorColor),
+                    lineWidth: 0.5
+                )
+            }
+    }
+}
+
+extension View {
+    /// Applies Nativ's standard semantic panel surface.
+    func nativPanelStyle(
+        cornerRadius: NativPanelCornerRadius = .standard,
+        isHighlighted: Bool = false
+    ) -> some View {
+        modifier(
+            NativPanelSurfaceModifier(
+                cornerRadius: cornerRadius,
+                isHighlighted: isHighlighted
+            )
+        )
+    }
+}
+
 /// A semantic status color, shared by dots, badges, and tool states.
 enum NativStatusTone {
     case neutral
@@ -318,6 +380,27 @@ struct NativTintedIconTile: View {
             in: RoundedRectangle(cornerRadius: size * 0.28, style: .continuous)
         )
     }
+}
+
+#Preview("Panel Surfaces") {
+    VStack {
+        Text("Compact")
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .nativPanelStyle(cornerRadius: .compact)
+
+        Text("Standard")
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .nativPanelStyle()
+
+        Text("Highlighted")
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .nativPanelStyle(cornerRadius: .large, isHighlighted: true)
+    }
+    .padding()
+    .frame(width: 320)
 }
 
 /// A borderless close (X) button that reveals a soft circular hover hue —

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -537,7 +537,7 @@ private struct SystemSensorsPage: View {
                         }
                     }
                     .padding(14)
-                    .systemMonitorPanel()
+                    .nativPanelStyle()
                 }
             }
         }
@@ -881,7 +881,7 @@ private struct SystemCPUPage: View {
                     }
                 }
                 .padding(14)
-                .systemMonitorPanel()
+                .nativPanelStyle()
             }
 
         }
@@ -1291,7 +1291,7 @@ private struct SystemPanel<Content: View>: View {
         content
             .padding(18)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .systemMonitorPanel()
+            .nativPanelStyle()
     }
 }
 
@@ -1326,7 +1326,7 @@ private struct SystemOverviewMetric: View {
         }
         .padding(15)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .systemMonitorPanel()
+        .nativPanelStyle()
     }
 }
 
@@ -1344,7 +1344,7 @@ private struct SystemInfoCard<Content: View>: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .topLeading)
-        .systemMonitorPanel()
+        .nativPanelStyle()
     }
 }
 
@@ -1624,7 +1624,7 @@ private struct SystemPercentHistoryChart: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .systemMonitorPanel()
+        .nativPanelStyle()
     }
 }
 
@@ -1753,7 +1753,7 @@ private struct SystemDiskHistoryChart: View {
             }
         }
         .padding(16)
-        .systemMonitorPanel()
+        .nativPanelStyle()
     }
 
     private func diskHoverRows(at date: Date) -> [SystemChartHoverRow] {
@@ -1955,7 +1955,7 @@ private struct SystemValueHistoryChart: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .systemMonitorPanel()
+        .nativPanelStyle()
     }
 
     private var axisRange: ClosedRange<Double> {
@@ -2379,26 +2379,6 @@ private enum SystemMonitorPalette {
     static let positive = Color(red: 0.18, green: 0.72, blue: 0.38)
     static let metricLabel = Color.primary.opacity(0.72)
     static let metricDetail = Color.primary.opacity(0.58)
-}
-
-private struct SystemMonitorPanelModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .background {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color(nsColor: .controlBackgroundColor))
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-            }
-    }
-}
-
-private extension View {
-    func systemMonitorPanel() -> some View {
-        modifier(SystemMonitorPanelModifier())
-    }
 }
 
 private extension Array {


### PR DESCRIPTION
Unifies panel surfaces across Dashboard, System Monitor, and Scheduled Tasks with shared semantic styling primitives.

Didn't see any issues @lucasnewman with the ui on this branch, but unsure if this is the right approach