### PR TITLE
Separate shared and window scoped dependencies

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -64,8 +64,10 @@
 		252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
 		256B07A9158557D2E3AD2A35 /* Manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AF8F6359E4523814FB0EFDA /* Manifest.json */; };
 		25A5064ED5552EA7DC8A562F /* SafeLocalFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E56BA346D88CC58DE21D448 /* SafeLocalFileWriter.swift */; };
+		276CD3A0BBC5127714E407CA /* ControlPanelDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90494E1AE30EF515482DDBE7 /* ControlPanelDependencies.swift */; };
 		28197A70541BE1F1F482BCF4 /* PDFDocumentTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2C50E190D5DBA2E237FB2 /* PDFDocumentTextExtractor.swift */; };
 		28FA870CA6BE85C4BC41F77B /* FirecrawlBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195075F70CCB0E7DE02934DF /* FirecrawlBrowsingProvider.swift */; };
+		290E09A7AB40D3D4755EAE40 /* ControlPanelDependencyOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D567A929D30844940A94F4 /* ControlPanelDependencyOwnershipTests.swift */; };
 		293A976A334DFC98CFED82A0 /* SystemMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */; };
 		29AF2DBA578CF6446B782866 /* ControlPanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE6470BBA56F75D1F12FE09 /* ControlPanelNavigation.swift */; };
 		2A099D183B49ADF6E1170D4B /* ScheduledTaskChatLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCD9D4118F0B3580590998F /* ScheduledTaskChatLinker.swift */; };
@@ -97,12 +99,14 @@
 		37733336E268AC8DFE5AEC6C /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
 		388F4BD381D9732C614162C4 /* WebBrowsingRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254FDFBF7C5F7C8019E9E03F /* WebBrowsingRuntime.swift */; };
 		393DC62E524B83E0216268B8 /* AudioInputLevelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DDA5274474AC8D54DFDF71 /* AudioInputLevelMonitor.swift */; };
+		3977A640C42E111507073E2B /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEC2FFE7F1CFAC59170AC63 /* DashboardViewModel.swift */; };
 		39ADE4524CF22ED36D505546 /* NativExtensionHostBroker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586D3A7976823159DE5C00F9 /* NativExtensionHostBroker.swift */; };
 		39DF704E9F1D23E2F8248F02 /* LocalModelDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */; };
 		39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		3A4D3E1F9313D9896173130D /* VoiceShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */; };
 		3AA3A795AAD2F1EE33BECFCB /* NimbleBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32ECE279A81609EFF928C0D5 /* NimbleBrowsingProvider.swift */; };
 		3D7F718E2E136C35CD3509B4 /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
+		3D96ED3F0E463F75A47071C6 /* ArtifactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C2AB90FC12D1B83D6691F4 /* ArtifactStore.swift */; };
 		3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */; };
 		402FF67FA99A26739AA4A653 /* MCPCatalog.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C57E985705899CDD8DB5996 /* MCPCatalog.json */; };
 		40FAF7AC21743208E1C38AC2 /* WebBrowsingProviderClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E0214BE1D88EB4CDB66836 /* WebBrowsingProviderClient.swift */; };
@@ -128,6 +132,7 @@
 		4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B965B701714787B0A85AE6B /* AudioTests.swift */; };
 		4BD354A4C41C62B7F11E1686 /* WebSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2580C52ECE6D40D71E44463F /* WebSearchProvider.swift */; };
 		4CB31A9AACD344FA2CD1B6FD /* VoiceAnimationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632EB67BFAC2BCBE082A3E2B /* VoiceAnimationPreferences.swift */; };
+		4D68ADCC4BD23950C9E8F6FD /* LaunchAtLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */; };
 		4DB478CE9FB6079C7B55B097 /* DevHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E646A2A68BB20D0CD4933E2A /* DevHubView.swift */; };
 		4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */; };
 		4E81E2CBA8DBB61035A07C86 /* ChatDocumentExtractionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */; };
@@ -352,6 +357,7 @@
 		F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */; };
 		F9B4AAA3C467240C00807753 /* ChatReadFileToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */; };
+		FBF7379DD55C920F6D5C4197 /* ControlPanelDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90494E1AE30EF515482DDBE7 /* ControlPanelDependencies.swift */; };
 		FC65EA7675E8441D11372F9C /* ChatDocumentContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */; };
 		FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
 		FEAADABA1D25B153BE25E58F /* StatusMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85179B12862D6319C3F91027 /* StatusMenuController.swift */; };
@@ -457,6 +463,7 @@
 		141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPrimaryTaskResolver.swift; sourceTree = "<group>"; };
 		14F98763452E5A3BED006155 /* ChatFileWriteTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFileWriteTools.swift; sourceTree = "<group>"; };
 		1573A2D88784C9D404156D25 /* VoiceDictationExtensionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtensionRuntime.swift; sourceTree = "<group>"; };
+		18D567A929D30844940A94F4 /* ControlPanelDependencyOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelDependencyOwnershipTests.swift; sourceTree = "<group>"; };
 		195075F70CCB0E7DE02934DF /* FirecrawlBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirecrawlBrowsingProvider.swift; sourceTree = "<group>"; };
 		1A96F57099AE45BFC2F74E66 /* ControlPanelSidebarActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarActions.swift; sourceTree = "<group>"; };
 		1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubModelSizeResolver.swift; sourceTree = "<group>"; };
@@ -584,6 +591,7 @@
 		8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureCoordinator.swift; sourceTree = "<group>"; };
 		8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProviderTests.swift; sourceTree = "<group>"; };
 		90012E8ECF43A5A55BFD8787 /* RoutineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineSupport.swift; sourceTree = "<group>"; };
+		90494E1AE30EF515482DDBE7 /* ControlPanelDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelDependencies.swift; sourceTree = "<group>"; };
 		908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceCuratedModelLoaderTests.swift; sourceTree = "<group>"; };
 		9483127E124DE562AFFFAC94 /* ChatAttachmentValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentValidator.swift; sourceTree = "<group>"; };
 		96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativEmbeddingsClient.swift; sourceTree = "<group>"; };
@@ -1036,6 +1044,7 @@
 			isa = PBXGroup;
 			children = (
 				FD296E4B5897E7E46606B697 /* ControlPanelActions.swift */,
+				90494E1AE30EF515482DDBE7 /* ControlPanelDependencies.swift */,
 				03496D30CE58F138CA30EB0D /* ControlPanelDetail.swift */,
 				BDE6470BBA56F75D1F12FE09 /* ControlPanelNavigation.swift */,
 				1A96F57099AE45BFC2F74E66 /* ControlPanelSidebarActions.swift */,
@@ -1294,6 +1303,7 @@
 				7FE817B51A37BDB25AD26A11 /* ChatViewModelTests.swift */,
 				83D56A7BC388C8D6DEAEFA18 /* ChatWebReadToolTests.swift */,
 				AFA5142DB692E378ADE8DFA0 /* ChatWebSearchToolTests.swift */,
+				18D567A929D30844940A94F4 /* ControlPanelDependencyOwnershipTests.swift */,
 				DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */,
 				06D5CBFB467AADEE51EE098E /* DocumentTextExtractionTests.swift */,
 				1F39043C3E9B07A5EC3B7688 /* FormattingTests.swift */,
@@ -1643,6 +1653,7 @@
 				BF5A1AD007F259A2F926AF57 /* ChatWorkspacePicker.swift in Sources */,
 				FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */,
 				5196EA3B5CC4CE166899FE19 /* ControlPanelActions.swift in Sources */,
+				276CD3A0BBC5127714E407CA /* ControlPanelDependencies.swift in Sources */,
 				C8EA1C08FDDD7F0AF87C2E47 /* ControlPanelDetail.swift in Sources */,
 				29AF2DBA578CF6446B782866 /* ControlPanelNavigation.swift in Sources */,
 				C04192DCEE3B50535BE6E83D /* ControlPanelSidebarActions.swift in Sources */,
@@ -1774,6 +1785,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				145464A2B098437667795AFB /* Artifact.swift in Sources */,
+				3D96ED3F0E463F75A47071C6 /* ArtifactStore.swift in Sources */,
 				AB1C4B8494B46754E6E8BE24 /* AudioAnalyticsStore.swift in Sources */,
 				01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */,
 				393DC62E524B83E0216268B8 /* AudioInputLevelMonitor.swift in Sources */,
@@ -1813,8 +1825,11 @@
 				A9A3CE3DEBA182260722FEA8 /* ChatWebSearchTool.swift in Sources */,
 				FEB97639F6A1334E409830CF /* ChatWebSearchToolTests.swift in Sources */,
 				1C6295D830FE941FDCE3ECCC /* CodexCLIProfile.swift in Sources */,
+				FBF7379DD55C920F6D5C4197 /* ControlPanelDependencies.swift in Sources */,
+				290E09A7AB40D3D4755EAE40 /* ControlPanelDependencyOwnershipTests.swift in Sources */,
 				44F8A17BDE2610C6E90CE53F /* CustomTool.swift in Sources */,
 				AB4C49A5BFDAA9352BD257B7 /* CustomToolTests.swift in Sources */,
+				3977A640C42E111507073E2B /* DashboardViewModel.swift in Sources */,
 				4944DC4357DA195C1E8D8B75 /* DocumentTextExtraction.swift in Sources */,
 				487C0D234A1B2F700F3BB5DA /* DocumentTextExtractionTests.swift in Sources */,
 				9FC9DFAEC00710427FDD509C /* ExaBrowsingProvider.swift in Sources */,
@@ -1842,6 +1857,7 @@
 				41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */,
 				351B2202E8690FC608A32AEF /* IntegrationServicesTests.swift in Sources */,
 				F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */,
+				4D68ADCC4BD23950C9E8F6FD /* LaunchAtLoginController.swift in Sources */,
 				39DF704E9F1D23E2F8248F02 /* LocalModelDiscovery.swift in Sources */,
 				4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */,
 				4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */,

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
         builtInExtensions: [voiceDictationExtension]
     )
     private let controlPanelNavigation = ControlPanelNavigation()
+    private let controlPanelSharedDependencies = ControlPanelSharedDependencies()
     private let runtime = SystemRuntimeMonitor()
     private let routineStore = RoutineStore.shared
     private let routineSessionStore = ChatSessionStore()
@@ -129,13 +130,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
         model.applicationWillTerminate()
     }
 
-    var rootView: some View {
+    func makeControlPanelDependencies() -> ControlPanelDependencies {
+        ControlPanelDependencies(shared: controlPanelSharedDependencies)
+    }
+
+    func rootView(controlPanelDependencies: ControlPanelDependencies) -> some View {
         WelcomeGateView(
             model: model,
             navigation: controlPanelNavigation,
             runtime: runtime,
             extensionManager: extensionManager,
             softwareUpdater: softwareUpdater,
+            controlPanelDependencies: controlPanelDependencies,
             onComplete: { [weak self] modelID, serverAPIKey in
                 self?.completeWelcome(modelID: modelID, serverAPIKey: serverAPIKey)
             }

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@MainActor
+final class ControlPanelSharedDependencies {
+    let mcpHost = MCPHostManager()
+    let systemMonitor = SystemMonitorStore()
+    let launchAtLogin = LaunchAtLoginController()
+}
+
+@MainActor
+final class ControlPanelDependencies: ObservableObject {
+    let mcpHost: MCPHostManager
+    let systemMonitor: SystemMonitorStore
+    let launchAtLogin: LaunchAtLoginController
+
+    lazy var chat = ChatViewModel()
+    lazy var imageGeneration = ImageGenerationViewModel()
+    lazy var artifacts = ArtifactStore()
+    lazy var dashboard = DashboardViewModel()
+    lazy var downloads = HuggingFaceDownloadManager.shared
+    lazy var embeddingLibrary = LocalModelLibrary()
+    lazy var routineModelLibrary = LocalModelLibrary()
+
+    init(shared: ControlPanelSharedDependencies = .init()) {
+        mcpHost = shared.mcpHost
+        systemMonitor = shared.systemMonitor
+        launchAtLogin = shared.launchAtLogin
+    }
+}

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelState.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelState.swift
@@ -6,20 +6,6 @@ import Observation
 import SwiftUI
 import UniformTypeIdentifiers
 
-@MainActor
-final class ControlPanelDependencies: ObservableObject {
-    lazy var chat = ChatViewModel()
-    lazy var mcpHost = MCPHostManager()
-    lazy var imageGeneration = ImageGenerationViewModel()
-    lazy var artifacts = ArtifactStore()
-    lazy var dashboard = DashboardViewModel()
-    lazy var systemMonitor = SystemMonitorStore()
-    lazy var launchAtLogin = LaunchAtLoginController()
-    lazy var downloads = HuggingFaceDownloadManager.shared
-    lazy var embeddingLibrary = LocalModelLibrary()
-    lazy var routineModelLibrary = LocalModelLibrary()
-}
-
 /// Filters `NativModel` down to values that can change control-panel chrome.
 @MainActor
 final class ControlPanelChromeState: ObservableObject {

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -180,10 +180,18 @@ private struct NativApplication: App {
 private struct NativRootView: View {
     @Environment(\.openWindow) private var openWindow
     @AppStorage(AppAppearance.storageKey) private var appearance = AppAppearance.system
+    @StateObject private var controlPanelDependencies: ControlPanelDependencies
     let appDelegate: AppDelegate
 
+    init(appDelegate: AppDelegate) {
+        self.appDelegate = appDelegate
+        _controlPanelDependencies = StateObject(
+            wrappedValue: appDelegate.makeControlPanelDependencies()
+        )
+    }
+
     var body: some View {
-        appDelegate.rootView
+        appDelegate.rootView(controlPanelDependencies: controlPanelDependencies)
             .onAppear {
                 applyAppearance(appearance)
                 appDelegate.registerMainWindowOpener {

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -15,13 +15,13 @@ enum WelcomePreferences {
 
 struct WelcomeGateView: View {
     @AppStorage(WelcomePreferences.completionKey) private var hasCompletedWelcome = false
-    @StateObject private var controlPanelDependencies = ControlPanelDependencies()
 
     let model: NativModel
     let navigation: ControlPanelNavigation
     let runtime: SystemRuntimeMonitor
     let extensionManager: NativExtensionManager
     let softwareUpdater: SoftwareUpdater
+    let controlPanelDependencies: ControlPanelDependencies
     let onComplete: (_ modelID: String?, _ serverAPIKey: String?) -> Void
 
     var body: some View {

--- a/Tests/NativTests/ControlPanelDependencyOwnershipTests.swift
+++ b/Tests/NativTests/ControlPanelDependencyOwnershipTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+@MainActor
+final class ControlPanelDependencyOwnershipTests: XCTestCase {
+    func testApplicationDependenciesAreSharedAcrossControlPanels() {
+        let shared = ControlPanelSharedDependencies()
+        let first = ControlPanelDependencies(shared: shared)
+        let second = ControlPanelDependencies(shared: shared)
+
+        XCTAssertTrue(first.mcpHost === second.mcpHost)
+        XCTAssertTrue(first.systemMonitor === second.systemMonitor)
+        XCTAssertTrue(first.launchAtLogin === second.launchAtLogin)
+        XCTAssertTrue(first.downloads === second.downloads)
+    }
+
+    func testControlPanelStateIsIndependent() {
+        let shared = ControlPanelSharedDependencies()
+        let first = ControlPanelDependencies(shared: shared)
+        let second = ControlPanelDependencies(shared: shared)
+
+        XCTAssertFalse(first.chat === second.chat)
+        XCTAssertFalse(first.imageGeneration === second.imageGeneration)
+        XCTAssertFalse(first.artifacts === second.artifacts)
+        XCTAssertFalse(first.dashboard === second.dashboard)
+        XCTAssertFalse(first.embeddingLibrary === second.embeddingLibrary)
+        XCTAssertFalse(first.routineModelLibrary === second.routineModelLibrary)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -252,6 +252,9 @@ targets:
       - path: Sources/Nativ/Features/Chat/ChatDocumentExtractionCache.swift
       - path: Sources/Nativ/Features/Chat/ChatDocumentContextBuilder.swift
       - path: Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+      - path: Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
+      - path: Sources/Nativ/Features/Artifacts/ArtifactStore.swift
+      - path: Sources/Nativ/Features/Dashboard/DashboardViewModel.swift
       - path: Sources/Nativ/Features/SystemMonitor/SystemMonitorStore.swift
       - path: Sources/Nativ/Features/SystemMonitor/SystemSensorSampler.swift
       - path: Sources/Nativ/Features/Dashboard/NativAnalyticsStore.swift
@@ -264,6 +267,7 @@ targets:
       - path: Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
       - path: Sources/Nativ/Features/Chat/ChatScreenCapture.swift
       - path: Sources/Nativ/Features/MCP/MCPHostManager.swift
+      - path: Sources/Nativ/Utilities/LaunchAtLoginController.swift
       - path: Sources/Nativ/Features/Routines/Routine.swift
       - path: Sources/Nativ/Features/Routines/RoutineStore.swift
     dependencies:


### PR DESCRIPTION
This is the second PR in the multi window stack and builds on #429. Separates application-wide services from state that should belong to an individual window, and adds tests covering which dependencies are shared and which remain independent.