### PR TITLE
Make artifact deletion transactional

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		40FAF7AC21743208E1C38AC2 /* WebBrowsingProviderClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E0214BE1D88EB4CDB66836 /* WebBrowsingProviderClient.swift */; };
 		41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
+		4262747AC6425403FC1F2210 /* ArtifactDeletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */; };
 		444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */; };
 		44F8A17BDE2610C6E90CE53F /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
 		455662EBEFC2C805F0223541 /* ControlPanelSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B9207F7063BEC112E5CAB /* ControlPanelSidebarView.swift */; };
@@ -703,6 +704,7 @@
 		FB497800D0F8B237A1891EE1 /* WebBrowsingTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingTransport.swift; sourceTree = "<group>"; };
 		FD296E4B5897E7E46606B697 /* ControlPanelActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelActions.swift; sourceTree = "<group>"; };
 		FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelReadme.swift; sourceTree = "<group>"; };
+		FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDeletionTests.swift; sourceTree = "<group>"; };
 		FE82B4EBA796206F12005498 /* OfficeArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeArchive.swift; sourceTree = "<group>"; };
 		FF6D2D7280064648E0EFC847 /* BraveBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveBrowsingProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1303,6 +1305,7 @@
 		F1DA823EC3D3358ABDB845B7 /* NativTests */ = {
 			isa = PBXGroup;
 			children = (
+				FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */,
 				3B965B701714787B0A85AE6B /* AudioTests.swift */,
 				C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */,
 				B059AF48F10F1B0502DC5E6F /* ChatConversationBranchTests.swift */,
@@ -1801,6 +1804,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				145464A2B098437667795AFB /* Artifact.swift in Sources */,
+				4262747AC6425403FC1F2210 /* ArtifactDeletionTests.swift in Sources */,
 				3D96ED3F0E463F75A47071C6 /* ArtifactStore.swift in Sources */,
 				AB1C4B8494B46754E6E8BE24 /* AudioAnalyticsStore.swift in Sources */,
 				01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */,

--- a/Sources/Nativ/Features/Artifacts/ArtifactStore.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactStore.swift
@@ -6,41 +6,66 @@ import UniformTypeIdentifiers
 
 @MainActor
 final class ArtifactStore: ObservableObject {
+    struct StorageLocations {
+        let indexURL: URL
+        let cacheDirectory: URL
+        let favoritesURL: URL
+        let displayNamesURL: URL
+
+        static var application: Self {
+            let fileManager = FileManager.default
+            let support = fileManager
+                .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+                .first ?? fileManager.temporaryDirectory
+            let nativDirectory = support.appendingPathComponent("Nativ", isDirectory: true)
+            let caches = fileManager
+                .urls(for: .cachesDirectory, in: .userDomainMask)
+                .first ?? fileManager.temporaryDirectory
+
+            return Self(
+                indexURL: nativDirectory.appendingPathComponent("Artifacts Index.json"),
+                cacheDirectory: caches
+                    .appendingPathComponent("Nativ", isDirectory: true)
+                    .appendingPathComponent("Artifacts", isDirectory: true),
+                favoritesURL: nativDirectory.appendingPathComponent("Artifact Favorites.json"),
+                displayNamesURL: nativDirectory.appendingPathComponent("Artifact Names.json")
+            )
+        }
+    }
+
+    typealias DeletionHandler = (Artifact) -> Bool
+
     @Published private(set) var artifacts: [Artifact] = []
     @Published private(set) var isRefreshing = false
-
-    var onDeleteArtifact: ((Artifact) -> Void)?
 
     @Published private(set) var favoriteIDs: Set<UUID> = []
     @Published private(set) var displayNames: [UUID: String] = [:]
 
+    private let deletionHandler: DeletionHandler
     private let indexURL: URL
     private let cacheDirectory: URL
     private let favoritesURL: URL
     private let displayNamesURL: URL
     private let thumbnailCache = NSCache<NSString, NSImage>()
 
-    init() {
-        let support = FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first ?? FileManager.default.temporaryDirectory
-        let nativDirectory = support.appendingPathComponent("Nativ", isDirectory: true)
-        indexURL = nativDirectory.appendingPathComponent("Artifacts Index.json")
-        favoritesURL = nativDirectory.appendingPathComponent("Artifact Favorites.json")
-        displayNamesURL = nativDirectory.appendingPathComponent("Artifact Names.json")
-
-        let caches = FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask)
-            .first ?? FileManager.default.temporaryDirectory
-        cacheDirectory = caches
-            .appendingPathComponent("Nativ", isDirectory: true)
-            .appendingPathComponent("Artifacts", isDirectory: true)
+    init(
+        storage: StorageLocations = .application,
+        refreshesAutomatically: Bool = true,
+        deletionHandler: @escaping DeletionHandler = { _ in true }
+    ) {
+        self.deletionHandler = deletionHandler
+        indexURL = storage.indexURL
+        cacheDirectory = storage.cacheDirectory
+        favoritesURL = storage.favoritesURL
+        displayNamesURL = storage.displayNamesURL
 
         thumbnailCache.countLimit = 150
         favoriteIDs = Self.loadFavorites(favoritesURL)
         displayNames = Self.loadNames(displayNamesURL)
         artifacts = Self.loadIndex(indexURL)
-        refresh()
+        if refreshesAutomatically {
+            refresh()
+        }
     }
 
     func fileURL(for artifact: Artifact) -> URL {
@@ -155,21 +180,30 @@ final class ArtifactStore: ObservableObject {
         }
     }
 
-    func delete(_ artifact: Artifact) {
-        onDeleteArtifact?(artifact)
+    @discardableResult
+    func delete(_ artifact: Artifact) -> Bool {
+        guard deletionHandler(artifact) else {
+            return false
+        }
         try? FileManager.default.removeItem(at: fileURL(for: artifact))
         artifacts.removeAll { $0.id == artifact.id }
         Self.writeIndex(artifacts, to: indexURL)
+        return true
     }
 
-    func delete(_ toDelete: [Artifact]) {
+    @discardableResult
+    func delete(_ toDelete: [Artifact]) -> Set<Artifact.ID> {
+        var deletedIDs: Set<Artifact.ID> = []
         for artifact in toDelete {
-            onDeleteArtifact?(artifact)
+            guard !deletedIDs.contains(artifact.id), deletionHandler(artifact) else {
+                continue
+            }
             try? FileManager.default.removeItem(at: fileURL(for: artifact))
+            deletedIDs.insert(artifact.id)
         }
-        let ids = Set(toDelete.map(\.id))
-        artifacts.removeAll { ids.contains($0.id) }
+        artifacts.removeAll { deletedIDs.contains($0.id) }
         Self.writeIndex(artifacts, to: indexURL)
+        return deletedIDs
     }
 
     func revealInFinder(_ artifact: Artifact) {

--- a/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
@@ -506,8 +506,8 @@ struct ArtifactsView: View {
         }
         .alert("Delete \(pendingDelete.count) \(pendingDelete.count == 1 ? "item" : "items")?", isPresented: $isConfirmingDelete) {
             Button("Delete", role: .destructive) {
-                store.delete(pendingDelete)
-                selection.subtract(pendingDelete.map(\.id))
+                let deletedIDs = store.delete(pendingDelete)
+                selection.subtract(deletedIDs)
                 pendingDelete = []
                 if selection.isEmpty {
                     isSelecting = false

--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -525,7 +525,8 @@ struct ChatSessionStore {
         loadSession(from: sessionURL(for: id))
     }
 
-    func saveSession(_ session: ChatSession) {
+    @discardableResult
+    func saveSession(_ session: ChatSession) -> Bool {
         do {
             try fileManager.createDirectory(
                 at: sessionsDirectory,
@@ -537,8 +538,10 @@ struct ChatSessionStore {
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             let data = try encoder.encode(session)
             try data.write(to: sessionURL(for: session.id), options: .atomic)
+            return true
         } catch {
             reportFailure("saveSession", sessionID: session.id, error: error)
+            return false
         }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -375,30 +375,62 @@ final class ChatViewModel: ObservableObject {
         pendingImageAttachments.append(attachment)
     }
 
-    func removeAttachment(sessionID: UUID, messageID: UUID, attachmentID: UUID) {
+    @discardableResult
+    func removeAttachment(sessionID: UUID, messageID: UUID, attachmentID: UUID) -> Bool {
         guard canModifySession(sessionID) else {
-            return
+            return false
         }
         if sessionID == currentSessionID {
-            for index in messages.indices where messages[index].id == messageID {
-                messages[index].imageAttachments.removeAll { $0.id == attachmentID }
+            let previousMessages = messages
+            guard removeAttachment(
+                messageID: messageID,
+                attachmentID: attachmentID,
+                from: &messages
+            ) else {
+                return false
             }
-            persistCurrentSession(updateTimestamp: false)
-            return
+            guard persistCurrentSession(updateTimestamp: false) else {
+                messages = previousMessages
+                return false
+            }
+            return true
         }
 
         guard
             var session = storedSessions.first(where: { $0.id == sessionID })
                 ?? sessionStore.loadSession(id: sessionID)
         else {
-            return
+            return false
         }
-        for index in session.messages.indices where session.messages[index].id == messageID {
-            session.messages[index].imageAttachments.removeAll { $0.id == attachmentID }
+        guard removeAttachment(
+            messageID: messageID,
+            attachmentID: attachmentID,
+            from: &session.messages
+        ) else {
+            return false
+        }
+        guard saveSession(session) else {
+            return false
         }
         upsertStoredSession(session)
-        saveSession(session)
         refreshSessionList()
+        return true
+    }
+
+    private func removeAttachment(
+        messageID: UUID,
+        attachmentID: UUID,
+        from messages: inout [ChatTranscriptMessage]
+    ) -> Bool {
+        guard let messageIndex = messages.firstIndex(where: { $0.id == messageID }),
+            let attachmentIndex = messages[messageIndex].imageAttachments.firstIndex(
+                where: { $0.id == attachmentID }
+            )
+        else {
+            return false
+        }
+        messages[messageIndex].imageAttachments.remove(at: attachmentIndex)
+        return true
     }
 
     func selectSession(_ sessionID: UUID) {
@@ -2536,9 +2568,10 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
-    private func persistCurrentSession(updateTimestamp: Bool) {
+    @discardableResult
+    private func persistCurrentSession(updateTimestamp: Bool) -> Bool {
         guard var session = currentSession, canModifySession(session.id) else {
-            return
+            return false
         }
 
         session.messages = messages
@@ -2547,10 +2580,13 @@ final class ChatViewModel: ObservableObject {
             session.updatedAt = Date()
         }
 
+        guard saveSession(session) else {
+            return false
+        }
         currentSession = session
         upsertStoredSession(session)
-        saveSession(session)
         refreshSessionList()
+        return true
     }
 
     private var currentSessionSnapshot: ChatSession? {
@@ -2649,12 +2685,16 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
-    private func saveSession(_ session: ChatSession) {
+    @discardableResult
+    private func saveSession(_ session: ChatSession) -> Bool {
         guard canModifySession(session.id) else {
-            return
+            return false
         }
-        sessionStore.saveSession(session)
+        guard sessionStore.saveSession(session) else {
+            return false
+        }
         persistedDataChanges.send(.chatSession(session.id), originWindowID: windowID)
+        return true
     }
 
     func canModifySession(_ sessionID: UUID) -> Bool {

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
@@ -28,7 +28,25 @@ final class ControlPanelDependencies: ObservableObject {
         persistedDataChanges: persistedDataChanges,
         inferenceActivity: inferenceActivity
     )
-    lazy var artifacts = ArtifactStore()
+    lazy var artifacts = ArtifactStore { [weak self] artifact in
+        guard let self else {
+            return false
+        }
+        switch artifact.source {
+        case .uploaded:
+            return chat.removeAttachment(
+                sessionID: artifact.sessionID,
+                messageID: artifact.messageID,
+                attachmentID: artifact.id
+            )
+        case .generated:
+            return imageGeneration.removeOutput(
+                sessionID: artifact.sessionID,
+                turnID: artifact.messageID,
+                outputID: artifact.id
+            )
+        }
+    }
     lazy var dashboard = DashboardViewModel()
     lazy var downloads = HuggingFaceDownloadManager.shared
     lazy var embeddingLibrary = LocalModelLibrary()

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelView.swift
@@ -166,22 +166,6 @@ struct ControlPanelView: View {
                 navigation.requestedTab.map(ControlPanelSidebarSelection.tab) ?? sidebarSelection)
             handleNewChatRequest()
             embeddingLibrary.scan(searchPaths: chromeState.artifactSettings.localModelSearchPaths)
-            artifacts.onDeleteArtifact = { artifact in
-                switch artifact.source {
-                case .uploaded:
-                    chat.removeAttachment(
-                        sessionID: artifact.sessionID,
-                        messageID: artifact.messageID,
-                        attachmentID: artifact.id
-                    )
-                case .generated:
-                    imageGeneration.removeOutput(
-                        sessionID: artifact.sessionID,
-                        turnID: artifact.messageID,
-                        outputID: artifact.id
-                    )
-                }
-            }
         }
         .onReceive(navigation.$requestedTab) { tab in
             guard let tab else { return }

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -761,34 +761,57 @@ final class ImageGenerationViewModel: ObservableObject {
         currentSessionID = session.id
     }
 
-    func removeOutput(sessionID: UUID, turnID: UUID, outputID: UUID) {
+    @discardableResult
+    func removeOutput(sessionID: UUID, turnID: UUID, outputID: UUID) -> Bool {
         guard canModifySession(sessionID) else {
-            return
+            return false
         }
         if sessionID == currentSessionID {
-            for turnIndex in turns.indices where turns[turnIndex].id == turnID {
-                turns[turnIndex].outputs.removeAll { $0.id == outputID }
+            let previousTurns = turns
+            guard removeOutput(turnID: turnID, outputID: outputID, from: &turns) else {
+                return false
             }
-            persistCurrentSession(updateTimestamp: false)
-            return
+            guard persistCurrentSession(updateTimestamp: false) else {
+                turns = previousTurns
+                return false
+            }
+            return true
         }
 
         guard var session = storedSessions.first(where: { $0.id == sessionID })
             ?? sessionStore.loadSession(id: sessionID)
         else {
-            return
+            return false
         }
-        for turnIndex in session.turns.indices where session.turns[turnIndex].id == turnID {
-            session.turns[turnIndex].outputs.removeAll { $0.id == outputID }
+        guard removeOutput(turnID: turnID, outputID: outputID, from: &session.turns) else {
+            return false
+        }
+        guard saveSession(session) else {
+            return false
         }
         upsertStoredSession(session)
-        saveSession(session)
         refreshSessionList()
+        return true
     }
 
-    private func persistCurrentSession(updateTimestamp: Bool) {
+    private func removeOutput(
+        turnID: UUID,
+        outputID: UUID,
+        from turns: inout [ImageGenerationTurn]
+    ) -> Bool {
+        guard let turnIndex = turns.firstIndex(where: { $0.id == turnID }),
+            let outputIndex = turns[turnIndex].outputs.firstIndex(where: { $0.id == outputID })
+        else {
+            return false
+        }
+        turns[turnIndex].outputs.remove(at: outputIndex)
+        return true
+    }
+
+    @discardableResult
+    private func persistCurrentSession(updateTimestamp: Bool) -> Bool {
         guard var session = currentSession, canModifySession(session.id) else {
-            return
+            return false
         }
         session.modelKind = .imageGeneration
         session.modelID = normalized(modelID) ?? Self.fallbackModelID
@@ -804,10 +827,13 @@ final class ImageGenerationViewModel: ObservableObject {
             session.updatedAt = Date()
         }
 
+        guard saveSession(session) else {
+            return false
+        }
         currentSession = session
         upsertStoredSession(session)
-        saveSession(session)
         refreshSessionList()
+        return true
     }
 
     private func upsertStoredSession(_ session: ImageGenerationSession) {
@@ -855,15 +881,19 @@ final class ImageGenerationViewModel: ObservableObject {
         refreshSessionList()
     }
 
-    private func saveSession(_ session: ImageGenerationSession) {
+    @discardableResult
+    private func saveSession(_ session: ImageGenerationSession) -> Bool {
         guard canModifySession(session.id) else {
-            return
+            return false
         }
-        sessionStore.saveSession(session)
+        guard sessionStore.saveSession(session) else {
+            return false
+        }
         persistedDataChanges.send(
             .imageGenerationSession(session.id),
             originWindowID: windowID
         )
+        return true
     }
 
     private func canModifySession(_ sessionID: UUID) -> Bool {
@@ -1070,15 +1100,18 @@ private struct ImageGenerationSessionStore {
             .joined(separator: "|")
     }
 
-    func saveSession(_ session: ImageGenerationSession) {
+    @discardableResult
+    func saveSession(_ session: ImageGenerationSession) -> Bool {
         do {
             try fileManager.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             try encoder.encode(session).write(to: sessionURL(for: session.id), options: .atomic)
+            return true
         } catch {
             // Persistence should never prevent local image generation.
+            return false
         }
     }
 

--- a/Tests/NativTests/ArtifactDeletionTests.swift
+++ b/Tests/NativTests/ArtifactDeletionTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@MainActor
+final class ArtifactDeletionTests: XCTestCase {
+    func testLockedImageSessionRejectsOutputRemoval() {
+        let inferenceActivity = InferenceActivityCoordinator()
+        let sessionID = UUID()
+        let operationID = UUID()
+        let viewModel = ImageGenerationViewModel(
+            windowID: UUID(),
+            inferenceActivity: inferenceActivity
+        )
+
+        XCTAssertTrue(inferenceActivity.begin(
+            resource: .imageGeneration(sessionID),
+            windowID: UUID(),
+            operationID: operationID
+        ))
+
+        XCTAssertFalse(viewModel.removeOutput(
+            sessionID: sessionID,
+            turnID: UUID(),
+            outputID: UUID()
+        ))
+    }
+
+    func testBatchDeletionPreservesArtifactsRejectedByHistory() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let storage = ArtifactStore.StorageLocations(
+            indexURL: temporaryDirectory.appendingPathComponent("Artifacts Index.json"),
+            cacheDirectory: temporaryDirectory.appendingPathComponent(
+                "Artifacts",
+                isDirectory: true
+            ),
+            favoritesURL: temporaryDirectory.appendingPathComponent("Artifact Favorites.json"),
+            displayNamesURL: temporaryDirectory.appendingPathComponent("Artifact Names.json")
+        )
+        let allowed = makeArtifact(filename: "allowed.png")
+        let rejected = makeArtifact(filename: "rejected.png")
+        try writeArtifacts([allowed, rejected], to: storage.indexURL)
+        try writeArtifactFile(allowed, storage: storage)
+        try writeArtifactFile(rejected, storage: storage)
+
+        let store = ArtifactStore(
+            storage: storage,
+            refreshesAutomatically: false,
+            deletionHandler: { $0.id == allowed.id }
+        )
+
+        let deletedIDs = store.delete([allowed, rejected])
+
+        XCTAssertEqual(deletedIDs, Set([allowed.id]))
+        XCTAssertEqual(store.artifacts.map(\.id), [rejected.id])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.fileURL(for: allowed).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.fileURL(for: rejected).path))
+        XCTAssertEqual(try loadArtifacts(from: storage.indexURL).map(\.id), [rejected.id])
+    }
+
+    private func makeArtifact(filename: String) -> Artifact {
+        let id = UUID()
+        return Artifact(
+            id: id,
+            kind: .image,
+            source: .generated,
+            sessionID: UUID(),
+            messageID: UUID(),
+            filename: filename,
+            mimeType: "image/png",
+            relativePath: "image/\(id.uuidString).png",
+            byteSize: 1,
+            createdAt: .now,
+            prompt: nil,
+            sessionTitle: "Test session"
+        )
+    }
+
+    private func writeArtifactFile(
+        _ artifact: Artifact,
+        storage: ArtifactStore.StorageLocations
+    ) throws {
+        let url = storage.cacheDirectory.appendingPathComponent(artifact.relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data([0]).write(to: url)
+    }
+
+    private func writeArtifacts(_ artifacts: [Artifact], to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(artifacts).write(to: url)
+    }
+
+    private func loadArtifacts(from url: URL) throws -> [Artifact] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([Artifact].self, from: Data(contentsOf: url))
+    }
+}


### PR DESCRIPTION
This makes artifact deletion transactional with its chat or image generation history. An artifact is removed from the cache and index only after its corresponding attachment or generated output is successfully removed and persisted, while locked sessions or persistence failures leave it intact