### PR TITLE
Feat/external cache model operations

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -45,6 +45,7 @@ final class ChatViewModel: ObservableObject {
 
     private struct ImageModelPreparationContext {
         let modelSearchPath: String
+        let modelCacheVolumeIdentifier: String?
         let additionalModelSearchPaths: [String]
         let huggingFaceToken: String?
     }
@@ -945,6 +946,7 @@ final class ChatViewModel: ObservableObject {
                     repoID: selectedModel.modelID,
                     sizeBytes: selectedModel.downloadSizeBytes,
                     cachePath: preparationContext.modelSearchPath,
+                    volumeIdentifier: preparationContext.modelCacheVolumeIdentifier,
                     token: preparationContext.huggingFaceToken
                 )
                 try Task.checkCancellation()
@@ -1751,6 +1753,8 @@ final class ChatViewModel: ObservableObject {
                     )
                     let imageModelPreparationContext = ImageModelPreparationContext(
                         modelSearchPath: queuedRequest.settings.expandedModelSearchPath,
+                        modelCacheVolumeIdentifier: queuedRequest.settings
+                            .externalModelCache?.volumeIdentifier,
                         additionalModelSearchPaths: queuedRequest.settings
                             .additionalModelSearchPaths,
                         huggingFaceToken: appModel?.effectiveHuggingFaceToken

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelDetail.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelDetail.swift
@@ -339,6 +339,7 @@ struct ArtifactsPageHost: View {
             repoID: modelID,
             sizeBytes: Self.embeddingModelSize,
             cachePath: settings.modelSearchPath,
+            volumeIdentifier: settings.modelCacheVolumeIdentifier,
             token: model.effectiveHuggingFaceToken
         ) {
             EmbeddingModelPreparer.prepare(
@@ -356,7 +357,8 @@ struct ArtifactsPageHost: View {
         Task {
             try? await LocalModelDiscovery.delete(
                 repoID: modelID,
-                path: settings.modelSearchPath
+                path: settings.modelSearchPath,
+                volumeIdentifier: settings.modelCacheVolumeIdentifier
             )
             embeddingLibrary.scan(searchPaths: settings.localModelSearchPaths)
             NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelState.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelState.swift
@@ -13,6 +13,7 @@ final class ControlPanelChromeState: ObservableObject {
         let serverPort: Int
         let serverAPIKey: String?
         let modelSearchPath: String
+        let modelCacheVolumeIdentifier: String?
         let localModelSearchPaths: LocalModelSearchPaths
     }
 
@@ -129,6 +130,7 @@ final class ControlPanelChromeState: ObservableObject {
                 serverPort: settings.serverPort,
                 serverAPIKey: settings.serverAPIKey,
                 modelSearchPath: settings.modelSearchPath,
+                modelCacheVolumeIdentifier: settings.externalModelCache?.volumeIdentifier,
                 localModelSearchPaths: settings.localModelSearchPaths
             )
         )

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -446,6 +446,7 @@ final class ImageGenerationViewModel: ObservableObject {
         let serverBaseURL = serverSettings.serverBaseURL
         let serverAPIKey = serverSettings.serverAPIKey
         let modelSearchPath = serverSettings.modelSearchPath
+        let modelCacheVolumeIdentifier = serverSettings.externalModelCache?.volumeIdentifier
         let huggingFaceToken = appModel.effectiveHuggingFaceToken
         activeTask = Task { @MainActor [weak self, weak appModel, inferenceActivity] in
             defer {
@@ -464,6 +465,7 @@ final class ImageGenerationViewModel: ObservableObject {
                         repoID: requestModelID,
                         sizeBytes: nil,
                         cachePath: modelSearchPath,
+                        volumeIdentifier: modelCacheVolumeIdentifier,
                         token: huggingFaceToken
                     )
                     try Task.checkCancellation()

--- a/Sources/Nativ/Features/Models/ExternalModelCacheReference.swift
+++ b/Sources/Nativ/Features/Models/ExternalModelCacheReference.swift
@@ -80,6 +80,24 @@ struct ExternalModelCacheReference: Codable, Equatable, Sendable {
         throw lastError
     }
 
+    static func validateForUse(
+        path: String,
+        expectedVolumeIdentifier: String?
+    ) throws -> URL {
+        let expandedPath = NSString(string: path).expandingTildeInPath
+        let url = URL(filePath: expandedPath, directoryHint: .isDirectory)
+        guard let expectedVolumeIdentifier else { return url.standardizedFileURL }
+
+        let validatedURL = try validate(url)
+        let actualVolumeIdentifier = try validatedURL.resourceValues(
+            forKeys: [.volumeUUIDStringKey]
+        ).volumeUUIDString
+        guard actualVolumeIdentifier == expectedVolumeIdentifier else {
+            throw ValidationError.differentVolume
+        }
+        return validatedURL
+    }
+
     static func validate(_ selectedURL: URL) throws -> URL {
         guard selectedURL.isFileURL else {
             throw ValidationError.unavailable

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -1038,15 +1038,23 @@ final class HuggingFaceDownloadManager: ObservableObject {
     private final class DownloadContext {
         let modelID: String
         let cachePath: String
+        let volumeIdentifier: String?
         let token: String?
         var onCompletion: (() -> Void)?
         var operation: HuggingFaceDownloadOperation?
         var task: Task<Void, Never>?
         var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
 
-        init(modelID: String, cachePath: String, token: String?, onCompletion: (() -> Void)?) {
+        init(
+            modelID: String,
+            cachePath: String,
+            volumeIdentifier: String?,
+            token: String?,
+            onCompletion: (() -> Void)?
+        ) {
             self.modelID = modelID
             self.cachePath = cachePath
+            self.volumeIdentifier = volumeIdentifier
             self.token = token
             self.onCompletion = onCompletion
         }
@@ -1125,20 +1133,24 @@ final class HuggingFaceDownloadManager: ObservableObject {
         repoID: String,
         sizeBytes: Int64?,
         cachePath: String,
+        volumeIdentifier: String?,
         token: String?,
         onCompletion: @escaping () -> Void
     ) {
         guard contexts[repoID] == nil else { return }
-        if let blocker = capacityBlocker(sizeBytes: sizeBytes, cachePath: cachePath) {
-            errorByModelID[repoID] = .message(blocker)
-            rowUpdates.send(repoID)
-            return
-        }
         do {
+            _ = try ExternalModelCacheReference.validateForUse(
+                path: cachePath,
+                expectedVolumeIdentifier: volumeIdentifier
+            )
+            if let blocker = capacityBlocker(sizeBytes: sizeBytes, cachePath: cachePath) {
+                throw HuggingFaceDownloadFailure.message(blocker)
+            }
             try enqueue(
                 repoID: repoID,
                 sizeBytes: sizeBytes,
                 cachePath: cachePath,
+                volumeIdentifier: volumeIdentifier,
                 token: token,
                 onCompletion: onCompletion
             )
@@ -1152,11 +1164,13 @@ final class HuggingFaceDownloadManager: ObservableObject {
         repoID: String,
         sizeBytes: Int64?,
         cachePath: String,
+        volumeIdentifier: String?,
         token: String?
     ) async throws {
         let expandedCachePath = LocalModelDiscovery.expandedPath(cachePath)
         if let context = contexts[repoID] {
-            guard context.cachePath == expandedCachePath else {
+            guard context.cachePath == expandedCachePath,
+                  context.volumeIdentifier == volumeIdentifier else {
                 throw HuggingFaceHubError.anotherDownloadInProgress(repoID)
             }
         } else {
@@ -1165,6 +1179,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
                     repoID: repoID,
                     sizeBytes: sizeBytes,
                     cachePath: expandedCachePath,
+                    volumeIdentifier: volumeIdentifier,
                     token: token,
                     onCompletion: nil
                 )
@@ -1200,6 +1215,17 @@ final class HuggingFaceDownloadManager: ObservableObject {
 
     func resumeDownload(_ modelID: String) {
         guard let context = contexts[modelID], state(for: modelID) == .paused else { return }
+        do {
+            _ = try ExternalModelCacheReference.validateForUse(
+                path: context.cachePath,
+                expectedVolumeIdentifier: context.volumeIdentifier
+            )
+        } catch {
+            context.task?.cancel()
+            context.operation?.cancel()
+            finishDownload(repoID: modelID, error: downloadFailure(for: error))
+            return
+        }
         context.operation?.resume()
         setState(modelID, .downloading)
     }
@@ -1208,6 +1234,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
         guard let context = contexts[modelID] else { return }
         let task = context.task
         let cachePath = context.cachePath
+        let volumeIdentifier = context.volumeIdentifier
         task?.cancel()
         let waiters = Array(context.waiters.values)
         removeContext(modelID)
@@ -1216,7 +1243,11 @@ final class HuggingFaceDownloadManager: ObservableObject {
         Task {
             await task?.value
             await Task.detached(priority: .utility) {
-                HuggingFaceSnapshotDownloader.removeDownload(repoID: modelID, cachePath: cachePath)
+                HuggingFaceSnapshotDownloader.removeDownload(
+                    repoID: modelID,
+                    cachePath: cachePath,
+                    volumeIdentifier: volumeIdentifier
+                )
             }.value
         }
     }
@@ -1253,13 +1284,18 @@ final class HuggingFaceDownloadManager: ObservableObject {
         repoID: String,
         sizeBytes: Int64?,
         cachePath: String,
+        volumeIdentifier: String?,
         token: String?,
         onCompletion: (() -> Void)?
     ) throws {
-        let expandedCachePath = LocalModelDiscovery.expandedPath(cachePath)
+        let cacheURL = try ExternalModelCacheReference.validateForUse(
+            path: cachePath,
+            expectedVolumeIdentifier: volumeIdentifier
+        )
         let context = DownloadContext(
             modelID: repoID,
-            cachePath: expandedCachePath,
+            cachePath: cacheURL.path,
+            volumeIdentifier: volumeIdentifier,
             token: token,
             onCompletion: onCompletion
         )
@@ -1477,9 +1513,18 @@ private enum HuggingFaceSnapshotDownloader {
         }
     }
 
-    static func removeDownload(repoID: String, cachePath: String) {
+    static func removeDownload(
+        repoID: String,
+        cachePath: String,
+        volumeIdentifier: String?
+    ) {
+        guard let cacheURL = try? ExternalModelCacheReference.validateForUse(
+            path: cachePath,
+            expectedVolumeIdentifier: volumeIdentifier
+        ) else {
+            return
+        }
         let repositoryDirectory = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
-        let cacheURL = URL(fileURLWithPath: cachePath, isDirectory: true)
         let fileManager = FileManager.default
         try? fileManager.removeItem(at: cacheURL.appendingPathComponent(repositoryDirectory, isDirectory: true))
         try? fileManager.removeItem(

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -354,11 +354,18 @@ enum LocalModelDiscovery {
         }
     }
 
-    static func delete(repoID: String, path: String) async throws {
+    static func delete(
+        repoID: String,
+        path: String,
+        volumeIdentifier: String?
+    ) async throws {
         let expandedPath = Self.expandedPath(path)
         try await Task.detached(priority: .utility) {
+            let cacheURL = try ExternalModelCacheReference.validateForUse(
+                path: expandedPath,
+                expectedVolumeIdentifier: volumeIdentifier
+            )
             let directoryName = "models--" + repoID.replacingOccurrences(of: "/", with: "--")
-            let cacheURL = URL(fileURLWithPath: expandedPath, isDirectory: true)
             let fileManager = FileManager.default
             let repositoryURL = cacheURL.appendingPathComponent(directoryName, isDirectory: true)
             let lockURL = cacheURL
@@ -1759,6 +1766,7 @@ final class LocalModelLibrary: ObservableObject {
     func delete(
         model: LocalModel,
         path: String,
+        volumeIdentifier: String?,
         onCompletion: @escaping () -> Void
     ) {
         guard !deletingModelIDs.contains(model.repoID) else { return }
@@ -1767,7 +1775,11 @@ final class LocalModelLibrary: ObservableObject {
 
         Task { [weak self] in
             do {
-                try await LocalModelDiscovery.delete(repoID: model.repoID, path: path)
+                try await LocalModelDiscovery.delete(
+                    repoID: model.repoID,
+                    path: path,
+                    volumeIdentifier: volumeIdentifier
+                )
                 self?.models.removeAll { $0.repoID == model.repoID }
                 self?.deletingModelIDs.remove(model.repoID)
                 onCompletion()

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -717,6 +717,8 @@ struct ModelsView: View {
                                     repoID: hubModel.id,
                                     sizeBytes: downloadSizeBytes,
                                     cachePath: modelState.settings.modelSearchPath,
+                                    volumeIdentifier: modelState.settings
+                                        .externalModelCache?.volumeIdentifier,
                                     token: modelState.effectiveHuggingFaceToken
                                 ) {}
                             },
@@ -896,7 +898,8 @@ struct ModelsView: View {
         guard localModel.isDeletable else { return }
         localLibrary.delete(
             model: localModel,
-            path: modelState.settings.modelSearchPath
+            path: modelState.settings.modelSearchPath,
+            volumeIdentifier: modelState.settings.externalModelCache?.volumeIdentifier
         ) {
             var settings = modelState.settings
             if settings.languageModelID == localModel.repoID {

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -790,6 +790,7 @@ private struct WelcomeView: View {
             repoID: hubModel.id,
             sizeBytes: hubModel.sizeBytes,
             cachePath: model.settings.modelSearchPath,
+            volumeIdentifier: model.settings.externalModelCache?.volumeIdentifier,
             token: model.effectiveHuggingFaceToken
         ) {
             modelLibrary.scan(searchPaths: model.settings.localModelSearchPaths)


### PR DESCRIPTION
This is the second PR in the external model storage stack. It carries the saved volume identity through every model download and deletion path, including onboarding, the model browser, semantic search, chat image models, and image generation.

Downloads are validated before starting or resuming. Cleanup and deletion are skipped if the original drive is unavailable or has been replaced by another drive at the same path.