### PR TITLE
Add spawn_agent: multi-agent delegation with background execution and messaging

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
+++ b/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
@@ -16,12 +16,14 @@ enum ChatAgentLoop {
         modelID: String,
         settings: NativSettings,
         canEditImage: Bool,
-        context: ChatToolExecutionContext
+        context: ChatToolExecutionContext,
+        onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)? = nil
     ) async throws -> MLXChatCompletion {
         let client = NativChatClient(baseURL: context.baseURL, apiKey: context.apiKey)
         let toolDefinitions = subAgentToolDefinitions(settings: settings, canEditImage: canEditImage, context: context)
         let systemPrompt = subAgentSystemPrompt(settings: settings, hasTools: !toolDefinitions.isEmpty)
         let customTools = settings.customTools.filter { $0.kind != .script }
+        let transcript = ChatAgentDisplayTranscript(onUpdate: onUpdate)
 
         var messages = initialMessages
         if let systemPrompt {
@@ -46,9 +48,14 @@ enum ChatAgentLoop {
                 tools: advertisesTools ? toolDefinitions : nil,
                 toolChoice: advertisesTools ? "auto" : nil
             )
-            let completion = try await client.completeChat(request)
-            let toolCalls = normalizedToolCalls(completion.toolCalls)
 
+            let assistantDisplayID = transcript.appendAssistantPlaceholder()
+            let completion = try await client.streamChat(request, onEvent: { event in
+                await transcript.appendDelta(event, to: assistantDisplayID)
+            })
+            transcript.finishAssistant(assistantDisplayID, completion: completion)
+
+            let toolCalls = normalizedToolCalls(completion.toolCalls)
             guard advertisesTools, !toolCalls.isEmpty else {
                 return completion
             }
@@ -62,11 +69,13 @@ enum ChatAgentLoop {
 
             for toolCall in toolCalls {
                 try Task.checkCancellation()
-                let content = await executeToolCall(
+                let toolDisplayID = transcript.appendToolPlaceholder(for: toolCall)
+                let (content, succeeded) = await executeToolCall(
                     toolCall,
                     customTools: customTools,
                     context: context
                 )
+                transcript.finishTool(toolDisplayID, content: content, succeeded: succeeded)
                 messages.append(MLXChatMessage(
                     role: "tool",
                     content: content,
@@ -82,23 +91,23 @@ enum ChatAgentLoop {
         _ toolCall: MLXChatToolCall,
         customTools: [CustomTool],
         context: ChatToolExecutionContext
-    ) async -> String {
+    ) async -> (content: String, succeeded: Bool) {
         let name = toolCall.function?.name
         if name == ChatSpawnAgentToolRegistry.toolName {
-            return ChatSpawnAgentToolExecutor().failurePayload(error: ChatAgentLoopError.recursiveSpawnNotAllowed)
+            return (ChatSpawnAgentToolExecutor().failurePayload(error: ChatAgentLoopError.recursiveSpawnNotAllowed), false)
         }
         do {
             if let customTool = name.flatMap({ toolName in customTools.first { $0.toolName == toolName } }) {
                 let result = try await CustomToolExecutor.execute(customTool, argumentsJSON: toolCall.function?.arguments)
-                return result
+                return (result, true)
             }
             if let host = context.mcpHost, let name, host.handlesTool(named: name) {
-                return try await host.callTool(named: name, argumentsJSON: toolCall.function?.arguments)
+                return (try await host.callTool(named: name, argumentsJSON: toolCall.function?.arguments), true)
             }
             let outcome = try await ChatToolDispatcher.execute(call: toolCall, context: context)
-            return outcome.content
+            return (outcome.content, true)
         } catch {
-            return ChatToolDispatcher.failurePayload(toolName: name, error: error)
+            return (ChatToolDispatcher.failurePayload(toolName: name, error: error), false)
         }
     }
 
@@ -148,5 +157,67 @@ enum ChatAgentLoop {
             }
             return normalized
         }
+    }
+}
+
+@MainActor
+private final class ChatAgentDisplayTranscript {
+    private var messages: [ChatTranscriptMessage] = []
+    private let onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)?
+
+    init(onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)?) {
+        self.onUpdate = onUpdate
+    }
+
+    func appendAssistantPlaceholder() -> UUID {
+        let id = UUID()
+        messages.append(ChatTranscriptMessage(id: id, role: .assistant, content: "", isStreaming: true))
+        onUpdate?(messages)
+        return id
+    }
+
+    func appendDelta(_ event: MLXChatStreamDelta, to id: UUID) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        messages[index].content += event.content ?? ""
+        messages[index].reasoningContent += event.reasoningContent ?? ""
+        onUpdate?(messages)
+    }
+
+    func finishAssistant(_ id: UUID, completion: MLXChatCompletion) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        messages[index].content = completion.content
+        messages[index].reasoningContent = completion.reasoningContent ?? ""
+        messages[index].isStreaming = false
+        onUpdate?(messages)
+    }
+
+    func appendToolPlaceholder(for call: MLXChatToolCall) -> UUID {
+        let id = UUID()
+        messages.append(ChatTranscriptMessage(
+            id: id,
+            role: .tool,
+            content: "",
+            isStreaming: true,
+            toolCallID: call.id,
+            toolName: call.function?.name,
+            toolStatus: .running,
+            toolArguments: call.function?.arguments
+        ))
+        onUpdate?(messages)
+        return id
+    }
+
+    func finishTool(_ id: UUID, content: String, succeeded: Bool) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        messages[index].content = content
+        messages[index].isStreaming = false
+        messages[index].toolStatus = succeeded ? .succeeded : .failed
+        onUpdate?(messages)
     }
 }

--- a/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
+++ b/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
@@ -9,6 +9,11 @@ enum ChatAgentLoopError: LocalizedError {
     }
 }
 
+struct ChatAgentLoopResult {
+    let completion: MLXChatCompletion
+    let stopReason: ChatSpawnedAgentStopReason?
+}
+
 @MainActor
 enum ChatAgentLoop {
     static func run(
@@ -18,13 +23,15 @@ enum ChatAgentLoop {
         canEditImage: Bool,
         context: ChatToolExecutionContext,
         agentID: String? = nil,
+        limits: ChatSpawnAgentResourceLimits = .default,
         onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)? = nil
-    ) async throws -> MLXChatCompletion {
+    ) async throws -> ChatAgentLoopResult {
         let client = NativChatClient(baseURL: context.baseURL, apiKey: context.apiKey)
         let toolDefinitions = subAgentToolDefinitions(settings: settings, canEditImage: canEditImage, context: context)
         let systemPrompt = subAgentSystemPrompt(settings: settings, hasTools: !toolDefinitions.isEmpty)
         let customTools = settings.customTools.filter { $0.kind != .script }
         let transcript = ChatAgentDisplayTranscript(onUpdate: onUpdate)
+        let startedAt = Date()
 
         var messages = initialMessages
         if let systemPrompt {
@@ -32,6 +39,7 @@ enum ChatAgentLoop {
         }
 
         var round = 0
+        var totalTokensUsed = 0
         while true {
             try Task.checkCancellation()
 
@@ -43,7 +51,13 @@ enum ChatAgentLoop {
                 }
             }
 
-            let advertisesTools = ChatToolRoundGate.advertisesTools(atRound: round) && !toolDefinitions.isEmpty
+            let stopReason: ChatSpawnedAgentStopReason? =
+                if round >= limits.maxTurns { .turnLimit }
+                else if totalTokensUsed >= limits.maxTokens { .tokenLimit }
+                else if Date().timeIntervalSince(startedAt) >= limits.maxWallTimeSeconds { .timeout }
+                else { nil }
+            let advertisesTools = stopReason == nil && !toolDefinitions.isEmpty
+
             let request = MLXChatCompletionRequest(
                 model: modelID,
                 messages: messages,
@@ -64,10 +78,11 @@ enum ChatAgentLoop {
                 await transcript.appendDelta(event, to: assistantDisplayID)
             })
             transcript.finishAssistant(assistantDisplayID, completion: completion)
+            totalTokensUsed += completion.usage?.totalTokens ?? 0
 
             let toolCalls = normalizedToolCalls(completion.toolCalls)
             guard advertisesTools, !toolCalls.isEmpty else {
-                return completion
+                return ChatAgentLoopResult(completion: completion, stopReason: stopReason)
             }
 
             messages.append(MLXChatMessage(

--- a/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
+++ b/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
@@ -1,0 +1,152 @@
+import Foundation
+import NativServerKit
+
+enum ChatAgentLoopError: LocalizedError {
+    case recursiveSpawnNotAllowed
+
+    var errorDescription: String? {
+        "A sub-agent can't spawn further sub-agents."
+    }
+}
+
+@MainActor
+enum ChatAgentLoop {
+    static func run(
+        messages initialMessages: [MLXChatMessage],
+        modelID: String,
+        settings: NativSettings,
+        canEditImage: Bool,
+        context: ChatToolExecutionContext
+    ) async throws -> MLXChatCompletion {
+        let client = NativChatClient(baseURL: context.baseURL, apiKey: context.apiKey)
+        let toolDefinitions = subAgentToolDefinitions(settings: settings, canEditImage: canEditImage, context: context)
+        let systemPrompt = subAgentSystemPrompt(settings: settings, hasTools: !toolDefinitions.isEmpty)
+        let customTools = settings.customTools.filter { $0.kind != .script }
+
+        var messages = initialMessages
+        if let systemPrompt {
+            messages.insert(MLXChatMessage(role: "system", content: systemPrompt), at: 0)
+        }
+
+        var round = 0
+        while true {
+            try Task.checkCancellation()
+            let advertisesTools = ChatToolRoundGate.advertisesTools(atRound: round) && !toolDefinitions.isEmpty
+            let request = MLXChatCompletionRequest(
+                model: modelID,
+                messages: messages,
+                maxTokens: settings.maxTokens,
+                temperature: settings.temperature,
+                topK: settings.topK,
+                topP: settings.topP,
+                minP: settings.minP,
+                repetitionPenalty: settings.repetitionPenaltyEnabled ? settings.repetitionPenalty : nil,
+                enableThinking: settings.thinkingEnabled,
+                responseFormat: advertisesTools ? nil : settings.chatResponseFormat,
+                tools: advertisesTools ? toolDefinitions : nil,
+                toolChoice: advertisesTools ? "auto" : nil
+            )
+            let completion = try await client.completeChat(request)
+            let toolCalls = normalizedToolCalls(completion.toolCalls)
+
+            guard advertisesTools, !toolCalls.isEmpty else {
+                return completion
+            }
+
+            messages.append(MLXChatMessage(
+                role: "assistant",
+                content: completion.content,
+                reasoningContent: completion.reasoningContent,
+                toolCalls: toolCalls
+            ))
+
+            for toolCall in toolCalls {
+                try Task.checkCancellation()
+                let content = await executeToolCall(
+                    toolCall,
+                    customTools: customTools,
+                    context: context
+                )
+                messages.append(MLXChatMessage(
+                    role: "tool",
+                    content: content,
+                    toolCallID: toolCall.id
+                ))
+            }
+
+            round += 1
+        }
+    }
+
+    private static func executeToolCall(
+        _ toolCall: MLXChatToolCall,
+        customTools: [CustomTool],
+        context: ChatToolExecutionContext
+    ) async -> String {
+        let name = toolCall.function?.name
+        if name == ChatSpawnAgentToolRegistry.toolName {
+            return ChatSpawnAgentToolExecutor().failurePayload(error: ChatAgentLoopError.recursiveSpawnNotAllowed)
+        }
+        do {
+            if let customTool = name.flatMap({ toolName in customTools.first { $0.toolName == toolName } }) {
+                let result = try await CustomToolExecutor.execute(customTool, argumentsJSON: toolCall.function?.arguments)
+                return result
+            }
+            if let host = context.mcpHost, let name, host.handlesTool(named: name) {
+                return try await host.callTool(named: name, argumentsJSON: toolCall.function?.arguments)
+            }
+            let outcome = try await ChatToolDispatcher.execute(call: toolCall, context: context)
+            return outcome.content
+        } catch {
+            return ChatToolDispatcher.failurePayload(toolName: name, error: error)
+        }
+    }
+
+    private static func subAgentToolDefinitions(
+        settings: NativSettings,
+        canEditImage: Bool,
+        context: ChatToolExecutionContext
+    ) -> [MLXChatToolDefinition] {
+        var definitions = ChatToolRegistry.definitions(canEditImage: canEditImage)
+        definitions += settings.customTools.filter { $0.kind != .script }.compactMap { try? $0.definition() }
+        definitions += context.mcpHost?.toolDefinitions() ?? []
+        let webSearchIsConfigured = ChatWebSearchToolRegistry.isConfigured()
+        let webReadIsConfigured = ChatWebReadToolRegistry.isConfigured()
+        definitions.removeAll {
+            $0.function.name == ChatSwitchModelToolRegistry.toolName
+                || $0.function.name == ChatSpawnAgentToolRegistry.toolName
+                || !settings.isToolEnabled($0.function.name)
+                || ($0.function.name == ChatWebSearchToolRegistry.toolName && !webSearchIsConfigured)
+                || ($0.function.name == ChatWebReadToolRegistry.toolName && !webReadIsConfigured)
+        }
+        return definitions
+    }
+
+    private static func subAgentSystemPrompt(settings: NativSettings, hasTools: Bool) -> String? {
+        var parts: [String] = []
+        if !settings.systemPrompt.isEmpty {
+            parts.append(settings.systemPrompt)
+        }
+        if hasTools {
+            parts.append(NativSkill.builtInToolGuide.instructions)
+        }
+        for skill in settings.skills where skill.isEnabled && !skill.instructions.isEmpty {
+            parts.append(skill.instructions)
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: "\n\n")
+    }
+
+    private static func normalizedToolCalls(_ toolCalls: [MLXChatToolCall]) -> [MLXChatToolCall] {
+        toolCalls.enumerated().map { index, call in
+            var normalized = call
+            normalized.index = index
+            if normalized.id?.isEmpty != false {
+                normalized.id = "call_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+            }
+            if normalized.type?.isEmpty != false {
+                normalized.type = "function"
+            }
+            return normalized
+        }
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
+++ b/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
@@ -215,6 +215,12 @@ private final class ChatAgentDisplayTranscript {
         }
         messages[index].content += event.content ?? ""
         messages[index].reasoningContent += event.reasoningContent ?? ""
+        if event.generatedTokens != nil || event.decodeTokensPerSecond != nil {
+            messages[index].responseMetrics = ChatResponseMetrics(
+                generatedTokens: event.generatedTokens,
+                decodeTokensPerSecond: event.decodeTokensPerSecond
+            )
+        }
         onUpdate?(messages)
     }
 
@@ -225,6 +231,7 @@ private final class ChatAgentDisplayTranscript {
         messages[index].content = completion.content
         messages[index].reasoningContent = completion.reasoningContent ?? ""
         messages[index].isStreaming = false
+        messages[index].responseMetrics = ChatResponseMetrics(completion: completion)
         onUpdate?(messages)
     }
 

--- a/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
+++ b/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
@@ -124,6 +124,8 @@ enum ChatAgentLoop {
         definitions.removeAll {
             $0.function.name == ChatSwitchModelToolRegistry.toolName
                 || $0.function.name == ChatSpawnAgentToolRegistry.toolName
+                || $0.function.name == ChatListAgentsToolRegistry.toolName
+                || $0.function.name == ChatCheckAgentToolRegistry.toolName
                 || !settings.isToolEnabled($0.function.name)
                 || ($0.function.name == ChatWebSearchToolRegistry.toolName && !webSearchIsConfigured)
                 || ($0.function.name == ChatWebReadToolRegistry.toolName && !webReadIsConfigured)

--- a/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
+++ b/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
@@ -190,8 +190,11 @@ enum ChatAgentLoop {
 
 @MainActor
 private final class ChatAgentDisplayTranscript {
+    private static let publishInterval: TimeInterval = 0.05
+
     private var messages: [ChatTranscriptMessage] = []
     private let onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)?
+    private var lastPublishedAt: Date?
 
     init(onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)?) {
         self.onUpdate = onUpdate
@@ -221,7 +224,7 @@ private final class ChatAgentDisplayTranscript {
                 decodeTokensPerSecond: event.decodeTokensPerSecond
             )
         }
-        onUpdate?(messages)
+        publish(throttled: true)
     }
 
     func finishAssistant(_ id: UUID, completion: MLXChatCompletion) {
@@ -232,6 +235,15 @@ private final class ChatAgentDisplayTranscript {
         messages[index].reasoningContent = completion.reasoningContent ?? ""
         messages[index].isStreaming = false
         messages[index].responseMetrics = ChatResponseMetrics(completion: completion)
+        publish(throttled: false)
+    }
+
+    private func publish(throttled: Bool) {
+        let now = Date()
+        if throttled, let last = lastPublishedAt, now.timeIntervalSince(last) < Self.publishInterval {
+            return
+        }
+        lastPublishedAt = now
         onUpdate?(messages)
     }
 

--- a/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
+++ b/Sources/Nativ/Features/Chat/ChatAgentLoop.swift
@@ -17,6 +17,7 @@ enum ChatAgentLoop {
         settings: NativSettings,
         canEditImage: Bool,
         context: ChatToolExecutionContext,
+        agentID: String? = nil,
         onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)? = nil
     ) async throws -> MLXChatCompletion {
         let client = NativChatClient(baseURL: context.baseURL, apiKey: context.apiKey)
@@ -33,6 +34,15 @@ enum ChatAgentLoop {
         var round = 0
         while true {
             try Task.checkCancellation()
+
+            if let agentID, let steerMessages = context.agentRegistry?.drainSteerMessages(for: agentID),
+               !steerMessages.isEmpty {
+                for steerMessage in steerMessages {
+                    messages.append(MLXChatMessage(role: "user", content: steerMessage))
+                    transcript.appendSteerMessage(steerMessage)
+                }
+            }
+
             let advertisesTools = ChatToolRoundGate.advertisesTools(atRound: round) && !toolDefinitions.isEmpty
             let request = MLXChatCompletionRequest(
                 model: modelID,
@@ -126,6 +136,7 @@ enum ChatAgentLoop {
                 || $0.function.name == ChatSpawnAgentToolRegistry.toolName
                 || $0.function.name == ChatListAgentsToolRegistry.toolName
                 || $0.function.name == ChatCheckAgentToolRegistry.toolName
+                || $0.function.name == ChatSteerAgentToolRegistry.toolName
                 || !settings.isToolEnabled($0.function.name)
                 || ($0.function.name == ChatWebSearchToolRegistry.toolName && !webSearchIsConfigured)
                 || ($0.function.name == ChatWebReadToolRegistry.toolName && !webReadIsConfigured)
@@ -169,6 +180,11 @@ private final class ChatAgentDisplayTranscript {
 
     init(onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)?) {
         self.onUpdate = onUpdate
+    }
+
+    func appendSteerMessage(_ content: String) {
+        messages.append(ChatTranscriptMessage(role: .user, content: content))
+        onUpdate?(messages)
     }
 
     func appendAssistantPlaceholder() -> UUID {

--- a/Sources/Nativ/Features/Chat/ChatAgentRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatAgentRegistry.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+enum ChatSpawnedAgentStatus: String, Codable, Equatable, Sendable {
+    case queued
+    case running
+    case completed
+    case error
+    case stopped
+}
+
+enum ChatSpawnedAgentStopReason: String, Codable, Equatable, Sendable {
+    case turnLimit = "turn_limit"
+    case tokenLimit = "token_limit"
+    case timeout
+    case cancelled
+}
+
+struct ChatSpawnedAgentRecord: Identifiable, Equatable, Sendable {
+    let id: String
+    let task: String
+    var modelID: String?
+    var status: ChatSpawnedAgentStatus
+    var stopReason: ChatSpawnedAgentStopReason?
+    var result: String?
+    var error: String?
+    let startedAt: Date
+    var finishedAt: Date?
+}
+
+/// In-memory only. Owned by ChatViewModel so it survives session switches
+/// but not app relaunch.
+@MainActor
+final class ChatAgentRegistry {
+    private static let maximumTrackedTerminalAgents = 50
+
+    private var records: [String: ChatSpawnedAgentRecord] = [:]
+    private var order: [String] = []
+    private var tasks: [String: Task<Void, Never>] = [:]
+    private var pendingSteerMessages: [String: [String]] = [:]
+    private var sequence = 0
+
+    func register(task: String, modelID: String?) -> String {
+        sequence += 1
+        let id = "agent_\(sequence)"
+        records[id] = ChatSpawnedAgentRecord(
+            id: id,
+            task: task,
+            modelID: modelID,
+            status: .queued,
+            stopReason: nil,
+            result: nil,
+            error: nil,
+            startedAt: Date(),
+            finishedAt: nil
+        )
+        order.append(id)
+        return id
+    }
+
+    func setTask(_ task: Task<Void, Never>, for id: String) {
+        tasks[id] = task
+    }
+
+    func markRunning(_ id: String) {
+        records[id]?.status = .running
+    }
+
+    func complete(_ id: String, result: String) {
+        records[id]?.status = .completed
+        records[id]?.result = result
+        records[id]?.finishedAt = Date()
+        tasks[id] = nil
+        evictTerminalOverflow()
+    }
+
+    func fail(_ id: String, error: String) {
+        records[id]?.status = .error
+        records[id]?.error = error
+        records[id]?.finishedAt = Date()
+        tasks[id] = nil
+        evictTerminalOverflow()
+    }
+
+    func stop(_ id: String, reason: ChatSpawnedAgentStopReason, partialResult: String?) {
+        records[id]?.status = .stopped
+        records[id]?.stopReason = reason
+        records[id]?.result = partialResult
+        records[id]?.finishedAt = Date()
+        tasks[id] = nil
+        evictTerminalOverflow()
+    }
+
+    func record(for id: String) -> ChatSpawnedAgentRecord? {
+        records[id]
+    }
+
+    func allRecords() -> [ChatSpawnedAgentRecord] {
+        order.compactMap { records[$0] }
+    }
+
+    func queueSteerMessage(_ message: String, for id: String) -> Bool {
+        guard let status = records[id]?.status, status == .queued || status == .running else {
+            return false
+        }
+        pendingSteerMessages[id, default: []].append(message)
+        return true
+    }
+
+    func drainSteerMessages(for id: String) -> [String] {
+        defer { pendingSteerMessages[id] = nil }
+        return pendingSteerMessages[id] ?? []
+    }
+
+    /// Only cancels the task -- the record's own status/stopReason update happens
+    /// when the cancelled run unwinds and calls `stop(_:reason:.cancelled...)`,
+    /// same as any other stop reason.
+    func cancel(_ id: String) {
+        tasks[id]?.cancel()
+    }
+
+    private func evictTerminalOverflow() {
+        let terminalIDs = order.filter {
+            switch records[$0]?.status {
+            case .completed, .error, .stopped: true
+            default: false
+            }
+        }
+        guard terminalIDs.count > Self.maximumTrackedTerminalAgents else {
+            return
+        }
+        for id in terminalIDs.prefix(terminalIDs.count - Self.maximumTrackedTerminalAgents) {
+            records[id] = nil
+            order.removeAll { $0 == id }
+        }
+    }
+
+    deinit {
+        for task in tasks.values {
+            task.cancel()
+        }
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -158,7 +158,7 @@ struct ChatFolder: Identifiable, Equatable, Codable {
     }
 }
 
-struct ChatTranscriptMessage: Identifiable, Equatable, Codable {
+struct ChatTranscriptMessage: Identifiable, Equatable, Codable, Sendable {
     enum Role: String, Equatable, Codable {
         case user
         case assistant
@@ -193,6 +193,7 @@ struct ChatTranscriptMessage: Identifiable, Equatable, Codable {
     var toolName: String?
     var toolStatus: ToolStatus?
     var toolArguments: String?
+    var subMessages: [ChatTranscriptMessage]
 
     init(
         id: UUID = UUID(),
@@ -210,7 +211,8 @@ struct ChatTranscriptMessage: Identifiable, Equatable, Codable {
         toolCallID: String? = nil,
         toolName: String? = nil,
         toolStatus: ToolStatus? = nil,
-        toolArguments: String? = nil
+        toolArguments: String? = nil,
+        subMessages: [ChatTranscriptMessage] = []
     ) {
         self.id = id
         self.role = role
@@ -228,6 +230,7 @@ struct ChatTranscriptMessage: Identifiable, Equatable, Codable {
         self.toolName = toolName
         self.toolStatus = toolStatus
         self.toolArguments = toolArguments
+        self.subMessages = subMessages
     }
 
     enum CodingKeys: String, CodingKey {
@@ -247,6 +250,7 @@ struct ChatTranscriptMessage: Identifiable, Equatable, Codable {
         case toolName
         case toolStatus
         case toolArguments
+        case subMessages
     }
 
     init(from decoder: Decoder) throws {
@@ -267,6 +271,7 @@ struct ChatTranscriptMessage: Identifiable, Equatable, Codable {
         toolName = try container.decodeIfPresent(String.self, forKey: .toolName)
         toolStatus = try container.decodeIfPresent(ToolStatus.self, forKey: .toolStatus)
         toolArguments = try container.decodeIfPresent(String.self, forKey: .toolArguments)
+        subMessages = try container.decodeIfPresent([ChatTranscriptMessage].self, forKey: .subMessages) ?? []
 
         if role == .error,
            content == NativChatError.missingAssistantContent.localizedDescription,
@@ -294,6 +299,7 @@ struct ChatTranscriptMessage: Identifiable, Equatable, Codable {
         try container.encodeIfPresent(toolName, forKey: .toolName)
         try container.encodeIfPresent(toolStatus, forKey: .toolStatus)
         try container.encodeIfPresent(toolArguments, forKey: .toolArguments)
+        try container.encode(subMessages, forKey: .subMessages)
     }
 
     var apiMessage: MLXChatMessage? {

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -31,6 +31,9 @@ struct ChatToolExecutionContext: Sendable {
     var fileWriteToolDependencies = ChatFileWriteToolDependencies.live
     var imageModelSelection: ChatImageModelSelectionHandler? = nil
     var imageExecutionWillStart: (@MainActor @Sendable (String) -> Void)? = nil
+    var mcpHost: MCPHostManager? = nil
+    var settings: NativSettings? = nil
+    var spawnAgentParentMessages: [ChatTranscriptMessage] = []
 }
 
 struct ChatToolExecutionOutcome: Sendable {
@@ -189,6 +192,13 @@ enum ChatToolRegistry {
                 displayDescription: "Read and find relevant information on public web pages.",
                 configuration: .webRead
             ))
+        tools += ChatSpawnAgentToolRegistry.definitions().map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: "Delegate a focused sub-task to a separate agent.",
+                configuration: nil
+            )
+        }
         return tools
     }
 }
@@ -235,6 +245,9 @@ enum ChatToolDispatcher {
         ChatFileWriteToolRegistry.patchToolName: { call, context in
             try await executeFileWriteTool(call: call, context: context)
         },
+        ChatSpawnAgentToolRegistry.toolName: { call, context in
+            try await executeSpawnAgentTool(call: call, context: context)
+        },
     ]
 
     private static let failureHandlers: [String: FailureHandler] = [
@@ -273,6 +286,9 @@ enum ChatToolDispatcher {
         },
         ChatFileWriteToolRegistry.patchToolName: { _, error in
             ChatFileWriteToolExecutor().failurePayload(error: error)
+        },
+        ChatSpawnAgentToolRegistry.toolName: { _, error in
+            ChatSpawnAgentToolExecutor().failurePayload(error: error)
         },
     ]
 
@@ -415,6 +431,14 @@ enum ChatToolDispatcher {
         context: ChatToolExecutionContext
     ) async throws -> ChatToolExecutionOutcome {
         let content = try await ChatFileWriteToolExecutor().execute(call: call, context: context)
+        return ChatToolExecutionOutcome(content: content, attachments: [])
+    }
+
+    private static func executeSpawnAgentTool(
+        call: MLXChatToolCall,
+        context: ChatToolExecutionContext
+    ) async throws -> ChatToolExecutionOutcome {
+        let content = try await ChatSpawnAgentToolExecutor().execute(call: call, context: context)
         return ChatToolExecutionOutcome(content: content, attachments: [])
     }
 

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -215,6 +215,13 @@ enum ChatToolRegistry {
                 configuration: nil
             )
         }
+        tools += ChatSteerAgentToolRegistry.definitions().map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: "Send a running sub-agent an additional message.",
+                configuration: nil
+            )
+        }
         return tools
     }
 }
@@ -272,6 +279,10 @@ enum ChatToolDispatcher {
             let content = try await ChatCheckAgentToolExecutor().execute(call: call, registry: context.agentRegistry)
             return ChatToolExecutionOutcome(content: content, attachments: [])
         },
+        ChatSteerAgentToolRegistry.toolName: { call, context in
+            let content = try await ChatSteerAgentToolExecutor().execute(call: call, registry: context.agentRegistry)
+            return ChatToolExecutionOutcome(content: content, attachments: [])
+        },
     ]
 
     private static let failureHandlers: [String: FailureHandler] = [
@@ -319,6 +330,9 @@ enum ChatToolDispatcher {
         },
         ChatCheckAgentToolRegistry.toolName: { _, error in
             ChatCheckAgentToolExecutor().failurePayload(error: error)
+        },
+        ChatSteerAgentToolRegistry.toolName: { _, error in
+            ChatSteerAgentToolExecutor().failurePayload(error: error)
         },
     ]
 
@@ -560,6 +574,8 @@ enum ChatToolPresentation {
             return listAgentsTitle(status: status)
         case ChatCheckAgentToolRegistry.toolName:
             return checkAgentTitle(status: status)
+        case ChatSteerAgentToolRegistry.toolName:
+            return steerAgentTitle(status: status)
         default:
             return genericTitle(toolName: toolName, status: status)
         }
@@ -607,6 +623,8 @@ enum ChatToolPresentation {
                 return "list.bullet"
             case ChatCheckAgentToolRegistry.toolName:
                 return "checkmark.circle"
+            case ChatSteerAgentToolRegistry.toolName:
+                return "arrow.turn.up.right"
             default:
                 return "wrench.and.screwdriver"
             }
@@ -798,6 +816,19 @@ enum ChatToolPresentation {
             return "Check sub-agent"
         case nil:
             return "Check sub-agent tool"
+        }
+    }
+
+    private static func steerAgentTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {
+        switch status {
+        case .preparing, .running:
+            return "Steering sub-agent…"
+        case .succeeded:
+            return "Steered sub-agent"
+        case .failed, .cancelled, .awaitingConsent, .awaitingImageModelSelection, .declined:
+            return "Steer sub-agent"
+        case nil:
+            return "Steer sub-agent tool"
         }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -35,6 +35,7 @@ struct ChatToolExecutionContext: Sendable {
     var settings: NativSettings? = nil
     var spawnAgentParentMessages: [ChatTranscriptMessage] = []
     var spawnAgentUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)? = nil
+    var agentRegistry: ChatAgentRegistry? = nil
 }
 
 struct ChatToolExecutionOutcome: Sendable {
@@ -200,6 +201,20 @@ enum ChatToolRegistry {
                 configuration: nil
             )
         }
+        tools += ChatListAgentsToolRegistry.definitions().map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: "See every spawned sub-agent and its status.",
+                configuration: nil
+            )
+        }
+        tools += ChatCheckAgentToolRegistry.definitions().map {
+            ChatNativeToolDescriptor(
+                definition: $0,
+                displayDescription: "Check a spawned sub-agent's status and result.",
+                configuration: nil
+            )
+        }
         return tools
     }
 }
@@ -249,6 +264,14 @@ enum ChatToolDispatcher {
         ChatSpawnAgentToolRegistry.toolName: { call, context in
             try await executeSpawnAgentTool(call: call, context: context)
         },
+        ChatListAgentsToolRegistry.toolName: { _, context in
+            let content = await ChatListAgentsToolExecutor().execute(registry: context.agentRegistry)
+            return ChatToolExecutionOutcome(content: content, attachments: [])
+        },
+        ChatCheckAgentToolRegistry.toolName: { call, context in
+            let content = try await ChatCheckAgentToolExecutor().execute(call: call, registry: context.agentRegistry)
+            return ChatToolExecutionOutcome(content: content, attachments: [])
+        },
     ]
 
     private static let failureHandlers: [String: FailureHandler] = [
@@ -290,6 +313,12 @@ enum ChatToolDispatcher {
         },
         ChatSpawnAgentToolRegistry.toolName: { _, error in
             ChatSpawnAgentToolExecutor().failurePayload(error: error)
+        },
+        ChatListAgentsToolRegistry.toolName: { _, error in
+            ChatListAgentsToolExecutor().failurePayload(error: error)
+        },
+        ChatCheckAgentToolRegistry.toolName: { _, error in
+            ChatCheckAgentToolExecutor().failurePayload(error: error)
         },
     ]
 
@@ -527,6 +556,10 @@ enum ChatToolPresentation {
             return fileWriteTitle(isPatch: true, status: status)
         case ChatSpawnAgentToolRegistry.toolName:
             return spawnAgentTitle(status: status)
+        case ChatListAgentsToolRegistry.toolName:
+            return listAgentsTitle(status: status)
+        case ChatCheckAgentToolRegistry.toolName:
+            return checkAgentTitle(status: status)
         default:
             return genericTitle(toolName: toolName, status: status)
         }
@@ -570,6 +603,10 @@ enum ChatToolPresentation {
                 return "square.and.pencil"
             case ChatSpawnAgentToolRegistry.toolName:
                 return "person.2.wave.2"
+            case ChatListAgentsToolRegistry.toolName:
+                return "list.bullet"
+            case ChatCheckAgentToolRegistry.toolName:
+                return "checkmark.circle"
             default:
                 return "wrench.and.screwdriver"
             }
@@ -735,6 +772,32 @@ enum ChatToolPresentation {
             return "Sub-agent"
         case nil:
             return "Sub-agent tool"
+        }
+    }
+
+    private static func listAgentsTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {
+        switch status {
+        case .preparing, .running:
+            return "Listing sub-agents…"
+        case .succeeded:
+            return "Listed sub-agents"
+        case .failed, .cancelled, .awaitingConsent, .awaitingImageModelSelection, .declined:
+            return "List sub-agents"
+        case nil:
+            return "List sub-agents tool"
+        }
+    }
+
+    private static func checkAgentTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {
+        switch status {
+        case .preparing, .running:
+            return "Checking sub-agent…"
+        case .succeeded:
+            return "Checked sub-agent"
+        case .failed, .cancelled, .awaitingConsent, .awaitingImageModelSelection, .declined:
+            return "Check sub-agent"
+        case nil:
+            return "Check sub-agent tool"
         }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+++ b/Sources/Nativ/Features/Chat/ChatToolRegistry.swift
@@ -34,6 +34,7 @@ struct ChatToolExecutionContext: Sendable {
     var mcpHost: MCPHostManager? = nil
     var settings: NativSettings? = nil
     var spawnAgentParentMessages: [ChatTranscriptMessage] = []
+    var spawnAgentUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)? = nil
 }
 
 struct ChatToolExecutionOutcome: Sendable {
@@ -524,6 +525,8 @@ enum ChatToolPresentation {
             return fileWriteTitle(isPatch: false, status: status)
         case ChatFileWriteToolRegistry.patchToolName:
             return fileWriteTitle(isPatch: true, status: status)
+        case ChatSpawnAgentToolRegistry.toolName:
+            return spawnAgentTitle(status: status)
         default:
             return genericTitle(toolName: toolName, status: status)
         }
@@ -565,6 +568,8 @@ enum ChatToolPresentation {
             case ChatFileWriteToolRegistry.writeToolName,
                 ChatFileWriteToolRegistry.patchToolName:
                 return "square.and.pencil"
+            case ChatSpawnAgentToolRegistry.toolName:
+                return "person.2.wave.2"
             default:
                 return "wrench.and.screwdriver"
             }
@@ -717,6 +722,19 @@ enum ChatToolPresentation {
             return isPatch ? "File patch" : "File write"
         case nil:
             return isPatch ? "File patch" : "File write"
+        }
+    }
+
+    private static func spawnAgentTitle(status: ChatTranscriptMessage.ToolStatus?) -> String {
+        switch status {
+        case .preparing, .running:
+            return "Sub-agent working…"
+        case .succeeded:
+            return "Sub-agent finished"
+        case .failed, .cancelled, .awaitingConsent, .awaitingImageModelSelection, .declined:
+            return "Sub-agent"
+        case nil:
+            return "Sub-agent tool"
         }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -718,6 +718,26 @@ private struct ChatAgentStepCell: View {
             && imageModelSelectionRequest != nil
     }
 
+    private var spawnAgentAccumulatedMetrics: ChatResponseMetrics? {
+        guard message.toolName == ChatSpawnAgentToolRegistry.toolName else { return nil }
+        return accumulatedResponseMetrics(from: message.subMessages)
+    }
+
+    @ViewBuilder
+    private var spawnAgentMetricsWidget: some View {
+        if let metrics = spawnAgentAccumulatedMetrics, metrics.hasVisibleValues {
+            Group {
+                if isAnyRoundStreaming(in: message.subMessages) {
+                    ChatLiveDecodeMetricsBadge(metrics: metrics)
+                        .equatable()
+                } else {
+                    ChatResponseMetricsRow(metrics: metrics)
+                }
+            }
+            .padding(.top, 4)
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
@@ -731,6 +751,10 @@ private struct ChatAgentStepCell: View {
             .help(isExpanded ? "Hide call details" : "Show call details")
             .disabled(isAwaitingConsent || isAwaitingImageModelSelection)
 
+            if !isExpanded {
+                spawnAgentMetricsWidget
+            }
+
             if isAwaitingImageModelSelection {
                 Divider()
                     .padding(.top, 7)
@@ -743,6 +767,7 @@ private struct ChatAgentStepCell: View {
                 Divider()
                     .padding(.top, 7)
                 details
+                spawnAgentMetricsWidget
             }
         }
         .padding(.horizontal, 10)
@@ -1037,6 +1062,27 @@ private struct ChatAgentStepCell: View {
         }
         return object["error"] as? String
     }
+}
+
+private func accumulatedResponseMetrics(from subMessages: [ChatTranscriptMessage]) -> ChatResponseMetrics? {
+    let allMetrics = subMessages
+        .filter { $0.role == .assistant }
+        .compactMap(\.responseMetrics)
+    guard !allMetrics.isEmpty else { return nil }
+
+    let totalTokens = allMetrics.compactMap(\.totalTokens).reduce(0, +)
+    let generatedTokens = allMetrics.compactMap(\.generatedTokens).reduce(0, +)
+    return ChatResponseMetrics(
+        totalTokens: totalTokens > 0 ? totalTokens : nil,
+        generatedTokens: generatedTokens > 0 ? generatedTokens : nil,
+        decodeTokensPerSecond: allMetrics.last?.decodeTokensPerSecond,
+        peakMemoryGB: allMetrics.compactMap(\.peakMemoryGB).max(),
+        specAcceptanceRate: allMetrics.last?.specAcceptanceRate
+    )
+}
+
+private func isAnyRoundStreaming(in subMessages: [ChatTranscriptMessage]) -> Bool {
+    subMessages.contains { $0.role == .assistant && $0.isStreaming }
 }
 
 private struct ChatSpawnAgentSubTranscriptView: View {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -162,6 +162,7 @@ private struct ChatTranscriptView: View {
                             onDenyToolConsent: chat.denyToolConsent,
                             onSelectImageModel: chat.selectImageModel,
                             onCancelImageModelSelection: chat.cancelImageModelSelection,
+                            onCancelAgent: chat.cancelSpawnedAgent,
                             onExploreImageModels: onExploreImageModels,
                             onPreviewAttachment: onPreviewAttachment
                         )
@@ -368,6 +369,7 @@ private struct ChatMessageRow: View, @MainActor Equatable {
     let onDenyToolConsent: (UUID) -> Void
     let onSelectImageModel: (UUID, String) -> Void
     let onCancelImageModelSelection: (UUID) -> Void
+    let onCancelAgent: (String) -> Void
     let onExploreImageModels: (ChatImageOperation) -> Void
     let onPreviewAttachment: (ChatImageAttachment) -> Void
     @State private var didCopyMessage = false
@@ -399,6 +401,7 @@ private struct ChatMessageRow: View, @MainActor Equatable {
                     onDeny: onDenyToolConsent,
                     onSelectImageModel: onSelectImageModel,
                     onCancelImageModelSelection: onCancelImageModelSelection,
+                    onCancelAgent: onCancelAgent,
                     onExploreImageModels: onExploreImageModels
                 )
             }
@@ -687,11 +690,27 @@ private struct ChatAgentStepCell: View {
     let onDeny: (UUID) -> Void
     let onSelectImageModel: (UUID, String) -> Void
     let onCancelImageModelSelection: (UUID) -> Void
+    let onCancelAgent: (String) -> Void
     let onExploreImageModels: (ChatImageOperation) -> Void
     @State private var isExpanded = false
 
     private var isAwaitingConsent: Bool {
         message.toolStatus == .awaitingConsent
+    }
+
+    /// Non-nil only for spawn_agent's own cell while it's actually running --
+    /// parsed from the tool result JSON since that's the only place agent_id
+    /// lives on this message.
+    private var runningSpawnAgentID: String? {
+        guard message.toolName == ChatSpawnAgentToolRegistry.toolName,
+              message.toolStatus == .running,
+              let data = message.content.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let agentID = object["agent_id"] as? String
+        else {
+            return nil
+        }
+        return agentID
     }
 
     private var isAwaitingImageModelSelection: Bool {
@@ -756,6 +775,18 @@ private struct ChatAgentStepCell: View {
                 statusBadge
 
                 Spacer(minLength: 12)
+
+                if let runningSpawnAgentID {
+                    Button {
+                        onCancelAgent(runningSpawnAgentID)
+                    } label: {
+                        Image(systemName: "stop.fill")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Stop this agent")
+                }
 
                 if !isAwaitingConsent && !isAwaitingImageModelSelection {
                     Image(systemName: "chevron.right")
@@ -909,6 +940,14 @@ private struct ChatAgentStepCell: View {
                     .foregroundStyle(.secondary)
                 NativCodeBlock(raw: formattedArguments)
             }
+            if !message.subMessages.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Sub-agent")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                    ChatSpawnAgentSubTranscriptView(subMessages: message.subMessages, onCancelAgent: onCancelAgent)
+                }
+            }
             if !message.content.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Result")
@@ -997,6 +1036,45 @@ private struct ChatAgentStepCell: View {
             return nil
         }
         return object["error"] as? String
+    }
+}
+
+private struct ChatSpawnAgentSubTranscriptView: View {
+    let subMessages: [ChatTranscriptMessage]
+    let onCancelAgent: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(subMessages) { subMessage in
+                switch subMessage.role {
+                case .assistant:
+                    if !subMessage.content.isEmpty {
+                        Text(subMessage.content)
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                    } else if subMessage.isStreaming {
+                        Text(subMessage.reasoningContent.isEmpty ? "Thinking…" : subMessage.reasoningContent)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .italic()
+                    }
+                case .tool:
+                    ChatAgentStepCell(
+                        message: subMessage,
+                        imageModelSelectionRequest: nil,
+                        onConfirm: { _ in },
+                        onDeny: { _ in },
+                        onSelectImageModel: { _, _ in },
+                        onCancelImageModelSelection: { _ in },
+                        onCancelAgent: onCancelAgent,
+                        onExploreImageModels: { _ in }
+                    )
+                default:
+                    EmptyView()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -1047,6 +1047,10 @@ private struct ChatSpawnAgentSubTranscriptView: View {
         VStack(alignment: .leading, spacing: 6) {
             ForEach(subMessages) { subMessage in
                 switch subMessage.role {
+                case .user:
+                    Text("Steered: \(subMessage.content)")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
                 case .assistant:
                     if !subMessage.content.isEmpty {
                         Text(subMessage.content)

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -2000,7 +2000,8 @@ final class ChatViewModel: ObservableObject {
                     return
                 }
                 let content = await executor.run(prepared)
-                let succeeded = prepared.registry?.record(for: prepared.agentID)?.status == .completed
+                let finalStatus = prepared.registry?.record(for: prepared.agentID)?.status
+                let succeeded = finalStatus == .completed || finalStatus == .stopped
                 await self.updateToolMessage(
                     toolMessageID,
                     in: sessionID,

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -1559,7 +1559,10 @@ final class ChatViewModel: ObservableObject {
                                 modelID: selectedModelID,
                                 in: queuedRequest.sessionID
                             )
-                        }
+                        },
+                        mcpHost: mcpHost,
+                        settings: activeSettings,
+                        spawnAgentParentMessages: sessionMessages(for: queuedRequest.sessionID) ?? []
                     )
                     let outcome: ChatToolExecutionOutcome
                     if let customTool {

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -2042,21 +2042,36 @@ final class ChatViewModel: ObservableObject {
                     callContext.spawnAgentUpdate = { [weak self] subMessages in
                         _ = self?.updateMessage(toolMessageID, in: sessionID) { $0.subMessages = subMessages }
                     }
+                    let executor = ChatSpawnAgentToolExecutor()
                     do {
-                        let content = try await ChatSpawnAgentToolExecutor().execute(call: call, context: callContext)
+                        let prepared = try await executor.prepare(call: call, context: callContext)
                         await self.updateToolMessage(
                             toolMessageID,
                             in: sessionID,
-                            status: .succeeded,
-                            content: content,
+                            status: .running,
+                            content: executor.handlePayload(agentID: prepared.agentID),
                             attachments: []
                         )
+                        let task = Task<Void, Never> {
+                            let content = await executor.run(prepared)
+                            let finalStatus = await prepared.registry?.record(for: prepared.agentID)?.status
+                            let succeeded = finalStatus == .completed || finalStatus == .stopped
+                            await self.updateToolMessage(
+                                toolMessageID,
+                                in: sessionID,
+                                status: succeeded ? .succeeded : .failed,
+                                content: content,
+                                attachments: []
+                            )
+                        }
+                        await prepared.registry?.setTask(task, for: prepared.agentID)
+                        await task.value
                     } catch {
                         await self.updateToolMessage(
                             toolMessageID,
                             in: sessionID,
                             status: .failed,
-                            content: ChatSpawnAgentToolExecutor().failurePayload(error: error),
+                            content: executor.failurePayload(error: error),
                             attachments: []
                         )
                     }

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -1964,8 +1964,12 @@ final class ChatViewModel: ObservableObject {
                     guard let self else {
                         return
                     }
+                    var callContext = context
+                    callContext.spawnAgentUpdate = { [weak self] subMessages in
+                        _ = self?.updateMessage(toolMessageID, in: sessionID) { $0.subMessages = subMessages }
+                    }
                     do {
-                        let content = try await ChatSpawnAgentToolExecutor().execute(call: call, context: context)
+                        let content = try await ChatSpawnAgentToolExecutor().execute(call: call, context: callContext)
                         await self.updateToolMessage(
                             toolMessageID,
                             in: sessionID,

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -23,6 +23,7 @@ private struct ChatSessionBootstrap {
 final class ChatViewModel: ObservableObject {
     /// MCP tool host, set by ChatView. Provides MCP tool definitions + execution.
     weak var mcpHost: MCPHostManager?
+    let agentRegistry = ChatAgentRegistry()
     private static let liveDecodeRateRefreshInterval: TimeInterval = 0.25
     private static let streamFlushInterval: TimeInterval = 1.0 / 15.0
 
@@ -750,6 +751,10 @@ final class ChatViewModel: ObservableObject {
         toolConsentGate.deny(toolMessageID)
     }
 
+    func cancelSpawnedAgent(_ agentID: String) {
+        agentRegistry.cancel(agentID)
+    }
+
     func imageModelSelectionRequest(
         for toolMessageID: UUID
     ) -> ChatImageModelSelectionRequest? {
@@ -1322,23 +1327,44 @@ final class ChatViewModel: ObservableObject {
                         batchMessageIDs.append(toolMessageID)
                         handledSpawnAgentIndices.insert(index + offset)
                     }
-                    await runConcurrentSpawnAgentBatch(
-                        calls: Array(batch),
-                        messageIDs: batchMessageIDs,
-                        context: ChatToolExecutionContext(
-                            imageGenerationModelID: activeImageModelID,
-                            baseURL: queuedRequest.settings.serverBaseURL,
-                            apiKey: queuedRequest.settings.serverAPIKey,
-                            imageReferences: [],
-                            modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
-                            additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
-                            huggingFaceToken: appModel?.effectiveHuggingFaceToken,
-                            mcpHost: mcpHost,
-                            settings: activeSettings,
-                            spawnAgentParentMessages: sessionMessages(for: queuedRequest.sessionID) ?? []
-                        ),
-                        in: queuedRequest.sessionID
+
+                    let sharedContext = ChatToolExecutionContext(
+                        imageGenerationModelID: activeImageModelID,
+                        baseURL: queuedRequest.settings.serverBaseURL,
+                        apiKey: queuedRequest.settings.serverAPIKey,
+                        imageReferences: [],
+                        modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
+                        additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
+                        huggingFaceToken: appModel?.effectiveHuggingFaceToken,
+                        mcpHost: mcpHost,
+                        settings: activeSettings,
+                        spawnAgentParentMessages: sessionMessages(for: queuedRequest.sessionID) ?? [],
+                        agentRegistry: agentRegistry
                     )
+
+                    var foregroundCalls: [MLXChatToolCall] = []
+                    var foregroundMessageIDs: [UUID] = []
+                    for (call, toolMessageID) in zip(batch, batchMessageIDs) {
+                        if ChatSpawnAgentToolArguments.runsInBackground(call.function?.arguments) {
+                            await startBackgroundSpawnAgent(
+                                call: call,
+                                toolMessageID: toolMessageID,
+                                context: sharedContext,
+                                in: queuedRequest.sessionID
+                            )
+                        } else {
+                            foregroundCalls.append(call)
+                            foregroundMessageIDs.append(toolMessageID)
+                        }
+                    }
+                    if !foregroundCalls.isEmpty {
+                        await runConcurrentSpawnAgentBatch(
+                            calls: foregroundCalls,
+                            messageIDs: foregroundMessageIDs,
+                            context: sharedContext,
+                            in: queuedRequest.sessionID
+                        )
+                    }
                     appModel?.refreshMetricsIfRunning(force: true)
                     continue
                 }
@@ -1607,7 +1633,8 @@ final class ChatViewModel: ObservableObject {
                         },
                         mcpHost: mcpHost,
                         settings: activeSettings,
-                        spawnAgentParentMessages: sessionMessages(for: queuedRequest.sessionID) ?? []
+                        spawnAgentParentMessages: sessionMessages(for: queuedRequest.sessionID) ?? [],
+                        agentRegistry: agentRegistry
                     )
                     let outcome: ChatToolExecutionOutcome
                     if let customTool {
@@ -1946,6 +1973,52 @@ final class ChatViewModel: ObservableObject {
         }
         storedSessions[sessionIndex].messages.insert(message, at: anchorIndex + 1)
         return true
+    }
+
+    private func startBackgroundSpawnAgent(
+        call: MLXChatToolCall,
+        toolMessageID: UUID,
+        context: ChatToolExecutionContext,
+        in sessionID: UUID
+    ) async {
+        var callContext = context
+        callContext.spawnAgentUpdate = { [weak self] subMessages in
+            _ = self?.updateMessage(toolMessageID, in: sessionID) { $0.subMessages = subMessages }
+        }
+        let executor = ChatSpawnAgentToolExecutor()
+        do {
+            let prepared = try await executor.prepare(call: call, context: callContext)
+            updateToolMessage(
+                toolMessageID,
+                in: sessionID,
+                status: .running,
+                content: executor.handlePayload(agentID: prepared.agentID),
+                attachments: []
+            )
+            let task = Task { [weak self] in
+                guard let self else {
+                    return
+                }
+                let content = await executor.run(prepared)
+                let succeeded = prepared.registry?.record(for: prepared.agentID)?.status == .completed
+                await self.updateToolMessage(
+                    toolMessageID,
+                    in: sessionID,
+                    status: succeeded ? .succeeded : .failed,
+                    content: content,
+                    attachments: []
+                )
+            }
+            prepared.registry?.setTask(task, for: prepared.agentID)
+        } catch {
+            updateToolMessage(
+                toolMessageID,
+                in: sessionID,
+                status: .failed,
+                content: executor.failurePayload(error: error),
+                attachments: []
+            )
+        }
     }
 
     private func runConcurrentSpawnAgentBatch(

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -1296,8 +1296,53 @@ final class ChatViewModel: ObservableObject {
             }
 
             var insertionAnchor = assistantMessageID
+            var handledSpawnAgentIndices = Set<Int>()
             for (index, toolCall) in toolCalls.enumerated() {
                 try Task.checkCancellation()
+                if handledSpawnAgentIndices.contains(index) {
+                    continue
+                }
+
+                if toolCall.function?.name == ChatSpawnAgentToolRegistry.toolName {
+                    let batch = toolCalls[index...].prefix {
+                        $0.function?.name == ChatSpawnAgentToolRegistry.toolName
+                    }
+                    var batchMessageIDs: [UUID] = []
+                    for (offset, call) in batch.enumerated() {
+                        let toolMessageID = UUID()
+                        guard insertToolMessage(
+                            id: toolMessageID,
+                            call: call,
+                            after: insertionAnchor,
+                            in: queuedRequest.sessionID
+                        ) else {
+                            throw NativChatError.invalidResponse
+                        }
+                        insertionAnchor = toolMessageID
+                        batchMessageIDs.append(toolMessageID)
+                        handledSpawnAgentIndices.insert(index + offset)
+                    }
+                    await runConcurrentSpawnAgentBatch(
+                        calls: Array(batch),
+                        messageIDs: batchMessageIDs,
+                        context: ChatToolExecutionContext(
+                            imageGenerationModelID: activeImageModelID,
+                            baseURL: queuedRequest.settings.serverBaseURL,
+                            apiKey: queuedRequest.settings.serverAPIKey,
+                            imageReferences: [],
+                            modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
+                            additionalModelSearchPaths: queuedRequest.settings.additionalModelSearchPaths,
+                            huggingFaceToken: appModel?.effectiveHuggingFaceToken,
+                            mcpHost: mcpHost,
+                            settings: activeSettings,
+                            spawnAgentParentMessages: sessionMessages(for: queuedRequest.sessionID) ?? []
+                        ),
+                        in: queuedRequest.sessionID
+                    )
+                    appModel?.refreshMetricsIfRunning(force: true)
+                    continue
+                }
+
                 let toolMessageID = UUID()
                 let initialToolStatus: ChatTranscriptMessage.ToolStatus =
                     switch toolCall.function?.name {
@@ -1901,6 +1946,51 @@ final class ChatViewModel: ObservableObject {
         }
         storedSessions[sessionIndex].messages.insert(message, at: anchorIndex + 1)
         return true
+    }
+
+    private func runConcurrentSpawnAgentBatch(
+        calls: [MLXChatToolCall],
+        messageIDs: [UUID],
+        context: ChatToolExecutionContext,
+        in sessionID: UUID
+    ) async {
+        await withTaskGroup(of: Void.self) { group in
+            var remaining = zip(calls, messageIDs).makeIterator()
+            func addNext() {
+                guard let (call, toolMessageID) = remaining.next() else {
+                    return
+                }
+                group.addTask { [weak self] in
+                    guard let self else {
+                        return
+                    }
+                    do {
+                        let content = try await ChatSpawnAgentToolExecutor().execute(call: call, context: context)
+                        await self.updateToolMessage(
+                            toolMessageID,
+                            in: sessionID,
+                            status: .succeeded,
+                            content: content,
+                            attachments: []
+                        )
+                    } catch {
+                        await self.updateToolMessage(
+                            toolMessageID,
+                            in: sessionID,
+                            status: .failed,
+                            content: ChatSpawnAgentToolExecutor().failurePayload(error: error),
+                            attachments: []
+                        )
+                    }
+                }
+            }
+            for _ in 0..<min(ChatConcurrentSpawnGate.maximumConcurrent, calls.count) {
+                addNext()
+            }
+            while await group.next() != nil {
+                addNext()
+            }
+        }
     }
 
     private func normalizedToolCalls(_ toolCalls: [MLXChatToolCall]) -> [MLXChatToolCall] {

--- a/Sources/Nativ/Features/Chat/Tools/ChatAgentRegistryTools.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatAgentRegistryTools.swift
@@ -191,3 +191,90 @@ struct ChatCheckAgentToolExecutor {
         return String(decoding: try encoder.encode(payload), as: UTF8.self)
     }
 }
+
+enum ChatSteerAgentToolRegistry {
+    static let toolName = "steer_agent"
+
+    static func definitions() -> [MLXChatToolDefinition] {
+        [MLXChatToolDefinition(function: MLXChatFunctionDefinition(
+            name: toolName,
+            description: "Queue a message into a running sub-agent, delivered at its next turn.",
+            parameters: .object([
+                "type": .string("object"),
+                "additionalProperties": .bool(false),
+                "properties": .object([
+                    "agent_id": .object([
+                        "type": .string("string"),
+                        "description": .string("The agent_id from spawn_agent or list_agents.")
+                    ]),
+                    "message": .object([
+                        "type": .string("string"),
+                        "description": .string("The message to deliver as the sub-agent's next turn.")
+                    ])
+                ]),
+                "required": .array([.string("agent_id"), .string("message")])
+            ])
+        ))]
+    }
+}
+
+struct ChatSteerAgentToolArguments: Decodable {
+    let agentID: String
+    let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case agentID = "agent_id"
+        case message
+    }
+}
+
+struct ChatSteerAgentToolResultPayload: Encodable {
+    let ok: Bool
+    let error: String?
+}
+
+enum ChatSteerAgentToolError: LocalizedError {
+    case invalidArguments
+    case emptyMessage
+    case unknownOrFinishedAgent(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidArguments:
+            return "The steer_agent arguments were not valid JSON."
+        case .emptyMessage:
+            return "steer_agent requires a non-empty message."
+        case .unknownOrFinishedAgent(let agentID):
+            return "\(agentID) isn't a running or queued agent, so it can't be steered."
+        }
+    }
+}
+
+struct ChatSteerAgentToolExecutor {
+    @MainActor
+    func execute(call: MLXChatToolCall, registry: ChatAgentRegistry?) throws -> String {
+        guard let argumentsData = call.function?.arguments?.data(using: .utf8),
+              let arguments = try? JSONDecoder().decode(ChatSteerAgentToolArguments.self, from: argumentsData)
+        else {
+            throw ChatSteerAgentToolError.invalidArguments
+        }
+        guard !arguments.message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ChatSteerAgentToolError.emptyMessage
+        }
+        guard let registry, registry.queueSteerMessage(arguments.message, for: arguments.agentID) else {
+            throw ChatSteerAgentToolError.unknownOrFinishedAgent(arguments.agentID)
+        }
+        return try encodedPayload(ChatSteerAgentToolResultPayload(ok: true, error: nil))
+    }
+
+    func failurePayload(error: Error) -> String {
+        let payload = ChatSteerAgentToolResultPayload(ok: false, error: error.localizedDescription)
+        return (try? encodedPayload(payload)) ?? #"{"ok":false,"error":"steer_agent failed."}"#
+    }
+
+    private func encodedPayload(_ payload: ChatSteerAgentToolResultPayload) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return String(decoding: try encoder.encode(payload), as: UTF8.self)
+    }
+}

--- a/Sources/Nativ/Features/Chat/Tools/ChatAgentRegistryTools.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatAgentRegistryTools.swift
@@ -1,0 +1,193 @@
+import Foundation
+import NativServerKit
+
+enum ChatListAgentsToolRegistry {
+    static let toolName = "list_agents"
+
+    static func definitions() -> [MLXChatToolDefinition] {
+        [MLXChatToolDefinition(function: MLXChatFunctionDefinition(
+            name: toolName,
+            description: "List every spawned sub-agent tracked this session, with its status.",
+            parameters: .object([
+                "type": .string("object"),
+                "additionalProperties": .bool(false),
+                "properties": .object([:])
+            ])
+        ))]
+    }
+}
+
+struct ChatListAgentsToolResultPayload: Encodable {
+    struct Agent: Encodable {
+        let agentID: String
+        let task: String
+        let status: String
+        let stopReason: String?
+
+        enum CodingKeys: String, CodingKey {
+            case agentID = "agent_id"
+            case task
+            case status
+            case stopReason = "stop_reason"
+        }
+    }
+
+    let ok: Bool
+    let agents: [Agent]
+    let error: String?
+}
+
+struct ChatListAgentsToolExecutor {
+    @MainActor
+    func execute(registry: ChatAgentRegistry?) -> String {
+        let agents = (registry?.allRecords() ?? []).map {
+            ChatListAgentsToolResultPayload.Agent(
+                agentID: $0.id,
+                task: $0.task,
+                status: $0.status.rawValue,
+                stopReason: $0.stopReason?.rawValue
+            )
+        }
+        return (try? encodedPayload(ChatListAgentsToolResultPayload(ok: true, agents: agents, error: nil)))
+            ?? #"{"ok":true,"agents":[]}"#
+    }
+
+    func failurePayload(error: Error) -> String {
+        let payload = ChatListAgentsToolResultPayload(ok: false, agents: [], error: error.localizedDescription)
+        return (try? encodedPayload(payload)) ?? #"{"ok":false,"error":"list_agents failed."}"#
+    }
+
+    private func encodedPayload(_ payload: ChatListAgentsToolResultPayload) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return String(decoding: try encoder.encode(payload), as: UTF8.self)
+    }
+}
+
+enum ChatCheckAgentToolRegistry {
+    static let toolName = "check_agent"
+
+    static func definitions() -> [MLXChatToolDefinition] {
+        [MLXChatToolDefinition(function: MLXChatFunctionDefinition(
+            name: toolName,
+            description: "Check a sub-agent's status, and its result once done.",
+            parameters: .object([
+                "type": .string("object"),
+                "additionalProperties": .bool(false),
+                "properties": .object([
+                    "agent_id": .object([
+                        "type": .string("string"),
+                        "description": .string("The agent_id from spawn_agent or list_agents.")
+                    ]),
+                    "wait": .object([
+                        "type": .string("boolean"),
+                        "description": .string("If true, blocks until the agent finishes. Defaults to false.")
+                    ])
+                ]),
+                "required": .array([.string("agent_id")])
+            ])
+        ))]
+    }
+}
+
+struct ChatCheckAgentToolArguments: Decodable {
+    let agentID: String
+    let wait: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case agentID = "agent_id"
+        case wait
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        agentID = try container.decode(String.self, forKey: .agentID)
+        wait = try container.decodeIfPresent(Bool.self, forKey: .wait) ?? false
+    }
+}
+
+struct ChatCheckAgentToolResultPayload: Encodable {
+    let ok: Bool
+    let agentID: String?
+    let status: String?
+    let stopReason: String?
+    let answer: String?
+    let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case agentID = "agent_id"
+        case status
+        case stopReason = "stop_reason"
+        case answer
+        case error
+    }
+}
+
+enum ChatCheckAgentToolError: LocalizedError {
+    case invalidArguments
+    case unknownAgent(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidArguments:
+            return "The check_agent arguments were not valid JSON."
+        case .unknownAgent(let agentID):
+            return "No spawned agent with id \(agentID) is tracked this session."
+        }
+    }
+}
+
+struct ChatCheckAgentToolExecutor {
+    private static let pollInterval: UInt64 = 200_000_000
+
+    @MainActor
+    func execute(call: MLXChatToolCall, registry: ChatAgentRegistry?) async throws -> String {
+        guard let argumentsData = call.function?.arguments?.data(using: .utf8),
+              let arguments = try? JSONDecoder().decode(ChatCheckAgentToolArguments.self, from: argumentsData)
+        else {
+            throw ChatCheckAgentToolError.invalidArguments
+        }
+        guard let registry, var record = registry.record(for: arguments.agentID) else {
+            throw ChatCheckAgentToolError.unknownAgent(arguments.agentID)
+        }
+
+        if arguments.wait {
+            while record.status == .queued || record.status == .running {
+                try Task.checkCancellation()
+                try await Task.sleep(nanoseconds: Self.pollInterval)
+                guard let refreshed = registry.record(for: arguments.agentID) else {
+                    break
+                }
+                record = refreshed
+            }
+        }
+
+        return try encodedPayload(ChatCheckAgentToolResultPayload(
+            ok: true,
+            agentID: record.id,
+            status: record.status.rawValue,
+            stopReason: record.stopReason?.rawValue,
+            answer: record.result,
+            error: record.error
+        ))
+    }
+
+    func failurePayload(error: Error) -> String {
+        let payload = ChatCheckAgentToolResultPayload(
+            ok: false,
+            agentID: nil,
+            status: nil,
+            stopReason: nil,
+            answer: nil,
+            error: error.localizedDescription
+        )
+        return (try? encodedPayload(payload)) ?? #"{"ok":false,"error":"check_agent failed."}"#
+    }
+
+    private func encodedPayload(_ payload: ChatCheckAgentToolResultPayload) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return String(decoding: try encoder.encode(payload), as: UTF8.self)
+    }
+}

--- a/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
@@ -1,0 +1,232 @@
+import Foundation
+import NativServerKit
+
+enum ChatSpawnAgentToolRegistry {
+    static let toolName = "spawn_agent"
+
+    static func definitions() -> [MLXChatToolDefinition] {
+        [MLXChatToolDefinition(function: MLXChatFunctionDefinition(
+            name: toolName,
+            description: "Delegate a sub-task to a separate, independent agent.",
+            parameters: .object([
+                "type": .string("object"),
+                "additionalProperties": .bool(false),
+                "properties": .object([
+                    "task": .object([
+                        "type": .string("string"),
+                        "description": .string("The sub-agent's instruction.")
+                    ]),
+                    "mode": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("fresh"), .string("branch")]),
+                        "description": .string(
+                            "'fresh' (default): starts with just the task. 'branch': clones this conversation's history first, then adds the task."
+                        )
+                    ]),
+                    "context": .object([
+                        "type": .string("string"),
+                        "description": .string("Facts the sub-agent needs, without full history. Ignored in 'branch' mode.")
+                    ]),
+                    "model": .object([
+                        "type": .string("string"),
+                        "description": .string("A downloaded model ID, e.g. 'mlx-community/Qwen3-4B-4bit'. Omit to use the current model.")
+                    ])
+                ]),
+                "required": .array([.string("task")])
+            ])
+        ))]
+    }
+}
+
+enum ChatSpawnAgentMode: String, Decodable {
+    case fresh
+    case branch
+}
+
+struct ChatSpawnAgentToolArguments: Decodable {
+    let task: String
+    let mode: ChatSpawnAgentMode
+    let context: String?
+    let modelID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case task
+        case mode
+        case context
+        case modelID = "model"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        task = try container.decode(String.self, forKey: .task)
+        mode = try container.decodeIfPresent(ChatSpawnAgentMode.self, forKey: .mode) ?? .fresh
+        context = try container.decodeIfPresent(String.self, forKey: .context)
+        modelID = try container.decodeIfPresent(String.self, forKey: .modelID)
+    }
+}
+
+struct ChatSpawnAgentToolResultPayload: Encodable {
+    let ok: Bool
+    let answer: String?
+    let error: String?
+}
+
+enum ChatSpawnAgentToolError: LocalizedError {
+    case invalidArguments
+    case emptyTask
+    case modelUnavailable(modelID: String?)
+    case modelKindNotSupported(modelID: String)
+    case noParentHistory
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidArguments:
+            return "The spawn_agent arguments were not valid JSON."
+        case .emptyTask:
+            return "spawn_agent requires a non-empty task."
+        case .modelUnavailable(let modelID):
+            if let modelID {
+                return "\(modelID) isn't a downloaded model."
+            }
+            return "No language model is available to run the sub-agent."
+        case .modelKindNotSupported(let modelID):
+            return "\(modelID) doesn't support text generation, so it can't run as a spawn_agent sub-agent yet."
+        case .noParentHistory:
+            return "No conversation history is available to branch from."
+        }
+    }
+}
+
+enum ChatSpawnAgentModelKind: Equatable {
+    case textGeneration
+    case unsupported
+
+    static func resolve(_ model: LocalModel) -> ChatSpawnAgentModelKind {
+        model.isEligibleForLanguageModelPicker ? .textGeneration : .unsupported
+    }
+}
+
+enum ChatSpawnAgentModelResolver {
+    static func resolve(
+        requestedModelID: String?,
+        fallbackModelID: String?,
+        searchPaths: LocalModelSearchPaths
+    ) async throws -> String {
+        guard let requestedModelID, !requestedModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            guard let fallbackModelID else {
+                throw ChatSpawnAgentToolError.modelUnavailable(modelID: nil)
+            }
+            return fallbackModelID
+        }
+
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+        guard let model = models.first(where: { $0.repoID == requestedModelID }) else {
+            throw ChatSpawnAgentToolError.modelUnavailable(modelID: requestedModelID)
+        }
+        guard ChatSpawnAgentModelKind.resolve(model) == .textGeneration else {
+            throw ChatSpawnAgentToolError.modelKindNotSupported(modelID: requestedModelID)
+        }
+        return requestedModelID
+    }
+}
+
+enum ChatSpawnAgentTranscriptBuilder {
+    static func initialMessages(
+        arguments: ChatSpawnAgentToolArguments,
+        parentMessages: [ChatTranscriptMessage]
+    ) throws -> [MLXChatMessage] {
+        switch arguments.mode {
+        case .fresh:
+            let content = arguments.context.map { "Context:\n\($0)\n\nTask:\n\(arguments.task)" }
+                ?? arguments.task
+            return [MLXChatMessage(role: "user", content: content)]
+        case .branch:
+            guard !parentMessages.isEmpty else {
+                throw ChatSpawnAgentToolError.noParentHistory
+            }
+            var cloned = parentMessages.compactMap { $0.apiMessage }
+            cloned.append(MLXChatMessage(role: "user", content: arguments.task))
+            return cloned
+        }
+    }
+}
+
+struct ChatSpawnAgentToolExecutor {
+    func execute(call: MLXChatToolCall, context: ChatToolExecutionContext) async throws -> String {
+        guard call.function?.name == ChatSpawnAgentToolRegistry.toolName else {
+            throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
+        }
+        guard let argumentsData = call.function?.arguments?.data(using: .utf8),
+              let arguments = try? JSONDecoder().decode(ChatSpawnAgentToolArguments.self, from: argumentsData)
+        else {
+            throw ChatSpawnAgentToolError.invalidArguments
+        }
+        guard !arguments.task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ChatSpawnAgentToolError.emptyTask
+        }
+        guard let settings = context.settings else {
+            throw ChatSpawnAgentToolError.modelUnavailable(modelID: nil)
+        }
+
+        let modelID = try await ChatSpawnAgentModelResolver.resolve(
+            requestedModelID: arguments.modelID,
+            fallbackModelID: settings.languageModelID,
+            searchPaths: LocalModelSearchPaths(
+                primary: context.modelSearchPath,
+                additional: context.additionalModelSearchPaths
+            )
+        )
+        let messages = try ChatSpawnAgentTranscriptBuilder.initialMessages(
+            arguments: arguments,
+            parentMessages: context.spawnAgentParentMessages
+        )
+        let parentImages = context.spawnAgentParentMessages.reversed().lazy
+            .map { $0.imageAttachments.filter { $0.chatAttachmentKind == .image } }
+            .first { !$0.isEmpty } ?? []
+
+        var subAgentContext = ChatToolExecutionContext(
+            imageGenerationModelID: context.imageGenerationModelID,
+            baseURL: context.baseURL,
+            apiKey: context.apiKey,
+            imageReferences: parentImages,
+            modelSearchPath: context.modelSearchPath,
+            additionalModelSearchPaths: context.additionalModelSearchPaths,
+            huggingFaceToken: context.huggingFaceToken,
+            mcpHost: context.mcpHost
+        )
+        subAgentContext.fileReadRootPath = context.fileReadRootPath
+        subAgentContext.fileReadTracker = context.fileReadTracker
+        subAgentContext.fileReadMaximumResultCharacters = context.fileReadMaximumResultCharacters
+        subAgentContext.fileReadToolDependencies = context.fileReadToolDependencies
+
+        let completion = try await ChatAgentLoop.run(
+            messages: messages,
+            modelID: modelID,
+            settings: settings,
+            canEditImage: !parentImages.isEmpty,
+            context: subAgentContext
+        )
+
+        return try encodedPayload(ChatSpawnAgentToolResultPayload(
+            ok: true,
+            answer: completion.content,
+            error: nil
+        ))
+    }
+
+    func failurePayload(error: Error) -> String {
+        let payload = ChatSpawnAgentToolResultPayload(
+            ok: false,
+            answer: nil,
+            error: error.localizedDescription
+        )
+        return (try? encodedPayload(payload))
+            ?? #"{"ok":false,"error":"spawn_agent failed."}"#
+    }
+
+    private func encodedPayload(_ payload: ChatSpawnAgentToolResultPayload) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return String(decoding: try encoder.encode(payload), as: UTF8.self)
+    }
+}

--- a/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
@@ -208,7 +208,8 @@ struct ChatSpawnAgentToolExecutor {
             modelID: modelID,
             settings: settings,
             canEditImage: !parentImages.isEmpty,
-            context: subAgentContext
+            context: subAgentContext,
+            onUpdate: context.spawnAgentUpdate
         )
 
         return try encodedPayload(ChatSpawnAgentToolResultPayload(

--- a/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
@@ -38,6 +38,10 @@ enum ChatSpawnAgentToolRegistry {
     }
 }
 
+enum ChatConcurrentSpawnGate {
+    static let maximumConcurrent = 5
+}
+
 enum ChatSpawnAgentMode: String, Decodable {
     case fresh
     case branch

--- a/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
@@ -272,6 +272,7 @@ struct ChatSpawnAgentToolExecutor {
                 settings: prepared.settings,
                 canEditImage: prepared.canEditImage,
                 context: prepared.subAgentContext,
+                agentID: prepared.agentID,
                 onUpdate: prepared.onUpdate
             )
             await prepared.registry?.complete(prepared.agentID, result: completion.content)

--- a/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
@@ -30,6 +30,12 @@ enum ChatSpawnAgentToolRegistry {
                     "model": .object([
                         "type": .string("string"),
                         "description": .string("A downloaded model ID, e.g. 'mlx-community/Qwen3-4B-4bit'. Omit to use the current model.")
+                    ]),
+                    "run_in_background": .object([
+                        "type": .string("boolean"),
+                        "description": .string(
+                            "If true, returns an agent_id immediately instead of waiting. Check via check_agent/list_agents. Defaults to false."
+                        )
                     ])
                 ]),
                 "required": .array([.string("task")])
@@ -52,12 +58,14 @@ struct ChatSpawnAgentToolArguments: Decodable {
     let mode: ChatSpawnAgentMode
     let context: String?
     let modelID: String?
+    let runInBackground: Bool
 
     enum CodingKeys: String, CodingKey {
         case task
         case mode
         case context
         case modelID = "model"
+        case runInBackground = "run_in_background"
     }
 
     init(from decoder: Decoder) throws {
@@ -66,13 +74,33 @@ struct ChatSpawnAgentToolArguments: Decodable {
         mode = try container.decodeIfPresent(ChatSpawnAgentMode.self, forKey: .mode) ?? .fresh
         context = try container.decodeIfPresent(String.self, forKey: .context)
         modelID = try container.decodeIfPresent(String.self, forKey: .modelID)
+        runInBackground = try container.decodeIfPresent(Bool.self, forKey: .runInBackground) ?? false
+    }
+
+    static func runsInBackground(_ argumentsJSON: String?) -> Bool {
+        guard let data = argumentsJSON?.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return false
+        }
+        return (object["run_in_background"] as? Bool) ?? false
     }
 }
 
 struct ChatSpawnAgentToolResultPayload: Encodable {
     let ok: Bool
+    let agentID: String?
+    let status: String?
     let answer: String?
     let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case agentID = "agent_id"
+        case status
+        case answer
+        case error
+    }
 }
 
 enum ChatSpawnAgentToolError: LocalizedError {
@@ -155,8 +183,24 @@ enum ChatSpawnAgentTranscriptBuilder {
     }
 }
 
+struct ChatSpawnAgentPreparedCall {
+    let agentID: String
+    let modelID: String
+    let messages: [MLXChatMessage]
+    let settings: NativSettings
+    let canEditImage: Bool
+    let subAgentContext: ChatToolExecutionContext
+    let onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)?
+    let registry: ChatAgentRegistry?
+}
+
 struct ChatSpawnAgentToolExecutor {
     func execute(call: MLXChatToolCall, context: ChatToolExecutionContext) async throws -> String {
+        let prepared = try await prepare(call: call, context: context)
+        return await run(prepared)
+    }
+
+    func prepare(call: MLXChatToolCall, context: ChatToolExecutionContext) async throws -> ChatSpawnAgentPreparedCall {
         guard call.function?.name == ChatSpawnAgentToolRegistry.toolName else {
             throw ChatImageToolError.unsupportedTool(call.function?.name ?? "unknown")
         }
@@ -196,32 +240,73 @@ struct ChatSpawnAgentToolExecutor {
             modelSearchPath: context.modelSearchPath,
             additionalModelSearchPaths: context.additionalModelSearchPaths,
             huggingFaceToken: context.huggingFaceToken,
-            mcpHost: context.mcpHost
+            mcpHost: context.mcpHost,
+            agentRegistry: context.agentRegistry
         )
         subAgentContext.fileReadRootPath = context.fileReadRootPath
         subAgentContext.fileReadTracker = context.fileReadTracker
         subAgentContext.fileReadMaximumResultCharacters = context.fileReadMaximumResultCharacters
         subAgentContext.fileReadToolDependencies = context.fileReadToolDependencies
 
-        let completion = try await ChatAgentLoop.run(
-            messages: messages,
+        let agentID = await context.agentRegistry?.register(task: arguments.task, modelID: modelID)
+            ?? UUID().uuidString
+
+        return ChatSpawnAgentPreparedCall(
+            agentID: agentID,
             modelID: modelID,
+            messages: messages,
             settings: settings,
             canEditImage: !parentImages.isEmpty,
-            context: subAgentContext,
-            onUpdate: context.spawnAgentUpdate
+            subAgentContext: subAgentContext,
+            onUpdate: context.spawnAgentUpdate,
+            registry: context.agentRegistry
         )
+    }
 
-        return try encodedPayload(ChatSpawnAgentToolResultPayload(
+    func run(_ prepared: ChatSpawnAgentPreparedCall) async -> String {
+        await prepared.registry?.markRunning(prepared.agentID)
+        do {
+            let completion = try await ChatAgentLoop.run(
+                messages: prepared.messages,
+                modelID: prepared.modelID,
+                settings: prepared.settings,
+                canEditImage: prepared.canEditImage,
+                context: prepared.subAgentContext,
+                onUpdate: prepared.onUpdate
+            )
+            await prepared.registry?.complete(prepared.agentID, result: completion.content)
+            return (try? encodedPayload(ChatSpawnAgentToolResultPayload(
+                ok: true,
+                agentID: prepared.agentID,
+                status: ChatSpawnedAgentStatus.completed.rawValue,
+                answer: completion.content,
+                error: nil
+            ))) ?? #"{"ok":true}"#
+        } catch {
+            await prepared.registry?.fail(prepared.agentID, error: error.localizedDescription)
+            return failurePayload(agentID: prepared.agentID, error: error)
+        }
+    }
+
+    func handlePayload(agentID: String) -> String {
+        (try? encodedPayload(ChatSpawnAgentToolResultPayload(
             ok: true,
-            answer: completion.content,
+            agentID: agentID,
+            status: ChatSpawnedAgentStatus.queued.rawValue,
+            answer: nil,
             error: nil
-        ))
+        ))) ?? #"{"ok":true,"status":"queued"}"#
     }
 
     func failurePayload(error: Error) -> String {
+        failurePayload(agentID: nil, error: error)
+    }
+
+    func failurePayload(agentID: String?, error: Error) -> String {
         let payload = ChatSpawnAgentToolResultPayload(
             ok: false,
+            agentID: agentID,
+            status: agentID == nil ? nil : ChatSpawnedAgentStatus.error.rawValue,
             answer: nil,
             error: error.localizedDescription
         )

--- a/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
@@ -53,12 +53,27 @@ enum ChatSpawnAgentMode: String, Decodable {
     case branch
 }
 
+struct ChatSpawnAgentResourceLimits: Equatable {
+    static let `default` = ChatSpawnAgentResourceLimits(maxTurns: 50, maxTokens: 8_000, maxWallTimeSeconds: 600)
+
+    let maxTurns: Int
+    let maxTokens: Int
+    let maxWallTimeSeconds: TimeInterval
+
+    init(maxTurns: Int, maxTokens: Int, maxWallTimeSeconds: TimeInterval) {
+        self.maxTurns = max(1, maxTurns)
+        self.maxTokens = max(1, maxTokens)
+        self.maxWallTimeSeconds = max(1, maxWallTimeSeconds)
+    }
+}
+
 struct ChatSpawnAgentToolArguments: Decodable {
     let task: String
     let mode: ChatSpawnAgentMode
     let context: String?
     let modelID: String?
     let runInBackground: Bool
+    let resourceLimits = ChatSpawnAgentResourceLimits.default
 
     enum CodingKeys: String, CodingKey {
         case task
@@ -91,6 +106,7 @@ struct ChatSpawnAgentToolResultPayload: Encodable {
     let ok: Bool
     let agentID: String?
     let status: String?
+    let stopReason: String?
     let answer: String?
     let error: String?
 
@@ -98,6 +114,7 @@ struct ChatSpawnAgentToolResultPayload: Encodable {
         case ok
         case agentID = "agent_id"
         case status
+        case stopReason = "stop_reason"
         case answer
         case error
     }
@@ -192,6 +209,7 @@ struct ChatSpawnAgentPreparedCall {
     let subAgentContext: ChatToolExecutionContext
     let onUpdate: (@MainActor @Sendable ([ChatTranscriptMessage]) -> Void)?
     let registry: ChatAgentRegistry?
+    let limits: ChatSpawnAgentResourceLimits
 }
 
 struct ChatSpawnAgentToolExecutor {
@@ -259,28 +277,52 @@ struct ChatSpawnAgentToolExecutor {
             canEditImage: !parentImages.isEmpty,
             subAgentContext: subAgentContext,
             onUpdate: context.spawnAgentUpdate,
-            registry: context.agentRegistry
+            registry: context.agentRegistry,
+            limits: arguments.resourceLimits
         )
     }
 
     func run(_ prepared: ChatSpawnAgentPreparedCall) async -> String {
         await prepared.registry?.markRunning(prepared.agentID)
         do {
-            let completion = try await ChatAgentLoop.run(
+            let result = try await ChatAgentLoop.run(
                 messages: prepared.messages,
                 modelID: prepared.modelID,
                 settings: prepared.settings,
                 canEditImage: prepared.canEditImage,
                 context: prepared.subAgentContext,
                 agentID: prepared.agentID,
+                limits: prepared.limits,
                 onUpdate: prepared.onUpdate
             )
-            await prepared.registry?.complete(prepared.agentID, result: completion.content)
+            if let stopReason = result.stopReason {
+                await prepared.registry?.stop(prepared.agentID, reason: stopReason, partialResult: result.completion.content)
+                return (try? encodedPayload(ChatSpawnAgentToolResultPayload(
+                    ok: true,
+                    agentID: prepared.agentID,
+                    status: ChatSpawnedAgentStatus.stopped.rawValue,
+                    stopReason: stopReason.rawValue,
+                    answer: result.completion.content,
+                    error: nil
+                ))) ?? #"{"ok":true}"#
+            }
+            await prepared.registry?.complete(prepared.agentID, result: result.completion.content)
             return (try? encodedPayload(ChatSpawnAgentToolResultPayload(
                 ok: true,
                 agentID: prepared.agentID,
                 status: ChatSpawnedAgentStatus.completed.rawValue,
-                answer: completion.content,
+                stopReason: nil,
+                answer: result.completion.content,
+                error: nil
+            ))) ?? #"{"ok":true}"#
+        } catch is CancellationError {
+            await prepared.registry?.stop(prepared.agentID, reason: .cancelled, partialResult: nil)
+            return (try? encodedPayload(ChatSpawnAgentToolResultPayload(
+                ok: true,
+                agentID: prepared.agentID,
+                status: ChatSpawnedAgentStatus.stopped.rawValue,
+                stopReason: ChatSpawnedAgentStopReason.cancelled.rawValue,
+                answer: nil,
                 error: nil
             ))) ?? #"{"ok":true}"#
         } catch {
@@ -294,6 +336,7 @@ struct ChatSpawnAgentToolExecutor {
             ok: true,
             agentID: agentID,
             status: ChatSpawnedAgentStatus.queued.rawValue,
+            stopReason: nil,
             answer: nil,
             error: nil
         ))) ?? #"{"ok":true,"status":"queued"}"#
@@ -308,6 +351,7 @@ struct ChatSpawnAgentToolExecutor {
             ok: false,
             agentID: agentID,
             status: agentID == nil ? nil : ChatSpawnedAgentStatus.error.rawValue,
+            stopReason: nil,
             answer: nil,
             error: error.localizedDescription
         )

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -1367,6 +1367,60 @@ final class ChatTranscriptMessageCodableTests: XCTestCase {
         let decoded = try JSONDecoder().decode(ChatTranscriptMessage.self, from: data)
         XCTAssertEqual(decoded, original)
     }
+
+    func testSubMessagesDefaultEmptyWhenAbsentFromLegacyData() throws {
+        let legacyJSON = #"{"id":"\#(UUID().uuidString)","role":"tool","content":"{}"}"#
+        let decoded = try JSONDecoder().decode(
+            ChatTranscriptMessage.self,
+            from: XCTUnwrap(legacyJSON.data(using: .utf8))
+        )
+        XCTAssertEqual(decoded.subMessages, [])
+    }
+
+    func testSubMessagesRoundTrip() throws {
+        let original = ChatTranscriptMessage(
+            role: .tool,
+            content: #"{"ok":true,"answer":"done"}"#,
+            toolCallID: "call_1",
+            toolName: ChatSpawnAgentToolRegistry.toolName,
+            toolStatus: .succeeded,
+            toolArguments: #"{"task":"summarize"}"#,
+            subMessages: [
+                ChatTranscriptMessage(role: .assistant, content: "working on it"),
+                ChatTranscriptMessage(
+                    role: .tool,
+                    content: #"{"ok":true}"#,
+                    toolCallID: "sub_call_1",
+                    toolName: ChatSystemMonitorToolRegistry.toolName,
+                    toolStatus: .succeeded
+                ),
+            ]
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatTranscriptMessage.self, from: data)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.subMessages.count, 2)
+    }
+}
+
+final class ChatToolPresentationSpawnAgentTests: XCTestCase {
+    func testTitleReflectsStatus() {
+        XCTAssertEqual(
+            ChatToolPresentation.title(toolName: ChatSpawnAgentToolRegistry.toolName, status: .running),
+            "Sub-agent working…"
+        )
+        XCTAssertEqual(
+            ChatToolPresentation.title(toolName: ChatSpawnAgentToolRegistry.toolName, status: .succeeded),
+            "Sub-agent finished"
+        )
+    }
+
+    func testSymbolNameIsDistinctFromGenericTool() {
+        XCTAssertEqual(
+            ChatToolPresentation.symbolName(toolName: ChatSpawnAgentToolRegistry.toolName, status: .succeeded),
+            "person.2.wave.2"
+        )
+    }
 }
 
 final class ChatConcurrentSpawnGateTests: XCTestCase {

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -1369,6 +1369,12 @@ final class ChatTranscriptMessageCodableTests: XCTestCase {
     }
 }
 
+final class ChatConcurrentSpawnGateTests: XCTestCase {
+    func testCapsConcurrentSpawnsAtFive() {
+        XCTAssertEqual(ChatConcurrentSpawnGate.maximumConcurrent, 5)
+    }
+}
+
 final class ChatSpawnAgentToolRegistryTests: XCTestCase {
     func testDefinitionRequiresTaskAndOffersModeContextModel() throws {
         let definitions = ChatSpawnAgentToolRegistry.definitions()

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -13,6 +13,7 @@ private let nativeToolNames = [
     ChatSpawnAgentToolRegistry.toolName,
     ChatListAgentsToolRegistry.toolName,
     ChatCheckAgentToolRegistry.toolName,
+    ChatSteerAgentToolRegistry.toolName,
 ]
 
 private struct FakeToolError: Error, LocalizedError {
@@ -95,6 +96,7 @@ final class ChatToolRegistryTests: XCTestCase {
             ChatSpawnAgentToolRegistry.toolName,
             ChatListAgentsToolRegistry.toolName,
             ChatCheckAgentToolRegistry.toolName,
+            ChatSteerAgentToolRegistry.toolName,
         ])
     }
 
@@ -2034,6 +2036,89 @@ final class ChatCheckAgentToolTests: XCTestCase {
 
     func testFailurePayloadShape() throws {
         let payload = try decode(ChatCheckAgentToolExecutor().failurePayload(error: FakeToolError()))
+        XCTAssertEqual(payload["ok"] as? Bool, false)
+        XCTAssertEqual(payload["error"] as? String, "fake failure")
+    }
+
+    private func decode(_ json: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}
+
+final class ChatSteerAgentToolTests: XCTestCase {
+    func testDefinitionRequiresAgentIDAndMessage() throws {
+        let definitions = ChatSteerAgentToolRegistry.definitions()
+        XCTAssertEqual(definitions.count, 1)
+        let function = definitions[0].function
+        XCTAssertEqual(function.name, "steer_agent")
+        guard case .object(let parameters) = function.parameters,
+              case .array(let required)? = parameters["required"]
+        else {
+            return XCTFail("expected an object schema with required")
+        }
+        XCTAssertEqual(required, [.string("agent_id"), .string("message")])
+    }
+
+    @MainActor
+    func testExecuteQueuesMessageOnRunningAgent() throws {
+        let registry = ChatAgentRegistry()
+        let id = registry.register(task: "task", modelID: nil)
+        registry.markRunning(id)
+
+        let payload = try decode(try ChatSteerAgentToolExecutor().execute(
+            call: makeCall(name: ChatSteerAgentToolRegistry.toolName, arguments: #"{"agent_id":"\#(id)","message":"also check the sources"}"#),
+            registry: registry
+        ))
+        XCTAssertEqual(payload["ok"] as? Bool, true)
+        XCTAssertEqual(registry.drainSteerMessages(for: id), ["also check the sources"])
+    }
+
+    @MainActor
+    func testExecuteOnFinishedAgentThrows() {
+        let registry = ChatAgentRegistry()
+        let id = registry.register(task: "task", modelID: nil)
+        registry.complete(id, result: "done")
+
+        do {
+            _ = try ChatSteerAgentToolExecutor().execute(
+                call: makeCall(name: ChatSteerAgentToolRegistry.toolName, arguments: #"{"agent_id":"\#(id)","message":"too late"}"#),
+                registry: registry
+            )
+            XCTFail("steering a finished agent must throw")
+        } catch let error as ChatSteerAgentToolError {
+            guard case .unknownOrFinishedAgent(let steeredID) = error else {
+                return XCTFail("expected .unknownOrFinishedAgent, got \(error)")
+            }
+            XCTAssertEqual(steeredID, id)
+        } catch {
+            XCTFail("expected ChatSteerAgentToolError, got \(error)")
+        }
+    }
+
+    @MainActor
+    func testEmptyMessageThrows() {
+        let registry = ChatAgentRegistry()
+        let id = registry.register(task: "task", modelID: nil)
+        registry.markRunning(id)
+
+        do {
+            _ = try ChatSteerAgentToolExecutor().execute(
+                call: makeCall(name: ChatSteerAgentToolRegistry.toolName, arguments: #"{"agent_id":"\#(id)","message":"   "}"#),
+                registry: registry
+            )
+            XCTFail("a blank message must throw")
+        } catch let error as ChatSteerAgentToolError {
+            guard case .emptyMessage = error else {
+                return XCTFail("expected .emptyMessage, got \(error)")
+            }
+        } catch {
+            XCTFail("expected ChatSteerAgentToolError, got \(error)")
+        }
+    }
+
+    func testFailurePayloadShape() throws {
+        let payload = try decode(ChatSteerAgentToolExecutor().failurePayload(error: FakeToolError()))
         XCTAssertEqual(payload["ok"] as? Bool, false)
         XCTAssertEqual(payload["error"] as? String, "fake failure")
     }

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -1028,6 +1028,13 @@ final class ChatToolPresentationTests: XCTestCase {
                 .awaitingImageModelSelection: "File patch",
                 .awaitingConsent: "Patch protected file?", .declined: "Patch declined",
             ],
+            ChatSpawnAgentToolRegistry.toolName: [
+                nil: "Sub-agent tool", .preparing: "Sub-agent working…",
+                .running: "Sub-agent working…", .succeeded: "Sub-agent finished",
+                .failed: "Sub-agent", .cancelled: "Sub-agent",
+                .awaitingImageModelSelection: "Sub-agent",
+                .awaitingConsent: "Sub-agent", .declined: "Sub-agent",
+            ],
             "some_unknown_tool": [
                 nil: "some_unknown_tool", .preparing: "Running some_unknown_tool…",
                 .running: "Running some_unknown_tool…", .succeeded: "Ran some_unknown_tool",
@@ -1061,6 +1068,7 @@ final class ChatToolPresentationTests: XCTestCase {
             ChatReadFileToolRegistry.toolName,
             ChatSearchFilesToolRegistry.toolName,
             ChatFileWriteToolRegistry.writeToolName, ChatFileWriteToolRegistry.patchToolName,
+            ChatSpawnAgentToolRegistry.toolName,
             "some_unknown_tool",
         ]
         let successLikeSymbol: [String: String] = [
@@ -1074,6 +1082,7 @@ final class ChatToolPresentationTests: XCTestCase {
             ChatSearchFilesToolRegistry.toolName: "doc.text.magnifyingglass",
             ChatFileWriteToolRegistry.writeToolName: "square.and.pencil",
             ChatFileWriteToolRegistry.patchToolName: "square.and.pencil",
+            ChatSpawnAgentToolRegistry.toolName: "person.2.wave.2",
             "some_unknown_tool": "wrench.and.screwdriver",
         ]
 
@@ -1409,33 +1418,12 @@ final class ChatTranscriptMessageCodableTests: XCTestCase {
     }
 }
 
-final class ChatToolPresentationSpawnAgentTests: XCTestCase {
-    func testTitleReflectsStatus() {
-        XCTAssertEqual(
-            ChatToolPresentation.title(toolName: ChatSpawnAgentToolRegistry.toolName, status: .running),
-            "Sub-agent working…"
-        )
-        XCTAssertEqual(
-            ChatToolPresentation.title(toolName: ChatSpawnAgentToolRegistry.toolName, status: .succeeded),
-            "Sub-agent finished"
-        )
-    }
-
-    func testSymbolNameIsDistinctFromGenericTool() {
-        XCTAssertEqual(
-            ChatToolPresentation.symbolName(toolName: ChatSpawnAgentToolRegistry.toolName, status: .succeeded),
-            "person.2.wave.2"
-        )
-    }
-}
-
-final class ChatConcurrentSpawnGateTests: XCTestCase {
+@MainActor
+final class ChatSpawnAgentToolTests: XCTestCase {
     func testCapsConcurrentSpawnsAtFive() {
         XCTAssertEqual(ChatConcurrentSpawnGate.maximumConcurrent, 5)
     }
-}
 
-final class ChatSpawnAgentToolRegistryTests: XCTestCase {
     func testDefinitionRequiresTaskAndOffersModeContextModel() throws {
         let definitions = ChatSpawnAgentToolRegistry.definitions()
         XCTAssertEqual(definitions.count, 1)
@@ -1458,9 +1446,7 @@ final class ChatSpawnAgentToolRegistryTests: XCTestCase {
         let names = ChatToolRegistry.definitions(canEditImage: false).map(\.function.name)
         XCTAssertTrue(names.contains(ChatSpawnAgentToolRegistry.toolName))
     }
-}
 
-final class ChatSpawnAgentToolArgumentsTests: XCTestCase {
     func testModeDefaultsToFresh() throws {
         let arguments = try decodeArguments(#"{"task":"do the thing"}"#)
         XCTAssertEqual(arguments.mode, .fresh)
@@ -1480,12 +1466,6 @@ final class ChatSpawnAgentToolArgumentsTests: XCTestCase {
         XCTAssertThrowsError(try decodeArguments(#"{"mode":"fresh"}"#))
     }
 
-    private func decodeArguments(_ json: String) throws -> ChatSpawnAgentToolArguments {
-        try JSONDecoder().decode(ChatSpawnAgentToolArguments.self, from: XCTUnwrap(json.data(using: .utf8)))
-    }
-}
-
-final class ChatSpawnAgentModelKindTests: XCTestCase {
     func testTextCapableModelIsTextGeneration() {
         XCTAssertEqual(ChatSpawnAgentModelKind.resolve(makeModel(capabilities: [.text])), .textGeneration)
     }
@@ -1509,25 +1489,6 @@ final class ChatSpawnAgentModelKindTests: XCTestCase {
         XCTAssertEqual(ChatSpawnAgentModelKind.resolve(makeModel(capabilities: [.text, .drafter])), .unsupported)
     }
 
-    private func makeModel(capabilities: Set<LocalModelCapability>) -> LocalModel {
-        LocalModel(
-            repoID: "org/model",
-            snapshotURL: nil,
-            modifiedAt: nil,
-            sizeBytes: nil,
-            parameterCount: nil,
-            quantizationBits: nil,
-            quantizationGroupSize: nil,
-            contextSize: nil,
-            provider: nil,
-            capabilities: capabilities,
-            drafterKind: nil,
-            hiddenSize: nil
-        )
-    }
-}
-
-final class ChatSpawnAgentModelResolverTests: XCTestCase {
     func testNoRequestedModelFallsBackToCurrentModel() async throws {
         let resolved = try await ChatSpawnAgentModelResolver.resolve(
             requestedModelID: nil,
@@ -1573,14 +1534,6 @@ final class ChatSpawnAgentModelResolverTests: XCTestCase {
         }
     }
 
-    private func temporaryEmptyDirectory() -> String {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url.path
-    }
-}
-
-final class ChatSpawnAgentTranscriptBuilderTests: XCTestCase {
     func testFreshModeWithoutContextUsesTaskAsTheOnlyMessage() throws {
         let messages = try ChatSpawnAgentTranscriptBuilder.initialMessages(
             arguments: makeArguments(task: "summarize this", mode: .fresh),
@@ -1638,25 +1591,6 @@ final class ChatSpawnAgentTranscriptBuilderTests: XCTestCase {
         }
     }
 
-    private func makeArguments(
-        task: String,
-        mode: ChatSpawnAgentMode,
-        context: String? = nil,
-        modelID: String? = nil
-    ) -> ChatSpawnAgentToolArguments {
-        var json = "{\"task\":\"\(task)\",\"mode\":\"\(mode.rawValue)\""
-        if let context {
-            json += ",\"context\":\"\(context)\""
-        }
-        if let modelID {
-            json += ",\"model\":\"\(modelID)\""
-        }
-        json += "}"
-        return try! JSONDecoder().decode(ChatSpawnAgentToolArguments.self, from: Data(json.utf8))
-    }
-}
-
-final class ChatSpawnAgentToolExecutorTests: XCTestCase {
     func testInvalidJSONArgumentsThrowsInvalidArguments() async {
         do {
             _ = try await ChatSpawnAgentToolExecutor().execute(
@@ -1711,6 +1645,159 @@ final class ChatSpawnAgentToolExecutorTests: XCTestCase {
         XCTAssertEqual(object["ok"] as? Bool, false)
         XCTAssertEqual(object["error"] as? String, "fake failure")
         XCTAssertNil(object["answer"])
+    }
+
+    func testRunInBackgroundDefaultsFalse() throws {
+        let arguments = try JSONDecoder().decode(
+            ChatSpawnAgentToolArguments.self,
+            from: XCTUnwrap(#"{"task":"do it"}"#.data(using: .utf8))
+        )
+        XCTAssertFalse(arguments.runInBackground)
+    }
+
+    func testRunInBackgroundDecodesTrue() throws {
+        let arguments = try JSONDecoder().decode(
+            ChatSpawnAgentToolArguments.self,
+            from: XCTUnwrap(#"{"task":"do it","run_in_background":true}"#.data(using: .utf8))
+        )
+        XCTAssertTrue(arguments.runInBackground)
+    }
+
+    func testRunsInBackgroundPeekMatchesFullDecode() {
+        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x"}"#))
+        XCTAssertTrue(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x","run_in_background":true}"#))
+        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x","run_in_background":false}"#))
+    }
+
+    func testRunsInBackgroundPeekIsFalseOnMalformedJSON() {
+        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground("not json"))
+        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(nil))
+    }
+
+    func testDefaultsMatchDocumentedValues() {
+        XCTAssertEqual(ChatSpawnAgentResourceLimits.default.maxTurns, 50)
+        XCTAssertEqual(ChatSpawnAgentResourceLimits.default.maxTokens, 8_000)
+        XCTAssertEqual(ChatSpawnAgentResourceLimits.default.maxWallTimeSeconds, 600)
+    }
+
+    func testClampsNonPositiveValuesToOne() {
+        let limits = ChatSpawnAgentResourceLimits(maxTurns: 0, maxTokens: -5, maxWallTimeSeconds: -1)
+        XCTAssertEqual(limits.maxTurns, 1)
+        XCTAssertEqual(limits.maxTokens, 1)
+        XCTAssertEqual(limits.maxWallTimeSeconds, 1)
+    }
+
+    func testArgumentsDefaultToStandardLimits() throws {
+        let arguments = try JSONDecoder().decode(
+            ChatSpawnAgentToolArguments.self,
+            from: XCTUnwrap(#"{"task":"do it"}"#.data(using: .utf8))
+        )
+        XCTAssertEqual(arguments.resourceLimits, .default)
+    }
+
+    func testArgumentsIgnoreLimitOverridesInInput() throws {
+        let arguments = try JSONDecoder().decode(
+            ChatSpawnAgentToolArguments.self,
+            from: XCTUnwrap(#"{"task":"do it","max_turns":2,"max_tokens":500,"max_wall_time_seconds":30}"#.data(using: .utf8))
+        )
+        XCTAssertEqual(arguments.resourceLimits, .default)
+    }
+
+    func testPrepareRegistersAgentAndReturnsHandlePayload() async throws {
+        let registry = ChatAgentRegistry()
+        var context = makeContext(modelSearchPath: "")
+        context.settings = NativSettings(languageModelID: "org/model")
+        context.agentRegistry = registry
+
+        let executor = ChatSpawnAgentToolExecutor()
+        let prepared = try await executor.prepare(
+            call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: #"{"task":"summarize"}"#),
+            context: context
+        )
+
+        XCTAssertEqual(registry.record(for: prepared.agentID)?.status, .queued)
+        XCTAssertEqual(registry.record(for: prepared.agentID)?.task, "summarize")
+
+        let handle = try decode(executor.handlePayload(agentID: prepared.agentID))
+        XCTAssertEqual(handle["ok"] as? Bool, true)
+        XCTAssertEqual(handle["agent_id"] as? String, prepared.agentID)
+        XCTAssertEqual(handle["status"] as? String, "queued")
+        XCTAssertEqual(prepared.limits, .default)
+    }
+
+    func testPrepareCarriesFileReadConfigurationToTheSubAgent() async throws {
+        var context = makeContext(modelSearchPath: "")
+        context.settings = NativSettings(languageModelID: "org/model")
+        context.fileReadRootPath = "/tmp/some-authorized-folder"
+
+        let prepared = try await ChatSpawnAgentToolExecutor().prepare(
+            call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: #"{"task":"summarize"}"#),
+            context: context
+        )
+
+        XCTAssertEqual(prepared.subAgentContext.fileReadRootPath, "/tmp/some-authorized-folder")
+    }
+
+    func testPrepareThrowsBeforeRegisteringOnInvalidArguments() async throws {
+        let registry = ChatAgentRegistry()
+        var context = makeContext(modelSearchPath: "")
+        context.settings = NativSettings(languageModelID: "org/model")
+        context.agentRegistry = registry
+
+        let executor = ChatSpawnAgentToolExecutor()
+        do {
+            _ = try await executor.prepare(
+                call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: "not json"),
+                context: context
+            )
+            XCTFail("invalid arguments must throw before registering")
+        } catch is ChatSpawnAgentToolError {
+            XCTAssertTrue(registry.allRecords().isEmpty)
+        }
+    }
+
+    private func decodeArguments(_ json: String) throws -> ChatSpawnAgentToolArguments {
+        try JSONDecoder().decode(ChatSpawnAgentToolArguments.self, from: XCTUnwrap(json.data(using: .utf8)))
+    }
+
+    private func makeModel(capabilities: Set<LocalModelCapability>) -> LocalModel {
+        LocalModel(
+            repoID: "org/model",
+            snapshotURL: nil,
+            modifiedAt: nil,
+            sizeBytes: nil,
+            parameterCount: nil,
+            quantizationBits: nil,
+            quantizationGroupSize: nil,
+            contextSize: nil,
+            provider: nil,
+            capabilities: capabilities,
+            drafterKind: nil,
+            hiddenSize: nil
+        )
+    }
+
+    private func temporaryEmptyDirectory() -> String {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.path
+    }
+
+    private func makeArguments(
+        task: String,
+        mode: ChatSpawnAgentMode,
+        context: String? = nil,
+        modelID: String? = nil
+    ) -> ChatSpawnAgentToolArguments {
+        var json = "{\"task\":\"\(task)\",\"mode\":\"\(mode.rawValue)\""
+        if let context {
+            json += ",\"context\":\"\(context)\""
+        }
+        if let modelID {
+            json += ",\"model\":\"\(modelID)\""
+        }
+        json += "}"
+        return try! JSONDecoder().decode(ChatSpawnAgentToolArguments.self, from: Data(json.utf8))
     }
 
     private func decode(_ json: String) throws -> [String: Any] {
@@ -1832,95 +1919,6 @@ final class ChatAgentRegistryTests: XCTestCase {
             registry.markRunning(id)
         }
         XCTAssertEqual(registry.allRecords().count, 55)
-    }
-}
-
-final class ChatSpawnAgentBackgroundArgumentsTests: XCTestCase {
-    func testRunInBackgroundDefaultsFalse() throws {
-        let arguments = try JSONDecoder().decode(
-            ChatSpawnAgentToolArguments.self,
-            from: XCTUnwrap(#"{"task":"do it"}"#.data(using: .utf8))
-        )
-        XCTAssertFalse(arguments.runInBackground)
-    }
-
-    func testRunInBackgroundDecodesTrue() throws {
-        let arguments = try JSONDecoder().decode(
-            ChatSpawnAgentToolArguments.self,
-            from: XCTUnwrap(#"{"task":"do it","run_in_background":true}"#.data(using: .utf8))
-        )
-        XCTAssertTrue(arguments.runInBackground)
-    }
-
-    func testRunsInBackgroundPeekMatchesFullDecode() {
-        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x"}"#))
-        XCTAssertTrue(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x","run_in_background":true}"#))
-        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x","run_in_background":false}"#))
-    }
-
-    func testRunsInBackgroundPeekIsFalseOnMalformedJSON() {
-        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground("not json"))
-        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(nil))
-    }
-}
-
-@MainActor
-final class ChatSpawnAgentToolExecutorBackgroundTests: XCTestCase {
-    func testPrepareRegistersAgentAndReturnsHandlePayload() async throws {
-        let registry = ChatAgentRegistry()
-        var context = makeContext(modelSearchPath: "")
-        context.settings = NativSettings(languageModelID: "org/model")
-        context.agentRegistry = registry
-
-        let executor = ChatSpawnAgentToolExecutor()
-        let prepared = try await executor.prepare(
-            call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: #"{"task":"summarize"}"#),
-            context: context
-        )
-
-        XCTAssertEqual(registry.record(for: prepared.agentID)?.status, .queued)
-        XCTAssertEqual(registry.record(for: prepared.agentID)?.task, "summarize")
-
-        let handle = try decode(executor.handlePayload(agentID: prepared.agentID))
-        XCTAssertEqual(handle["ok"] as? Bool, true)
-        XCTAssertEqual(handle["agent_id"] as? String, prepared.agentID)
-        XCTAssertEqual(handle["status"] as? String, "queued")
-    }
-
-    func testPrepareCarriesFileReadConfigurationToTheSubAgent() async throws {
-        var context = makeContext(modelSearchPath: "")
-        context.settings = NativSettings(languageModelID: "org/model")
-        context.fileReadRootPath = "/tmp/some-authorized-folder"
-
-        let prepared = try await ChatSpawnAgentToolExecutor().prepare(
-            call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: #"{"task":"summarize"}"#),
-            context: context
-        )
-
-        XCTAssertEqual(prepared.subAgentContext.fileReadRootPath, "/tmp/some-authorized-folder")
-    }
-
-    func testPrepareThrowsBeforeRegisteringOnInvalidArguments() async throws {
-        let registry = ChatAgentRegistry()
-        var context = makeContext(modelSearchPath: "")
-        context.settings = NativSettings(languageModelID: "org/model")
-        context.agentRegistry = registry
-
-        let executor = ChatSpawnAgentToolExecutor()
-        do {
-            _ = try await executor.prepare(
-                call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: "not json"),
-                context: context
-            )
-            XCTFail("invalid arguments must throw before registering")
-        } catch is ChatSpawnAgentToolError {
-            XCTAssertTrue(registry.allRecords().isEmpty)
-        }
-    }
-
-    private func decode(_ json: String) throws -> [String: Any] {
-        let data = try XCTUnwrap(json.data(using: .utf8))
-        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 }
 

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -11,6 +11,8 @@ private let nativeToolNames = [
     ChatFileWriteToolRegistry.writeToolName,
     ChatFileWriteToolRegistry.patchToolName,
     ChatSpawnAgentToolRegistry.toolName,
+    ChatListAgentsToolRegistry.toolName,
+    ChatCheckAgentToolRegistry.toolName,
 ]
 
 private struct FakeToolError: Error, LocalizedError {
@@ -91,6 +93,8 @@ final class ChatToolRegistryTests: XCTestCase {
             ChatWebSearchToolRegistry.toolName,
             ChatWebReadToolRegistry.toolName,
             ChatSpawnAgentToolRegistry.toolName,
+            ChatListAgentsToolRegistry.toolName,
+            ChatCheckAgentToolRegistry.toolName,
         ])
     }
 
@@ -1705,6 +1709,333 @@ final class ChatSpawnAgentToolExecutorTests: XCTestCase {
         XCTAssertEqual(object["ok"] as? Bool, false)
         XCTAssertEqual(object["error"] as? String, "fake failure")
         XCTAssertNil(object["answer"])
+    }
+
+    private func decode(_ json: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}
+
+@MainActor
+final class ChatAgentRegistryTests: XCTestCase {
+    func testRegisterAssignsSequentialIDsStartingQueued() {
+        let registry = ChatAgentRegistry()
+        let first = registry.register(task: "task one", modelID: "org/model")
+        let second = registry.register(task: "task two", modelID: "org/model")
+
+        XCTAssertEqual(first, "agent_1")
+        XCTAssertEqual(second, "agent_2")
+        XCTAssertEqual(registry.record(for: first)?.status, .queued)
+        XCTAssertEqual(registry.record(for: first)?.task, "task one")
+    }
+
+    func testStatusTransitionsThroughRunningToCompleted() {
+        let registry = ChatAgentRegistry()
+        let id = registry.register(task: "task", modelID: nil)
+
+        registry.markRunning(id)
+        XCTAssertEqual(registry.record(for: id)?.status, .running)
+
+        registry.complete(id, result: "the answer")
+        let record = registry.record(for: id)
+        XCTAssertEqual(record?.status, .completed)
+        XCTAssertEqual(record?.result, "the answer")
+        XCTAssertNotNil(record?.finishedAt)
+    }
+
+    func testFailAndStopSetDistinctTerminalState() {
+        let registry = ChatAgentRegistry()
+        let failedID = registry.register(task: "a", modelID: nil)
+        registry.fail(failedID, error: "boom")
+        XCTAssertEqual(registry.record(for: failedID)?.status, .error)
+        XCTAssertEqual(registry.record(for: failedID)?.error, "boom")
+
+        let stoppedID = registry.register(task: "b", modelID: nil)
+        registry.stop(stoppedID, reason: .turnLimit, partialResult: "partial")
+        let stopped = registry.record(for: stoppedID)
+        XCTAssertEqual(stopped?.status, .stopped)
+        XCTAssertEqual(stopped?.stopReason, .turnLimit)
+        XCTAssertEqual(stopped?.result, "partial")
+    }
+
+    func testCancelCancelsTheTrackedTask() {
+        let registry = ChatAgentRegistry()
+        let id = registry.register(task: "task", modelID: nil)
+        let task = Task<Void, Never> {}
+        registry.setTask(task, for: id)
+
+        XCTAssertFalse(task.isCancelled)
+        registry.cancel(id)
+        XCTAssertTrue(task.isCancelled)
+    }
+
+    func testCancelOnUnknownAgentDoesNothing() {
+        let registry = ChatAgentRegistry()
+        registry.cancel("agent_does_not_exist")
+    }
+
+    func testAllRecordsPreservesRegistrationOrder() {
+        let registry = ChatAgentRegistry()
+        let ids = (1...3).map { registry.register(task: "task \($0)", modelID: nil) }
+        XCTAssertEqual(registry.allRecords().map(\.id), ids)
+    }
+
+    func testUnknownAgentIDReturnsNilRecord() {
+        let registry = ChatAgentRegistry()
+        XCTAssertNil(registry.record(for: "agent_999"))
+    }
+
+    func testSteerMessagesQueueOnlyForTrackedRunningOrQueuedAgents() {
+        let registry = ChatAgentRegistry()
+        let runningID = registry.register(task: "task", modelID: nil)
+        registry.markRunning(runningID)
+        XCTAssertTrue(registry.queueSteerMessage("keep going", for: runningID))
+
+        let finishedID = registry.register(task: "task", modelID: nil)
+        registry.complete(finishedID, result: "done")
+        XCTAssertFalse(registry.queueSteerMessage("too late", for: finishedID))
+
+        XCTAssertFalse(registry.queueSteerMessage("nope", for: "agent_unknown"))
+    }
+
+    func testDrainSteerMessagesReturnsInOrderAndClears() {
+        let registry = ChatAgentRegistry()
+        let id = registry.register(task: "task", modelID: nil)
+        registry.markRunning(id)
+        XCTAssertTrue(registry.queueSteerMessage("first", for: id))
+        XCTAssertTrue(registry.queueSteerMessage("second", for: id))
+
+        XCTAssertEqual(registry.drainSteerMessages(for: id), ["first", "second"])
+        XCTAssertEqual(registry.drainSteerMessages(for: id), [])
+    }
+
+    func testEvictsOldestTerminalAgentsPastFifty() {
+        let registry = ChatAgentRegistry()
+        var ids: [String] = []
+        for index in 1...55 {
+            let id = registry.register(task: "task \(index)", modelID: nil)
+            registry.complete(id, result: "done")
+            ids.append(id)
+        }
+        XCTAssertEqual(registry.allRecords().count, 50)
+        XCTAssertNil(registry.record(for: ids[0]))
+        XCTAssertNotNil(registry.record(for: ids.last!))
+    }
+
+    func testRunningAgentsAreNeverEvictedEvenPastFifty() {
+        let registry = ChatAgentRegistry()
+        for index in 1...55 {
+            let id = registry.register(task: "task \(index)", modelID: nil)
+            registry.markRunning(id)
+        }
+        XCTAssertEqual(registry.allRecords().count, 55)
+    }
+}
+
+final class ChatSpawnAgentBackgroundArgumentsTests: XCTestCase {
+    func testRunInBackgroundDefaultsFalse() throws {
+        let arguments = try JSONDecoder().decode(
+            ChatSpawnAgentToolArguments.self,
+            from: XCTUnwrap(#"{"task":"do it"}"#.data(using: .utf8))
+        )
+        XCTAssertFalse(arguments.runInBackground)
+    }
+
+    func testRunInBackgroundDecodesTrue() throws {
+        let arguments = try JSONDecoder().decode(
+            ChatSpawnAgentToolArguments.self,
+            from: XCTUnwrap(#"{"task":"do it","run_in_background":true}"#.data(using: .utf8))
+        )
+        XCTAssertTrue(arguments.runInBackground)
+    }
+
+    func testRunsInBackgroundPeekMatchesFullDecode() {
+        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x"}"#))
+        XCTAssertTrue(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x","run_in_background":true}"#))
+        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(#"{"task":"x","run_in_background":false}"#))
+    }
+
+    func testRunsInBackgroundPeekIsFalseOnMalformedJSON() {
+        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground("not json"))
+        XCTAssertFalse(ChatSpawnAgentToolArguments.runsInBackground(nil))
+    }
+}
+
+@MainActor
+final class ChatSpawnAgentToolExecutorBackgroundTests: XCTestCase {
+    func testPrepareRegistersAgentAndReturnsHandlePayload() async throws {
+        let registry = ChatAgentRegistry()
+        var context = makeContext(modelSearchPath: "")
+        context.settings = NativSettings(languageModelID: "org/model")
+        context.agentRegistry = registry
+
+        let executor = ChatSpawnAgentToolExecutor()
+        let prepared = try await executor.prepare(
+            call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: #"{"task":"summarize"}"#),
+            context: context
+        )
+
+        XCTAssertEqual(registry.record(for: prepared.agentID)?.status, .queued)
+        XCTAssertEqual(registry.record(for: prepared.agentID)?.task, "summarize")
+
+        let handle = try decode(executor.handlePayload(agentID: prepared.agentID))
+        XCTAssertEqual(handle["ok"] as? Bool, true)
+        XCTAssertEqual(handle["agent_id"] as? String, prepared.agentID)
+        XCTAssertEqual(handle["status"] as? String, "queued")
+    }
+
+    func testPrepareCarriesFileReadConfigurationToTheSubAgent() async throws {
+        var context = makeContext(modelSearchPath: "")
+        context.settings = NativSettings(languageModelID: "org/model")
+        context.fileReadRootPath = "/tmp/some-authorized-folder"
+
+        let prepared = try await ChatSpawnAgentToolExecutor().prepare(
+            call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: #"{"task":"summarize"}"#),
+            context: context
+        )
+
+        XCTAssertEqual(prepared.subAgentContext.fileReadRootPath, "/tmp/some-authorized-folder")
+    }
+
+    func testPrepareThrowsBeforeRegisteringOnInvalidArguments() async throws {
+        let registry = ChatAgentRegistry()
+        var context = makeContext(modelSearchPath: "")
+        context.settings = NativSettings(languageModelID: "org/model")
+        context.agentRegistry = registry
+
+        let executor = ChatSpawnAgentToolExecutor()
+        do {
+            _ = try await executor.prepare(
+                call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: "not json"),
+                context: context
+            )
+            XCTFail("invalid arguments must throw before registering")
+        } catch is ChatSpawnAgentToolError {
+            XCTAssertTrue(registry.allRecords().isEmpty)
+        }
+    }
+
+    private func decode(_ json: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}
+
+final class ChatListAgentsToolTests: XCTestCase {
+    func testDefinitionHasNoParameters() throws {
+        let definitions = ChatListAgentsToolRegistry.definitions()
+        XCTAssertEqual(definitions.count, 1)
+        XCTAssertEqual(definitions[0].function.name, "list_agents")
+    }
+
+    @MainActor
+    func testExecuteReturnsAllTrackedAgentsInOrder() async throws {
+        let registry = ChatAgentRegistry()
+        let first = registry.register(task: "task one", modelID: nil)
+        registry.markRunning(first)
+        let second = registry.register(task: "task two", modelID: nil)
+        registry.complete(second, result: "done")
+
+        let payload = try decode(ChatListAgentsToolExecutor().execute(registry: registry))
+        let agents = try XCTUnwrap(payload["agents"] as? [[String: Any]])
+        XCTAssertEqual(agents.count, 2)
+        XCTAssertEqual(agents[0]["agent_id"] as? String, first)
+        XCTAssertEqual(agents[0]["status"] as? String, "running")
+        XCTAssertEqual(agents[1]["agent_id"] as? String, second)
+        XCTAssertEqual(agents[1]["status"] as? String, "completed")
+    }
+
+    @MainActor
+    func testExecuteWithNoRegistryReturnsEmptyList() throws {
+        let payload = try decode(ChatListAgentsToolExecutor().execute(registry: nil))
+        XCTAssertEqual(payload["ok"] as? Bool, true)
+        XCTAssertEqual((payload["agents"] as? [[String: Any]])?.count, 0)
+    }
+
+    func testFailurePayloadShape() throws {
+        let payload = try decode(ChatListAgentsToolExecutor().failurePayload(error: FakeToolError()))
+        XCTAssertEqual(payload["ok"] as? Bool, false)
+        XCTAssertEqual(payload["error"] as? String, "fake failure")
+    }
+
+    private func decode(_ json: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}
+
+final class ChatCheckAgentToolTests: XCTestCase {
+    func testDefinitionRequiresAgentIDOnly() throws {
+        let definitions = ChatCheckAgentToolRegistry.definitions()
+        XCTAssertEqual(definitions.count, 1)
+        let function = definitions[0].function
+        XCTAssertEqual(function.name, "check_agent")
+        guard case .object(let parameters) = function.parameters,
+              case .array(let required)? = parameters["required"]
+        else {
+            return XCTFail("expected an object schema with required")
+        }
+        XCTAssertEqual(required, [.string("agent_id")])
+    }
+
+    @MainActor
+    func testExecuteReturnsCurrentStatusWithoutWaitingByDefault() async throws {
+        let registry = ChatAgentRegistry()
+        let id = registry.register(task: "task", modelID: nil)
+        registry.markRunning(id)
+
+        let payload = try decode(try await ChatCheckAgentToolExecutor().execute(
+            call: makeCall(name: ChatCheckAgentToolRegistry.toolName, arguments: #"{"agent_id":"\#(id)"}"#),
+            registry: registry
+        ))
+        XCTAssertEqual(payload["status"] as? String, "running")
+        XCTAssertNil(payload["answer"])
+    }
+
+    @MainActor
+    func testExecuteWithWaitBlocksUntilTerminal() async throws {
+        let registry = ChatAgentRegistry()
+        let id = registry.register(task: "task", modelID: nil)
+        registry.markRunning(id)
+
+        let checkTask = Task {
+            try await ChatCheckAgentToolExecutor().execute(
+                call: makeCall(name: ChatCheckAgentToolRegistry.toolName, arguments: #"{"agent_id":"\#(id)","wait":true}"#),
+                registry: registry
+            )
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        registry.complete(id, result: "final answer")
+
+        let payload = try decode(try await checkTask.value)
+        XCTAssertEqual(payload["status"] as? String, "completed")
+        XCTAssertEqual(payload["answer"] as? String, "final answer")
+    }
+
+    @MainActor
+    func testUnknownAgentThrows() async {
+        let registry = ChatAgentRegistry()
+        do {
+            _ = try await ChatCheckAgentToolExecutor().execute(
+                call: makeCall(name: ChatCheckAgentToolRegistry.toolName, arguments: #"{"agent_id":"agent_999"}"#),
+                registry: registry
+            )
+            XCTFail("unknown agent id must throw")
+        } catch let error as ChatCheckAgentToolError {
+            guard case .unknownAgent(let id) = error else {
+                return XCTFail("expected .unknownAgent, got \(error)")
+            }
+            XCTAssertEqual(id, "agent_999")
+        } catch {
+            XCTFail("expected ChatCheckAgentToolError, got \(error)")
+        }
+    }
+
+    func testFailurePayloadShape() throws {
+        let payload = try decode(ChatCheckAgentToolExecutor().failurePayload(error: FakeToolError()))
+        XCTAssertEqual(payload["ok"] as? Bool, false)
+        XCTAssertEqual(payload["error"] as? String, "fake failure")
     }
 
     private func decode(_ json: String) throws -> [String: Any] {

--- a/Tests/NativTests/ChatToolRegistryTests.swift
+++ b/Tests/NativTests/ChatToolRegistryTests.swift
@@ -10,6 +10,7 @@ private let nativeToolNames = [
     ChatSearchFilesToolRegistry.toolName,
     ChatFileWriteToolRegistry.writeToolName,
     ChatFileWriteToolRegistry.patchToolName,
+    ChatSpawnAgentToolRegistry.toolName,
 ]
 
 private struct FakeToolError: Error, LocalizedError {
@@ -89,6 +90,7 @@ final class ChatToolRegistryTests: XCTestCase {
             ChatFileWriteToolRegistry.patchToolName,
             ChatWebSearchToolRegistry.toolName,
             ChatWebReadToolRegistry.toolName,
+            ChatSpawnAgentToolRegistry.toolName,
         ])
     }
 
@@ -1364,5 +1366,289 @@ final class ChatTranscriptMessageCodableTests: XCTestCase {
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(ChatTranscriptMessage.self, from: data)
         XCTAssertEqual(decoded, original)
+    }
+}
+
+final class ChatSpawnAgentToolRegistryTests: XCTestCase {
+    func testDefinitionRequiresTaskAndOffersModeContextModel() throws {
+        let definitions = ChatSpawnAgentToolRegistry.definitions()
+        XCTAssertEqual(definitions.count, 1)
+        let function = try XCTUnwrap(definitions.first).function
+        XCTAssertEqual(function.name, "spawn_agent")
+        guard case .object(let parameters) = function.parameters,
+              case .array(let required)? = parameters["required"],
+              case .object(let properties)? = parameters["properties"]
+        else {
+            return XCTFail("expected an object schema with properties/required")
+        }
+        XCTAssertEqual(required, [.string("task")])
+        XCTAssertNotNil(properties["task"])
+        XCTAssertNotNil(properties["mode"])
+        XCTAssertNotNil(properties["context"])
+        XCTAssertNotNil(properties["model"])
+    }
+
+    func testIsAdvertisedAlongsideBuiltInTools() {
+        let names = ChatToolRegistry.definitions(canEditImage: false).map(\.function.name)
+        XCTAssertTrue(names.contains(ChatSpawnAgentToolRegistry.toolName))
+    }
+}
+
+final class ChatSpawnAgentToolArgumentsTests: XCTestCase {
+    func testModeDefaultsToFresh() throws {
+        let arguments = try decodeArguments(#"{"task":"do the thing"}"#)
+        XCTAssertEqual(arguments.mode, .fresh)
+        XCTAssertNil(arguments.context)
+        XCTAssertNil(arguments.modelID)
+    }
+
+    func testDecodesAllFields() throws {
+        let arguments = try decodeArguments(#"{"task":"do it","mode":"branch","context":"facts","model":"org/model"}"#)
+        XCTAssertEqual(arguments.task, "do it")
+        XCTAssertEqual(arguments.mode, .branch)
+        XCTAssertEqual(arguments.context, "facts")
+        XCTAssertEqual(arguments.modelID, "org/model")
+    }
+
+    func testMissingTaskFailsToDecode() {
+        XCTAssertThrowsError(try decodeArguments(#"{"mode":"fresh"}"#))
+    }
+
+    private func decodeArguments(_ json: String) throws -> ChatSpawnAgentToolArguments {
+        try JSONDecoder().decode(ChatSpawnAgentToolArguments.self, from: XCTUnwrap(json.data(using: .utf8)))
+    }
+}
+
+final class ChatSpawnAgentModelKindTests: XCTestCase {
+    func testTextCapableModelIsTextGeneration() {
+        XCTAssertEqual(ChatSpawnAgentModelKind.resolve(makeModel(capabilities: [.text])), .textGeneration)
+    }
+
+    func testVisionOnlyChatModelIsTextGeneration() {
+        XCTAssertEqual(ChatSpawnAgentModelKind.resolve(makeModel(capabilities: [.vision])), .textGeneration)
+    }
+
+    func testImageGenerationOnlyModelIsUnsupported() {
+        XCTAssertEqual(ChatSpawnAgentModelKind.resolve(makeModel(capabilities: [.imageGeneration])), .unsupported)
+    }
+
+    func testVisionModelThatIsAlsoImageGenerationIsUnsupported() {
+        XCTAssertEqual(
+            ChatSpawnAgentModelKind.resolve(makeModel(capabilities: [.vision, .imageGeneration])),
+            .unsupported
+        )
+    }
+
+    func testDrafterModelIsUnsupportedEvenWithText() {
+        XCTAssertEqual(ChatSpawnAgentModelKind.resolve(makeModel(capabilities: [.text, .drafter])), .unsupported)
+    }
+
+    private func makeModel(capabilities: Set<LocalModelCapability>) -> LocalModel {
+        LocalModel(
+            repoID: "org/model",
+            snapshotURL: nil,
+            modifiedAt: nil,
+            sizeBytes: nil,
+            parameterCount: nil,
+            quantizationBits: nil,
+            quantizationGroupSize: nil,
+            contextSize: nil,
+            provider: nil,
+            capabilities: capabilities,
+            drafterKind: nil,
+            hiddenSize: nil
+        )
+    }
+}
+
+final class ChatSpawnAgentModelResolverTests: XCTestCase {
+    func testNoRequestedModelFallsBackToCurrentModel() async throws {
+        let resolved = try await ChatSpawnAgentModelResolver.resolve(
+            requestedModelID: nil,
+            fallbackModelID: "org/current",
+            searchPaths: LocalModelSearchPaths(primary: temporaryEmptyDirectory())
+        )
+        XCTAssertEqual(resolved, "org/current")
+    }
+
+    func testNoRequestedModelAndNoFallbackThrowsModelUnavailable() async {
+        do {
+            _ = try await ChatSpawnAgentModelResolver.resolve(
+                requestedModelID: nil,
+                fallbackModelID: nil,
+                searchPaths: LocalModelSearchPaths(primary: temporaryEmptyDirectory())
+            )
+            XCTFail("must throw without a requested or fallback model")
+        } catch let error as ChatSpawnAgentToolError {
+            guard case .modelUnavailable(let modelID) = error else {
+                return XCTFail("expected .modelUnavailable, got \(error)")
+            }
+            XCTAssertNil(modelID)
+        } catch {
+            XCTFail("expected ChatSpawnAgentToolError, got \(error)")
+        }
+    }
+
+    func testUndownloadedRequestedModelThrowsModelUnavailable() async {
+        do {
+            _ = try await ChatSpawnAgentModelResolver.resolve(
+                requestedModelID: "org/not-downloaded",
+                fallbackModelID: "org/current",
+                searchPaths: LocalModelSearchPaths(primary: temporaryEmptyDirectory())
+            )
+            XCTFail("must throw for a model that isn't downloaded")
+        } catch let error as ChatSpawnAgentToolError {
+            guard case .modelUnavailable(let modelID) = error else {
+                return XCTFail("expected .modelUnavailable, got \(error)")
+            }
+            XCTAssertEqual(modelID, "org/not-downloaded")
+        } catch {
+            XCTFail("expected ChatSpawnAgentToolError, got \(error)")
+        }
+    }
+
+    private func temporaryEmptyDirectory() -> String {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.path
+    }
+}
+
+final class ChatSpawnAgentTranscriptBuilderTests: XCTestCase {
+    func testFreshModeWithoutContextUsesTaskAsTheOnlyMessage() throws {
+        let messages = try ChatSpawnAgentTranscriptBuilder.initialMessages(
+            arguments: makeArguments(task: "summarize this", mode: .fresh),
+            parentMessages: []
+        )
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages[0].role, "user")
+        XCTAssertEqual(messages[0].textContent, "summarize this")
+    }
+
+    func testFreshModeWithContextPrependsIt() throws {
+        let messages = try ChatSpawnAgentTranscriptBuilder.initialMessages(
+            arguments: makeArguments(task: "summarize this", mode: .fresh, context: "the doc is about X"),
+            parentMessages: []
+        )
+        XCTAssertEqual(messages.count, 1)
+        let text = try XCTUnwrap(messages[0].textContent)
+        XCTAssertTrue(text.contains("the doc is about X"))
+        XCTAssertTrue(text.contains("summarize this"))
+    }
+
+    func testBranchModeClonesParentHistoryAndAppendsTask() throws {
+        let parent = [
+            ChatTranscriptMessage(role: .user, content: "hello"),
+            ChatTranscriptMessage(role: .assistant, content: "hi there"),
+        ]
+        let messages = try ChatSpawnAgentTranscriptBuilder.initialMessages(
+            arguments: makeArguments(task: "continue", mode: .branch),
+            parentMessages: parent
+        )
+        XCTAssertEqual(messages.count, 3)
+        XCTAssertEqual(messages[0].textContent, "hello")
+        XCTAssertEqual(messages[1].textContent, "hi there")
+        XCTAssertEqual(messages[2].role, "user")
+        XCTAssertEqual(messages[2].textContent, "continue")
+    }
+
+    func testBranchModeIgnoresContext() throws {
+        let parent = [ChatTranscriptMessage(role: .user, content: "hello")]
+        let messages = try ChatSpawnAgentTranscriptBuilder.initialMessages(
+            arguments: makeArguments(task: "continue", mode: .branch, context: "should be ignored"),
+            parentMessages: parent
+        )
+        XCTAssertFalse(messages.contains { $0.textContent?.contains("should be ignored") == true })
+    }
+
+    func testBranchModeWithNoParentHistoryThrows() {
+        XCTAssertThrowsError(try ChatSpawnAgentTranscriptBuilder.initialMessages(
+            arguments: makeArguments(task: "continue", mode: .branch),
+            parentMessages: []
+        )) { error in
+            guard case ChatSpawnAgentToolError.noParentHistory = error else {
+                return XCTFail("expected .noParentHistory, got \(error)")
+            }
+        }
+    }
+
+    private func makeArguments(
+        task: String,
+        mode: ChatSpawnAgentMode,
+        context: String? = nil,
+        modelID: String? = nil
+    ) -> ChatSpawnAgentToolArguments {
+        var json = "{\"task\":\"\(task)\",\"mode\":\"\(mode.rawValue)\""
+        if let context {
+            json += ",\"context\":\"\(context)\""
+        }
+        if let modelID {
+            json += ",\"model\":\"\(modelID)\""
+        }
+        json += "}"
+        return try! JSONDecoder().decode(ChatSpawnAgentToolArguments.self, from: Data(json.utf8))
+    }
+}
+
+final class ChatSpawnAgentToolExecutorTests: XCTestCase {
+    func testInvalidJSONArgumentsThrowsInvalidArguments() async {
+        do {
+            _ = try await ChatSpawnAgentToolExecutor().execute(
+                call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: "not json"),
+                context: makeContext()
+            )
+            XCTFail("malformed JSON arguments must throw")
+        } catch let error as ChatSpawnAgentToolError {
+            guard case .invalidArguments = error else {
+                return XCTFail("expected .invalidArguments, got \(error)")
+            }
+        } catch {
+            XCTFail("expected ChatSpawnAgentToolError, got \(error)")
+        }
+    }
+
+    func testBlankTaskThrowsEmptyTask() async {
+        do {
+            _ = try await ChatSpawnAgentToolExecutor().execute(
+                call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: #"{"task":"   "}"#),
+                context: makeContext()
+            )
+            XCTFail("a blank task must throw")
+        } catch let error as ChatSpawnAgentToolError {
+            guard case .emptyTask = error else {
+                return XCTFail("expected .emptyTask, got \(error)")
+            }
+        } catch {
+            XCTFail("expected ChatSpawnAgentToolError, got \(error)")
+        }
+    }
+
+    func testMissingSettingsThrowsModelUnavailable() async {
+        do {
+            _ = try await ChatSpawnAgentToolExecutor().execute(
+                call: makeCall(name: ChatSpawnAgentToolRegistry.toolName, arguments: #"{"task":"do it"}"#),
+                context: makeContext()
+            )
+            XCTFail("a context without settings must throw")
+        } catch let error as ChatSpawnAgentToolError {
+            guard case .modelUnavailable = error else {
+                return XCTFail("expected .modelUnavailable, got \(error)")
+            }
+        } catch {
+            XCTFail("expected ChatSpawnAgentToolError, got \(error)")
+        }
+    }
+
+    func testFailurePayloadShape() throws {
+        let payload = ChatSpawnAgentToolExecutor().failurePayload(error: FakeToolError())
+        let object = try decode(payload)
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["error"] as? String, "fake failure")
+        XCTAssertNil(object["answer"])
+    }
+
+    private func decode(_ json: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -205,6 +205,7 @@ targets:
         buildPhase: resources
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
+      - path: Sources/Nativ/Features/Chat/ChatAgentLoop.swift
       - path: Sources/Nativ/Features/Chat/ChatViewModel.swift
       - path: Sources/Nativ/Features/Chat/ChatConversationBranch.swift
       - path: Sources/Nativ/Features/Chat/ChatPromptRevision.swift
@@ -214,6 +215,7 @@ targets:
       - path: Sources/Nativ/Features/Chat/Tools/ChatListModelsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatServerStatsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatSwitchModelTool.swift
+      - path: Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatWebSearchTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatWebReadTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatReadFileTool.swift

--- a/project.yml
+++ b/project.yml
@@ -206,6 +206,7 @@ targets:
       - path: Sources/Nativ/Utilities/ShellEnvironment.swift
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
       - path: Sources/Nativ/Features/Chat/ChatAgentLoop.swift
+      - path: Sources/Nativ/Features/Chat/ChatAgentRegistry.swift
       - path: Sources/Nativ/Features/Chat/ChatViewModel.swift
       - path: Sources/Nativ/Features/Chat/ChatConversationBranch.swift
       - path: Sources/Nativ/Features/Chat/ChatPromptRevision.swift
@@ -216,6 +217,7 @@ targets:
       - path: Sources/Nativ/Features/Chat/Tools/ChatServerStatsTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatSwitchModelTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatSpawnAgentTool.swift
+      - path: Sources/Nativ/Features/Chat/Tools/ChatAgentRegistryTools.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatWebSearchTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatWebReadTool.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatReadFileTool.swift


### PR DESCRIPTION
This PR introduces the `spawn_agent()` tool, along with helper tools `list_agents()`, `check_agent()`, `steer_agent()`.

Agents can be spawned as a fork of the main agent (inheriting its context) or start with empty context. The main agent can choose to run sub-agents in the background or not (blocking vs. non-blocking).

## New tools

Adds 4 new tool schemas to the model's tool list, ~606 marginal prompt tokens (measured live against the server: baseline 13 tokens, +606 with just these 4 tools added, vs. +1,700 for all 13 native tools combined).

`spawn_agent(task, mode: fresh|branch, context, model, run_in_background)`: returns `{ok, agent_id, status, stop_reason, answer, error}`. If `run_in_background` is `false`, blocks until the sub-agent finishes and `status`/`answer` reflect its final result. If `true`, returns immediately with `status: "queued"` and no `answer` yet
- `task`: the sub-agent's instruction
- `mode`: `fresh` (default): starts with just the task. `branch`: clones this conversation's history first, then adds the task
- `context`: facts the sub-agent needs, without full history. Ignored in `branch` mode
- `model`: a downloaded model ID, e.g. `mlx-community/Qwen3-4B-4bit`. Omit to use the current model
- `run_in_background`: if true, returns an `agent_id` immediately instead of waiting. Check via `check_agent`/`list_agents`. Defaults to `false`

`list_agents()`: returns `{ok, agents: [{agent_id, task, status, stop_reason}]}`, one entry per sub-agent spawned this session

`check_agent(agent_id, wait)`: returns `{ok, agent_id, status, stop_reason, answer, error}` for the given agent
- `agent_id`: from `spawn_agent` or `list_agents`
- `wait`: block until the agent reaches a terminal state instead of returning its current status

`steer_agent(agent_id, message)`: returns `{ok, error}`. `ok: false` if the agent is unknown or already finished
- `agent_id`: from `spawn_agent` or `list_agents`
- `message`: queued into the running sub-agent, delivered at its next turn

Sub-agents cannot call any of the 4 tools above on themselves (recursive spawning is blocked, and they'd otherwise waste rounds calling `list_agents`/`check_agent` with fabricated IDs).

New Files:

| File | Purpose |
|---|---|
| `ChatSpawnAgentTool.swift` | `spawn_agent` tool schema + executor, two-phase `prepare()`/`run()` design so `run_in_background` can return immediately |
| `ChatAgentRegistryTools.swift` | `list_agents`/`check_agent`/`steer_agent` tool schemas + executors |
| `ChatAgentRegistry.swift` | `@MainActor` in-memory registry of spawned agents (status, result, cancel), owned by `ChatViewModel`, survives session switches but not app relaunch |
| `ChatAgentLoop.swift` | Sub-agent's own round-loop, including `subAgentToolDefinitions()` which filters out `switch_model`/`spawn_agent`/`list_agents`/`check_agent`/`steer_agent` |

Updated Files:

| File | Change |
|---|---|
| `ChatToolRegistry.swift` | Wiring for the 4 new tools into the model's tool list |
| `ChatSessionStore.swift` | Link up new sub-agent messages to the session store |
| `ChatViewModel.swift` | Edits `runChatLoop` so multiple sequential `spawn_agent` calls run in parallel, not sequentially: adds `runConcurrentSpawnAgentBatch` (blocking, `TaskGroup`-based, capped at 5 concurrent) and `startBackgroundSpawnAgent` (non-blocking, fire-and-forget) |
| `ChatView.swift` | New UI for showing sub-agent chats: per-sub-agent transcript view, live decode-metrics widget, and a stop/cancel button per running agent |
| `ChatToolRegistryTests.swift` | Coverage for all 4 tools, concurrent/background execution, and cancellation |

![spawn_agent multi-agent demo](https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/spawn-agent-multi-agent-demo.gif?raw=true)
Full quality: https://github.com/C-K-Loan/nativ/blob/demo-assets/demos/spawn-agent-multi-agent-demo.mp4

**Improvements left for follow up PRs:**
- Choose running sub-agents concurrently vs. sequentially. Depending on available resources, the optimal choice differs.
- Make the choice of tools available to sub-agents configurable in the UI; right now it's hardcoded in `ChatAgentLoop.swift`.
- For background sub-agent spawns, the main agent is never informed of completion and has to fetch results manually via `check_agent(id)`. Instead, we should resume the coordinator's turn as soon as a background agent finishes (queuing the resume if the coordinator is mid-turn), rather than waiting on the whole batch or requiring a manual poll.
- Investigate performance flakyness. Sometimes my sub-agents grinded with 20 tok/s sometimes 3 tok/s for the same prompt. Might be related to KV-Caching mechanisms, not sure
- Memory aware model spawns for sub-agents: spawn_agent() has no logic to dedicde if requested model actually fits before spawning it, it just fires a request.  https://github.com/Blaizzy/nativ/pull/268 has a draft implementation for this I would refactor and address after this is merged and once I have access to more URAM to properly test it :) 

