### PR TITLE
Standardize shared status indicators in Nativ

### DIFF
--- a/Sources/Nativ/Features/Browsing/WebSearchSettingsView.swift
+++ b/Sources/Nativ/Features/Browsing/WebSearchSettingsView.swift
@@ -365,12 +365,7 @@ struct WebBrowsingSettingsView: View {
     }
 
     private func routeBadge(_ text: String) -> some View {
-        Text(text)
-            .font(.system(size: 8, weight: .semibold))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
-            .background(Color.secondary.opacity(0.1), in: Capsule())
+        NativStatusBadge(text: text, tone: .active)
     }
 
     @ViewBuilder
@@ -379,15 +374,15 @@ struct WebBrowsingSettingsView: View {
         case .disconnected:
             EmptyView()
         case .connected:
-            Circle()
-                .fill(Color.green)
-                .frame(width: 6, height: 6)
+            NativStatusDot(tone: .success, diameter: 6)
                 .help("Connected")
+                .accessibilityLabel("Connected")
         case .issue:
             Image(systemName: "exclamationmark.circle.fill")
-                .font(.system(size: 10))
-                .foregroundStyle(.orange)
+                .font(.caption2)
+                .foregroundStyle(NativStatusTone.warning.color)
                 .help("This connection needs attention")
+                .accessibilityLabel("Connection needs attention")
         }
     }
 

--- a/Sources/Nativ/Features/Dashboard/StatsView.swift
+++ b/Sources/Nativ/Features/Dashboard/StatsView.swift
@@ -184,9 +184,9 @@ private struct DashboardContentView: View, @MainActor Equatable {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack(spacing: 8) {
-                Circle()
-                    .fill(modelState.isRunning ? DashboardPalette.positive : Color.secondary)
-                    .frame(width: 7, height: 7)
+                NativStatusDot(
+                    tone: modelState.isRunning ? .success : .neutral
+                )
                 Text(modelState.isRunning ? "Live" : "Offline")
                     .font(.caption.weight(.semibold))
 

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -249,13 +249,7 @@ private struct ExtensionRow: View {
     }
 
     private var includedBadge: some View {
-        Text("INCLUDED")
-            .font(.system(size: 10, weight: .semibold))
-            .tracking(0.4)
-            .foregroundStyle(Color.accentColor)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 3)
-            .background(Color.accentColor.opacity(0.12), in: Capsule())
+        NativStatusBadge(text: "Included", tone: .active)
     }
 
     private var permissions: some View {
@@ -306,9 +300,7 @@ private struct ExtensionRow: View {
         actionTitle: String?
     ) -> some View {
         HStack(spacing: 6) {
-            Circle()
-                .fill(status.color)
-                .frame(width: 7, height: 7)
+            NativStatusDot(tone: status.nativTone)
             Text(permission.displayName)
             Text("· \(status.title)")
                 .foregroundStyle(.secondary)
@@ -326,6 +318,16 @@ private struct ExtensionRow: View {
             in: Capsule()
         )
         .contentShape(Capsule())
+    }
+}
+
+private extension NativExtensionPermissionStatus {
+    var nativTone: NativStatusTone {
+        switch self {
+        case .granted: .success
+        case .denied: .danger
+        case .notRequested: .neutral
+        }
     }
 }
 

--- a/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
+++ b/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
@@ -794,13 +794,6 @@ enum NativExtensionPermissionStatus: Hashable {
         }
     }
 
-    var color: Color {
-        switch self {
-        case .granted: .green
-        case .denied: .red
-        case .notRequested: .secondary
-        }
-    }
 }
 
 extension AppExtensionPoint {

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -870,16 +870,31 @@ private struct IntegrationAvailabilityBadge: View {
     var isGuidedSetup: Bool = false
 
     var body: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(isGuidedSetup ? Color.accentColor : (status.executableURL == nil ? Color.secondary : (status.isConfigured ? .green : .orange)))
-                .frame(width: 7, height: 7)
-            Text(isGuidedSetup ? "Guided setup" : (status.executableURL == nil ? "Not installed" : (status.isConfigured ? "Configured" : "Not configured")))
+        NativStatusBadge(
+            text: title,
+            tone: tone,
+            showsDot: true
+        )
+    }
+
+    private var title: String {
+        if isGuidedSetup {
+            return "Guided setup"
         }
-        .font(.caption.weight(.semibold))
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(.quaternary, in: Capsule())
+        guard status.executableURL != nil else {
+            return "Not installed"
+        }
+        return status.isConfigured ? "Configured" : "Not configured"
+    }
+
+    private var tone: NativStatusTone {
+        if isGuidedSetup {
+            return .active
+        }
+        guard status.executableURL != nil else {
+            return .neutral
+        }
+        return status.isConfigured ? .success : .warning
     }
 }
 

--- a/Sources/Nativ/Features/Shared/NativComponents.swift
+++ b/Sources/Nativ/Features/Shared/NativComponents.swift
@@ -284,40 +284,74 @@ struct NativStatusDot: View {
     var pulsing: Bool = false
     var diameter: CGFloat = 7
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var animating = false
 
     var body: some View {
         Circle()
             .fill(tone.color)
             .frame(width: diameter, height: diameter)
-            .opacity(pulsing && animating ? 0.35 : 1)
+            .opacity(pulsing && animating && !reduceMotion ? 0.35 : 1)
             .animation(
-                pulsing ? .easeInOut(duration: 0.8).repeatForever(autoreverses: true) : .default,
+                pulsing && !reduceMotion
+                    ? .easeInOut(duration: 0.8).repeatForever(autoreverses: true)
+                    : nil,
                 value: animating
             )
             .onAppear { animating = pulsing }
+            .onChange(of: pulsing) { _, newValue in
+                animating = newValue
+            }
     }
 }
 
-/// A compact capsule badge: a short label tinted by tone, with an optional leading symbol.
+/// A compact capsule badge with an optional leading status dot or symbol.
 struct NativStatusBadge: View {
     let text: String
     var tone: NativStatusTone = .neutral
     var symbol: String? = nil
+    var showsDot = false
 
     var body: some View {
         HStack(spacing: 4) {
+            if showsDot {
+                NativStatusDot(tone: tone, diameter: 6)
+            }
             if let symbol {
                 Image(systemName: symbol)
             }
             Text(text)
         }
-        .font(.caption2.weight(.semibold))
+        .font(.caption.weight(.semibold))
         .foregroundStyle(tone.color)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 2)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
         .background(tone.color.opacity(0.12), in: Capsule())
+        .accessibilityElement(children: .combine)
     }
+}
+
+#Preview("Status Indicators") {
+    VStack(alignment: .leading) {
+        HStack {
+            NativStatusDot(tone: .neutral)
+            NativStatusDot(tone: .active)
+            NativStatusDot(tone: .success)
+            NativStatusDot(tone: .warning)
+            NativStatusDot(tone: .danger)
+        }
+
+        NativStatusBadge(text: "Inactive")
+        NativStatusBadge(text: "Active", tone: .active, showsDot: true)
+        NativStatusBadge(text: "Connected", tone: .success, showsDot: true)
+        NativStatusBadge(
+            text: "Needs attention",
+            tone: .warning,
+            symbol: "exclamationmark.triangle.fill"
+        )
+        NativStatusBadge(text: "Failed", tone: .danger)
+    }
+    .padding()
 }
 
 /// A monospaced code/JSON block with a subtle background and selectable text.

--- a/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
+++ b/Sources/Nativ/Features/SystemMonitor/SystemMonitorView.swift
@@ -87,9 +87,9 @@ struct SystemMonitorView: View {
             menuBarControl
 
             HStack(spacing: 7) {
-                Circle()
-                    .fill(store.isSampling ? SystemMonitorPalette.positive : Color.secondary)
-                    .frame(width: 7, height: 7)
+                NativStatusDot(
+                    tone: store.isSampling ? .success : .neutral
+                )
                 Text(store.isSampling ? "Live" : "Paused")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
Standardizes shared status indicators across Nativ to reduce duplicated styling and improve application-wide visual consistency.

This also doesn't change ui significantly, just makes it easier to define ui components and reuse them