### PR TITLE
show active downloads

### DIFF
--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -1077,6 +1077,8 @@ final class HuggingFaceDownloadManager: ObservableObject {
     /// Emits the affected model ID for progress/state changes. `nil` denotes
     /// a structural change that can affect capacity for every download row.
     let rowUpdates = PassthroughSubject<String?, Never>()
+    /// Emits only after a model download succeeds.
+    let completedDownloads = PassthroughSubject<String, Never>()
 
     private var contexts: [String: DownloadContext] = [:]
     private let progressClock = ContinuousClock()
@@ -1354,6 +1356,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
         if let error {
             waiters.forEach { $0.resume(throwing: error) }
         } else {
+            completedDownloads.send(repoID)
             NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
             completion?()
             waiters.forEach { $0.resume() }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -225,6 +225,8 @@ struct ModelsView: View {
     @State private var handledImageModelDiscoveryRequest = 0
     @State private var lastStartedHubSearchTaskID: HubSearchTaskID?
     @State private var readmeSelection: ModelReadmeSelection?
+    @State private var activeDownloadIDs = Set<String>()
+    @State private var recentlyCompletedModelIDs = Set<String>()
 
     init(
         model: NativModel,
@@ -266,7 +268,15 @@ struct ModelsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
             rescanLocalModels()
         }
+        .onReceive(downloadManager.rowUpdates) { updatedModelID in
+            guard updatedModelID == nil else { return }
+            synchronizeActiveDownloads()
+        }
+        .onReceive(downloadManager.completedDownloads) { modelID in
+            recentlyCompletedModelIDs.insert(modelID)
+        }
         .onAppear {
+            synchronizeActiveDownloads()
             openSpeechModelDiscoveryIfRequested()
             openImageModelDiscoveryIfRequested()
         }
@@ -277,6 +287,9 @@ struct ModelsView: View {
             openImageModelDiscoveryIfRequested()
         }
         .onChange(of: section) { _, newSection in
+            if newSection != .installed {
+                clearRecentlyCompletedModels()
+            }
             // Let the segmented control commit before replacing the toolbar
             // and active rows. This queues one main-loop turn with no fixed
             // delay and keeps only one section's content mounted at a time.
@@ -322,6 +335,7 @@ struct ModelsView: View {
             )
         }
         .onDisappear {
+            clearRecentlyCompletedModels()
             localLibrary.cancel()
             hubLibrary.cancel()
             lastStartedHubSearchTaskID = nil
@@ -490,8 +504,23 @@ struct ModelsView: View {
 
     @ViewBuilder
     private func installedRows(showsResultsHeader: Bool) -> some View {
-        let visibleModels = filteredLocalModels
+        let visibleModels = filteredLocalModels.filter {
+            !activeDownloadIDs.contains($0.repoID)
+        }
         let normalizedSettings = modelState.settings.normalized()
+
+        if !activeDownloadIDs.isEmpty {
+            InstalledActiveDownloadRows(
+                hubModels: hubLibrary.models,
+                onShowReadme: { repoID, provider in
+                    showReadme(
+                        repoID: repoID,
+                        provider: provider,
+                        localSnapshotURL: nil
+                    )
+                }
+            )
+        }
 
         if let error = localLibrary.error {
             ModelsNotice(
@@ -503,10 +532,13 @@ struct ModelsView: View {
             .modelsListRow()
         }
 
-        if localLibrary.isScanning && localLibrary.allModels.isEmpty {
+        if localLibrary.isScanning
+            && localLibrary.allModels.isEmpty
+            && activeDownloadIDs.isEmpty
+        {
             ModelsLoadingState(title: "Scanning your Hugging Face cache…")
                 .modelsListRow()
-        } else if visibleModels.isEmpty {
+        } else if visibleModels.isEmpty && activeDownloadIDs.isEmpty {
             ModelsEmptyState(
                 systemImage: installedFilterIsActive
                     ? "line.3.horizontal.decrease.circle" : "shippingbox",
@@ -543,7 +575,7 @@ struct ModelsView: View {
                     isModelLoading: modelState.modelLoadingID
                         == localModel.repoID,
                     modelLoadingPercentage: modelState.modelLoadingPercentage,
-                    isReadmeSelected: readmeSelection?.repoID == localModel.repoID,
+                    isNew: recentlyCompletedModelIDs.contains(localModel.repoID),
                     isDeleting: localLibrary.deletingModelIDs.contains(
                         localModel.repoID),
                     canDelete: localModel.isDeletable && !modelState.modelSwitchInProgress
@@ -575,9 +607,10 @@ struct ModelsView: View {
     }
 
     private var installedResultsHeader: some View {
-        let visibleModels = filteredLocalModels
+        let visibleModelIDs = Set(filteredLocalModels.map(\.repoID))
+        let visibleCount = visibleModelIDs.union(activeDownloadIDs).count
         return HStack {
-            Text("\(visibleModels.count) \(visibleModels.count == 1 ? "model" : "models")")
+            Text("\(visibleCount) \(visibleCount == 1 ? "model" : "models")")
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
             Spacer()
@@ -599,6 +632,7 @@ struct ModelsView: View {
 
     private var refreshButton: some View {
         Button {
+            clearRecentlyCompletedModels()
             rescanLocalModels()
         } label: {
             Label("Refresh", systemImage: "arrow.clockwise")
@@ -899,6 +933,11 @@ struct ModelsView: View {
                 settings.modelID(for: $0)
             })
         return models.enumerated().sorted { lhs, rhs in
+            let lhsIsNew = recentlyCompletedModelIDs.contains(lhs.element.repoID)
+            let rhsIsNew = recentlyCompletedModelIDs.contains(rhs.element.repoID)
+            if lhsIsNew != rhsIsNew {
+                return lhsIsNew
+            }
             let lhsIsSelected = selectedModelIDs.contains(lhs.element.repoID)
             let rhsIsSelected = selectedModelIDs.contains(rhs.element.repoID)
             if lhsIsSelected != rhsIsSelected {
@@ -1165,6 +1204,14 @@ struct ModelsView: View {
 
     private func rescanLocalModels() {
         localLibrary.scan(searchPaths: modelState.settings.localModelSearchPaths)
+    }
+
+    private func synchronizeActiveDownloads() {
+        activeDownloadIDs = Set(downloadManager.downloads.map(\.modelID))
+    }
+
+    private func clearRecentlyCompletedModels() {
+        recentlyCompletedModelIDs.removeAll()
     }
 
     private func addModelSourceFolder() {
@@ -1469,7 +1516,7 @@ private struct InstalledModelRow: View, @MainActor Equatable {
     let isSelectionDisabled: Bool
     let isModelLoading: Bool
     let modelLoadingPercentage: Int?
-    let isReadmeSelected: Bool
+    let isNew: Bool
     let isDeleting: Bool
     let canDelete: Bool
     let onSetPreload: (ModelPreloadSlot, Bool) -> Void
@@ -1486,7 +1533,7 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             && lhs.isSelectionDisabled == rhs.isSelectionDisabled
             && lhs.isModelLoading == rhs.isModelLoading
             && lhs.modelLoadingPercentage == rhs.modelLoadingPercentage
-            && lhs.isReadmeSelected == rhs.isReadmeSelected
+            && lhs.isNew == rhs.isNew
             && lhs.isDeleting == rhs.isDeleting
             && lhs.canDelete == rhs.canDelete
     }
@@ -1515,6 +1562,13 @@ private struct InstalledModelRow: View, @MainActor Equatable {
                                     title: sourceLabel,
                                     systemImage: "cube",
                                     color: .purple
+                                )
+                            }
+                            if isNew {
+                                ModelPill(
+                                    title: "New",
+                                    systemImage: "sparkles",
+                                    color: .green
                                 )
                             }
                             if isLoading {
@@ -1605,7 +1659,7 @@ private struct InstalledModelRow: View, @MainActor Equatable {
         }
         .padding(14)
         .contentShape(RoundedRectangle(cornerRadius: 12))
-        .modelRowBackground(isHighlighted: isReadmeSelected)
+        .modelRowBackground(isHighlighted: false)
         .alert("Delete \(modelName(localModel.repoID))?", isPresented: $showsDeleteConfirmation) {
             Button("Delete Model", role: .destructive, action: onDelete)
                 .keyboardShortcut(.defaultAction)
@@ -1692,6 +1746,133 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             return "Preload \(localModel.repoID) for \(preferredPreloadSlot.displayName)"
         }
         return "Try loading \(localModel.repoID) as a language model"
+    }
+}
+
+private struct InstalledActiveDownloadRows: View {
+    @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
+
+    let hubModels: [HuggingFaceModel]
+    let onShowReadme: (String, LocalModelProvider?) -> Void
+
+    var body: some View {
+        ForEach(downloadManager.downloads) { download in
+            if let hubModel = hubModels.first(where: { $0.id == download.modelID }) {
+                HubModelRowContainer(
+                    model: hubModel,
+                    isInstalled: false,
+                    isReadmeSelected: false,
+                    onShowReadme: {
+                        onShowReadme(download.modelID, hubModel.provider)
+                    },
+                    onDownload: { _ in },
+                    onPauseResume: {
+                        toggleDownload(download.modelID)
+                    },
+                    onRemoveDownload: {
+                        downloadManager.removeDownload(download.modelID)
+                    }
+                )
+                .equatable()
+                .modelsListRow()
+            } else {
+                let provider = LocalModelProviderResolver.resolve(
+                    repoID: download.modelID,
+                    modelType: nil,
+                    architectures: []
+                )
+                InstalledActiveDownloadRow(
+                    download: download,
+                    provider: provider,
+                    onShowReadme: { onShowReadme(download.modelID, provider) },
+                    onPauseResume: {
+                        toggleDownload(download.modelID)
+                    },
+                    onRemoveDownload: {
+                        downloadManager.removeDownload(download.modelID)
+                    }
+                )
+                .modelsListRow()
+            }
+        }
+    }
+
+    private func toggleDownload(_ modelID: String) {
+        if downloadManager.isPaused(for: modelID) {
+            downloadManager.resumeDownload(modelID)
+        } else {
+            downloadManager.pauseDownload(modelID)
+        }
+    }
+}
+
+private struct InstalledActiveDownloadRow: View {
+    let download: HuggingFaceDownloadManager.ActiveDownload
+    let provider: LocalModelProvider?
+    let onShowReadme: () -> Void
+    let onPauseResume: () -> Void
+    let onRemoveDownload: () -> Void
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Button(action: onShowReadme) {
+                HStack(spacing: 14) {
+                    ModelProviderBadge(provider: provider)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(modelName)
+                            .font(.body.weight(.semibold))
+                            .lineLimit(1)
+
+                        Text(download.modelID)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+
+                        HStack(spacing: 6) {
+                            if let totalBytes = download.metrics.totalBytes {
+                                ModelPill(
+                                    title: ByteCountFormatter.string(
+                                        fromByteCount: totalBytes,
+                                        countStyle: .file
+                                    ),
+                                    systemImage: "internaldrive"
+                                )
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Color.clear
+                            .frame(maxWidth: .infinity, minHeight: 19, alignment: .leading)
+                    }
+                    .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+
+                    Spacer(minLength: 12)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+            .help("Show README for \(download.modelID)")
+            .accessibilityLabel("Show details for \(download.modelID)")
+
+            ModelDownloadProgressControl(
+                progress: download.progress,
+                isPaused: download.state == .paused,
+                onPauseResume: onPauseResume,
+                onRemove: onRemoveDownload
+            )
+        }
+        .padding(14)
+        .modelRowBackground(isHighlighted: false)
+    }
+
+    private var modelName: String {
+        NativFormatting.truncateModelName(
+            download.modelID.split(separator: "/").last.map(String.init) ?? download.modelID,
+            maxLength: 44
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

This PR shows active model downloads in the Installed Models page while preserving the existing download experience in Discover.

A downloading model appears at the top of Installed Models using the same download-state UI and controls as the Discover page. After the download succeeds, the installed model remains pinned at the top with a temporary green `New` badge.

## What changed

- Added active downloads to the Installed Models page.
- Reused the existing Discover download-state UI and controls.
- Kept the existing top download progress banner unchanged.
- Added a success-only download notification for the UI.
- Added a temporary green `New` badge after successful completion.
- Pinned newly downloaded models above the regular installed-model sorting.
- Removed blue selection outlines from Installed Models rows.
- Prevented the active download and installed model from appearing as duplicate rows.

## Behavior

While a model is downloading:

- The existing progress banner remains visible at the top of the page.
- The model also appears at the top of Installed Models.
- Its row provides the same pause, resume, remove, and progress controls used in Discover.

After a successful download:

- The completed model remains at the top of Installed Models.
- It receives a green `New` badge.
- The temporary badge and pinned position disappear after refreshing or leaving the page.
- Normal installed-model sorting then resumes.

Failed or cancelled downloads are not marked as new.

## Testing

- Built the Nativ macOS application successfully.
- Ran 33 existing model discovery and provider tests with no failures.
- Verified the existing download banner and Discover progress components remain unchanged.
- Verified the rejected cache and retry implementation is absent.

This PR targets `pr/02-model-support` and depends on the preceding PRs in the stack.



<img width="1728" height="1117" alt="Screenshot 2026-08-27 at 7 42 52 PM" src="https://github.com/user-attachments/assets/19563923-2e17-4f6b-8340-47c3e889665f" />
<img width="1469" height="1087" alt="Screenshot 2026-08-27 at 7 44 03 PM" src="https://github.com/user-attachments/assets/589dd372-afe0-4cb3-8b37-ac07c2819a0f" />
