### PR TITLE
detect model support

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		0DF842E2BE07D345918F3D54 /* Manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AF8F6359E4523814FB0EFDA /* Manifest.json */; };
 		0E326825AE5A1A5EEA33D928 /* NativExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */; };
 		0F60E87BC41F29381BD81F73 /* TextDocumentTextExtractors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91D4332044DCC5DCE4B27F6 /* TextDocumentTextExtractors.swift */; };
+		0F6B875201BCB3195D8E4020 /* HuggingFaceModelSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5734696DFCC890B33C2FC661 /* HuggingFaceModelSupport.swift */; };
 		113ED25CFBC57985D0336246 /* SafeLocalFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7A0A31B4307E2520BCD4F2 /* SafeLocalFileReader.swift */; };
 		11A14C51AE4E0170FBA89709 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6BB0CD839020E3F5FF4F8DED /* Assets.xcassets */; };
 		11BDCB609CF070A52C8394DB /* Nimble.png in Resources */ = {isa = PBXBuildFile; fileRef = BC6FDB4FAF6F7C9F7EC24F25 /* Nimble.png */; };
@@ -167,6 +168,7 @@
 		732D29870D9B330A520DF15C /* NativEmbeddingsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */; };
 		751C105813095FEC67349FBB /* NativNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577B24B3B022E78F7664C76E /* NativNotificationService.swift */; };
 		759391363423D786EF850BE3 /* RoutineEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */; };
+		76A3913F8BEDBF621E852FCA /* HuggingFaceModelSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5734696DFCC890B33C2FC661 /* HuggingFaceModelSupport.swift */; };
 		76DA7BB4EB87C407B55D5E05 /* ChatAttachmentKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEE7582DCB286B9D878E28E /* ChatAttachmentKind.swift */; };
 		76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */; };
 		7719AEDEE627A29CA30D6FE3 /* ChatReadFileTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60FD94BFE0DEFB5A1A21601 /* ChatReadFileTool.swift */; };
@@ -484,6 +486,7 @@
 		530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionStore.swift; sourceTree = "<group>"; };
 		5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDocumentExtractionCache.swift; sourceTree = "<group>"; };
 		5682AEE2C7DF8C9A3AFAC3DF /* RealtimeAudioMeter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeAudioMeter.swift; sourceTree = "<group>"; };
+		5734696DFCC890B33C2FC661 /* HuggingFaceModelSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelSupport.swift; sourceTree = "<group>"; };
 		577B24B3B022E78F7664C76E /* NativNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativNotificationService.swift; sourceTree = "<group>"; };
 		586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionHostBroker.swift; sourceTree = "<group>"; };
 		5919AB4E9488642C73886266 /* ShellEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironment.swift; sourceTree = "<group>"; };
@@ -1056,6 +1059,7 @@
 				E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */,
 				7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */,
 				FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */,
+				5734696DFCC890B33C2FC661 /* HuggingFaceModelSupport.swift */,
 				EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */,
 				F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */,
 				61126D4235AFF77D82F1F80B /* MLXImageModelResolver.swift */,
@@ -1588,6 +1592,7 @@
 				7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */,
 				B55A6BE5C7B03181E2CD03D6 /* HuggingFaceHub.swift in Sources */,
 				E36D43D088EF55D617BCDDBB /* HuggingFaceModelReadme.swift in Sources */,
+				0F6B875201BCB3195D8E4020 /* HuggingFaceModelSupport.swift in Sources */,
 				575DCB7EC96DAB35B415434C /* ImageGenerationView.swift in Sources */,
 				BC0753B567DC8935199FCDFB /* ImageGenerationViewModel.swift in Sources */,
 				2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */,
@@ -1733,6 +1738,7 @@
 				D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */,
 				C92083D5C6AF4F5FE29A39E9 /* HuggingFaceModelReadme.swift in Sources */,
 				060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */,
+				76A3913F8BEDBF621E852FCA /* HuggingFaceModelSupport.swift in Sources */,
 				237BB8D2F99FFE536CF0421B /* ImageGenerationViewModel.swift in Sources */,
 				41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */,
 				351B2202E8690FC608A32AEF /* IntegrationServicesTests.swift in Sources */,

--- a/PythonDistribution/Scripts/generate_model_capabilities_manifest.py
+++ b/PythonDistribution/Scripts/generate_model_capabilities_manifest.py
@@ -5,6 +5,7 @@ import argparse
 import ast
 import importlib.metadata
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -123,6 +124,65 @@ def _loader_packages(root: Path, *, requires_config_type: bool = True) -> set[st
     return loaders
 
 
+def _runtime_loader_mapping(
+    site_packages: Path, candidate_model_types: set[str]
+) -> dict[str, str]:
+    """Resolve candidates through the bundled runtime's real dispatch function."""
+    python = site_packages.parents[2] / "bin" / "python3"
+    if not python.exists():
+        raise FileNotFoundError(f"Missing bundled Python interpreter: {python}")
+
+    resolver = """
+import json
+import sys
+
+from mlx_vlm.utils import get_model_and_args
+
+candidates = json.load(sys.stdin)
+resolved = {}
+for candidate in candidates:
+    module, loader = get_model_and_args({"model_type": candidate})
+    if not hasattr(module, "Model") or not hasattr(module, "ModelConfig"):
+        raise RuntimeError(
+            f"Resolved loader {loader!r} for {candidate!r} does not expose "
+            "Model and ModelConfig"
+        )
+    resolved[candidate] = loader
+json.dump(resolved, sys.stdout, sort_keys=True)
+"""
+    result = subprocess.run(
+        [str(python), "-c", resolver],
+        input=json.dumps(sorted(candidate_model_types)),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(
+            "Could not resolve model types with the bundled MLX runtime"
+            + (f": {details}" if details else "")
+        )
+
+    try:
+        mapping = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("Bundled MLX resolver returned invalid JSON") from error
+    if (
+        not isinstance(mapping, dict)
+        or set(mapping) != candidate_model_types
+        or not all(
+            isinstance(candidate, str)
+            and isinstance(loader, str)
+            and candidate.strip().lower() == candidate
+            and loader.strip().lower() == loader
+            for candidate, loader in mapping.items()
+        )
+    ):
+        raise RuntimeError("Bundled MLX resolver returned an invalid loader mapping")
+    return mapping
+
+
 def _image_model_types(models_root: Path) -> tuple[set[str], set[str]]:
     if not models_root.is_dir():
         raise FileNotFoundError(f"Missing mlx-vlm models directory: {models_root}")
@@ -208,12 +268,31 @@ def model_capabilities(site_packages: Path) -> dict[str, object]:
     mlx_audio_root = site_packages / "mlx_audio"
     vlm_models_root = mlx_vlm_root / "models"
 
-    language_types = _loader_packages(vlm_models_root)
-    drafter_types = _loader_packages(mlx_vlm_root / "speculative" / "drafters")
+    language_loaders = _loader_packages(vlm_models_root)
+    drafter_loaders = _loader_packages(
+        mlx_vlm_root / "speculative" / "drafters"
+    )
     vlm_alias_mapping = _string_mapping(mlx_vlm_root / "utils.py", "MODEL_REMAPPING")
-    _validate_mapping_targets(vlm_alias_mapping, language_types | drafter_types)
-    language_types = _apply_alias_precedence(language_types, vlm_alias_mapping)
-    drafter_types = _apply_alias_precedence(drafter_types, vlm_alias_mapping)
+    all_loaders = language_loaders | drafter_loaders
+    _validate_mapping_targets(vlm_alias_mapping, all_loaders)
+    resolved_model_types = _runtime_loader_mapping(
+        site_packages,
+        all_loaders | set(vlm_alias_mapping),
+    )
+    if set(resolved_model_types.values()) != all_loaders:
+        missing = all_loaders - set(resolved_model_types.values())
+        unexpected = set(resolved_model_types.values()) - all_loaders
+        details = []
+        if missing:
+            details.append("unresolved loaders: " + ", ".join(sorted(missing)))
+        if unexpected:
+            details.append("unexpected loaders: " + ", ".join(sorted(unexpected)))
+        raise RuntimeError("Bundled MLX loader mapping is incomplete: " + "; ".join(details))
+
+    language_types = _apply_alias_precedence(language_loaders, resolved_model_types)
+    drafter_types = _apply_alias_precedence(drafter_loaders, resolved_model_types)
+    language_aliases = _aliases_for(resolved_model_types, language_types)
+    drafter_aliases = _aliases_for(resolved_model_types, drafter_types)
 
     image_generation_types, image_editing_types = _image_model_types(vlm_models_root)
 
@@ -252,11 +331,11 @@ def model_capabilities(site_packages: Path) -> dict[str, object]:
     capabilities = {
         "language": _entry(
             language_types,
-            _aliases_for(vlm_alias_mapping, language_types),
+            language_aliases,
         ),
         "speculative_drafters": _entry(
             drafter_types,
-            _aliases_for(vlm_alias_mapping, drafter_types),
+            drafter_aliases,
         ),
         "image_generation": _entry(
             image_generation_types,

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -157,6 +157,8 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
     let isPrivate: Bool
     let isGated: Bool
     let safetensors: HuggingFaceSafetensors?
+    let configuration: HuggingFaceModelConfiguration?
+    let support: HuggingFaceModelSupport
     // These values are used by every visible row. Resolve them once while the
     // response is decoded instead of repeating string parsing, provider lookup,
     // and memory estimation during every SwiftUI body pass while scrolling.
@@ -175,7 +177,12 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         case isPrivate = "private"
         case gated
         case safetensors
+        case config
     }
+
+    private static let supportClassifier = try? HuggingFaceModelSupportClassifier(
+        registry: Nativ.modelTypeRegistry()
+    )
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -187,6 +194,10 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
         isPrivate = try container.decodeIfPresent(Bool.self, forKey: .isPrivate) ?? false
         safetensors = try container.decodeIfPresent(HuggingFaceSafetensors.self, forKey: .safetensors)
+        configuration = try container.decodeIfPresent(
+            HuggingFaceModelConfiguration.self,
+            forKey: .config
+        )
 
         if let value = try? container.decode(Bool.self, forKey: .gated) {
             isGated = value
@@ -196,7 +207,16 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
             isGated = false
         }
 
-        provider = LocalModelProviderResolver.resolve(repoID: id, modelType: nil, architectures: [])
+        support = Self.supportClassifier?.classify(
+            configuration: configuration,
+            pipelineTag: pipelineTag,
+            tags: tags
+        ) ?? .unknown
+        provider = LocalModelProviderResolver.resolve(
+            repoID: id,
+            modelType: configuration?.modelType,
+            architectures: configuration?.architectures ?? []
+        )
         sizeBytes = safetensors?.sizeBytes
         capabilities = Self.resolveCapabilities(
             pipelineTag: pipelineTag,
@@ -539,7 +559,7 @@ private struct HuggingFaceHubClient: Sendable {
         }
         queryItems.append(contentsOf: [
             "downloads", "likes", "pipeline_tag", "library_name", "tags",
-            "private", "gated", "safetensors"
+            "private", "gated", "safetensors", "config"
         ].map { URLQueryItem(name: "expand[]", value: $0) })
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedQuery.isEmpty {
@@ -561,7 +581,7 @@ private struct HuggingFaceHubClient: Sendable {
         components.path = "/api/models/\(id)"
         components.queryItems = [
             "downloads", "likes", "pipeline_tag", "library_name", "tags",
-            "private", "gated", "safetensors"
+            "private", "gated", "safetensors", "config"
         ].map { URLQueryItem(name: "expand[]", value: $0) }
 
         guard let url = components.url else {

--- a/Sources/Nativ/Features/Models/HuggingFaceModelSupport.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceModelSupport.swift
@@ -1,0 +1,124 @@
+import Foundation
+import NativServerKit
+
+enum HuggingFaceModelSupport: Equatable, Sendable {
+    case supported
+    case unsupported
+    case unknown
+}
+
+struct HuggingFaceModelConfiguration: Decodable, Equatable, Sendable {
+    let modelType: String?
+    let speculatorsModelType: String?
+    let architectures: [String]
+    let hasVisionConfig: Bool
+    let hasAudioConfig: Bool
+    let hasDFlashConfig: Bool
+    let usesCustomCode: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case speculatorsModelType = "speculators_model_type"
+        case architectures
+        case visionConfig = "vision_config"
+        case audioConfig = "audio_config"
+        case dFlashConfig = "dflash_config"
+        case modelFile = "model_file"
+        case autoMap = "auto_map"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try container.decodeIfPresent(String.self, forKey: .modelType)
+        speculatorsModelType = try container.decodeIfPresent(
+            String.self,
+            forKey: .speculatorsModelType
+        )
+        architectures = try container.decodeIfPresent(
+            [String].self,
+            forKey: .architectures
+        ) ?? []
+        hasVisionConfig = try container.hasValue(forKey: .visionConfig)
+        hasAudioConfig = try container.hasValue(forKey: .audioConfig)
+        hasDFlashConfig = try container.hasValue(forKey: .dFlashConfig)
+        let modelFile = try container.decodeIfPresent(String.self, forKey: .modelFile)
+        let hasAutoMap = try container.hasValue(forKey: .autoMap)
+        usesCustomCode = modelFile?.isEmpty == false || hasAutoMap
+    }
+}
+
+struct HuggingFaceModelSupportClassifier: Sendable {
+    private let registry: NativModelTypeRegistry
+
+    init(registry: NativModelTypeRegistry) {
+        self.registry = registry
+    }
+
+    func classify(
+        configuration: HuggingFaceModelConfiguration?,
+        pipelineTag: String?,
+        tags: [String]
+    ) -> HuggingFaceModelSupport {
+        guard let configuration else {
+            return .unknown
+        }
+
+        let architectures = Set(configuration.architectures.map { $0.lowercased() })
+        if architectures.contains("boundaryextractor")
+            || architectures.contains("dflash2draftmodel") {
+            return .supported
+        }
+
+        let normalizedTags = Set(tags.map { $0.lowercased() })
+        if configuration.usesCustomCode
+            || normalizedTags.contains("custom_code")
+            || normalizedTags.contains("trust_remote_code") {
+            return .unknown
+        }
+
+        // DFlash changes the effective loader derived from model_type. Unless
+        // the explicit DFlash2 architecture above identifies it, the public
+        // config does not provide enough information for a conclusive result.
+        if configuration.hasDFlashConfig {
+            return .unknown
+        }
+
+        let candidateTypes = [
+            configuration.modelType,
+            configuration.speculatorsModelType,
+        ].compactMap { $0 }
+        if candidateTypes.contains(where: {
+            !registry.capabilities(for: $0).isEmpty
+        }) {
+            return .supported
+        }
+
+        // A standard repository with an explicit Hub task and a model type
+        // absent from every bundled backend has no remaining loader path.
+        // This also covers clearly unrelated tasks such as classification and
+        // object detection instead of silently treating them as uncertain.
+        let normalizedPipelineTag = pipelineTag?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard normalizedPipelineTag?.isEmpty == false,
+              configuration.modelType?.trimmingCharacters(
+                  in: .whitespacesAndNewlines
+              ).isEmpty == false,
+              configuration.speculatorsModelType == nil,
+              !configuration.hasVisionConfig,
+              !configuration.hasAudioConfig
+        else {
+            return .unknown
+        }
+        return .unsupported
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func hasValue(forKey key: Key) throws -> Bool {
+        guard contains(key) else {
+            return false
+        }
+        return try !decodeNil(forKey: key)
+    }
+}

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -276,6 +276,11 @@ struct LocalModelConfigurationMetadata: Equatable, Sendable {
     let hiddenSize: Int?
 }
 
+struct LocalModelInventory: Sendable {
+    let models: [LocalModel]
+    let cachedModels: [LocalModel]
+}
+
 enum LocalModelDiscovery {
     private actor ScanCache {
         struct Key: Hashable, Sendable {
@@ -284,18 +289,18 @@ enum LocalModelDiscovery {
         }
 
         private struct Entry: Sendable {
-            let models: [LocalModel]
+            let inventory: LocalModelInventory
             let expiresAt: Date
         }
 
         private var entries: [Key: Entry] = [:]
-        private var inFlight: [Key: Task<[LocalModel], Error>] = [:]
+        private var inFlight: [Key: Task<LocalModelInventory, Error>] = [:]
 
-        func scan(key: Key) async throws -> [LocalModel] {
+        func scan(key: Key) async throws -> LocalModelInventory {
             let now = Date()
             entries = entries.filter { $0.value.expiresAt > now }
             if let entry = entries[key] {
-                return entry.models
+                return entry.inventory
             }
 
             if let task = inFlight[key] {
@@ -313,7 +318,7 @@ enum LocalModelDiscovery {
             do {
                 let models = try await task.value
                 entries[key] = Entry(
-                    models: models,
+                    inventory: models,
                     expiresAt: Date().addingTimeInterval(2)
                 )
                 inFlight.removeValue(forKey: key)
@@ -328,7 +333,11 @@ enum LocalModelDiscovery {
     private static let scanCache = ScanCache()
 
     static func scan(searchPaths: LocalModelSearchPaths) async throws -> [LocalModel] {
-        return try await scanCache.scan(
+        try await inventory(searchPaths: searchPaths).models
+    }
+
+    static func inventory(searchPaths: LocalModelSearchPaths) async throws -> LocalModelInventory {
+        try await scanCache.scan(
             key: ScanCache.Key(
                 path: searchPaths.primary,
                 additionalPaths: searchPaths.additional
@@ -339,18 +348,25 @@ enum LocalModelDiscovery {
     private static func performScan(
         path: String,
         additionalPaths: [String]
-    ) throws -> [LocalModel] {
+    ) throws -> LocalModelInventory {
         let externalModels = Self.scanAdditionalPathsSynchronously(
             additionalPaths,
             fileManager: FileManager.default
         )
         do {
-            return Self.sortedByDisplayName(try Self.scanSynchronously(path: path) + externalModels)
+            let inventory = try Self.scanSynchronously(path: path)
+            return LocalModelInventory(
+                models: Self.sortedByDisplayName(inventory.models + externalModels),
+                cachedModels: Self.sortedByDisplayName(inventory.cachedModels)
+            )
         } catch {
             guard !externalModels.isEmpty else {
                 throw error
             }
-            return Self.sortedByDisplayName(externalModels)
+            return LocalModelInventory(
+                models: Self.sortedByDisplayName(externalModels),
+                cachedModels: []
+            )
         }
     }
 
@@ -393,7 +409,7 @@ enum LocalModelDiscovery {
         return (effectivePath as NSString).expandingTildeInPath
     }
 
-    private static func scanSynchronously(path: String) throws -> [LocalModel] {
+    private static func scanSynchronously(path: String) throws -> LocalModelInventory {
         let fileManager = FileManager.default
         let rootURL = URL(fileURLWithPath: path, isDirectory: true)
         var isDirectory: ObjCBool = false
@@ -411,55 +427,68 @@ enum LocalModelDiscovery {
             options: [.skipsHiddenFiles]
         )
 
-        let models = repoURLs.compactMap { repoURL -> LocalModel? in
+        var models: [LocalModel] = []
+        var cachedModels: [LocalModel] = []
+        for repoURL in repoURLs {
             guard repoURL.lastPathComponent.hasPrefix("models--"),
                   isDirectoryURL(repoURL, fileManager: fileManager),
                   let repoID = repoID(fromCacheDirectoryName: repoURL.lastPathComponent)
             else {
-                return nil
+                continue
             }
 
-            guard let snapshotURL = preferredSnapshotURL(for: repoURL, fileManager: fileManager),
-                  isLikelyMLXModelSnapshot(snapshotURL, model: repoID, fileManager: fileManager)
-            else {
-                return nil
-            }
+            let preferredSnapshotURL = preferredSnapshotURL(
+                for: repoURL,
+                fileManager: fileManager
+            )
+            let modelURL = preferredSnapshotURL ?? repoURL
+            let isRecognized = preferredSnapshotURL.map {
+                isLikelyMLXModelSnapshot($0, model: repoID, fileManager: fileManager)
+            } ?? false
 
-            let modifiedAt = (try? snapshotURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+            let modifiedAt = (try? modelURL.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ))?.contentModificationDate
             let memoryMetadata = modelMemoryMetadata(
                 repoID: repoID,
-                snapshotURL: snapshotURL,
+                snapshotURL: modelURL,
                 fileManager: fileManager
             )
             let speculativeMetadata = speculativeMetadata(
-                at: snapshotURL,
+                at: modelURL,
                 fileManager: fileManager
             )
-            return LocalModel(
+            let model = LocalModel(
                 repoID: repoID,
-                snapshotURL: snapshotURL,
+                snapshotURL: modelURL,
                 modifiedAt: modifiedAt,
-                sizeBytes: snapshotSize(at: snapshotURL, fileManager: fileManager),
+                sizeBytes: snapshotSize(at: modelURL, fileManager: fileManager),
                 parameterCount: memoryMetadata.parameterCount,
                 quantizationBits: memoryMetadata.quantizationBits,
                 quantizationGroupSize: memoryMetadata.quantizationGroupSize,
-                contextSize: contextSize(at: snapshotURL, fileManager: fileManager),
+                contextSize: contextSize(at: modelURL, fileManager: fileManager),
                 provider: modelProvider(
                     repoID: repoID,
-                    snapshotURL: snapshotURL,
+                    snapshotURL: modelURL,
                     fileManager: fileManager
                 ),
-                capabilities: modelCapabilities(
-                    model: repoID,
-                    at: snapshotURL,
-                    fileManager: fileManager
-                ),
+                capabilities: isRecognized
+                    ? modelCapabilities(
+                        model: repoID,
+                        at: modelURL,
+                        fileManager: fileManager
+                    ) : [],
                 drafterKind: speculativeMetadata.drafterKind,
                 hiddenSize: speculativeMetadata.hiddenSize
             )
+            if isRecognized {
+                models.append(model)
+            } else {
+                cachedModels.append(model)
+            }
         }
 
-        return models
+        return LocalModelInventory(models: models, cachedModels: cachedModels)
     }
 
     private static func sortedByDisplayName(_ models: [LocalModel]) -> [LocalModel] {
@@ -1710,6 +1739,8 @@ enum LocalModelDiscoveryError: LocalizedError, Equatable {
 @MainActor
 final class LocalModelLibrary: ObservableObject {
     @Published private(set) var models: [LocalModel] = []
+    private(set) var cachedModels: [LocalModel] = []
+    @Published private(set) var allModels: [LocalModel] = []
     @Published private(set) var isScanning = false
     @Published private(set) var deletingModelIDs = Set<String>()
     @Published private(set) var error: String?
@@ -1727,11 +1758,17 @@ final class LocalModelLibrary: ObservableObject {
 
         scanTask = Task { [weak self] in
             do {
-                let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+                let inventory = try await LocalModelDiscovery.inventory(
+                    searchPaths: searchPaths
+                )
                 guard !Task.isCancelled else {
                     return
                 }
-                self?.models = models
+                self?.models = inventory.models
+                self?.cachedModels = inventory.cachedModels
+                self?.allModels = Self.sortedByDisplayName(
+                    inventory.models + inventory.cachedModels
+                )
                 self?.error = nil
             } catch is CancellationError {
                 return
@@ -1740,6 +1777,8 @@ final class LocalModelLibrary: ObservableObject {
                     return
                 }
                 self?.models = []
+                self?.cachedModels = []
+                self?.allModels = []
                 self?.error = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
 
@@ -1769,11 +1808,26 @@ final class LocalModelLibrary: ObservableObject {
             do {
                 try await LocalModelDiscovery.delete(repoID: model.repoID, path: path)
                 self?.models.removeAll { $0.repoID == model.repoID }
+                self?.cachedModels.removeAll { $0.repoID == model.repoID }
+                self?.allModels.removeAll { $0.repoID == model.repoID }
                 self?.deletingModelIDs.remove(model.repoID)
                 onCompletion()
             } catch {
                 self?.deletingModelIDs.remove(model.repoID)
                 self?.error = "Couldn’t delete \(model.repoID): \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private static func sortedByDisplayName(_ models: [LocalModel]) -> [LocalModel] {
+        models.sorted { lhs, rhs in
+            switch lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) {
+            case .orderedAscending:
+                true
+            case .orderedDescending:
+                false
+            case .orderedSame:
+                lhs.repoID < rhs.repoID
             }
         }
     }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -290,7 +290,7 @@ struct ModelsView: View {
                 }
             }
         }
-        .onChange(of: localLibrary.models.map(\.repoID)) { _, _ in
+        .onChange(of: localLibrary.allModels.map(\.repoID)) { _, _ in
             selectFirstVisibleReadmeIfNeeded(in: .installed)
         }
         .onChange(of: hubLibrary.models.map(\.id)) { _, _ in
@@ -503,7 +503,7 @@ struct ModelsView: View {
             .modelsListRow()
         }
 
-        if localLibrary.isScanning && localLibrary.models.isEmpty {
+        if localLibrary.isScanning && localLibrary.allModels.isEmpty {
             ModelsLoadingState(title: "Scanning your Hugging Face cache…")
                 .modelsListRow()
         } else if visibleModels.isEmpty {
@@ -553,7 +553,7 @@ struct ModelsView: View {
                             model.requestPreloadedModelSwitch(
                                 to: localModel,
                                 for: slot,
-                                availableModels: localLibrary.models
+                                availableModels: localLibrary.allModels
                             )
                         } else {
                             model.switchPreloadedModel(to: nil, for: slot)
@@ -884,8 +884,8 @@ struct ModelsView: View {
         let query = localQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         var models =
             query.isEmpty
-            ? localLibrary.models
-            : localLibrary.models.filter {
+            ? localLibrary.allModels
+            : localLibrary.allModels.filter {
                 $0.repoID.localizedCaseInsensitiveContains(query)
                     || $0.displayName.localizedCaseInsensitiveContains(query)
                     || $0.provider?.displayName.localizedCaseInsensitiveContains(query) == true
@@ -909,7 +909,7 @@ struct ModelsView: View {
     }
 
     private var installedModelIDs: Set<String> {
-        Set(localLibrary.models.map(\.repoID))
+        Set(localLibrary.allModels.map(\.repoID))
     }
 
     private var pageTitle: some View {
@@ -1477,7 +1477,6 @@ private struct InstalledModelRow: View, @MainActor Equatable {
     let onDelete: () -> Void
 
     @State private var showsDeleteConfirmation = false
-    @State private var showsUnsupportedModelInformation = false
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.localModel == rhs.localModel
@@ -1607,14 +1606,6 @@ private struct InstalledModelRow: View, @MainActor Equatable {
         .padding(14)
         .contentShape(RoundedRectangle(cornerRadius: 12))
         .modelRowBackground(isHighlighted: isReadmeSelected)
-        .alert("Model isn’t supported", isPresented: $showsUnsupportedModelInformation) {
-            Button("OK", role: .cancel) {}
-                .keyboardShortcut(.defaultAction)
-        } message: {
-            Text(
-                "\(localModel.repoID) is installed in your Hugging Face cache, but Nativ can’t use it for chat, image generation, text-to-speech, or speech-to-text."
-            )
-        }
         .alert("Delete \(modelName(localModel.repoID))?", isPresented: $showsDeleteConfirmation) {
             Button("Delete Model", role: .destructive, action: onDelete)
                 .keyboardShortcut(.defaultAction)
@@ -1667,15 +1658,14 @@ private struct InstalledModelRow: View, @MainActor Equatable {
         }
     }
 
-    @ViewBuilder
     private var loadButton: some View {
-        if let preferredPreloadSlot {
-            let isLoaded = selectedPreloadSlots.contains(preferredPreloadSlot)
-            Button {
-                guard !isSelectionDisabled else { return }
-                onSetPreload(preferredPreloadSlot, !isLoaded)
-            } label: {
-                Image(systemName: isLoaded ? "stop.fill" : "play.fill")
+        let loadSlot = preferredPreloadSlot ?? .language
+        let isLoaded = selectedPreloadSlots.contains(loadSlot)
+        return Button {
+            guard !isSelectionDisabled else { return }
+            onSetPreload(loadSlot, !isLoaded)
+        } label: {
+            Image(systemName: isLoaded ? "stop.fill" : "play.fill")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.white)
                 .frame(width: 36, height: 30)
@@ -1684,30 +1674,12 @@ private struct InstalledModelRow: View, @MainActor Equatable {
                         .fill(isLoaded ? Color.red : Color.accentColor)
                 )
                 .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .disabled(isSelectionDisabled)
-            .help(rowHelp)
-            .accessibilityLabel(rowHelp)
-            .fixedSize()
-        } else {
-            Button {
-                showsUnsupportedModelInformation = true
-            } label: {
-                Label("Unavailable", systemImage: "exclamationmark.triangle")
-                    .font(.callout.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .frame(height: 30)
-                    .background(
-                        RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(Color.secondary.opacity(0.10))
-                    )
-            }
-            .buttonStyle(.plain)
-            .help(rowHelp)
-            .fixedSize()
         }
+        .buttonStyle(.plain)
+        .disabled(isSelectionDisabled)
+        .help(rowHelp)
+        .accessibilityLabel(rowHelp)
+        .fixedSize()
     }
 
     private var rowHelp: String {
@@ -1719,7 +1691,7 @@ private struct InstalledModelRow: View, @MainActor Equatable {
         if let preferredPreloadSlot {
             return "Preload \(localModel.repoID) for \(preferredPreloadSlot.displayName)"
         }
-        return "\(localModel.repoID) has no supported preload role"
+        return "Try loading \(localModel.repoID) as a language model"
     }
 }
 
@@ -1994,6 +1966,13 @@ private struct HubModelRow: View, @MainActor Equatable {
                                     .lineLimit(1)
                                 if model.isGated {
                                     ModelPill(title: "Gated", systemImage: "lock")
+                                }
+                                if model.support == .unsupported {
+                                    ModelPill(
+                                        title: "Unsupported",
+                                        systemImage: "exclamationmark.triangle.fill",
+                                        color: .orange
+                                    )
                                 }
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -351,17 +351,6 @@ final class NativModel: ChatModelSwitchingSurface {
         metricsClient = NativMetricsClient(baseURL: settings.serverBaseURL)
         modelLoadingProgress = settings.normalized().languageModelID == nil ? nil : 0
         var launchArguments = settings.launchArguments
-        if let languageModelID = settings.normalized().languageModelID,
-           isKnownNonGenerativeModel(languageModelID),
-           let modelFlagIndex = launchArguments.firstIndex(of: "--model"),
-           modelFlagIndex + 1 < launchArguments.count {
-            // A stale, non-chat selection (e.g. a BERT encoder) would make the
-            // server abort while pre-loading it. Start on-demand instead so it
-            // still comes up.
-            launchArguments.removeSubrange(modelFlagIndex...(modelFlagIndex + 1))
-            modelLoadingProgress = nil
-            appendLog("\n\(languageModelID) is not a text-generation model — starting the server without pre-loading it. Pick a chat model to load one.\n")
-        }
         if let speechToTextModelID = settings.normalized().speechToTextModelID,
            let speechIssue = LocalModelDiscovery.speechToTextPreloadIssue(
                repoID: speechToTextModelID,
@@ -402,47 +391,6 @@ final class NativModel: ChatModelSwitchingSurface {
             startMetricsPolling()
         }
         notifyMenuStateChanged()
-    }
-
-    /// Returns true only when the model is present locally and its config's
-    /// architectures are all non-generative (e.g. a BERT/RoBERTa encoder), which
-    /// mlx-vlm cannot load as a chat model. Any uncertainty returns false, so a
-    /// genuine chat model is never skipped.
-    private func isKnownNonGenerativeModel(_ repoID: String) -> Bool {
-        let cacheName = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
-        let fileManager = FileManager.default
-
-        // Consolidated roots (primary folder + user-added folders + HF hub cache) so
-        // this check also covers models the user keeps in custom folders.
-        let roots = settings.normalized().modelSearchRoots
-
-        let generativeMarkers = ["forcausallm", "forconditionalgeneration", "lmheadmodel"]
-        for root in roots {
-            let snapshots = URL(fileURLWithPath: root)
-                .appendingPathComponent(cacheName)
-                .appendingPathComponent("snapshots")
-            guard let revisions = try? fileManager.contentsOfDirectory(
-                at: snapshots,
-                includingPropertiesForKeys: nil
-            ) else {
-                continue
-            }
-            for revision in revisions {
-                let configURL = revision.appendingPathComponent("config.json")
-                guard let data = try? Data(contentsOf: configURL),
-                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let architectures = json["architectures"] as? [String],
-                      !architectures.isEmpty
-                else {
-                    continue
-                }
-                let isGenerative = architectures
-                    .map { $0.lowercased() }
-                    .contains { arch in generativeMarkers.contains { arch.contains($0) } }
-                return !isGenerative
-            }
-        }
-        return false
     }
 
     func stopServer(preserveSessionStats: Bool = false) {

--- a/Tests/NativTests/LocalModelProviderTests.swift
+++ b/Tests/NativTests/LocalModelProviderTests.swift
@@ -1,3 +1,4 @@
+import NativServerKit
 import XCTest
 
 final class LocalModelProviderTests: XCTestCase {
@@ -295,6 +296,254 @@ final class HuggingFaceCapabilityFilterTests: XCTestCase {
         payload["safetensors"] = safetensors
         let data = try JSONSerialization.data(withJSONObject: payload)
         return try JSONDecoder().decode(HuggingFaceModel.self, from: data)
+    }
+}
+
+final class HuggingFaceModelSupportTests: XCTestCase {
+    func testCanonicalAndAliasModelTypesAreSupported() throws {
+        let classifier = try makeClassifier()
+
+        for modelType in ["language-loader", "language-alias", "LANGUAGE-LOADER"] {
+            let result = classifier.classify(
+                configuration: try configuration(modelType: modelType),
+                pipelineTag: "text-generation",
+                tags: []
+            )
+
+            XCTAssertEqual(result, .supported, modelType)
+        }
+    }
+
+    func testSpeculatorModelTypeCanEstablishSupport() throws {
+        let result = try makeClassifier().classify(
+            configuration: configuration([
+                "model_type": "unrecognized-wrapper",
+                "speculators_model_type": "drafter-loader",
+            ]),
+            pipelineTag: "text-generation",
+            tags: ["draft-model"]
+        )
+
+        XCTAssertEqual(result, .supported)
+    }
+
+    func testUnknownStandardModelWithExplicitTaskIsUnsupported() throws {
+        let result = try makeClassifier().classify(
+            configuration: configuration([
+                "model_type": "not-in-the-bundled-runtime",
+                "architectures": ["UnsupportedForCausalLM"],
+            ]),
+            pipelineTag: "text-generation",
+            tags: []
+        )
+
+        XCTAssertEqual(result, .unsupported)
+    }
+
+    func testMissingEvidenceRemainsUnknown() throws {
+        let classifier = try makeClassifier()
+
+        XCTAssertEqual(
+            classifier.classify(
+                configuration: nil,
+                pipelineTag: "text-generation",
+                tags: []
+            ),
+            .unknown
+        )
+        XCTAssertEqual(
+            classifier.classify(
+                configuration: try configuration(modelType: "unrecognized"),
+                pipelineTag: nil,
+                tags: []
+            ),
+            .unknown
+        )
+        XCTAssertEqual(
+            classifier.classify(
+                configuration: try configuration([:]),
+                pipelineTag: "text-generation",
+                tags: []
+            ),
+            .unknown
+        )
+    }
+
+    func testCustomCodeEvidencePreventsUnsupportedClassification() throws {
+        let classifier = try makeClassifier()
+        let configurations: [[String: Any]] = [
+            [
+                "model_type": "unrecognized",
+                "model_file": "model.py",
+            ],
+            [
+                "model_type": "unrecognized",
+                "auto_map": ["AutoModel": "model.CustomModel"],
+            ],
+        ]
+
+        for payload in configurations {
+            XCTAssertEqual(
+                classifier.classify(
+                    configuration: try configuration(payload),
+                    pipelineTag: "text-generation",
+                    tags: []
+                ),
+                .unknown
+            )
+        }
+
+        for tag in ["custom_code", "trust_remote_code", "CUSTOM_CODE"] {
+            XCTAssertEqual(
+                classifier.classify(
+                    configuration: try configuration(modelType: "unrecognized"),
+                    pipelineTag: "text-generation",
+                    tags: [tag]
+                ),
+                .unknown,
+                tag
+            )
+        }
+    }
+
+    func testAmbiguousModalityAndDFlashMetadataRemainUnknown() throws {
+        let classifier = try makeClassifier()
+        let configurations: [[String: Any]] = [
+            [
+                "model_type": "unrecognized",
+                "vision_config": ["hidden_size": 1_024],
+            ],
+            [
+                "model_type": "unrecognized",
+                "audio_config": ["hidden_size": 1_024],
+            ],
+            [
+                "model_type": "unrecognized",
+                "dflash_config": ["num_layers": 1],
+            ],
+        ]
+
+        for payload in configurations {
+            XCTAssertEqual(
+                classifier.classify(
+                    configuration: try configuration(payload),
+                    pipelineTag: "text-generation",
+                    tags: []
+                ),
+                .unknown
+            )
+        }
+    }
+
+    func testExplicitSpecialLoaderArchitecturesAreSupported() throws {
+        let classifier = try makeClassifier()
+
+        for architecture in ["BoundaryExtractor", "DFlash2DraftModel"] {
+            let result = classifier.classify(
+                configuration: try configuration([
+                    "architectures": [architecture],
+                ]),
+                pipelineTag: nil,
+                tags: []
+            )
+
+            XCTAssertEqual(result, .supported, architecture)
+        }
+    }
+
+    func testConfigurationDecoderDistinguishesPresentMetadataFromNullValues() throws {
+        let populated = try configuration([
+            "model_type": "language-loader",
+            "architectures": ["ExampleForCausalLM"],
+            "vision_config": ["hidden_size": 1_024],
+            "audio_config": ["hidden_size": 768],
+            "dflash_config": ["num_layers": 1],
+            "auto_map": ["AutoModel": "model.CustomModel"],
+        ])
+
+        XCTAssertEqual(populated.modelType, "language-loader")
+        XCTAssertEqual(populated.architectures, ["ExampleForCausalLM"])
+        XCTAssertTrue(populated.hasVisionConfig)
+        XCTAssertTrue(populated.hasAudioConfig)
+        XCTAssertTrue(populated.hasDFlashConfig)
+        XCTAssertTrue(populated.usesCustomCode)
+
+        let nullMetadata = try configuration([
+            "model_type": "language-loader",
+            "vision_config": NSNull(),
+            "audio_config": NSNull(),
+            "dflash_config": NSNull(),
+            "auto_map": NSNull(),
+        ])
+
+        XCTAssertFalse(nullMetadata.hasVisionConfig)
+        XCTAssertFalse(nullMetadata.hasAudioConfig)
+        XCTAssertFalse(nullMetadata.hasDFlashConfig)
+        XCTAssertFalse(nullMetadata.usesCustomCode)
+    }
+
+    func testHubModelDecodingPropagatesConfigurationAndSupport() throws {
+        let payload: [String: Any] = [
+            "id": "test/unsupported-model",
+            "pipeline_tag": "text-generation",
+            "tags": ["safetensors"],
+            "config": [
+                "model_type": "definitely-not-a-bundled-loader",
+                "architectures": ["UnsupportedForCausalLM"],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let model = try JSONDecoder().decode(HuggingFaceModel.self, from: data)
+
+        XCTAssertEqual(model.configuration?.modelType, "definitely-not-a-bundled-loader")
+        XCTAssertEqual(model.configuration?.architectures, ["UnsupportedForCausalLM"])
+        XCTAssertEqual(model.support, .unsupported)
+    }
+
+    private func configuration(
+        modelType: String
+    ) throws -> HuggingFaceModelConfiguration {
+        try configuration(["model_type": modelType])
+    }
+
+    private func configuration(
+        _ payload: [String: Any]
+    ) throws -> HuggingFaceModelConfiguration {
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        return try JSONDecoder().decode(HuggingFaceModelConfiguration.self, from: data)
+    }
+
+    private func makeClassifier() throws -> HuggingFaceModelSupportClassifier {
+        let entry: (String, [String: String]) -> [String: Any] = { modelType, aliases in
+            [
+                "model_types": [modelType],
+                "aliases": aliases,
+            ]
+        }
+        let manifest: [String: Any] = [
+            "schema_version": 1,
+            "package_versions": [
+                "mlx-lm": "test",
+                "mlx-vlm": "test",
+                "mlx-audio": "test",
+            ],
+            "capabilities": [
+                "language": entry(
+                    "language-loader",
+                    ["language-alias": "language-loader"]
+                ),
+                "speculative_drafters": entry("drafter-loader", [:]),
+                "image_generation": entry("image-generator-loader", [:]),
+                "image_editing": entry("image-editor-loader", [:]),
+                "speech_to_text": entry("speech-recognizer-loader", [:]),
+                "text_to_speech": entry("speech-synthesizer-loader", [:]),
+                "embeddings": entry("embedding-loader", [:]),
+                "reranking": entry("reranker-loader", [:]),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: manifest)
+        let registry = try NativModelTypeRegistry(data: data)
+        return HuggingFaceModelSupportClassifier(registry: registry)
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -252,6 +252,7 @@ targets:
       - path: Sources/Nativ/Utilities/Formatting.swift
       - path: Sources/Nativ/Utilities/MarkdownFormatting.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceHub.swift
+      - path: Sources/Nativ/Features/Models/HuggingFaceModelSupport.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
       - path: Sources/Nativ/Features/Chat/ChatScreenCapture.swift
       - path: Sources/Nativ/Features/MCP/MCPHostManager.swift


### PR DESCRIPTION
## Summary

This PR connects the model capability registry to Hugging Face discovery and the local model library.

Models discovered on Hugging Face are classified as supported, unsupported, or unknown using their published configuration and the loaders bundled with Nativ.

Unsupported models remain visible and downloadable. Installed models also remain visible and can still be loaded manually, even when Nativ does not recognize a supported preload role.

## What changed

- Added a model-support classifier backed by `NativModelTypeRegistry`.
- Requested model configuration metadata from the Hugging Face API.
- Classified models as supported, unsupported, or unknown.
- Added an orange `Unsupported` badge to conclusive unsupported results in Discover.
- Kept unsupported models downloadable.
- Kept unrecognized Hugging Face cache entries visible on the Installed page.
- Allowed installed models without a recognized preload role to be loaded as language models.
- Used model configuration metadata to improve provider detection.
- Removed duplicated hard-coded model-support checks from `NativModel`.

## Why

The model registry introduced in the previous PR describes the loaders bundled with Nativ, but it does not yet affect model discovery.

This PR uses that registry to give users a clearer indication of whether Nativ has a candidate loader for a model before they download it.

The classification is deliberately conservative. A model is marked unsupported only when its published configuration provides enough information to reach that conclusion. Models using custom code, ambiguous multimodal configuration, or unfamiliar metadata remain unknown instead of being incorrectly rejected.

## How it works

The Hugging Face API response includes the repository’s configuration metadata, including `model_type`, architecture names, modality configuration, and custom-code indicators.

Nativ compares that metadata with the generated capability registry:

- A matching bundled loader produces a supported result.
- A standard model with an explicit type and task, but no matching loader, produces an unsupported result.
- Missing, custom, or ambiguous configuration produces an unknown result.

The support result affects the badge shown in Discover. It does not prevent downloading or manually attempting to load the model.

For installed models, Nativ keeps both recognized models and unrecognized Hugging Face cache entries visible. More precise separation of complete cached models and interrupted downloads is handled by the next PR.

## Stack

1. Model registry — #409
2. **Model support detection — this PR**
3. Active-download UI

This PR targets `pr/01-model-registry` and depends on #409.

It should remain a draft and must not be merged into the temporary base branch. After #409 merges, this PR will be retargeted to `main` and marked ready for review.




<img width="857" height="119" alt="image" src="https://github.com/user-attachments/assets/06644a18-5bd6-4725-821e-caa6c3fbb7be" />
