### PR TITLE
Add external model cache foundation

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0394DEE40DF5A06244F72794 /* MCPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F373627C4A522AF78E2A17 /* MCPClientTests.swift */; };
 		03B0228F483C7F76742D5245 /* PerplexityBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F316824C4C3D36A94717A62 /* PerplexityBrowsingProvider.swift */; };
 		04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
+		051790A7801DEB8772911289 /* ExternalModelCacheReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = F605E5C42FC442A37E4946BD /* ExternalModelCacheReference.swift */; };
 		052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */; };
 		060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */; };
 		06C8B891576DC3051282D367 /* NativKitRuntimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */; };
@@ -165,6 +166,7 @@
 		61598EC22589683F1A54B047 /* ChatConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF9F903E2609C4A522C19CF /* ChatConfigurationView.swift */; };
 		62CAD81D603FF4AC296279CB /* ChatToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */; };
 		63D4D3774994EAE5F5ABB7E9 /* AudioInputVolumeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A118DF27AE0EF852DC458BB7 /* AudioInputVolumeController.swift */; };
+		63FEFD395756E19E4C9E9A24 /* ExternalModelCacheReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = F605E5C42FC442A37E4946BD /* ExternalModelCacheReference.swift */; };
 		657DFF151F7E54EA66CC36F8 /* SystemSensorSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653E58FFA38742CD4D5D41F5 /* SystemSensorSampler.swift */; };
 		66745D5BB4D1454479FF6C9C /* RoutineScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C1220F03EC60874920E0CE /* RoutineScheduler.swift */; };
 		67560D2323090F583CCC39C6 /* NotificationAppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 6ABC782FB29B8C76EC8B60E6 /* NotificationAppIcon.icns */; };
@@ -693,6 +695,7 @@
 		F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPromptRevision.swift; sourceTree = "<group>"; };
 		F553434CA19B929108FF740F /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDocumentContextBuilderTests.swift; sourceTree = "<group>"; };
+		F605E5C42FC442A37E4946BD /* ExternalModelCacheReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalModelCacheReference.swift; sourceTree = "<group>"; };
 		F84C7B764CE1B6F63746E3BB /* Perplexity.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Perplexity.png; sourceTree = "<group>"; };
 		FB10CC03A96A3EA80EF9343B /* ScheduledCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledCapabilityTests.swift; sourceTree = "<group>"; };
 		FB497800D0F8B237A1891EE1 /* WebBrowsingTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingTransport.swift; sourceTree = "<group>"; };
@@ -1145,6 +1148,7 @@
 		BAC9F35045D83344BC059CB2 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				F605E5C42FC442A37E4946BD /* ExternalModelCacheReference.swift */,
 				1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */,
 				E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */,
 				7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */,
@@ -1681,6 +1685,7 @@
 				7C49B0A059A3495FF8BC8B66 /* EmbeddingModelPreparer.swift in Sources */,
 				AFBC36570418275354CE129B /* ExaBrowsingProvider.swift in Sources */,
 				C89558DC65CAAEC956198688 /* ExtensionsHubView.swift in Sources */,
+				63FEFD395756E19E4C9E9A24 /* ExternalModelCacheReference.swift in Sources */,
 				6794E481FC0BE317EAA7600C /* FileEditEngine.swift in Sources */,
 				B400776A9DE913FA1509FA06 /* FileMutationState.swift in Sources */,
 				52927A9A78C07E5E649AFDF6 /* FilePreview.swift in Sources */,
@@ -1841,6 +1846,7 @@
 				4944DC4357DA195C1E8D8B75 /* DocumentTextExtraction.swift in Sources */,
 				487C0D234A1B2F700F3BB5DA /* DocumentTextExtractionTests.swift in Sources */,
 				9FC9DFAEC00710427FDD509C /* ExaBrowsingProvider.swift in Sources */,
+				051790A7801DEB8772911289 /* ExternalModelCacheReference.swift in Sources */,
 				B4846F63E99C06434507B047 /* FileEditEngine.swift in Sources */,
 				546A23A6921BCB4D3A1DD908 /* FileMutationState.swift in Sources */,
 				C4381191592EC7C3B97E2C35 /* FilePreview.swift in Sources */,

--- a/Sources/Nativ/Features/Models/ExternalModelCacheReference.swift
+++ b/Sources/Nativ/Features/Models/ExternalModelCacheReference.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+struct ExternalModelCacheReference: Codable, Equatable, Sendable {
+    struct Resolved: Equatable, Sendable {
+        let url: URL
+        let reference: ExternalModelCacheReference
+    }
+
+    enum ValidationError: LocalizedError, Equatable, Sendable {
+        case unavailable
+        case notDirectory
+        case networkVolume
+        case internalVolume
+        case unsupportedFileSystem(String)
+        case readOnly
+        case notReadable
+        case notWritable
+        case differentVolume
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable:
+                "The selected folder is unavailable. Make sure its drive is connected and try again."
+            case .notDirectory:
+                "Choose a folder for Nativ’s model storage."
+            case .networkVolume:
+                "Choose a folder on a locally attached drive. Network storage is not supported."
+            case .internalVolume:
+                "Choose a folder on an external drive."
+            case .unsupportedFileSystem(let fileSystem):
+                "Choose an APFS-formatted drive. The selected drive uses \(fileSystem.uppercased())."
+            case .readOnly:
+                "The selected drive is read-only."
+            case .notReadable:
+                "Nativ cannot read the selected folder."
+            case .notWritable:
+                "Nativ cannot write to the selected folder."
+            case .differentVolume:
+                "A different drive is mounted at the selected location."
+            }
+        }
+    }
+
+    let bookmarkData: Data
+    let volumeIdentifier: String
+
+    init(url: URL) throws {
+        self = try Self.make(for: Self.validate(url))
+    }
+
+    func resolve(lastKnownPath: String) throws -> Resolved {
+        var bookmarkIsStale = false
+        let bookmarkedURL = try? URL(
+            resolvingBookmarkData: bookmarkData,
+            options: [.withoutUI],
+            relativeTo: nil,
+            bookmarkDataIsStale: &bookmarkIsStale
+        )
+        let lastKnownURL = URL(filePath: lastKnownPath, directoryHint: .isDirectory)
+
+        var lastError = ValidationError.unavailable
+        var seenPaths = Set<String>()
+        for candidate in [bookmarkedURL, lastKnownURL].compactMap({ $0 }) {
+            let path = candidate.standardizedFileURL.path
+            guard seenPaths.insert(path).inserted else { continue }
+
+            do {
+                let url = try Self.validate(candidate)
+                let reference = try Self.make(for: url)
+                guard reference.volumeIdentifier == volumeIdentifier else {
+                    throw ValidationError.differentVolume
+                }
+                return Resolved(url: url, reference: reference)
+            } catch let error as ValidationError {
+                lastError = error
+            } catch {
+                lastError = .unavailable
+            }
+        }
+        throw lastError
+    }
+
+    static func validate(_ selectedURL: URL) throws -> URL {
+        guard selectedURL.isFileURL else {
+            throw ValidationError.unavailable
+        }
+
+        let url = selectedURL.resolvingSymlinksInPath().standardizedFileURL
+        let values: URLResourceValues
+        do {
+            values = try url.resourceValues(forKeys: [
+                .isDirectoryKey,
+                .isReadableKey,
+                .isWritableKey,
+                .volumeIsLocalKey,
+                .volumeIsInternalKey,
+                .volumeIsEjectableKey,
+                .volumeIsRemovableKey,
+                .volumeIsReadOnlyKey,
+                .volumeTypeNameKey,
+            ])
+        } catch {
+            throw ValidationError.unavailable
+        }
+
+        guard let isDirectory = values.isDirectory,
+              let isReadable = values.isReadable,
+              let isWritable = values.isWritable,
+              let isLocal = values.volumeIsLocal,
+              let isReadOnly = values.volumeIsReadOnly,
+              let fileSystem = values.volumeTypeName else {
+            throw ValidationError.unavailable
+        }
+
+        guard isDirectory else { throw ValidationError.notDirectory }
+        guard isLocal else { throw ValidationError.networkVolume }
+        if values.volumeIsInternal == true {
+            throw ValidationError.internalVolume
+        }
+        guard values.volumeIsInternal == false
+                || values.volumeIsEjectable == true
+                || values.volumeIsRemovable == true else {
+            throw ValidationError.unavailable
+        }
+        guard fileSystem.caseInsensitiveCompare("apfs") == .orderedSame else {
+            throw ValidationError.unsupportedFileSystem(fileSystem)
+        }
+        guard !isReadOnly else { throw ValidationError.readOnly }
+        guard isReadable else { throw ValidationError.notReadable }
+        guard isWritable else { throw ValidationError.notWritable }
+        return url
+    }
+
+    private init(bookmarkData: Data, volumeIdentifier: String) {
+        self.bookmarkData = bookmarkData
+        self.volumeIdentifier = volumeIdentifier
+    }
+
+    private static func make(for url: URL) throws -> Self {
+        let volumeIdentifier = try url.resourceValues(
+            forKeys: [.volumeUUIDStringKey]
+        ).volumeUUIDString
+        guard let volumeIdentifier else {
+            throw ValidationError.unavailable
+        }
+
+        let bookmarkData = try url.bookmarkData(
+            options: [],
+            includingResourceValuesForKeys: [.volumeUUIDStringKey],
+            relativeTo: nil
+        )
+        return Self(
+            bookmarkData: bookmarkData,
+            volumeIdentifier: volumeIdentifier
+        )
+    }
+}

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -402,6 +402,7 @@ struct NativSettings: Codable, Equatable {
     static let serverSupportsEmbeddingModelArgument = false
 
     var modelSearchPath: String
+    var externalModelCache: ExternalModelCacheReference?
     var additionalModelSearchPaths: [String]
     var languageModelID: String?
     var mcpServers: [MCPServerConfig]
@@ -455,6 +456,7 @@ struct NativSettings: Codable, Equatable {
 
     init(
         modelSearchPath: String = Self.defaultModelSearchPath,
+        externalModelCache: ExternalModelCacheReference? = nil,
         additionalModelSearchPaths: [String] = [],
         languageModelID: String? = nil,
         mcpServers: [MCPServerConfig] = [],
@@ -507,6 +509,7 @@ struct NativSettings: Codable, Equatable {
         modelConfigs: [String: ModelConfigProfile] = [:]
     ) {
         self.modelSearchPath = modelSearchPath
+        self.externalModelCache = externalModelCache
         self.additionalModelSearchPaths = additionalModelSearchPaths
         self.languageModelID = languageModelID
         self.mcpServers = mcpServers
@@ -561,6 +564,7 @@ struct NativSettings: Codable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case modelSearchPath
+        case externalModelCache
         case additionalModelSearchPaths
         case languageModelID
         case mcpServers
@@ -620,6 +624,10 @@ struct NativSettings: Codable, Equatable {
         let legacySelectedModelID = try container.decodeIfPresent(String.self, forKey: .selectedModelID)
         let storedModelSearchPath = try container.decodeIfPresent(String.self, forKey: .modelSearchPath)
         modelSearchPath = HuggingFaceCache.resolvedSearchPath(stored: storedModelSearchPath)
+        externalModelCache = try container.decodeIfPresent(
+            ExternalModelCacheReference.self,
+            forKey: .externalModelCache
+        )
         additionalModelSearchPaths = try container.decodeIfPresent([String].self, forKey: .additionalModelSearchPaths) ?? defaults.additionalModelSearchPaths
         languageModelID = try container.decodeIfPresent(String.self, forKey: .languageModelID) ?? legacySelectedModelID ?? defaults.languageModelID
         mcpServers = try container.decodeIfPresent([MCPServerConfig].self, forKey: .mcpServers) ?? defaults.mcpServers
@@ -675,6 +683,7 @@ struct NativSettings: Codable, Equatable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(modelSearchPath, forKey: .modelSearchPath)
+        try container.encodeIfPresent(externalModelCache, forKey: .externalModelCache)
         try container.encode(additionalModelSearchPaths, forKey: .additionalModelSearchPaths)
         try container.encodeIfPresent(languageModelID, forKey: .languageModelID)
         try container.encode(mcpServers, forKey: .mcpServers)
@@ -961,6 +970,7 @@ struct NativSettings: Codable, Equatable {
         let lhsSpeculativeDecodingActive = lhs.speculativeDecodingActive
         let rhsSpeculativeDecodingActive = rhs.speculativeDecodingActive
         return lhs.modelSearchPath == rhs.modelSearchPath
+            && lhs.externalModelCache?.volumeIdentifier == rhs.externalModelCache?.volumeIdentifier
             && lhs.languageModelID == rhs.languageModelID
             && lhs.mcpServers == rhs.mcpServers
             && lhs.disabledToolNames == rhs.disabledToolNames

--- a/project.yml
+++ b/project.yml
@@ -184,6 +184,7 @@ targets:
       - path: Sources/Nativ/Features/VoiceCapture/RealtimeAudioMeter.swift
       - path: Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
+      - path: Sources/Nativ/Features/Models/ExternalModelCacheReference.swift
       - path: Sources/Nativ/Features/Models/HubModelSizeResolver.swift
       - path: Sources/Nativ/Features/Models/LocalModelDiscovery.swift
       - path: Sources/Nativ/Features/Models/LocalModelProvider.swift


### PR DESCRIPTION
This is the first PR in the external model storage stack. It adds the core type used to store and resolve an external model cache location. Selected folders are checked to make sure they are on a local, writable APFS external drive. The reference stores a macOS bookmark so moved folders can be recovered, along with the drive’s volume UUID so Nativ does not use the wrong drive if one appears at the same path.