### PR TITLE
Coordinate inference across windows

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		3D96ED3F0E463F75A47071C6 /* ArtifactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C2AB90FC12D1B83D6691F4 /* ArtifactStore.swift */; };
 		3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */; };
 		402FF67FA99A26739AA4A653 /* MCPCatalog.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C57E985705899CDD8DB5996 /* MCPCatalog.json */; };
+		40B9D69B537427CD54D388B8 /* InferenceActivityCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D726D6B7B3242DA22BDC8600 /* InferenceActivityCoordinatorTests.swift */; };
 		40FAF7AC21743208E1C38AC2 /* WebBrowsingProviderClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E0214BE1D88EB4CDB66836 /* WebBrowsingProviderClient.swift */; };
 		41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
@@ -175,6 +176,7 @@
 		6B5A139573E38850CE9C1E3F /* AudioInputDevicePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */; };
 		6B75126FADAA6F8B2016DBDF /* ChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE817B51A37BDB25AD26A11 /* ChatViewModelTests.swift */; };
 		6C872B0124611E3D0297E2FD /* MCPSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A814B8C04BCBF1C1F869A8 /* MCPSectionView.swift */; };
+		6CA6BFD98B270DBA87C36857 /* InferenceActivityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2C827258CAD4269D2428AD /* InferenceActivityCoordinator.swift */; };
 		6CFBB2F5B3720F1334BF3D47 /* UISFXMinimalStop.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8B12071ED75397C8639954B7 /* UISFXMinimalStop.mp3 */; };
 		6E7B34D02D005C83C71A412F /* NativServerKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6EFBB86CDB0CCCF393D7598E /* ChatDocumentExtractionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */; };
@@ -291,6 +293,7 @@
 		C03F87BD5E8649BBF42B35EE /* PowerPointDocumentTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4ED7BDFBC000148E13EA19 /* PowerPointDocumentTextExtractor.swift */; };
 		C04192DCEE3B50535BE6E83D /* ControlPanelSidebarActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A96F57099AE45BFC2F74E66 /* ControlPanelSidebarActions.swift */; };
 		C0800EB1320391290985A4C5 /* FileSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5668DEC01979A9C0F082682C /* FileSearchEngine.swift */; };
+		C0FB2977E50FBF588B6D3562 /* InferenceActivityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2C827258CAD4269D2428AD /* InferenceActivityCoordinator.swift */; };
 		C22170FAE93CAF0FCEF39675 /* GitHubOAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711EAE65183E78E000DD3253 /* GitHubOAuthTests.swift */; };
 		C3D251E72388C59FFEA7E9C4 /* ChatAttachmentNoticesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51539FFC3A9D763AA1746318 /* ChatAttachmentNoticesView.swift */; };
 		C4381191592EC7C3B97E2C35 /* FilePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C9FECAED1FB3E2D43716FF /* FilePreview.swift */; };
@@ -558,6 +561,7 @@
 		76F460CC6B734041A8C60AAE /* ControlPanelSidebarModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarModels.swift; sourceTree = "<group>"; };
 		780A9582305FC184F6C68D12 /* NativKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitTests.swift; sourceTree = "<group>"; };
 		7A1B88001E3E22C2E592C0BA /* WebBrowsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingError.swift; sourceTree = "<group>"; };
+		7A2C827258CAD4269D2428AD /* InferenceActivityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceActivityCoordinator.swift; sourceTree = "<group>"; };
 		7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontScale.swift; sourceTree = "<group>"; };
 		7B0425C365C50DD040161226 /* FileReadAccessPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReadAccessPolicy.swift; sourceTree = "<group>"; };
 		7B205BC53F36B8200F5D5FD8 /* EmbeddingModelPreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddingModelPreparer.swift; sourceTree = "<group>"; };
@@ -661,6 +665,7 @@
 		D34FBE730C051EFF28B1323B /* RoutineLaunchAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineLaunchAgent.swift; sourceTree = "<group>"; };
 		D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineEditorView.swift; sourceTree = "<group>"; };
 		D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReadFileToolTests.swift; sourceTree = "<group>"; };
+		D726D6B7B3242DA22BDC8600 /* InferenceActivityCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceActivityCoordinatorTests.swift; sourceTree = "<group>"; };
 		D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatImageModelSelection.swift; sourceTree = "<group>"; };
 		D873D2FEC84059F689E7F623 /* ChatWebSearchTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatWebSearchTool.swift; sourceTree = "<group>"; };
 		D941186B3A4BA46FB90201DE /* NativExtensionMessaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionMessaging.swift; sourceTree = "<group>"; };
@@ -1288,6 +1293,7 @@
 		EF0B01F9E49FE8776F139EC9 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				7A2C827258CAD4269D2428AD /* InferenceActivityCoordinator.swift */,
 				20EE1CE9AAE5A3B9A2D4669C /* NativComponents.swift */,
 				C8B94192425D46A59F516118 /* PersistedDataChangeHub.swift */,
 			);
@@ -1317,6 +1323,7 @@
 				A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */,
 				908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */,
 				2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */,
+				D726D6B7B3242DA22BDC8600 /* InferenceActivityCoordinatorTests.swift */,
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
 				8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */,
@@ -1701,6 +1708,7 @@
 				E36D43D088EF55D617BCDDBB /* HuggingFaceModelReadme.swift in Sources */,
 				575DCB7EC96DAB35B415434C /* ImageGenerationView.swift in Sources */,
 				BC0753B567DC8935199FCDFB /* ImageGenerationViewModel.swift in Sources */,
+				C0FB2977E50FBF588B6D3562 /* InferenceActivityCoordinator.swift in Sources */,
 				2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */,
 				42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */,
 				E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */,
@@ -1862,6 +1870,8 @@
 				C92083D5C6AF4F5FE29A39E9 /* HuggingFaceModelReadme.swift in Sources */,
 				060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */,
 				237BB8D2F99FFE536CF0421B /* ImageGenerationViewModel.swift in Sources */,
+				6CA6BFD98B270DBA87C36857 /* InferenceActivityCoordinator.swift in Sources */,
+				40B9D69B537427CD54D388B8 /* InferenceActivityCoordinatorTests.swift in Sources */,
 				41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */,
 				351B2202E8690FC608A32AEF /* IntegrationServicesTests.swift in Sources */,
 				F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */,

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -41,6 +41,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
     private var downloadShutdownTask: Task<Void, Never>?
     private var didFinishDownloadShutdown = false
 
+    override init() {
+        super.init()
+        model.observeInferenceActivity(controlPanelSharedDependencies.inferenceActivity)
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         runtime.onUpdate = { [weak self] in
             self?.updateStatusItemButton()

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -409,7 +409,8 @@ struct ChatComposer: View {
             secondarySection: reasoningPickerSection,
             isModelLoading: model.isModelLoading,
             modelLoadingPercentage: model.modelLoadingPercentage,
-            isDisabled: model.isModelLoading || viewModel.hasPendingRequests,
+            isDisabled: model.isModelLoading || viewModel.hasPendingRequests
+                || model.inferenceActivityInProgress,
             statusLabel: localModelStatusLabel,
             helpText: modelPickerHelp,
             accessibilityValue: modelPickerAccessibilityValue,
@@ -627,8 +628,8 @@ struct ChatComposer: View {
     }
 
     private var modelPickerHelp: String {
-        if viewModel.hasPendingRequests {
-            return "Model switching is unavailable while requests are active or queued"
+        if viewModel.hasPendingRequests || model.inferenceActivityInProgress {
+            return "Models can’t be changed while a response is being generated."
         }
         if model.isModelLoading {
             return model.modelLoadingStatusText ?? "Loading \(selectedModelLabel)"

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -326,7 +326,8 @@ private struct ChatComposerContainer: View {
                 ?? model.settings.structuredOutputValidationError,
             canCompose: (model.isRunning || model.isModelLoading)
                 && selectedModelID?.isEmpty == false
-                && model.settings.structuredOutputValidationError == nil,
+                && model.settings.structuredOutputValidationError == nil
+                && !chat.isCurrentSessionActiveInAnotherWindow,
             canSend: !model.isModelLoading
                 && model.settings.structuredOutputValidationError == nil
                 && chat.canSend(isRunning: model.isRunning, selectedModelID: selectedModelID),

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -2,6 +2,7 @@ import AppKit
 import Combine
 import Foundation
 import NativServerKit
+import Observation
 import UniformTypeIdentifiers
 
 struct ChatQueuedPrompt: Identifiable, Equatable {
@@ -82,6 +83,7 @@ final class ChatViewModel: ObservableObject {
     private let sessionStore = ChatSessionStore()
     private let windowID: UUID
     private let persistedDataChanges: PersistedDataChangeHub
+    private let inferenceActivity: InferenceActivityCoordinator
     private let documentContextBuilder: ChatDocumentContextBuilder
     private let attachmentValidator: ChatAttachmentValidator
     private var sessionLoadTask: Task<Void, Never>?
@@ -110,10 +112,12 @@ final class ChatViewModel: ObservableObject {
 
     init(
         windowID: UUID = UUID(),
-        persistedDataChanges: PersistedDataChangeHub = .init()
+        persistedDataChanges: PersistedDataChangeHub = .init(),
+        inferenceActivity: InferenceActivityCoordinator = .init()
     ) {
         self.windowID = windowID
         self.persistedDataChanges = persistedDataChanges
+        self.inferenceActivity = inferenceActivity
         let documentExtractionCache = ChatDocumentExtractionCache()
         documentContextBuilder = ChatDocumentContextBuilder(
             extractionCache: documentExtractionCache
@@ -145,12 +149,27 @@ final class ChatViewModel: ObservableObject {
             .sink { [weak self] change in
                 self?.handlePersistedDataChange(change)
             }
+        observeInferenceActivity()
     }
 
     deinit {
         activeTask?.cancel()
         sessionLoadTask?.cancel()
         attachmentValidationTasks.values.forEach { $0.cancel() }
+    }
+
+    private func observeInferenceActivity() {
+        withObservationTracking {
+            _ = inferenceActivity.hasActiveOperations
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    return
+                }
+                self.observeInferenceActivity()
+                self.startNextRequestIfNeeded()
+            }
+        }
     }
 
     var isCurrentSessionSending: Bool {
@@ -162,6 +181,13 @@ final class ChatViewModel: ObservableObject {
 
     var hasPendingRequests: Bool {
         activeRequestSessionID != nil || !requestQueue.isEmpty
+    }
+
+    var isCurrentSessionActiveInAnotherWindow: Bool {
+        guard let currentSessionID else {
+            return false
+        }
+        return !canModifySession(currentSessionID)
     }
 
     var visibleMessages: [ChatTranscriptMessage] {
@@ -238,6 +264,7 @@ final class ChatViewModel: ObservableObject {
     func canEditUserMessage(_ messageID: UUID) -> Bool {
         guard let currentSessionID,
             !isSessionBusy(currentSessionID),
+            canModifySession(currentSessionID),
             latestUserMessageID == messageID
         else {
             return false
@@ -311,6 +338,9 @@ final class ChatViewModel: ObservableObject {
         if activeRequestSessionID == currentSessionID {
             return "Working…"
         }
+        if isCurrentSessionActiveInAnotherWindow {
+            return "This chat is active in another window."
+        }
         return nil
     }
 
@@ -346,6 +376,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     func removeAttachment(sessionID: UUID, messageID: UUID, attachmentID: UUID) {
+        guard canModifySession(sessionID) else {
+            return
+        }
         if sessionID == currentSessionID {
             for index in messages.indices where messages[index].id == messageID {
                 messages[index].imageAttachments.removeAll { $0.id == attachmentID }
@@ -394,7 +427,9 @@ final class ChatViewModel: ObservableObject {
 
     func renameSession(_ sessionID: UUID, to newTitle: String) {
         let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
+        guard canModifySession(sessionID),
+            let index = storedSessions.firstIndex(where: { $0.id == sessionID })
+        else {
             return
         }
         storedSessions[index].customTitle = trimmed.isEmpty ? nil : trimmed
@@ -406,7 +441,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     func setPinned(_ sessionID: UUID, pinned: Bool) {
-        guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
+        guard canModifySession(sessionID),
+            let index = storedSessions.firstIndex(where: { $0.id == sessionID })
+        else {
             return
         }
         let order = pinned ? nextPinnedOrder() : nil
@@ -442,6 +479,12 @@ final class ChatViewModel: ObservableObject {
     }
 
     func deleteFolder(_ folderID: UUID) {
+        let affectedSessionIDs = storedSessions.lazy
+            .filter { $0.folderID == folderID }
+            .map(\.id)
+        guard affectedSessionIDs.allSatisfy(canModifySession) else {
+            return
+        }
         folders.removeAll { $0.id == folderID }
         saveFolders()
         for index in storedSessions.indices where storedSessions[index].folderID == folderID {
@@ -473,7 +516,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     func moveSession(_ sessionID: UUID, toFolder folderID: UUID?) {
-        guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
+        guard canModifySession(sessionID),
+            let index = storedSessions.firstIndex(where: { $0.id == sessionID })
+        else {
             return
         }
         storedSessions[index].folderID = folderID
@@ -507,6 +552,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     func applyPinnedOrder(_ orderedSessionIDs: [UUID]) {
+        guard orderedSessionIDs.allSatisfy(canModifySession) else {
+            return
+        }
         for (order, sessionID) in orderedSessionIDs.enumerated() {
             guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
                 continue
@@ -523,6 +571,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     func applySessionOrder(_ orderedSessionIDs: [UUID]) {
+        guard orderedSessionIDs.allSatisfy(canModifySession) else {
+            return
+        }
         for (order, sessionID) in orderedSessionIDs.enumerated() {
             guard let index = storedSessions.firstIndex(where: { $0.id == sessionID }) else {
                 continue
@@ -545,6 +596,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     func deleteSession(_ sessionID: UUID) {
+        guard canModifySession(sessionID) else {
+            return
+        }
         // A busy session used to be undeletable, so a chat whose stream never
         // finished could not be removed at all. Cancel its work and delete it.
         if isSessionBusy(sessionID) {
@@ -590,6 +644,9 @@ final class ChatViewModel: ObservableObject {
         case .keepChats:
             for index in storedSessions.indices where sessionIDs.contains(storedSessions[index].id)
             {
+                guard canModifySession(storedSessions[index].id) else {
+                    continue
+                }
                 let session = ScheduledTaskChatLinker.makeIndependentSession(
                     from: storedSessions[index]
                 )
@@ -667,7 +724,8 @@ final class ChatViewModel: ObservableObject {
         guard canSend(isRunning: appModel.isRunning, selectedModelID: settings.languageModelID),
             languageModelSupportsVision || !hasPendingImageAttachments,
             let modelID = settings.languageModelID,
-            let currentSession
+            let currentSession,
+            canModifySession(currentSession.id)
         else {
             return
         }
@@ -1126,6 +1184,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     func clear() {
+        if let currentSessionID, !canModifySession(currentSessionID) {
+            return
+        }
         activeTask?.cancel()
         activeTask = nil
         activeRequestID = nil
@@ -1153,7 +1214,22 @@ final class ChatViewModel: ObservableObject {
 
         while !requestQueue.isEmpty {
             let queuedRequest = requestQueue.removeFirst()
+            let resource = InferenceActivityCoordinator.Resource.chat(
+                queuedRequest.sessionID
+            )
+            guard inferenceActivity.begin(
+                resource: resource,
+                windowID: windowID,
+                operationID: queuedRequest.id
+            ) else {
+                requestQueue.insert(queuedRequest, at: 0)
+                return
+            }
             guard insertAssistantMessage(for: queuedRequest) else {
+                inferenceActivity.end(
+                    resource: resource,
+                    operationID: queuedRequest.id
+                )
                 continue
             }
 
@@ -1165,24 +1241,30 @@ final class ChatViewModel: ObservableObject {
                 bumpScroll()
             }
 
-            activeTask = Task { @MainActor [weak self] in
-                guard let self else {
-                    return
-                }
-
+            activeTask = Task { @MainActor [weak self, inferenceActivity] in
                 // Release the in-flight slot on every exit path. Clearing it only
                 // after the request returned normally meant a stalled stream left
                 // the session marked busy forever, which is what made a frozen
                 // chat impossible to delete, stop, or switch away from.
                 defer {
-                    let ownedRequest = ownsActiveRequest(queuedRequest.id)
-                    releaseActiveRequestSlot(matching: queuedRequest.id)
-                    if ownedRequest {
-                        if currentSessionID == queuedRequest.sessionID {
-                            bumpScroll()
+                    inferenceActivity.end(
+                        resource: resource,
+                        operationID: queuedRequest.id
+                    )
+                    if let self {
+                        let ownedRequest = self.ownsActiveRequest(queuedRequest.id)
+                        self.releaseActiveRequestSlot(matching: queuedRequest.id)
+                        if ownedRequest {
+                            if self.currentSessionID == queuedRequest.sessionID {
+                                self.bumpScroll()
+                            }
+                            self.startNextRequestIfNeeded()
                         }
-                        startNextRequestIfNeeded()
                     }
+                }
+
+                guard let self else {
+                    return
                 }
 
                 do {
@@ -2455,7 +2537,7 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func persistCurrentSession(updateTimestamp: Bool) {
-        guard var session = currentSession else {
+        guard var session = currentSession, canModifySession(session.id) else {
             return
         }
 
@@ -2494,6 +2576,9 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func persistSession(_ sessionID: UUID, updateTimestamp: Bool) {
+        guard canModifySession(sessionID) else {
+            return
+        }
         if sessionID == currentSessionID {
             persistCurrentSession(updateTimestamp: updateTimestamp)
             return
@@ -2565,8 +2650,18 @@ final class ChatViewModel: ObservableObject {
     }
 
     private func saveSession(_ session: ChatSession) {
+        guard canModifySession(session.id) else {
+            return
+        }
         sessionStore.saveSession(session)
         persistedDataChanges.send(.chatSession(session.id), originWindowID: windowID)
+    }
+
+    func canModifySession(_ sessionID: UUID) -> Bool {
+        !inferenceActivity.isOwnedByAnotherWindow(
+            .chat(sessionID),
+            windowID: windowID
+        )
     }
 
     private func deletePersistedSession(_ sessionID: UUID) {

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
@@ -6,6 +6,7 @@ final class ControlPanelSharedDependencies {
     let systemMonitor = SystemMonitorStore()
     let launchAtLogin = LaunchAtLoginController()
     let persistedDataChanges = PersistedDataChangeHub()
+    let inferenceActivity = InferenceActivityCoordinator()
 }
 
 @MainActor
@@ -15,14 +16,17 @@ final class ControlPanelDependencies: ObservableObject {
     let launchAtLogin: LaunchAtLoginController
     let windowID: UUID
     let persistedDataChanges: PersistedDataChangeHub
+    let inferenceActivity: InferenceActivityCoordinator
 
     lazy var chat = ChatViewModel(
         windowID: windowID,
-        persistedDataChanges: persistedDataChanges
+        persistedDataChanges: persistedDataChanges,
+        inferenceActivity: inferenceActivity
     )
     lazy var imageGeneration = ImageGenerationViewModel(
         windowID: windowID,
-        persistedDataChanges: persistedDataChanges
+        persistedDataChanges: persistedDataChanges,
+        inferenceActivity: inferenceActivity
     )
     lazy var artifacts = ArtifactStore()
     lazy var dashboard = DashboardViewModel()
@@ -39,5 +43,6 @@ final class ControlPanelDependencies: ObservableObject {
         launchAtLogin = shared.launchAtLogin
         self.windowID = windowID
         persistedDataChanges = shared.persistedDataChanges
+        inferenceActivity = shared.inferenceActivity
     }
 }

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationView.swift
@@ -217,6 +217,7 @@ private struct ImageGenerationComposer: View {
                     }
                     .buttonStyle(.plain)
                     .help("Image settings")
+                    .disabled(viewModel.isCurrentSessionActiveInAnotherWindow)
                     .popover(isPresented: $showsSettings, arrowEdge: .bottom) {
                         ImageGenerationSettingsView(viewModel: viewModel)
                     }
@@ -291,11 +292,13 @@ private struct ImageGenerationComposer: View {
         model.isRunning
             && selectedModelID != nil
             && !viewModel.isGenerating
+            && !viewModel.isCurrentSessionActiveInAnotherWindow
     }
 
     private var canSubmit: Bool {
         selectedModelID != nil
             && viewModel.canSubmit(isRunning: model.isRunning)
+            && !viewModel.isCurrentSessionActiveInAnotherWindow
             && (!selectedModelIsEditOnly || viewModel.nextRequestIsEdit)
     }
 
@@ -332,7 +335,7 @@ private struct ImageGenerationComposer: View {
             modelLoadingPercentage: isSelectedModelLoading
                 ? model.modelLoadingPercentage
                 : nil,
-            isDisabled: model.isModelLoading || viewModel.isGenerating,
+            isDisabled: model.isModelLoading || model.inferenceActivityInProgress,
             statusLabel: localModelStatusLabel,
             helpText: modelPickerHelp,
             accessibilityValue: modelLabel,
@@ -387,8 +390,8 @@ private struct ImageGenerationComposer: View {
     }
 
     private var modelPickerHelp: String {
-        if viewModel.isGenerating {
-            return "Model switching is unavailable while generating"
+        if viewModel.isGenerating || model.inferenceActivityInProgress {
+            return "Models can’t be changed while a response is being generated."
         }
         if model.isModelLoading {
             return model.modelLoadingStatusText ?? "Loading \(modelLabel)"
@@ -402,6 +405,9 @@ private struct ImageGenerationComposer: View {
     private var unavailableReason: String? {
         if !model.isRunning {
             return "Server is stopped."
+        }
+        if viewModel.isCurrentSessionActiveInAnotherWindow {
+            return "This image session is active in another window."
         }
         return nil
     }

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -168,6 +168,7 @@ final class ImageGenerationViewModel: ObservableObject {
     private let sessionStore = ImageGenerationSessionStore()
     private let windowID: UUID
     private let persistedDataChanges: PersistedDataChangeHub
+    private let inferenceActivity: InferenceActivityCoordinator
     private var activeTask: Task<Void, Never>?
     private var activeTurnID: UUID?
     private var storedSessions: [ImageGenerationSession] = []
@@ -181,10 +182,12 @@ final class ImageGenerationViewModel: ObservableObject {
 
     init(
         windowID: UUID = UUID(),
-        persistedDataChanges: PersistedDataChangeHub = .init()
+        persistedDataChanges: PersistedDataChangeHub = .init(),
+        inferenceActivity: InferenceActivityCoordinator = .init()
     ) {
         self.windowID = windowID
         self.persistedDataChanges = persistedDataChanges
+        self.inferenceActivity = inferenceActivity
         storedSessions = sessionStore.loadSessions().map { session in
             var repaired = session
             for index in repaired.turns.indices where repaired.turns[index].status == .inProgress {
@@ -224,6 +227,13 @@ final class ImageGenerationViewModel: ObservableObject {
         !effectiveReferenceImages.isEmpty
     }
 
+    var isCurrentSessionActiveInAnotherWindow: Bool {
+        guard let currentSessionID else {
+            return false
+        }
+        return !canModifySession(currentSessionID)
+    }
+
     func applyDefaultModel(
         _ selectedModelID: String?,
         installedImageModelIDs: [String] = []
@@ -231,7 +241,9 @@ final class ImageGenerationViewModel: ObservableObject {
         let resolvedModelID = normalized(selectedModelID)
             ?? installedImageModelIDs.lazy.compactMap(normalized).first
             ?? Self.fallbackModelID
-        guard modelID != resolvedModelID else {
+        guard !isCurrentSessionActiveInAnotherWindow,
+            modelID != resolvedModelID
+        else {
             return
         }
         modelID = resolvedModelID
@@ -263,6 +275,9 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     func applyLongestSide(_ longestSide: Int) {
+        guard !isCurrentSessionActiveInAnotherWindow else {
+            return
+        }
         let size = aspectFitSize(
             for: ImageGenerationPixelSize(
                 width: requestSettings.width,
@@ -298,7 +313,9 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     func selectSession(_ sessionID: UUID) {
-        guard !isGenerating, sessionID != currentSessionID else {
+        guard !isGenerating,
+            sessionID != currentSessionID
+        else {
             return
         }
 
@@ -315,7 +332,7 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     func deleteSession(_ sessionID: UUID) {
-        guard !isGenerating else {
+        guard !isGenerating, canModifySession(sessionID) else {
             return
         }
 
@@ -360,7 +377,26 @@ final class ImageGenerationViewModel: ObservableObject {
         else {
             return
         }
+        if let currentSessionID, !canModifySession(currentSessionID) {
+            statusText = "This image session is already generating in another window."
+            return
+        }
         materializeDraftSession(modelID: requestModelID)
+        guard let currentSessionID else {
+            return
+        }
+        let operationID = UUID()
+        let activityResource = InferenceActivityCoordinator.Resource.imageGeneration(
+            currentSessionID
+        )
+        guard inferenceActivity.begin(
+            resource: activityResource,
+            windowID: windowID,
+            operationID: operationID
+        ) else {
+            statusText = "This image session is already generating in another window."
+            return
+        }
         appModel.clearModelLoadFailure(for: requestModelID)
 
         var settings = requestSettings
@@ -411,7 +447,13 @@ final class ImageGenerationViewModel: ObservableObject {
         let serverAPIKey = serverSettings.serverAPIKey
         let modelSearchPath = serverSettings.modelSearchPath
         let huggingFaceToken = appModel.effectiveHuggingFaceToken
-        activeTask = Task { @MainActor [weak self, weak appModel] in
+        activeTask = Task { @MainActor [weak self, weak appModel, inferenceActivity] in
+            defer {
+                inferenceActivity.end(
+                    resource: activityResource,
+                    operationID: operationID
+                )
+            }
             guard let self else {
                 return
             }
@@ -485,7 +527,7 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     func chooseImageAttachments() {
-        guard !isGenerating else {
+        guard !isGenerating, !isCurrentSessionActiveInAnotherWindow else {
             return
         }
 
@@ -503,7 +545,7 @@ final class ImageGenerationViewModel: ObservableObject {
 
     @discardableResult
     func attachImages(from pasteboard: NSPasteboard) -> Bool {
-        guard !isGenerating else {
+        guard !isGenerating, !isCurrentSessionActiveInAnotherWindow else {
             return false
         }
         let attachments = ChatImageAttachment.imageAttachments(from: pasteboard)
@@ -519,7 +561,7 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     func captureScreenshot() {
-        guard !isGenerating else {
+        guard !isGenerating, !isCurrentSessionActiveInAnotherWindow else {
             return
         }
         let fileURL = FileManager.default.temporaryDirectory
@@ -537,7 +579,7 @@ final class ImageGenerationViewModel: ObservableObject {
 
     @discardableResult
     func loadImageAttachments(from providers: [NSItemProvider]) -> Bool {
-        guard !isGenerating else {
+        guard !isGenerating, !isCurrentSessionActiveInAnotherWindow else {
             return false
         }
 
@@ -581,11 +623,14 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     func removePendingImageAttachment(_ id: UUID) {
+        guard !isCurrentSessionActiveInAnotherWindow else {
+            return
+        }
         pendingImageAttachments.removeAll { $0.id == id }
     }
 
     func clearActiveReference() {
-        guard !isGenerating else {
+        guard !isGenerating, !isCurrentSessionActiveInAnotherWindow else {
             return
         }
         activeReference = nil
@@ -594,14 +639,14 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     func useAsReference(_ result: GeneratedImage) {
-        guard !isGenerating else {
+        guard !isGenerating, !isCurrentSessionActiveInAnotherWindow else {
             return
         }
         setActiveReference(result.attachment)
     }
 
     func useAsReference(_ attachment: ChatImageAttachment) {
-        guard !isGenerating else {
+        guard !isGenerating, !isCurrentSessionActiveInAnotherWindow else {
             return
         }
         setActiveReference(attachment)
@@ -717,6 +762,9 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     func removeOutput(sessionID: UUID, turnID: UUID, outputID: UUID) {
+        guard canModifySession(sessionID) else {
+            return
+        }
         if sessionID == currentSessionID {
             for turnIndex in turns.indices where turns[turnIndex].id == turnID {
                 turns[turnIndex].outputs.removeAll { $0.id == outputID }
@@ -739,7 +787,7 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     private func persistCurrentSession(updateTimestamp: Bool) {
-        guard var session = currentSession else {
+        guard var session = currentSession, canModifySession(session.id) else {
             return
         }
         session.modelKind = .imageGeneration
@@ -808,10 +856,20 @@ final class ImageGenerationViewModel: ObservableObject {
     }
 
     private func saveSession(_ session: ImageGenerationSession) {
+        guard canModifySession(session.id) else {
+            return
+        }
         sessionStore.saveSession(session)
         persistedDataChanges.send(
             .imageGenerationSession(session.id),
             originWindowID: windowID
+        )
+    }
+
+    private func canModifySession(_ sessionID: UUID) -> Bool {
+        !inferenceActivity.isOwnedByAnotherWindow(
+            .imageGeneration(sessionID),
+            windowID: windowID
         )
     }
 

--- a/Sources/Nativ/Features/Menu/StatusMenuController.swift
+++ b/Sources/Nativ/Features/Menu/StatusMenuController.swift
@@ -694,6 +694,13 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         let submenu = NSMenu()
         submenu.autoenablesItems = false
 
+        if model.inferenceActivityInProgress {
+            submenu.addItem(disabledMenuItem(
+                "Models can’t be changed while a response is being generated."
+            ))
+            return submenu
+        }
+
         if model.isModelLoading {
             submenu.addItem(disabledMenuItem(model.modelLoadingStatusText ?? "Loading model…"))
             return submenu

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -72,6 +72,7 @@ private final class ModelsNativState: ObservableObject {
         var settings: NativSettings
         var isRunning: Bool
         var modelSwitchInProgress: Bool
+        var inferenceActivityInProgress: Bool
         var modelSwitchTargetID: String?
         var modelLoadingProgress: Double?
         var metricsLoading: Bool
@@ -89,6 +90,7 @@ private final class ModelsNativState: ObservableObject {
             settings: model.settings,
             isRunning: model.isRunning,
             modelSwitchInProgress: model.modelSwitchInProgress,
+            inferenceActivityInProgress: model.inferenceActivityInProgress,
             modelSwitchTargetID: model.modelSwitchTargetID,
             modelLoadingProgress: model.modelLoadingProgress,
             metricsLoading: model.metricsLoading,
@@ -113,6 +115,7 @@ private final class ModelsNativState: ObservableObject {
             $0.settings = model.settings
             $0.isRunning = model.isRunning
             $0.modelSwitchInProgress = model.modelSwitchInProgress
+            $0.inferenceActivityInProgress = model.inferenceActivityInProgress
             $0.modelSwitchTargetID = model.modelSwitchTargetID
             $0.modelLoadingProgress = model.modelLoadingProgress
             $0.metricsLoading = model.metricsLoading
@@ -132,6 +135,7 @@ private final class ModelsNativState: ObservableObject {
     var settings: NativSettings { snapshot.settings }
     var isRunning: Bool { snapshot.isRunning }
     var modelSwitchInProgress: Bool { snapshot.modelSwitchInProgress }
+    var inferenceActivityInProgress: Bool { snapshot.inferenceActivityInProgress }
     var modelSwitchTargetID: String? { snapshot.modelSwitchTargetID }
     var modelLoadingProgress: Double? { snapshot.modelLoadingProgress }
     var metricsLoading: Bool { snapshot.metricsLoading }
@@ -539,7 +543,8 @@ struct ModelsView: View {
                     preferredPreloadSlot: preferredPreloadSlot(
                         among: preloadSlots
                     ),
-                    isSelectionDisabled: modelState.modelSwitchInProgress,
+                    isSelectionDisabled: modelState.modelSwitchInProgress
+                        || modelState.inferenceActivityInProgress,
                     isModelLoading: modelState.modelLoadingID
                         == localModel.repoID,
                     modelLoadingPercentage: modelState.modelLoadingPercentage,

--- a/Sources/Nativ/Features/Shared/InferenceActivityCoordinator.swift
+++ b/Sources/Nativ/Features/Shared/InferenceActivityCoordinator.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class InferenceActivityCoordinator {
+    enum Resource: Hashable {
+        case chat(UUID)
+        case imageGeneration(UUID)
+    }
+
+    private struct Activity {
+        let windowID: UUID
+        let operationID: UUID
+    }
+
+    private var activityByResource: [Resource: Activity] = [:]
+
+    var hasActiveOperations: Bool {
+        !activityByResource.isEmpty
+    }
+
+    func begin(resource: Resource, windowID: UUID, operationID: UUID) -> Bool {
+        guard activityByResource[resource] == nil else {
+            return false
+        }
+        activityByResource[resource] = Activity(
+            windowID: windowID,
+            operationID: operationID
+        )
+        return true
+    }
+
+    func end(resource: Resource, operationID: UUID) {
+        guard activityByResource[resource]?.operationID == operationID else {
+            return
+        }
+        activityByResource[resource] = nil
+    }
+
+    func isOwnedByAnotherWindow(_ resource: Resource, windowID: UUID) -> Bool {
+        guard let activity = activityByResource[resource] else {
+            return false
+        }
+        return activity.windowID != windowID
+    }
+}

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -74,6 +74,7 @@ final class NativModel: ChatModelSwitchingSurface {
     private(set) var modelSwitchInProgress = false
     private(set) var modelSwitchTargetID: String?
     private var modelSwitchWatchdog: Task<Void, Never>?
+    @ObservationIgnored private var inferenceActivity: InferenceActivityCoordinator?
     private(set) var modelLoadingProgress: Double?
     private(set) var modelLoadFailure: ModelLoadFailure?
     private(set) var modelPreloadMemoryWarning: ModelPreloadMemoryWarning?
@@ -119,6 +120,32 @@ final class NativModel: ChatModelSwitchingSurface {
         refreshAllTimeStats()
         resolveHuggingFaceEnvironmentFromLoginShell()
         migrateCustomHuggingFaceCredentialIfNeeded()
+    }
+
+    func observeInferenceActivity(_ coordinator: InferenceActivityCoordinator) {
+        inferenceActivity = coordinator
+        observeInferenceActivityChanges()
+    }
+
+    var inferenceActivityInProgress: Bool {
+        inferenceActivity?.hasActiveOperations == true
+    }
+
+    private func observeInferenceActivityChanges() {
+        guard let inferenceActivity else {
+            return
+        }
+        withObservationTracking {
+            _ = inferenceActivity.hasActiveOperations
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    return
+                }
+                self.observeInferenceActivityChanges()
+                self.notifyMenuStateChanged()
+            }
+        }
     }
 
     /// GUI apps inherit launchd's environment, which excludes exports from
@@ -595,7 +622,7 @@ final class NativModel: ChatModelSwitchingSurface {
         availableModels: [LocalModel],
         onSelectionAccepted: @escaping () -> Void = {}
     ) -> Bool {
-        guard !modelSwitchInProgress else {
+        guard !modelSwitchInProgress, !inferenceActivityInProgress else {
             return false
         }
 
@@ -619,6 +646,9 @@ final class NativModel: ChatModelSwitchingSurface {
     }
 
     func confirmPendingModelPreloadSwitch() {
+        guard !inferenceActivityInProgress else {
+            return
+        }
         guard let pendingModelPreloadSwitch else {
             modelPreloadMemoryWarning = nil
             return
@@ -642,7 +672,7 @@ final class NativModel: ChatModelSwitchingSurface {
         to modelID: String?,
         for slot: ModelPreloadSlot
     ) {
-        guard !modelSwitchInProgress else {
+        guard !modelSwitchInProgress, !inferenceActivityInProgress else {
             return
         }
         clearModelLoadFailure()

--- a/Tests/NativTests/ControlPanelDependencyOwnershipTests.swift
+++ b/Tests/NativTests/ControlPanelDependencyOwnershipTests.swift
@@ -11,6 +11,7 @@ final class ControlPanelDependencyOwnershipTests: XCTestCase {
         XCTAssertTrue(first.systemMonitor === second.systemMonitor)
         XCTAssertTrue(first.launchAtLogin === second.launchAtLogin)
         XCTAssertTrue(first.persistedDataChanges === second.persistedDataChanges)
+        XCTAssertTrue(first.inferenceActivity === second.inferenceActivity)
         XCTAssertTrue(first.downloads === second.downloads)
     }
 

--- a/Tests/NativTests/InferenceActivityCoordinatorTests.swift
+++ b/Tests/NativTests/InferenceActivityCoordinatorTests.swift
@@ -1,0 +1,145 @@
+import Observation
+import XCTest
+
+@MainActor
+final class InferenceActivityCoordinatorTests: XCTestCase {
+    func testSameResourceAllowsOnlyOneOperationAtATime() {
+        let subject = InferenceActivityCoordinator()
+        let resource = InferenceActivityCoordinator.Resource.chat(UUID())
+        let firstOperation = UUID()
+        let secondOperation = UUID()
+
+        XCTAssertTrue(subject.begin(
+            resource: resource,
+            windowID: UUID(),
+            operationID: firstOperation
+        ))
+        XCTAssertFalse(subject.begin(
+            resource: resource,
+            windowID: UUID(),
+            operationID: secondOperation
+        ))
+
+        subject.end(resource: resource, operationID: firstOperation)
+
+        XCTAssertTrue(subject.begin(
+            resource: resource,
+            windowID: UUID(),
+            operationID: secondOperation
+        ))
+    }
+
+    func testDifferentResourcesCanRunConcurrently() {
+        let subject = InferenceActivityCoordinator()
+
+        XCTAssertTrue(subject.begin(
+            resource: .chat(UUID()),
+            windowID: UUID(),
+            operationID: UUID()
+        ))
+        XCTAssertTrue(subject.begin(
+            resource: .imageGeneration(UUID()),
+            windowID: UUID(),
+            operationID: UUID()
+        ))
+    }
+
+    func testOnlyOwningOperationCanReleaseResource() {
+        let subject = InferenceActivityCoordinator()
+        let resource = InferenceActivityCoordinator.Resource.chat(UUID())
+        let owner = UUID()
+
+        XCTAssertTrue(subject.begin(
+            resource: resource,
+            windowID: UUID(),
+            operationID: owner
+        ))
+        subject.end(resource: resource, operationID: UUID())
+        XCTAssertFalse(subject.begin(
+            resource: resource,
+            windowID: UUID(),
+            operationID: UUID()
+        ))
+
+        subject.end(resource: resource, operationID: owner)
+        XCTAssertTrue(subject.begin(
+            resource: resource,
+            windowID: UUID(),
+            operationID: UUID()
+        ))
+    }
+
+    func testReportsOwnershipOnlyToOtherWindows() {
+        let subject = InferenceActivityCoordinator()
+        let resource = InferenceActivityCoordinator.Resource.chat(UUID())
+        let ownerWindowID = UUID()
+
+        XCTAssertTrue(subject.begin(
+            resource: resource,
+            windowID: ownerWindowID,
+            operationID: UUID()
+        ))
+        XCTAssertFalse(subject.isOwnedByAnotherWindow(resource, windowID: ownerWindowID))
+        XCTAssertTrue(subject.isOwnedByAnotherWindow(resource, windowID: UUID()))
+    }
+
+    func testReportsWhetherAnyInferenceIsActive() {
+        let subject = InferenceActivityCoordinator()
+        let resource = InferenceActivityCoordinator.Resource.chat(UUID())
+        let operationID = UUID()
+
+        XCTAssertFalse(subject.hasActiveOperations)
+        XCTAssertTrue(subject.begin(
+            resource: resource,
+            windowID: UUID(),
+            operationID: operationID
+        ))
+        XCTAssertTrue(subject.hasActiveOperations)
+
+        subject.end(resource: resource, operationID: operationID)
+
+        XCTAssertFalse(subject.hasActiveOperations)
+    }
+
+    func testActivityChangesInvalidateObservation() async {
+        let subject = InferenceActivityCoordinator()
+        let didChange = expectation(description: "Activity observation changed")
+
+        withObservationTracking {
+            _ = subject.hasActiveOperations
+        } onChange: {
+            didChange.fulfill()
+        }
+
+        XCTAssertTrue(subject.begin(
+            resource: .chat(UUID()),
+            windowID: UUID(),
+            operationID: UUID()
+        ))
+
+        await fulfillment(of: [didChange], timeout: 1)
+    }
+
+    func testModelSwitchIsBlockedWhileInferenceIsActive() {
+        let coordinator = InferenceActivityCoordinator()
+        let model = NativModel()
+        let originalModelID = model.settings.normalized().languageModelID
+        let resource = InferenceActivityCoordinator.Resource.chat(UUID())
+        let operationID = UUID()
+        model.observeInferenceActivity(coordinator)
+
+        XCTAssertTrue(coordinator.begin(
+            resource: resource,
+            windowID: UUID(),
+            operationID: operationID
+        ))
+        XCTAssertTrue(model.inferenceActivityInProgress)
+
+        model.switchLanguageModel(to: "nativ-tests/model-switch-must-stay-blocked")
+
+        XCTAssertEqual(model.settings.normalized().languageModelID, originalModelID)
+
+        coordinator.end(resource: resource, operationID: operationID)
+        XCTAssertFalse(model.inferenceActivityInProgress)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -264,6 +264,7 @@ targets:
       - path: Sources/Nativ/Utilities/MarkdownFormatting.swift
       - path: Sources/Nativ/Features/Shared/NativComponents.swift
       - path: Sources/Nativ/Features/Shared/PersistedDataChangeHub.swift
+      - path: Sources/Nativ/Features/Shared/InferenceActivityCoordinator.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceHub.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceModelReadme.swift
       - path: Sources/Nativ/Features/Chat/ChatScreenCapture.swift


### PR DESCRIPTION
This adds shared inference coordination across control panel windows so the same chat or image generation session cannot be operated on from two windows at once. Sessions that are active elsewhere are temporarily protected from conflicting changes, unrelated sessions can still run independently, and model switching is disabled while any response or image generation is in progress.