### PR TITLE
Add external model storage controls

### DIFF
--- a/Docs/features/models.md
+++ b/Docs/features/models.md
@@ -13,6 +13,22 @@ Installed models are found by scanning the Hugging Face cache plus any additiona
 - Capabilities are derived per model from its `config.json` (or `model_index.json` for
   diffusion pipelines) — see [`LocalModelDiscovery`](../../Sources/Nativ/Features/Models/LocalModelDiscovery.swift).
 
+## External model storage
+
+The primary Hugging Face cache can live on a locally attached APFS external drive. Open
+**Models → Sources → Choose External Location** and select a folder on that drive. Nativ records
+the drive identity as well as the folder, so reconnecting the same drive restores the location
+even if the volume is renamed.
+
+Changing locations stops and restarts the model server and clears its preloaded model selections.
+Active downloads must finish or be cancelled first. Existing model files are not moved or deleted;
+they remain in their original cache. Use **Restore System Default** to return to the cache selected
+by `HF_HUB_CACHE`, `HF_HOME`, or Nativ's per-user default.
+
+If the drive is disconnected, Nativ stops downloads using it, stops the model server, and marks the
+cache unavailable. Reconnect the original drive before downloading, deleting, or loading models.
+A different drive mounted at the same path is rejected.
+
 ## Capabilities
 
 Each model carries a set of capabilities (`LocalModelCapability`):

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Full feature and contributor documentation lives in **[`Docs/`](Docs/README.md)*
 | **Local chat and vision** | Streaming conversations, image attachments, reasoning output, response metrics, and persistent chat history. |
 | **Multiple windows** | Open independent workspaces with Command + Shift + N while sharing the same inference server, loaded models, and settings. |
 | **Image generation and editing** | Generate and edit images locally with compatible MLX image models in a dedicated Images tab. |
-| **Model library** | Discover installed MLX models, browse and download compatible models from Hugging Face with fit warnings for your memory, inspect capabilities, switch models, or remove old ones. Preload separate language, image-generation, speech, and embedding models at once, with a warning if the combination would exceed your Mac's memory. |
+| **Model library** | Discover installed MLX models, browse and download compatible models from Hugging Face with fit warnings for your memory, store the cache on an external APFS drive, inspect capabilities, switch models, or remove old ones. Preload separate language, image-generation, speech, and embedding models at once, with a warning if the combination would exceed your Mac's memory. |
 | **Performance analytics** | Track request volume, token usage, time to first token, decode speed, model performance, and recent activity. |
 | **System monitor** | Inspect live per-core CPU load, GPU utilization, unified memory and swap pressure, disk throughput, capacity, SMART health, and thermal and power sensors. |
 | **Local APIs** | OpenAI-compatible chat, Responses, image, audio, embeddings, and model endpoints, plus Anthropic Messages endpoints. |

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -78,6 +78,7 @@ private final class ModelsNativState: ObservableObject {
         var modelLoadFailure: ModelLoadFailure?
         var systemHuggingFaceCredential: HuggingFaceCredential?
         var loadedModelID: String?
+        var externalModelCacheState: ExternalModelCacheReference.State
     }
 
     @Published private var snapshot: Snapshot
@@ -95,7 +96,8 @@ private final class ModelsNativState: ObservableObject {
             metricsLoading: model.metricsLoading,
             modelLoadFailure: model.modelLoadFailure,
             systemHuggingFaceCredential: model.systemHuggingFaceCredential,
-            loadedModelID: model.metrics?.server.loadedModel
+            loadedModelID: model.metrics?.server.loadedModel,
+            externalModelCacheState: model.externalModelCacheState
         )
 
         observeModel()
@@ -121,6 +123,7 @@ private final class ModelsNativState: ObservableObject {
             $0.modelLoadFailure = model.modelLoadFailure
             $0.systemHuggingFaceCredential = model.systemHuggingFaceCredential
             $0.loadedModelID = model.metrics?.server.loadedModel
+            $0.externalModelCacheState = model.externalModelCacheState
         }
     }
 
@@ -143,6 +146,9 @@ private final class ModelsNativState: ObservableObject {
         snapshot.systemHuggingFaceCredential
     }
     var loadedModelID: String? { snapshot.loadedModelID }
+    var externalModelCacheState: ExternalModelCacheReference.State {
+        snapshot.externalModelCacheState
+    }
 
     var effectiveHuggingFaceToken: String? {
         HuggingFaceAuthentication.effectiveToken(
@@ -248,6 +254,8 @@ struct ModelsView: View {
     @State private var installedModelSelection = NativBulkSelection<String>()
     @State private var pendingInstalledModelDeletion: [LocalModel] = []
     @State private var isConfirmingInstalledModelDeletion = false
+    @State private var modelCacheErrorMessage = ""
+    @State private var showsModelCacheError = false
 
     init(
         model: NativModel,
@@ -285,6 +293,7 @@ struct ModelsView: View {
                 pageHeader
                 activeDownloadBanner
                 modelLoadFailureBanner
+                externalModelCacheBanner
 
                 modelsPage
             }
@@ -312,9 +321,11 @@ struct ModelsView: View {
             rescanLocalModels()
         }
         .onReceive(NotificationCenter.default.publisher(for: .localModelLibraryDidChange)) { _ in
+            model.refreshExternalModelCacheState()
             rescanLocalModels()
         }
         .onAppear {
+            model.refreshExternalModelCacheState()
             openSpeechModelDiscoveryIfRequested()
             openImageModelDiscoveryIfRequested()
             openModelDiscoveryIfRequested()
@@ -387,6 +398,10 @@ struct ModelsView: View {
             localLibrary.cancel()
             hubLibrary.cancel()
             lastStartedHubSearchTaskID = nil
+        }
+        .alert("Couldn’t Change Model Storage", isPresented: $showsModelCacheError) {
+        } message: {
+            Text(modelCacheErrorMessage)
         }
     }
 
@@ -467,6 +482,21 @@ struct ModelsView: View {
     @ViewBuilder
     private var activeDownloadBanner: some View {
         ActiveDownloadBannerView()
+    }
+
+    @ViewBuilder
+    private var externalModelCacheBanner: some View {
+        if case .unavailable(_, let reason) = modelState.externalModelCacheState {
+            ModelsNotice(
+                title: "External model storage is unavailable",
+                message: reason.localizedDescription,
+                systemImage: "externaldrive.badge.exclamationmark",
+                color: .orange
+            )
+            .padding(.horizontal, 22)
+            .padding(.vertical, 10)
+            Divider()
+        }
     }
 
     private var pageHeader: some View {
@@ -1333,6 +1363,19 @@ struct ModelsView: View {
         Menu {
             Section("Hugging Face Cache") {
                 Text(abbreviatedPath(modelState.settings.normalized().modelSearchPath))
+                externalModelCacheStatus
+                Button(
+                    "Choose External Location…",
+                    systemImage: "externaldrive",
+                    action: chooseExternalModelCache
+                )
+                if modelState.settings.externalModelCache != nil {
+                    Button(
+                        "Restore System Default",
+                        systemImage: "arrow.counterclockwise",
+                        action: restoreSystemModelCache
+                    )
+                }
             }
             Section("Model Folders") {
                 ForEach(modelState.settings.normalized().additionalModelSearchPaths, id: \.self) {
@@ -1353,7 +1396,25 @@ struct ModelsView: View {
             Label("Sources", systemImage: "folder")
         }
         .fixedSize()
-        .help("Folders scanned for MLX models in addition to the Hugging Face cache")
+        .help("Manage model storage and additional model folders")
+    }
+
+    @ViewBuilder
+    private var externalModelCacheStatus: some View {
+        switch modelState.externalModelCacheState {
+        case .systemDefault:
+            Label("System Default", systemImage: "internaldrive")
+        case .available(_, let availableCapacity):
+            Label("External Drive Connected", systemImage: "externaldrive.fill.badge.checkmark")
+            if let availableCapacity {
+                Text("\(availableCapacity.formatted(.byteCount(style: .file))) available")
+            }
+        case .unavailable:
+            Label(
+                "External Drive Unavailable",
+                systemImage: "externaldrive.badge.exclamationmark"
+            )
+        }
     }
 
     private func rescanLocalModels() {
@@ -1373,6 +1434,37 @@ struct ModelsView: View {
         model.settings.additionalModelSearchPaths.append(
             (url.path as NSString).abbreviatingWithTildeInPath
         )
+    }
+
+    private func chooseExternalModelCache() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = URL(filePath: "/Volumes", directoryHint: .isDirectory)
+        panel.prompt = "Choose"
+        panel.message = "Choose a folder on an external APFS drive. Nativ will unload selected models and restart the server."
+        guard panel.runModal() == .OK, let selectedURL = panel.url else { return }
+
+        do {
+            try model.selectExternalModelCache(at: selectedURL)
+        } catch {
+            showModelCacheError(error)
+        }
+    }
+
+    private func restoreSystemModelCache() {
+        do {
+            try model.restoreDefaultModelCache()
+        } catch {
+            showModelCacheError(error)
+        }
+    }
+
+    private func showModelCacheError(_ error: Error) {
+        modelCacheErrorMessage = error.localizedDescription
+        showsModelCacheError = true
     }
 
     private func removeModelSourceFolder(_ path: String) {


### PR DESCRIPTION
This adds the UI for choosing an external APFS drive as the model cache. The Sources menu now shows the active location, connection state, and available capacity, with clear errors when storage cannot be changed. It also adds an option to restore the system-default cache and documents how external model storage behaves