### PR TITLE
Synchronize persisted data across windows

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		3A4D3E1F9313D9896173130D /* VoiceShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */; };
 		3AA3A795AAD2F1EE33BECFCB /* NimbleBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32ECE279A81609EFF928C0D5 /* NimbleBrowsingProvider.swift */; };
+		3C612817DDB7C3800F41F61C /* PersistedDataChangeHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C870DD5A3B825D12BC04EB9D /* PersistedDataChangeHubTests.swift */; };
 		3D7F718E2E136C35CD3509B4 /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
 		3D96ED3F0E463F75A47071C6 /* ArtifactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C2AB90FC12D1B83D6691F4 /* ArtifactStore.swift */; };
 		3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */; };
@@ -182,6 +183,8 @@
 		71659335E55225ABCBB4E993 /* IssueReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46B388273DDFAD7C6C0F4E1 /* IssueReport.swift */; };
 		727CB29E8AF1A50C063FD972 /* ServerProcessEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055942EFAB585BE493AC9AD7 /* ServerProcessEnvironmentTests.swift */; };
 		732D29870D9B330A520DF15C /* NativEmbeddingsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96185929F990EA1470079AAB /* NativEmbeddingsClient.swift */; };
+		737E5B6221479CF7117F1107 /* PersistedDataChangeHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B94192425D46A59F516118 /* PersistedDataChangeHub.swift */; };
+		73C9A87201509AF2D0213485 /* PersistedDataChangeHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B94192425D46A59F516118 /* PersistedDataChangeHub.swift */; };
 		751C105813095FEC67349FBB /* NativNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577B24B3B022E78F7664C76E /* NativNotificationService.swift */; };
 		759391363423D786EF850BE3 /* RoutineEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */; };
 		76DA7BB4EB87C407B55D5E05 /* ChatAttachmentKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEE7582DCB286B9D878E28E /* ChatAttachmentKind.swift */; };
@@ -645,6 +648,8 @@
 		C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscoveryTests.swift; sourceTree = "<group>"; };
 		C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSwitchModelTool.swift; sourceTree = "<group>"; };
 		C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTool.swift; sourceTree = "<group>"; };
+		C870DD5A3B825D12BC04EB9D /* PersistedDataChangeHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedDataChangeHubTests.swift; sourceTree = "<group>"; };
+		C8B94192425D46A59F516118 /* PersistedDataChangeHub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedDataChangeHub.swift; sourceTree = "<group>"; };
 		C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolRegistryTests.swift; sourceTree = "<group>"; };
 		CCB2C50E190D5DBA2E237FB2 /* PDFDocumentTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentTextExtractor.swift; sourceTree = "<group>"; };
 		CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTypes.swift; sourceTree = "<group>"; };
@@ -1284,6 +1289,7 @@
 			isa = PBXGroup;
 			children = (
 				20EE1CE9AAE5A3B9A2D4669C /* NativComponents.swift */,
+				C8B94192425D46A59F516118 /* PersistedDataChangeHub.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1324,6 +1330,7 @@
 				982F3BB563023885587DC860 /* NativNotificationTests.swift */,
 				E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */,
 				8513AE482EB6C3113080826A /* PDFDocumentTextExtractorTests.swift */,
+				C870DD5A3B825D12BC04EB9D /* PersistedDataChangeHubTests.swift */,
 				C01D6D1C8C321F16B5FD31F8 /* RealtimeAudioMeterTests.swift */,
 				FB10CC03A96A3EA80EF9343B /* ScheduledCapabilityTests.swift */,
 				0DBC23C0369758C056A8182D /* ScheduledTaskChatLinkerTests.swift */,
@@ -1728,6 +1735,7 @@
 				28197A70541BE1F1F482BCF4 /* PDFDocumentTextExtractor.swift in Sources */,
 				C4A766A43FD62815D056BD93 /* ParallelBrowsingProvider.swift in Sources */,
 				03B0228F483C7F76742D5245 /* PerplexityBrowsingProvider.swift in Sources */,
+				73C9A87201509AF2D0213485 /* PersistedDataChangeHub.swift in Sources */,
 				E407C7F9CE883C978DE7D716 /* PersistentMenuActionView.swift in Sources */,
 				C03F87BD5E8649BBF42B35EE /* PowerPointDocumentTextExtractor.swift in Sources */,
 				330070AC18DC9F0752EB7138 /* RealtimeAudioMeter.swift in Sources */,
@@ -1892,6 +1900,8 @@
 				0B5170A046C3C587DE077072 /* PDFDocumentTextExtractorTests.swift in Sources */,
 				E0B07216A3D3638AA5FAA059 /* ParallelBrowsingProvider.swift in Sources */,
 				95711758521BCF469B48481E /* PerplexityBrowsingProvider.swift in Sources */,
+				737E5B6221479CF7117F1107 /* PersistedDataChangeHub.swift in Sources */,
+				3C612817DDB7C3800F41F61C /* PersistedDataChangeHubTests.swift in Sources */,
 				EE06C225BEBDD9D572B62A54 /* PowerPointDocumentTextExtractor.swift in Sources */,
 				2CA1076EA0874C55E7BB14B2 /* RealtimeAudioMeter.swift in Sources */,
 				D2D5168B1A4243EB55EB1D68 /* RealtimeAudioMeterTests.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -80,6 +80,8 @@ final class ChatViewModel: ObservableObject {
         [UUID: ChatImageModelSelectionRequest] = [:]
 
     private let sessionStore = ChatSessionStore()
+    private let windowID: UUID
+    private let persistedDataChanges: PersistedDataChangeHub
     private let documentContextBuilder: ChatDocumentContextBuilder
     private let attachmentValidator: ChatAttachmentValidator
     private var sessionLoadTask: Task<Void, Never>?
@@ -103,8 +105,15 @@ final class ChatViewModel: ObservableObject {
     private var imageModelRefreshTask: Task<Void, Never>?
     private var composerSnapshot: ComposerSnapshot?
     private var attachmentValidationTasks: [UUID: Task<Void, Never>] = [:]
+    private var persistedDataChangeCancellable: AnyCancellable?
+    private var needsPersistedSessionReload = false
 
-    init() {
+    init(
+        windowID: UUID = UUID(),
+        persistedDataChanges: PersistedDataChangeHub = .init()
+    ) {
+        self.windowID = windowID
+        self.persistedDataChanges = persistedDataChanges
         let documentExtractionCache = ChatDocumentExtractionCache()
         documentContextBuilder = ChatDocumentContextBuilder(
             extractionCache: documentExtractionCache
@@ -132,6 +141,10 @@ final class ChatViewModel: ObservableObject {
             guard let self, !Task.isCancelled else { return }
             finishLoadingSessions(bootstrap)
         }
+        persistedDataChangeCancellable = persistedDataChanges.changes
+            .sink { [weak self] change in
+                self?.handlePersistedDataChange(change)
+            }
     }
 
     deinit {
@@ -321,7 +334,7 @@ final class ChatViewModel: ObservableObject {
         persistCurrentSession(updateTimestamp: false)
         storedSessions.append(session)
         pruneRedundantEmptySessions()
-        sessionStore.saveSession(session)
+        saveSession(session)
         discardPromptEditing()
         draft = ""
         pendingImageAttachments.removeAll()
@@ -351,7 +364,7 @@ final class ChatViewModel: ObservableObject {
             session.messages[index].imageAttachments.removeAll { $0.id == attachmentID }
         }
         upsertStoredSession(session)
-        sessionStore.saveSession(session)
+        saveSession(session)
         refreshSessionList()
     }
 
@@ -388,7 +401,7 @@ final class ChatViewModel: ObservableObject {
         if currentSession?.id == sessionID {
             currentSession?.customTitle = trimmed.isEmpty ? nil : trimmed
         }
-        sessionStore.saveSession(storedSessions[index])
+        saveSession(storedSessions[index])
         refreshSessionList()
     }
 
@@ -403,7 +416,7 @@ final class ChatViewModel: ObservableObject {
             currentSession?.pinned = pinned
             currentSession?.pinnedOrder = order
         }
-        sessionStore.saveSession(storedSessions[index])
+        saveSession(storedSessions[index])
         refreshSessionList()
     }
 
@@ -412,7 +425,7 @@ final class ChatViewModel: ObservableObject {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let folder = ChatFolder(name: trimmed.isEmpty ? "New Folder" : trimmed, isCollapsed: true)
         folders.append(folder)
-        sessionStore.saveFolders(folders)
+        saveFolders()
         return folder.id
     }
 
@@ -425,15 +438,15 @@ final class ChatViewModel: ObservableObject {
             return
         }
         folders[index].name = trimmed
-        sessionStore.saveFolders(folders)
+        saveFolders()
     }
 
     func deleteFolder(_ folderID: UUID) {
         folders.removeAll { $0.id == folderID }
-        sessionStore.saveFolders(folders)
+        saveFolders()
         for index in storedSessions.indices where storedSessions[index].folderID == folderID {
             storedSessions[index].folderID = nil
-            sessionStore.saveSession(storedSessions[index])
+            saveSession(storedSessions[index])
         }
         if currentSession?.folderID == folderID {
             currentSession?.folderID = nil
@@ -446,7 +459,7 @@ final class ChatViewModel: ObservableObject {
             return
         }
         folders[index].isCollapsed = collapsed
-        sessionStore.saveFolders(folders)
+        saveFolders()
     }
 
     func setAllFoldersCollapsed(_ collapsed: Bool) {
@@ -456,7 +469,7 @@ final class ChatViewModel: ObservableObject {
         for index in folders.indices {
             folders[index].isCollapsed = collapsed
         }
-        sessionStore.saveFolders(folders)
+        saveFolders()
     }
 
     func moveSession(_ sessionID: UUID, toFolder folderID: UUID?) {
@@ -467,7 +480,7 @@ final class ChatViewModel: ObservableObject {
         if currentSession?.id == sessionID {
             currentSession?.folderID = folderID
         }
-        sessionStore.saveSession(storedSessions[index])
+        saveSession(storedSessions[index])
         refreshSessionList()
     }
 
@@ -476,7 +489,7 @@ final class ChatViewModel: ObservableObject {
             return
         }
         folders[index].isPinned = pinned
-        sessionStore.saveFolders(folders)
+        saveFolders()
     }
 
     func applyFolderOrder(_ orderedFolderIDs: [UUID]) {
@@ -490,7 +503,7 @@ final class ChatViewModel: ObservableObject {
             reordered.append(folder)
         }
         folders = reordered
-        sessionStore.saveFolders(folders)
+        saveFolders()
     }
 
     func applyPinnedOrder(_ orderedSessionIDs: [UUID]) {
@@ -504,7 +517,7 @@ final class ChatViewModel: ObservableObject {
                 currentSession?.pinned = true
                 currentSession?.pinnedOrder = order
             }
-            sessionStore.saveSession(storedSessions[index])
+            saveSession(storedSessions[index])
         }
         refreshSessionList()
     }
@@ -522,7 +535,7 @@ final class ChatViewModel: ObservableObject {
                 currentSession?.pinnedOrder = nil
                 currentSession?.sessionOrder = order
             }
-            sessionStore.saveSession(storedSessions[index])
+            saveSession(storedSessions[index])
         }
         refreshSessionList()
     }
@@ -540,7 +553,7 @@ final class ChatViewModel: ObservableObject {
 
         storedSessions.removeAll { $0.id == sessionID }
         RoutineStore.shared.detachSession(sessionID)
-        sessionStore.deleteSession(id: sessionID)
+        deletePersistedSession(sessionID)
         pruneRedundantEmptySessions()
 
         guard sessionID == currentSessionID else {
@@ -581,7 +594,7 @@ final class ChatViewModel: ObservableObject {
                     from: storedSessions[index]
                 )
                 storedSessions[index] = session
-                sessionStore.saveSession(session)
+                saveSession(session)
                 if currentSession?.id == session.id {
                     currentSession = session
                 }
@@ -2383,6 +2396,12 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func finishLoadingSessions(_ bootstrap: ChatSessionBootstrap) {
+        defer {
+            if needsPersistedSessionReload {
+                needsPersistedSessionReload = false
+                reloadPersistedSessions(preservingCurrentIfMissing: false)
+            }
+        }
         let localSession = currentSession
         let localSessionHasWork =
             localSession.map { session in
@@ -2409,7 +2428,7 @@ final class ChatViewModel: ObservableObject {
             applyCurrentSession(latestSession)
         } else if let localSession {
             storedSessions = [localSession]
-            sessionStore.saveSession(localSession)
+            saveSession(localSession)
             refreshSessionList()
         } else {
             createSession()
@@ -2448,7 +2467,7 @@ final class ChatViewModel: ObservableObject {
 
         currentSession = session
         upsertStoredSession(session)
-        sessionStore.saveSession(session)
+        saveSession(session)
         refreshSessionList()
     }
 
@@ -2470,7 +2489,7 @@ final class ChatViewModel: ObservableObject {
         pendingImageAttachments = composer?.attachments ?? []
         discardPromptEditing()
         upsertStoredSession(branch)
-        sessionStore.saveSession(branch)
+        saveSession(branch)
         applyCurrentSession(branch)
     }
 
@@ -2491,28 +2510,73 @@ final class ChatViewModel: ObservableObject {
         if updateTimestamp {
             storedSessions[index].updatedAt = Date()
         }
-        sessionStore.saveSession(storedSessions[index])
+        saveSession(storedSessions[index])
         refreshSessionList()
     }
 
     func reloadPersistedSessions() {
+        reloadPersistedSessions(preservingCurrentIfMissing: true)
+    }
+
+    private func reloadPersistedSessions(preservingCurrentIfMissing: Bool) {
         guard !isLoadingSessions else {
             return
         }
         storedSessions = sessionStore.loadSessions()
-        if let currentSession,
-            !storedSessions.contains(where: { $0.id == currentSession.id })
-        {
-            upsertStoredSession(currentSession)
-        }
-        if let id = currentSessionID,
-            activeRequestSessionID != id,
-            let fresh = storedSessions.first(where: { $0.id == id }),
-            fresh.messages.count != messages.count
-        {
-            applyCurrentSession(fresh)
+        if let currentSession {
+            if let fresh = storedSessions.first(where: { $0.id == currentSession.id }) {
+                if activeRequestSessionID != currentSession.id, fresh != currentSession {
+                    applyCurrentSession(fresh)
+                }
+            } else if preservingCurrentIfMissing || activeRequestSessionID == currentSession.id {
+                upsertStoredSession(currentSession)
+            } else {
+                discardPromptEditing()
+                draft = ""
+                pendingImageAttachments.removeAll()
+                if let replacement = storedSessions.sorted(by: ChatSession.recencySort).first {
+                    applyCurrentSession(replacement)
+                } else {
+                    currentSessionID = nil
+                    messages = []
+                    self.currentSession = nil
+                    createSession()
+                }
+            }
         }
         refreshSessionList()
+    }
+
+    private func handlePersistedDataChange(_ change: PersistedDataChange) {
+        guard change.originWindowID != windowID else { return }
+
+        switch change.kind {
+        case .chatSession:
+            if isLoadingSessions {
+                needsPersistedSessionReload = true
+            } else {
+                reloadPersistedSessions(preservingCurrentIfMissing: false)
+            }
+        case .chatFolders:
+            folders = sessionStore.loadFolders()
+        case .imageGenerationSession:
+            break
+        }
+    }
+
+    private func saveSession(_ session: ChatSession) {
+        sessionStore.saveSession(session)
+        persistedDataChanges.send(.chatSession(session.id), originWindowID: windowID)
+    }
+
+    private func deletePersistedSession(_ sessionID: UUID) {
+        sessionStore.deleteSession(id: sessionID)
+        persistedDataChanges.send(.chatSession(sessionID), originWindowID: windowID)
+    }
+
+    private func saveFolders() {
+        sessionStore.saveFolders(folders)
+        persistedDataChanges.send(.chatFolders, originWindowID: windowID)
     }
 
     private func upsertStoredSession(_ session: ChatSession) {
@@ -2567,7 +2631,7 @@ final class ChatViewModel: ObservableObject {
         storedSessions = keptSessions
         for sessionID in removedSessionIDs {
             RoutineStore.shared.detachSession(sessionID)
-            sessionStore.deleteSession(id: sessionID)
+            deletePersistedSession(sessionID)
         }
     }
 }

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
@@ -5,6 +5,7 @@ final class ControlPanelSharedDependencies {
     let mcpHost = MCPHostManager()
     let systemMonitor = SystemMonitorStore()
     let launchAtLogin = LaunchAtLoginController()
+    let persistedDataChanges = PersistedDataChangeHub()
 }
 
 @MainActor
@@ -12,18 +13,31 @@ final class ControlPanelDependencies: ObservableObject {
     let mcpHost: MCPHostManager
     let systemMonitor: SystemMonitorStore
     let launchAtLogin: LaunchAtLoginController
+    let windowID: UUID
+    let persistedDataChanges: PersistedDataChangeHub
 
-    lazy var chat = ChatViewModel()
-    lazy var imageGeneration = ImageGenerationViewModel()
+    lazy var chat = ChatViewModel(
+        windowID: windowID,
+        persistedDataChanges: persistedDataChanges
+    )
+    lazy var imageGeneration = ImageGenerationViewModel(
+        windowID: windowID,
+        persistedDataChanges: persistedDataChanges
+    )
     lazy var artifacts = ArtifactStore()
     lazy var dashboard = DashboardViewModel()
     lazy var downloads = HuggingFaceDownloadManager.shared
     lazy var embeddingLibrary = LocalModelLibrary()
     lazy var routineModelLibrary = LocalModelLibrary()
 
-    init(shared: ControlPanelSharedDependencies = .init()) {
+    init(
+        shared: ControlPanelSharedDependencies = .init(),
+        windowID: UUID = UUID()
+    ) {
         mcpHost = shared.mcpHost
         systemMonitor = shared.systemMonitor
         launchAtLogin = shared.launchAtLogin
+        self.windowID = windowID
+        persistedDataChanges = shared.persistedDataChanges
     }
 }

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -166,17 +166,25 @@ final class ImageGenerationViewModel: ObservableObject {
     @Published private(set) var scrollToken = 0
 
     private let sessionStore = ImageGenerationSessionStore()
+    private let windowID: UUID
+    private let persistedDataChanges: PersistedDataChangeHub
     private var activeTask: Task<Void, Never>?
     private var activeTurnID: UUID?
     private var storedSessions: [ImageGenerationSession] = []
     private var currentSession: ImageGenerationSession?
+    private var persistedDataChangeCancellable: AnyCancellable?
 
     private let imageSizeMultiple = 16
     private let minImageDimension = 64
     private let maxRequestDimension = 4_096
     private let maxAutoEditLongestSide = 2_048
 
-    init() {
+    init(
+        windowID: UUID = UUID(),
+        persistedDataChanges: PersistedDataChangeHub = .init()
+    ) {
+        self.windowID = windowID
+        self.persistedDataChanges = persistedDataChanges
         storedSessions = sessionStore.loadSessions().map { session in
             var repaired = session
             for index in repaired.turns.indices where repaired.turns[index].status == .inProgress {
@@ -187,6 +195,10 @@ final class ImageGenerationViewModel: ObservableObject {
         }
 
         refreshSessionList()
+        persistedDataChangeCancellable = persistedDataChanges.changes
+            .sink { [weak self] change in
+                self?.handlePersistedDataChange(change)
+            }
     }
 
     deinit {
@@ -308,7 +320,7 @@ final class ImageGenerationViewModel: ObservableObject {
         }
 
         storedSessions.removeAll { $0.id == sessionID }
-        sessionStore.deleteSession(id: sessionID)
+        deletePersistedSession(sessionID)
 
         guard sessionID == currentSessionID else {
             refreshSessionList()
@@ -722,7 +734,7 @@ final class ImageGenerationViewModel: ObservableObject {
             session.turns[turnIndex].outputs.removeAll { $0.id == outputID }
         }
         upsertStoredSession(session)
-        sessionStore.saveSession(session)
+        saveSession(session)
         refreshSessionList()
     }
 
@@ -746,7 +758,7 @@ final class ImageGenerationViewModel: ObservableObject {
 
         currentSession = session
         upsertStoredSession(session)
-        sessionStore.saveSession(session)
+        saveSession(session)
         refreshSessionList()
     }
 
@@ -762,6 +774,53 @@ final class ImageGenerationViewModel: ObservableObject {
         sessions = storedSessions
             .map(\.summary)
             .sorted(by: ImageGenerationSessionSummary.recencySort)
+    }
+
+    private func handlePersistedDataChange(_ change: PersistedDataChange) {
+        guard change.originWindowID != windowID else { return }
+        guard case .imageGenerationSession = change.kind else { return }
+
+        storedSessions = sessionStore.loadSessions()
+        if let currentSession {
+            if let fresh = storedSessions.first(where: { $0.id == currentSession.id }) {
+                if !isGenerating, fresh != currentSession {
+                    applyCurrentSession(fresh)
+                }
+            } else if !isGenerating {
+                prompt = ""
+                pendingImageAttachments.removeAll()
+                if let replacement = storedSessions.sorted(
+                    by: ImageGenerationSession.recencySort
+                ).first {
+                    applyCurrentSession(replacement)
+                } else {
+                    self.currentSession = nil
+                    currentSessionID = nil
+                    turns = []
+                    activeReference = nil
+                    statusText = nil
+                }
+            } else {
+                upsertStoredSession(currentSession)
+            }
+        }
+        refreshSessionList()
+    }
+
+    private func saveSession(_ session: ImageGenerationSession) {
+        sessionStore.saveSession(session)
+        persistedDataChanges.send(
+            .imageGenerationSession(session.id),
+            originWindowID: windowID
+        )
+    }
+
+    private func deletePersistedSession(_ sessionID: UUID) {
+        sessionStore.deleteSession(id: sessionID)
+        persistedDataChanges.send(
+            .imageGenerationSession(sessionID),
+            originWindowID: windowID
+        )
     }
 
     private func bumpScroll() {

--- a/Sources/Nativ/Features/Shared/PersistedDataChangeHub.swift
+++ b/Sources/Nativ/Features/Shared/PersistedDataChangeHub.swift
@@ -1,0 +1,22 @@
+import Combine
+import Foundation
+
+struct PersistedDataChange: Equatable {
+    enum Kind: Equatable {
+        case chatSession(UUID)
+        case chatFolders
+        case imageGenerationSession(UUID)
+    }
+
+    let originWindowID: UUID
+    let kind: Kind
+}
+
+@MainActor
+final class PersistedDataChangeHub {
+    let changes = PassthroughSubject<PersistedDataChange, Never>()
+
+    func send(_ kind: PersistedDataChange.Kind, originWindowID: UUID) {
+        changes.send(PersistedDataChange(originWindowID: originWindowID, kind: kind))
+    }
+}

--- a/Tests/NativTests/ControlPanelDependencyOwnershipTests.swift
+++ b/Tests/NativTests/ControlPanelDependencyOwnershipTests.swift
@@ -10,7 +10,19 @@ final class ControlPanelDependencyOwnershipTests: XCTestCase {
         XCTAssertTrue(first.mcpHost === second.mcpHost)
         XCTAssertTrue(first.systemMonitor === second.systemMonitor)
         XCTAssertTrue(first.launchAtLogin === second.launchAtLogin)
+        XCTAssertTrue(first.persistedDataChanges === second.persistedDataChanges)
         XCTAssertTrue(first.downloads === second.downloads)
+    }
+
+    func testControlPanelsReceiveDistinctWindowIdentifiers() {
+        let firstWindowID = UUID()
+        let secondWindowID = UUID()
+
+        let first = ControlPanelDependencies(windowID: firstWindowID)
+        let second = ControlPanelDependencies(windowID: secondWindowID)
+
+        XCTAssertEqual(first.windowID, firstWindowID)
+        XCTAssertEqual(second.windowID, secondWindowID)
     }
 
     func testControlPanelStateIsIndependent() {

--- a/Tests/NativTests/PersistedDataChangeHubTests.swift
+++ b/Tests/NativTests/PersistedDataChangeHubTests.swift
@@ -1,0 +1,33 @@
+import Combine
+import XCTest
+
+@MainActor
+final class PersistedDataChangeHubTests: XCTestCase {
+    func testBroadcastsPersistedChangesWithTheirOrigin() {
+        let subject = PersistedDataChangeHub()
+        let originWindowID = UUID()
+        let chatSessionID = UUID()
+        let imageSessionID = UUID()
+        var receivedChanges: [PersistedDataChange] = []
+        let cancellable = subject.changes.sink { change in
+            receivedChanges.append(change)
+        }
+
+        subject.send(.chatSession(chatSessionID), originWindowID: originWindowID)
+        subject.send(.chatFolders, originWindowID: originWindowID)
+        subject.send(.imageGenerationSession(imageSessionID), originWindowID: originWindowID)
+
+        XCTAssertEqual(receivedChanges, [
+            PersistedDataChange(
+                originWindowID: originWindowID,
+                kind: .chatSession(chatSessionID)
+            ),
+            PersistedDataChange(originWindowID: originWindowID, kind: .chatFolders),
+            PersistedDataChange(
+                originWindowID: originWindowID,
+                kind: .imageGenerationSession(imageSessionID)
+            ),
+        ])
+        withExtendedLifetime(cancellable) {}
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -263,6 +263,7 @@ targets:
       - path: Sources/Nativ/Utilities/Formatting.swift
       - path: Sources/Nativ/Utilities/MarkdownFormatting.swift
       - path: Sources/Nativ/Features/Shared/NativComponents.swift
+      - path: Sources/Nativ/Features/Shared/PersistedDataChangeHub.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceHub.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
       - path: Sources/Nativ/Features/Chat/ChatScreenCapture.swift


### PR DESCRIPTION
This is the third PR in the multi window stack and builds on #430. It gives each control panel a window ID and uses a shared change hub to keep chat sessions, folders, and image-generation sessions in sync when another window saves or deletes persisted data