### PR TITLE
Add custom Kit management

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		086BDF7ECBBC6CF5F63C63CB /* TavilyBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90AC464C5C04FB14A3C789 /* TavilyBrowsingProvider.swift */; };
 		088297CDFEFECD2787806AD7 /* VoiceCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */; };
 		0935A0AC0D6A6298D551EEAE /* ArtifactSemanticSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */; };
+		0940E69FB438245641377D01 /* NativKitLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE65855FB48CA89F7A0DDA8 /* NativKitLibrary.swift */; };
 		09AFBDCFDE11D1048329E070 /* WebBrowsingRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254FDFBF7C5F7C8019E9E03F /* WebBrowsingRuntime.swift */; };
 		0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */; };
 		0B11412D6A9FB77B9A204E7C /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */; };
@@ -82,6 +83,7 @@
 		2D2E2AE0FB5D588884E86BFB /* OfficeArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE82B4EBA796206F12005498 /* OfficeArchive.swift */; };
 		2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */; };
 		2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
+		31C08C22828567AEB0F8BC0E /* NativKitLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE65855FB48CA89F7A0DDA8 /* NativKitLibrary.swift */; };
 		31D67AFE2E2CD864C37D6CFA /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		326C969CB7D0F41F38467DFE /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
 		32E3DD03D61C201E783539AF /* ChatServerStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */; };
@@ -710,6 +712,7 @@
 		F84C7B764CE1B6F63746E3BB /* Perplexity.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Perplexity.png; sourceTree = "<group>"; };
 		FB10CC03A96A3EA80EF9343B /* ScheduledCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledCapabilityTests.swift; sourceTree = "<group>"; };
 		FB497800D0F8B237A1891EE1 /* WebBrowsingTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingTransport.swift; sourceTree = "<group>"; };
+		FBE65855FB48CA89F7A0DDA8 /* NativKitLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitLibrary.swift; sourceTree = "<group>"; };
 		FD296E4B5897E7E46606B697 /* ControlPanelActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelActions.swift; sourceTree = "<group>"; };
 		FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelReadme.swift; sourceTree = "<group>"; };
 		FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDeletionTests.swift; sourceTree = "<group>"; };
@@ -1212,6 +1215,7 @@
 				7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */,
 				27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */,
 				AA7F610FC8739BA80227DB26 /* NativKit.swift */,
+				FBE65855FB48CA89F7A0DDA8 /* NativKitLibrary.swift */,
 				3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */,
 				CDDB4C89F8DD338E9209E7FF /* NativSkill.swift */,
 				E902D6BB4117C3F240832FA3 /* ToolsSectionView.swift */,
@@ -1754,6 +1758,7 @@
 				F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */,
 				2B988CEEF0FD7FCCD3862AF6 /* NativExtensionStateStore.swift in Sources */,
 				C03E948D1C7E27B27838C4C6 /* NativKit.swift in Sources */,
+				0940E69FB438245641377D01 /* NativKitLibrary.swift in Sources */,
 				690202C6E092ABA0A086955F /* NativKitRuntimeResolver.swift in Sources */,
 				4EDF6704EAAC24ED6A205F7F /* NativModel.swift in Sources */,
 				751C105813095FEC67349FBB /* NativNotificationService.swift in Sources */,
@@ -1921,6 +1926,7 @@
 				ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */,
 				0E326825AE5A1A5EEA33D928 /* NativExtensionTests.swift in Sources */,
 				D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */,
+				31C08C22828567AEB0F8BC0E /* NativKitLibrary.swift in Sources */,
 				06C8B891576DC3051282D367 /* NativKitRuntimeResolver.swift in Sources */,
 				4B3B371072FF015C6CA2CA61 /* NativKitTests.swift in Sources */,
 				025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
+++ b/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
@@ -306,7 +306,7 @@ struct ChatKitsPickerSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        let kits = NativKitCatalog.bundled.kits
+        let kits = model.kitLibrary.catalog.kits
         VStack(alignment: .leading, spacing: 16) {
             HStack {
                 Text("Kits")

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -133,6 +133,7 @@ struct HubSectionScaffold<Content: View, Action: View>: View {
                     }
                     Spacer(minLength: 12)
                     action()
+                        .fixedSize(horizontal: true, vertical: true)
                 }
                 content()
             }

--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -38,48 +38,114 @@ private struct KitStateIcon: View {
     }
 }
 
+private enum KitSheet: Identifiable {
+    case detail(NativKit)
+    case editor(NativKit)
+
+    var id: String {
+        switch self {
+        case .detail(let kit): "detail-\(kit.id)"
+        case .editor(let kit): "editor-\(kit.id)"
+        }
+    }
+}
+
 struct KitsSectionView: View {
     @ObservedObject var manager: NativExtensionManager
     var model: NativModel
-    @State private var openKit: NativKit?
+    @State private var presentedSheet: KitSheet?
+    @State private var pendingDeletion: NativKit?
+    @State private var errorMessage: String?
 
     private static let columns = [GridItem(.adaptive(minimum: 260, maximum: 360), spacing: 14)]
 
     var body: some View {
+        let catalog = model.kitLibrary.catalog
         HubSectionScaffold(
             title: "Kits",
-            subtitle: "Ready-made setups. Enable one to turn on the MCP servers, skills, and extensions for a way of working — then manage any piece on its own."
+            subtitle: "Reusable groups of MCP servers, tools, skills, and extensions. Enabling a Kit only turns on what is missing."
         ) {
-            EmptyView()
+            Button(action: createKit) {
+                Label("Add Kit", systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .help("Create a custom Kit")
+            .accessibilityIdentifier("add-kit-button")
         } content: {
+            if let message = model.kitLibrary.lastErrorMessage {
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             LazyVGrid(columns: Self.columns, alignment: .leading, spacing: 14) {
-                ForEach(NativKitCatalog.bundled.kits) { kit in
-                    kitCard(for: kit)
+                ForEach(catalog.kits) { kit in
+                    kitCard(for: kit, catalog: catalog)
                 }
             }
         }
-        .sheet(item: $openKit) { kit in
-            KitDetailView(kit: kit, manager: manager, model: model)
+        .sheet(item: $presentedSheet) { sheet in
+            switch sheet {
+            case .detail(let kit):
+                KitDetailView(kit: kit, manager: manager, model: model)
+            case .editor(let kit):
+                NativKitEditorSheet(kit: kit, manager: manager, model: model)
+            }
+        }
+        .alert("Delete Kit?", isPresented: deletionIsPresented) {
+            Button("Delete", role: .destructive, action: deletePendingKit)
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: {
+            Text("This removes the Kit definition. Its enabled capabilities stay enabled.")
+        }
+        .alert("Couldn’t Update Kits", isPresented: errorIsPresented) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "Unknown error")
         }
     }
 
-    private func kitCard(for kit: NativKit) -> some View {
+    private var deletionIsPresented: Binding<Bool> {
+        Binding(
+            get: { pendingDeletion != nil },
+            set: { if !$0 { pendingDeletion = nil } }
+        )
+    }
+
+    private var errorIsPresented: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
+    }
+
+    private func kitCard(for kit: NativKit, catalog: NativKitCatalog) -> some View {
         let snapshot = NativKitActivation.snapshot(
             of: kit,
             model: model,
+            kitCatalog: catalog,
             extensionName: extensionName,
             isExtensionEnabled: manager.isEnabled(extensionID:)
         )
         return KitCard(
             kit: kit,
             snapshot: snapshot,
-            onOpen: { openKit = kit },
-            onEnable: { enableMissing(in: kit) }
+            isBuiltIn: catalog.isBundled(kitID: kit.id),
+            onOpen: { presentedSheet = .detail(kit) },
+            onEnable: { enableMissing(in: kit) },
+            onEdit: { presentedSheet = .editor(kit) },
+            onDelete: { pendingDeletion = kit }
         )
     }
 
-    private func extensionName(_ id: String) -> String {
-        manager.records.first { $0.id == id }?.manifest.displayName ?? id
+    private func createKit() {
+        presentedSheet = .editor(NativKit(
+            id: UUID().uuidString.lowercased(),
+            name: "",
+            summary: "",
+            symbol: "shippingbox",
+            tintName: "blue",
+            components: []
+        ))
     }
 
     private func enableMissing(in kit: NativKit) {
@@ -90,13 +156,31 @@ struct KitsSectionView: View {
             enableExtension: { manager.setEnabled(true, extensionID: $0) }
         )
     }
+
+    private func deletePendingKit() {
+        guard let kit = pendingDeletion else { return }
+        do {
+            try model.kitLibrary.delete(kitID: kit.id)
+            pendingDeletion = nil
+        } catch {
+            pendingDeletion = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func extensionName(_ id: String) -> String {
+        manager.records.first { $0.id == id }?.manifest.displayName ?? id
+    }
 }
 
 private struct KitCard: View {
     let kit: NativKit
     let snapshot: NativKitActivationSnapshot
+    let isBuiltIn: Bool
     let onOpen: () -> Void
     let onEnable: () -> Void
+    let onEdit: () -> Void
+    let onDelete: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -104,30 +188,40 @@ private struct KitCard: View {
                 NativTintedIconTile(symbol: kit.symbol, tint: .nativTint(kit.tintName))
                     .accessibilityHidden(true)
                 Spacer(minLength: 0)
-                NativStatusBadge(text: "Built-in")
-                    .help("Ships with Nativ")
+                NativStatusBadge(text: isBuiltIn ? "Built-in" : "Custom")
+                    .help(isBuiltIn ? "Ships with Nativ" : "Created by you")
                 KitStateIcon(state: snapshot.state)
+                if !isBuiltIn {
+                    Menu {
+                        Button("Edit", systemImage: "pencil", action: onEdit)
+                        Divider()
+                        Button("Delete", systemImage: "trash", role: .destructive, action: onDelete)
+                    } label: {
+                        Image(systemName: "ellipsis")
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                    .accessibilityLabel("Kit actions")
+                }
             }
             VStack(alignment: .leading, spacing: 3) {
                 Text(kit.name)
                     .nativTextStyle(.cardTitle)
-                Text(kit.summary)
-                    .nativTextStyle(.supporting)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if !kit.summary.isEmpty {
+                    Text(kit.summary)
+                        .nativTextStyle(.supporting)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             Text(capabilitiesText)
                 .nativTextStyle(.metadata)
                 .foregroundStyle(.tertiary)
                 .fixedSize(horizontal: false, vertical: true)
             ViewThatFits(in: .horizontal) {
-                HStack(spacing: 8) {
-                    actions
-                }
-                .fixedSize(horizontal: true, vertical: false)
-                VStack(alignment: .leading, spacing: 8) {
-                    actions
-                }
+                HStack(spacing: 8) { actions }
+                    .fixedSize(horizontal: true, vertical: false)
+                VStack(alignment: .leading, spacing: 8) { actions }
             }
             .nativTextStyle(.supporting)
             .controlSize(.regular)
@@ -138,10 +232,10 @@ private struct KitCard: View {
             Color(nsColor: .controlBackgroundColor),
             in: RoundedRectangle(cornerRadius: 10, style: .continuous)
         )
-        .overlay(
+        .overlay {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
-        )
+        }
         .accessibilityElement(children: .contain)
     }
 
@@ -149,7 +243,7 @@ private struct KitCard: View {
         if snapshot.state == .partial {
             "Needs: \(snapshot.inactivePartNames.joined(separator: " · "))"
         } else {
-            "Includes: \(kit.capabilityNames(in: .bundled).joined(separator: " · "))"
+            "Includes: \(kit.inventory)"
         }
     }
 
@@ -164,6 +258,29 @@ private struct KitCard: View {
     }
 }
 
+private enum KitComponentSection: String, CaseIterable, Identifiable {
+    case mcp = "MCP Servers"
+    case tools = "Tools"
+    case skills = "Skills"
+    case extensions = "Extensions"
+
+    var id: String { rawValue }
+}
+
+private struct KitComponentDescriptor: Identifiable {
+    let component: NativKitComponent
+    let section: KitComponentSection
+    let title: String
+    let subtitle: String?
+    let symbol: String
+    let tint: Color
+    let logoAssetName: String?
+    let isAvailable: Bool
+    let isEnabled: Bool
+
+    var id: String { component.id }
+}
+
 private struct KitDetailView: View {
     let kit: NativKit
     @ObservedObject var manager: NativExtensionManager
@@ -176,9 +293,19 @@ private struct KitDetailView: View {
             Divider()
             ScrollView {
                 VStack(alignment: .leading, spacing: 22) {
-                    mcpGroup
-                    if !kit.skills.isEmpty { skillsGroup }
-                    if !kit.extensionIDs.isEmpty { extensionsGroup }
+                    ForEach(KitComponentSection.allCases) { section in
+                        let components = descriptors.filter { $0.section == section }
+                        if !components.isEmpty {
+                            KitGroup(title: section.rawValue, caption: caption(for: section)) {
+                                ForEach(components) { descriptor in
+                                    KitPartRow(
+                                        descriptor: descriptor,
+                                        isOn: binding(for: descriptor.component)
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(20)
@@ -212,22 +339,17 @@ private struct KitDetailView: View {
                         .nativTextStyle(.detailTitle)
                     KitStateIcon(state: snapshot.state)
                 }
-                Text(kit.summary)
-                    .nativTextStyle(.supporting)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if !kit.summary.isEmpty {
+                    Text(kit.summary)
+                        .nativTextStyle(.supporting)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
                 if snapshot.state != .enabled {
-                    Button(snapshot.state == .partial ? "Enable Missing" : "Enable All") {
-                        NativKitActivation.enableMissing(
-                            in: kit,
-                            model: model,
-                            isExtensionEnabled: manager.isEnabled(extensionID:),
-                            enableExtension: { manager.setEnabled(true, extensionID: $0) }
-                        )
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.regular)
-                    .padding(.top, 4)
+                    Button(snapshot.state == .partial ? "Enable Missing" : "Enable All", action: enableAll)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.regular)
+                        .padding(.top, 4)
                 }
             }
             Spacer(minLength: 12)
@@ -236,91 +358,378 @@ private struct KitDetailView: View {
         .padding(20)
     }
 
-    // MARK: Groups
-
-    private var mcpGroup: some View {
-        KitGroup(title: "MCP Servers & Tools", caption: "Their tools become available in chat and appear under Tools.") {
-            ForEach(kit.mcpEntries(in: .bundled)) { entry in
-                KitPartRow(
-                    symbol: entry.symbol,
-                    tint: .nativTint(entry.tintName),
-                    logoAssetName: entry.logoAssetName,
-                    title: entry.name,
-                    subtitle: entry.summary,
-                    isOn: mcpBinding(entry)
-                )
-            }
-        }
+    private var descriptors: [KitComponentDescriptor] {
+        kit.components.map(descriptor(for:))
     }
 
-    private var skillsGroup: some View {
-        KitGroup(title: "Skills", caption: "Guidance added to the model when tools are available.") {
-            ForEach(kit.skills) { skill in
-                KitPartRow(
-                    symbol: "sparkles",
-                    tint: .nativTint(kit.tintName),
-                    logoAssetName: nil,
-                    title: skill.name,
-                    subtitle: nil,
-                    isOn: skillBinding(skill)
-                )
-            }
-        }
-    }
-
-    private var extensionsGroup: some View {
-        KitGroup(title: "Extensions", caption: nil) {
-            ForEach(kit.extensionIDs, id: \.self) { extensionID in
-                KitPartRow(
-                    symbol: "puzzlepiece.extension",
-                    tint: .nativTint(kit.tintName),
-                    logoAssetName: nil,
-                    title: extensionName(extensionID),
-                    subtitle: nil,
-                    isOn: extensionBinding(extensionID)
-                )
-            }
-        }
-    }
-
-    // MARK: Bindings
-
-    private func mcpBinding(_ entry: MCPCatalogEntry) -> Binding<Bool> {
-        let catalog = MCPServerCatalog.bundled
-        return Binding(
-            get: { catalog.isEnabled(entry, in: model.settings.mcpServers) },
-            set: { newValue in
-                var servers = model.settings.mcpServers
-                catalog.setEnabled(newValue, for: entry, in: &servers)
-                model.settings.mcpServers = servers
-            }
+    private func descriptor(for component: NativKitComponent) -> KitComponentDescriptor {
+        KitComponentInventory.descriptor(
+            for: component,
+            catalog: model.kitLibrary.catalog,
+            settings: model.settings,
+            records: manager.records
         )
     }
 
-    private func skillBinding(_ skill: NativSkill) -> Binding<Bool> {
+    private func caption(for section: KitComponentSection) -> String? {
+        switch section {
+        case .mcp: "All tools from these servers become available."
+        case .tools: "Built-in and custom tools included directly."
+        case .skills: "Guidance added to the model when tools are available."
+        case .extensions: nil
+        }
+    }
+
+    private func binding(for component: NativKitComponent) -> Binding<Bool> {
         Binding(
-            get: { model.settings.skills.first { $0.id == skill.id }?.isEnabled ?? false },
-            set: { newValue in
-                if let index = model.settings.skills.firstIndex(where: { $0.id == skill.id }) {
-                    model.settings.skills[index].isEnabled = newValue
-                } else if newValue {
-                    var enabled = skill
-                    enabled.isEnabled = true
-                    model.settings.skills.append(enabled)
+            get: { descriptor(for: component).isEnabled },
+            set: { setEnabled($0, component: component) }
+        )
+    }
+
+    private func setEnabled(_ enabled: Bool, component: NativKitComponent) {
+        switch component {
+        case .mcpServer(.catalog(let id)):
+            guard let entry = MCPServerCatalog.bundled.entry(id: id) else { return }
+            var servers = model.settings.mcpServers
+            MCPServerCatalog.bundled.setEnabled(enabled, for: entry, in: &servers)
+            model.settings.mcpServers = servers
+        case .mcpServer(.configured(let id)):
+            guard let index = model.settings.mcpServers.firstIndex(where: { $0.id == id }) else { return }
+            model.settings.mcpServers[index].isEnabled = enabled
+        case .nativeTool(let name):
+            model.settings.setToolEnabled(enabled, toolName: name)
+        case .customTool(let id):
+            guard let tool = model.settings.customTools.first(where: { $0.id == id }) else { return }
+            model.settings.setToolEnabled(enabled, toolName: tool.toolName)
+        case .skill(let id):
+            if let index = model.settings.skills.firstIndex(where: { $0.id == id }) {
+                model.settings.skills[index].isEnabled = enabled
+            } else if enabled, let skill = model.kitLibrary.catalog.skillDefinition(id: id) {
+                model.settings.skills.append(skill)
+            }
+        case .extensionPackage(let id):
+            manager.setEnabled(enabled, extensionID: id)
+        }
+    }
+
+    private func enableAll() {
+        NativKitActivation.enableMissing(
+            in: kit,
+            model: model,
+            isExtensionEnabled: manager.isEnabled(extensionID:),
+            enableExtension: { manager.setEnabled(true, extensionID: $0) }
+        )
+    }
+
+    private func extensionName(_ id: String) -> String {
+        manager.records.first { $0.id == id }?.manifest.displayName ?? id
+    }
+}
+
+private enum KitEditorField: Hashable {
+    case name
+}
+
+private struct NativKitEditorSheet: View {
+    @ObservedObject var manager: NativExtensionManager
+    var model: NativModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: NativKit
+    @State private var selectedComponents: Set<NativKitComponent>
+    @State private var query = ""
+    @State private var errorMessage: String?
+    @FocusState private var focusedField: KitEditorField?
+    private let inventory: [KitComponentDescriptor]
+
+    init(kit: NativKit, manager: NativExtensionManager, model: NativModel) {
+        self.manager = manager
+        self.model = model
+        _draft = State(initialValue: kit)
+        _selectedComponents = State(initialValue: Set(kit.components))
+        inventory = KitComponentInventory.choices(
+            selected: kit.components,
+            catalog: model.kitLibrary.catalog,
+            settings: model.settings,
+            records: manager.records
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(alignment: .leading) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(editorTitle)
+                            .font(.largeTitle.weight(.bold))
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityAddTraits(.isHeader)
+
+                        KitEditorFields(
+                            name: $draft.name,
+                            summary: $draft.summary,
+                            focusedField: $focusedField
+                        )
+                    }
+
+                    HStack(alignment: .firstTextBaseline) {
+                        Text("Capabilities")
+                            .font(.title3.weight(.semibold))
+                        Spacer()
+                        Text("\(selectedComponents.count) selected")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+
+                    if choiceGroups.isEmpty {
+                        ContentUnavailableView.search(text: query)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical)
+                    } else {
+                        ForEach(choiceGroups) { group in
+                            KitEditorCapabilityGroup(
+                                title: group.section.rawValue,
+                                choices: group.choices,
+                                selectedComponents: $selectedComponents
+                            )
+                        }
+                    }
+                }
+                .frame(maxWidth: 920, alignment: .leading)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal)
+                .padding(.bottom)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save", action: save)
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(!canSave)
+                }
+            }
+        }
+        .searchable(text: $query, prompt: "Search capabilities")
+        .defaultFocus($focusedField, .name)
+        .presentationSizing(.fitted)
+        .frame(
+            minWidth: 620,
+            idealWidth: 720,
+            maxWidth: 980,
+            minHeight: 520,
+            idealHeight: 680,
+            maxHeight: 900
+        )
+        .alert("Couldn’t Save Kit", isPresented: errorIsPresented) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "Unknown error")
+        }
+    }
+
+    private var editorTitle: String {
+        let name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !name.isEmpty { return name }
+        return "Make Kit"
+    }
+
+    private var canSave: Bool {
+        !draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !selectedComponents.isEmpty
+    }
+
+    private var errorIsPresented: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
+    }
+
+    private var filteredChoices: [KitComponentDescriptor] {
+        guard !query.isEmpty else { return inventory }
+        return inventory.filter {
+            $0.title.localizedStandardContains(query)
+                || ($0.subtitle?.localizedStandardContains(query) == true)
+        }
+    }
+
+    private var choiceGroups: [KitEditorChoiceGroup] {
+        let visibleChoices = filteredChoices
+        return KitComponentSection.allCases.compactMap { section in
+            let choices = visibleChoices.filter { $0.section == section }
+            return choices.isEmpty ? nil : KitEditorChoiceGroup(section: section, choices: choices)
+        }
+    }
+
+    private func save() {
+        do {
+            var kit = draft
+            kit.components = inventory
+                .map(\.component)
+                .filter(selectedComponents.contains)
+            try model.kitLibrary.upsert(kit)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct KitEditorChoiceGroup: Identifiable {
+    let section: KitComponentSection
+    let choices: [KitComponentDescriptor]
+
+    var id: KitComponentSection { section }
+}
+
+private struct KitEditorFields: View {
+    @Binding var name: String
+    @Binding var summary: String
+    var focusedField: FocusState<KitEditorField?>.Binding
+
+    var body: some View {
+        KitEditorSectionSurface {
+            TextField("Kit name", text: $name)
+                .textFieldStyle(.roundedBorder)
+                .focused(focusedField, equals: .name)
+
+            TextField("What is this Kit for?", text: $summary, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(2...4)
+        }
+    }
+}
+
+private struct KitEditorCapabilityGroup: View {
+    let title: String
+    let choices: [KitComponentDescriptor]
+    @Binding var selectedComponents: Set<NativKitComponent>
+
+    var body: some View {
+        KitEditorSectionSurface {
+            Text(title)
+                .font(.headline)
+
+            VStack {
+                ForEach(choices) { choice in
+                    KitMembershipRow(
+                        descriptor: choice,
+                        selectedComponents: $selectedComponents
+                    )
+                }
+            }
+        }
+    }
+}
+
+private struct KitEditorSectionSurface<Content: View>: View {
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            content()
+        }
+        .padding()
+        .background(
+            Color(nsColor: .controlBackgroundColor),
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
+    }
+}
+
+private struct KitMembershipRow: View {
+    let descriptor: KitComponentDescriptor
+    @Binding var selectedComponents: Set<NativKitComponent>
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Toggle(descriptor.title, isOn: isIncluded)
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .accessibilityLabel(accessibilityLabel)
+                .accessibilityHint(accessibilityHint)
+                .accessibilityIdentifier("kit-component-\(descriptor.id)")
+
+            KitMembershipIcon(descriptor: descriptor)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(descriptor.title)
+                if let subtitle = descriptor.subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityHidden(true)
+
+            if !descriptor.isAvailable {
+                Label("Unavailable", systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(
+            selectedComponents.contains(descriptor.component)
+                ? Color.accentColor.opacity(0.08)
+                : Color.clear,
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+    }
+
+    private var isIncluded: Binding<Bool> {
+        Binding(
+            get: { selectedComponents.contains(descriptor.component) },
+            set: { included in
+                if included {
+                    selectedComponents.insert(descriptor.component)
+                } else {
+                    selectedComponents.remove(descriptor.component)
                 }
             }
         )
     }
 
-    private func extensionBinding(_ extensionID: String) -> Binding<Bool> {
-        Binding(
-            get: { manager.isEnabled(extensionID: extensionID) },
-            set: { manager.setEnabled($0, extensionID: extensionID) }
-        )
+    private var accessibilityLabel: String {
+        descriptor.isAvailable ? descriptor.title : "\(descriptor.title), unavailable"
     }
 
-    private func extensionName(_ extensionID: String) -> String {
-        manager.records.first { $0.id == extensionID }?.manifest.displayName ?? extensionID
+    private var accessibilityHint: String {
+        if !descriptor.isAvailable {
+            return "Deselect this capability to remove its unavailable reference."
+        }
+        return descriptor.subtitle ?? ""
+    }
+}
+
+private struct KitMembershipIcon: View {
+    let descriptor: KitComponentDescriptor
+
+    var body: some View {
+        Group {
+            if let logoAssetName = descriptor.logoAssetName,
+               let image = NSImage(named: logoAssetName) {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                Image(systemName: descriptor.symbol)
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(descriptor.tint)
+            }
+        }
+        .frame(width: 20, height: 20)
     }
 }
 
@@ -341,46 +750,212 @@ private struct KitGroup<Content: View>: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            VStack(spacing: 0) {
-                content()
-            }
+            VStack(spacing: 0) { content() }
         }
     }
 }
 
 private struct KitPartRow: View {
-    let symbol: String
-    let tint: Color
-    let logoAssetName: String?
-    let title: String
-    let subtitle: String?
+    let descriptor: KitComponentDescriptor
     @Binding var isOn: Bool
 
     var body: some View {
         Toggle(isOn: $isOn) {
             HStack(spacing: 10) {
                 NativTintedIconTile(
-                    symbol: symbol,
-                    tint: tint,
-                    logoAssetName: logoAssetName,
+                    symbol: descriptor.symbol,
+                    tint: descriptor.tint,
+                    logoAssetName: descriptor.logoAssetName,
                     size: 30
                 )
                 .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(title)
+                    Text(descriptor.title)
                         .nativTextStyle(.rowTitle)
-                    if let subtitle {
+                    if let subtitle = descriptor.subtitle {
                         Text(subtitle)
                             .nativTextStyle(.metadata)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(descriptor.isAvailable ? Color.secondary : Color.orange)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 }
-                Spacer(minLength: 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .toggleStyle(.switch)
         .controlSize(.regular)
+        .disabled(!descriptor.isAvailable)
         .padding(.vertical, 8)
+    }
+}
+
+private enum KitComponentInventory {
+    static func choices(
+        selected: [NativKitComponent],
+        catalog: NativKitCatalog,
+        settings: NativSettings,
+        records: [NativExtensionRecord]
+    ) -> [KitComponentDescriptor] {
+        var components = MCPServerCatalog.bundled.entries.map {
+            NativKitComponent.mcpServer(.catalog(id: $0.id))
+        }
+        components += settings.mcpServers
+            .filter { MCPServerCatalog.bundled.entry(matching: $0) == nil }
+            .map { .mcpServer(.configured(id: $0.id)) }
+        components += ChatToolRegistry.descriptors(canEditImage: false)
+            .filter { $0.definition.function.name != ChatSwitchModelToolRegistry.toolName }
+            .map { .nativeTool(name: $0.definition.function.name) }
+        components += settings.customTools.map { .customTool(id: $0.id) }
+
+        var skillIDs = Set<UUID>()
+        for skill in catalog.skillDefinitions + settings.skills where skillIDs.insert(skill.id).inserted {
+            components.append(.skill(id: skill.id))
+        }
+        components += records.filter { !$0.isRemoved }.map { .extensionPackage(id: $0.id) }
+
+        let knownIDs = Set(components.map(\.id))
+        components += selected.filter { !knownIDs.contains($0.id) }
+
+        return components
+            .map {
+                descriptor(
+                    for: $0,
+                    catalog: catalog,
+                    settings: settings,
+                    records: records
+                )
+            }
+            .sorted {
+                if $0.section != $1.section {
+                    return KitComponentSection.allCases.firstIndex(of: $0.section)!
+                        < KitComponentSection.allCases.firstIndex(of: $1.section)!
+                }
+                return $0.title.localizedStandardCompare($1.title) == .orderedAscending
+            }
+    }
+
+    static func descriptor(
+        for component: NativKitComponent,
+        catalog: NativKitCatalog,
+        settings: NativSettings,
+        records: [NativExtensionRecord]
+    ) -> KitComponentDescriptor {
+        switch component {
+        case .mcpServer(.catalog(let id)):
+            guard let entry = MCPServerCatalog.bundled.entry(id: id) else {
+                return unavailable(component, section: .mcp, title: id)
+            }
+            return KitComponentDescriptor(
+                component: component,
+                section: .mcp,
+                title: entry.name,
+                subtitle: entry.summary,
+                symbol: entry.symbol,
+                tint: .nativTint(entry.tintName),
+                logoAssetName: entry.logoAssetName,
+                isAvailable: true,
+                isEnabled: MCPServerCatalog.bundled.isEnabled(entry, in: settings.mcpServers)
+            )
+        case .mcpServer(.configured(let id)):
+            guard let server = settings.mcpServers.first(where: { $0.id == id }) else {
+                return unavailable(component, section: .mcp, title: "MCP Server")
+            }
+            return KitComponentDescriptor(
+                component: component,
+                section: .mcp,
+                title: server.name.isEmpty ? "MCP Server" : server.name,
+                subtitle: server.command,
+                symbol: "server.rack",
+                tint: .accentColor,
+                logoAssetName: nil,
+                isAvailable: true,
+                isEnabled: server.isEnabled
+            )
+        case .nativeTool(let name):
+            let descriptor = ChatToolRegistry.descriptors(canEditImage: false)
+                .first { $0.definition.function.name == name }
+            guard let descriptor else {
+                return unavailable(component, section: .tools, title: humanized(name))
+            }
+            return KitComponentDescriptor(
+                component: component,
+                section: .tools,
+                title: descriptor.configuration?.displayName ?? humanized(name),
+                subtitle: descriptor.displayDescription,
+                symbol: "hammer",
+                tint: .accentColor,
+                logoAssetName: nil,
+                isAvailable: true,
+                isEnabled: settings.isToolEnabled(name)
+            )
+        case .customTool(let id):
+            guard let tool = settings.customTools.first(where: { $0.id == id }) else {
+                return unavailable(component, section: .tools, title: "Custom Tool")
+            }
+            return KitComponentDescriptor(
+                component: component,
+                section: .tools,
+                title: tool.name,
+                subtitle: tool.displaySummary,
+                symbol: "wrench.and.screwdriver",
+                tint: .accentColor,
+                logoAssetName: nil,
+                isAvailable: true,
+                isEnabled: settings.isToolEnabled(tool.toolName)
+            )
+        case .skill(let id):
+            let skill = settings.skills.first(where: { $0.id == id }) ?? catalog.skillDefinition(id: id)
+            guard let skill else {
+                return unavailable(component, section: .skills, title: "Skill")
+            }
+            return KitComponentDescriptor(
+                component: component,
+                section: .skills,
+                title: skill.name,
+                subtitle: skill.instructions,
+                symbol: "sparkles",
+                tint: .purple,
+                logoAssetName: nil,
+                isAvailable: true,
+                isEnabled: settings.skills.first(where: { $0.id == id })?.isEnabled == true
+            )
+        case .extensionPackage(let id):
+            guard let record = records.first(where: { $0.id == id && !$0.isRemoved }) else {
+                return unavailable(component, section: .extensions, title: id)
+            }
+            return KitComponentDescriptor(
+                component: component,
+                section: .extensions,
+                title: record.manifest.displayName,
+                subtitle: record.manifest.summary,
+                symbol: record.manifest.systemImage,
+                tint: .accentColor,
+                logoAssetName: nil,
+                isAvailable: record.hasRuntime,
+                isEnabled: record.isEnabled && record.hasRuntime
+            )
+        }
+    }
+
+    private static func unavailable(
+        _ component: NativKitComponent,
+        section: KitComponentSection,
+        title: String
+    ) -> KitComponentDescriptor {
+        KitComponentDescriptor(
+            component: component,
+            section: section,
+            title: title,
+            subtitle: "Unavailable — remove this reference or restore its capability.",
+            symbol: "exclamationmark.triangle",
+            tint: .orange,
+            logoAssetName: nil,
+            isAvailable: false,
+            isEnabled: false
+        )
+    }
+
+    private static func humanized(_ name: String) -> String {
+        name.split(separator: "_").map { String($0).capitalized }.joined(separator: " ")
     }
 }

--- a/Sources/Nativ/Features/Extensions/NativKit.swift
+++ b/Sources/Nativ/Features/Extensions/NativKit.swift
@@ -1,43 +1,124 @@
 import Foundation
 
-/// A capability included in a Kit definition.
-enum NativKitComponent: Equatable, Identifiable, Sendable {
-    case mcpServer(catalogID: String)
-    case skill(NativSkill)
+enum NativKitMCPReference: Equatable, Hashable, Sendable {
+    case catalog(id: String)
+    case configured(id: UUID)
+}
+
+/// A stable reference to a capability included in a Kit definition.
+enum NativKitComponent: Equatable, Hashable, Identifiable, Sendable {
+    case mcpServer(NativKitMCPReference)
+    case nativeTool(name: String)
+    case customTool(id: UUID)
+    case skill(id: UUID)
     case extensionPackage(id: String)
 
     var id: String {
         switch self {
-        case .mcpServer(let catalogID):
-            "mcp:\(catalogID)"
-        case .skill(let skill):
-            "skill:\(skill.id.uuidString)"
+        case .mcpServer(.catalog(let id)):
+            "mcp-catalog:\(id)"
+        case .mcpServer(.configured(let id)):
+            "mcp-configured:\(id.uuidString)"
+        case .nativeTool(let name):
+            "tool-native:\(name)"
+        case .customTool(let id):
+            "tool-custom:\(id.uuidString)"
+        case .skill(let id):
+            "skill:\(id.uuidString)"
         case .extensionPackage(let id):
             "extension:\(id)"
         }
     }
 }
 
-/// A ready-made, additive bundle of capabilities for a role or workflow.
-struct NativKit: Equatable, Identifiable, Sendable {
-    let id: String
-    let name: String
-    let summary: String
-    let symbol: String
-    let tintName: String
-    let components: [NativKitComponent]
+extension NativKitComponent: Codable {
+    private enum Kind: String, Codable {
+        case mcpCatalog
+        case mcpConfigured
+        case nativeTool
+        case customTool
+        case skill
+        case extensionPackage
+    }
 
-    var mcpServerIDs: [String] {
-        components.compactMap { component in
-            guard case .mcpServer(let catalogID) = component else { return nil }
-            return catalogID
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case catalogID
+        case configuredID
+        case name
+        case id
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .type) {
+        case .mcpCatalog:
+            self = .mcpServer(.catalog(id: try container.decode(String.self, forKey: .catalogID)))
+        case .mcpConfigured:
+            self = .mcpServer(.configured(id: try container.decode(UUID.self, forKey: .configuredID)))
+        case .nativeTool:
+            self = .nativeTool(name: try container.decode(String.self, forKey: .name))
+        case .customTool:
+            self = .customTool(id: try container.decode(UUID.self, forKey: .id))
+        case .skill:
+            self = .skill(id: try container.decode(UUID.self, forKey: .id))
+        case .extensionPackage:
+            self = .extensionPackage(id: try container.decode(String.self, forKey: .id))
         }
     }
 
-    var skills: [NativSkill] {
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .mcpServer(.catalog(let id)):
+            try container.encode(Kind.mcpCatalog, forKey: .type)
+            try container.encode(id, forKey: .catalogID)
+        case .mcpServer(.configured(let id)):
+            try container.encode(Kind.mcpConfigured, forKey: .type)
+            try container.encode(id, forKey: .configuredID)
+        case .nativeTool(let name):
+            try container.encode(Kind.nativeTool, forKey: .type)
+            try container.encode(name, forKey: .name)
+        case .customTool(let id):
+            try container.encode(Kind.customTool, forKey: .type)
+            try container.encode(id, forKey: .id)
+        case .skill(let id):
+            try container.encode(Kind.skill, forKey: .type)
+            try container.encode(id, forKey: .id)
+        case .extensionPackage(let id):
+            try container.encode(Kind.extensionPackage, forKey: .type)
+            try container.encode(id, forKey: .id)
+        }
+    }
+}
+
+/// An additive bundle of capabilities for a role or workflow.
+struct NativKit: Codable, Equatable, Hashable, Identifiable, Sendable {
+    let id: String
+    var name: String
+    var summary: String
+    var symbol: String
+    var tintName: String
+    var components: [NativKitComponent]
+
+    var mcpReferences: [NativKitMCPReference] {
         components.compactMap { component in
-            guard case .skill(let skill) = component else { return nil }
-            return skill
+            guard case .mcpServer(let reference) = component else { return nil }
+            return reference
+        }
+    }
+
+    var mcpServerIDs: [String] {
+        mcpReferences.compactMap { reference in
+            guard case .catalog(let id) = reference else { return nil }
+            return id
+        }
+    }
+
+    var skillIDs: [UUID] {
+        components.compactMap { component in
+            guard case .skill(let id) = component else { return nil }
+            return id
         }
     }
 
@@ -48,20 +129,25 @@ struct NativKit: Equatable, Identifiable, Sendable {
         }
     }
 
-    /// Catalog MCP entries this Kit references, in definition order.
-    func mcpEntries(in catalog: MCPServerCatalog) -> [MCPCatalogEntry] {
-        mcpServerIDs.compactMap(catalog.entry(id:))
+    var toolCount: Int {
+        components.count { component in
+            switch component {
+            case .nativeTool, .customTool: true
+            default: false
+            }
+        }
     }
 
-    /// A one-line inventory of the components in this Kit definition.
     var inventory: String {
         var parts: [String] = []
-        let serverCount = mcpServerIDs.count
-        if serverCount > 0 {
-            parts.append("\(serverCount) MCP server\(serverCount == 1 ? "" : "s")")
+        if !mcpReferences.isEmpty {
+            parts.append("\(mcpReferences.count) MCP server\(mcpReferences.count == 1 ? "" : "s")")
         }
-        if !skills.isEmpty {
-            parts.append("\(skills.count) skill\(skills.count == 1 ? "" : "s")")
+        if toolCount > 0 {
+            parts.append("\(toolCount) tool\(toolCount == 1 ? "" : "s")")
+        }
+        if !skillIDs.isEmpty {
+            parts.append("\(skillIDs.count) skill\(skillIDs.count == 1 ? "" : "s")")
         }
         if !extensionIDs.isEmpty {
             parts.append("\(extensionIDs.count) extension\(extensionIDs.count == 1 ? "" : "s")")
@@ -69,18 +155,8 @@ struct NativKit: Equatable, Identifiable, Sendable {
         return parts.joined(separator: " · ")
     }
 
-    /// Names the capabilities supplied by this Kit in definition order.
-    func capabilityNames(in catalog: MCPServerCatalog) -> [String] {
-        components.map { component in
-            switch component {
-            case .mcpServer(let catalogID):
-                catalog.entry(id: catalogID)?.name ?? catalogID
-            case .skill(let skill):
-                skill.name
-            case .extensionPackage(let id):
-                id
-            }
-        }
+    func mcpEntries(in catalog: MCPServerCatalog) -> [MCPCatalogEntry] {
+        mcpServerIDs.compactMap(catalog.entry(id:))
     }
 }
 
@@ -89,15 +165,17 @@ enum NativKitCatalogError: Error, Equatable {
     case duplicateComponent(kitID: String, componentID: String)
     case conflictingSkillIdentifier(UUID)
     case unknownMCPServer(kitID: String, catalogID: String)
+    case unknownSkill(kitID: String, skillID: UUID)
 }
 
-/// An immutable, validated collection of Kit definitions.
+/// An immutable, validated collection of bundled and user Kit definitions.
 struct NativKitCatalog: Sendable {
     static let bundled: NativKitCatalog = {
         do {
             return try NativKitCatalog(
                 kits: NativKit.bundledDefinitions,
-                mcpCatalog: .bundled
+                mcpCatalog: .bundled,
+                skillDefinitions: NativSkill.kitDefinitions
             )
         } catch {
             preconditionFailure("Invalid bundled Kit catalog: \(error)")
@@ -105,17 +183,95 @@ struct NativKitCatalog: Sendable {
     }()
 
     let kits: [NativKit]
+    let skillDefinitions: [NativSkill]
     private let kitsByID: [String: NativKit]
+    private let skillsByID: [UUID: NativSkill]
+    private let bundledKitIDs: Set<String>
 
-    init(kits: [NativKit], mcpCatalog: MCPServerCatalog) throws {
-        var kitsByID: [String: NativKit] = [:]
-        var skillsByID: [UUID: NativSkill] = [:]
+    init(
+        kits: [NativKit],
+        mcpCatalog: MCPServerCatalog,
+        skillDefinitions: [NativSkill] = []
+    ) throws {
+        let skillsByID = try Self.indexSkills(skillDefinitions)
+        let kitsByID = try Self.indexKits(
+            kits,
+            mcpCatalog: mcpCatalog,
+            skillsByID: skillsByID,
+            validatesReferences: true
+        )
+        self.kits = kits
+        self.skillDefinitions = skillDefinitions
+        self.kitsByID = kitsByID
+        self.skillsByID = skillsByID
+        bundledKitIDs = Set(kits.map(\.id))
+    }
 
+    private init(
+        kits: [NativKit],
+        skillDefinitions: [NativSkill],
+        kitsByID: [String: NativKit],
+        skillsByID: [UUID: NativSkill],
+        bundledKitIDs: Set<String>
+    ) {
+        self.kits = kits
+        self.skillDefinitions = skillDefinitions
+        self.kitsByID = kitsByID
+        self.skillsByID = skillsByID
+        self.bundledKitIDs = bundledKitIDs
+    }
+
+    func merging(userKits: [NativKit]) throws -> NativKitCatalog {
+        let merged = kits + userKits
+        let indexed = try Self.indexKits(
+            merged,
+            mcpCatalog: .empty,
+            skillsByID: skillsByID,
+            validatesReferences: false
+        )
+        return NativKitCatalog(
+            kits: merged,
+            skillDefinitions: skillDefinitions,
+            kitsByID: indexed,
+            skillsByID: skillsByID,
+            bundledKitIDs: bundledKitIDs
+        )
+    }
+
+    func kit(id: String) -> NativKit? {
+        kitsByID[id]
+    }
+
+    func skillDefinition(id: UUID) -> NativSkill? {
+        skillsByID[id]
+    }
+
+    func isBundled(kitID: String) -> Bool {
+        bundledKitIDs.contains(kitID)
+    }
+
+    private static func indexSkills(_ skills: [NativSkill]) throws -> [UUID: NativSkill] {
+        var indexed: [UUID: NativSkill] = [:]
+        for skill in skills {
+            if let existing = indexed[skill.id], existing != skill {
+                throw NativKitCatalogError.conflictingSkillIdentifier(skill.id)
+            }
+            indexed[skill.id] = skill
+        }
+        return indexed
+    }
+
+    private static func indexKits(
+        _ kits: [NativKit],
+        mcpCatalog: MCPServerCatalog,
+        skillsByID: [UUID: NativSkill],
+        validatesReferences: Bool
+    ) throws -> [String: NativKit] {
+        var indexed: [String: NativKit] = [:]
         for kit in kits {
-            guard kitsByID.updateValue(kit, forKey: kit.id) == nil else {
+            guard indexed.updateValue(kit, forKey: kit.id) == nil else {
                 throw NativKitCatalogError.duplicateKitIdentifier(kit.id)
             }
-
             var componentIDs = Set<String>()
             for component in kit.components {
                 guard componentIDs.insert(component.id).inserted else {
@@ -124,47 +280,66 @@ struct NativKitCatalog: Sendable {
                         componentID: component.id
                     )
                 }
-
+                guard validatesReferences else { continue }
                 switch component {
-                case .mcpServer(let catalogID):
-                    guard mcpCatalog.entry(id: catalogID) != nil else {
+                case .mcpServer(.catalog(let id)):
+                    guard mcpCatalog.entry(id: id) != nil else {
                         throw NativKitCatalogError.unknownMCPServer(
                             kitID: kit.id,
-                            catalogID: catalogID
+                            catalogID: id
                         )
                     }
-                case .skill(let skill):
-                    if let existing = skillsByID[skill.id], existing != skill {
-                        throw NativKitCatalogError.conflictingSkillIdentifier(skill.id)
+                case .skill(let id):
+                    guard skillsByID[id] != nil else {
+                        throw NativKitCatalogError.unknownSkill(kitID: kit.id, skillID: id)
                     }
-                    skillsByID[skill.id] = skill
-                case .extensionPackage:
+                case .mcpServer(.configured), .nativeTool, .customTool, .extensionPackage:
                     break
                 }
             }
         }
-
-        self.kits = kits
-        self.kitsByID = kitsByID
-    }
-
-    func kit(id: String) -> NativKit? {
-        kitsByID[id]
+        return indexed
     }
 }
 
 private extension NativSkill {
-    /// Creates a built-in Kit skill with a stable identity.
     static func kit(_ identifier: String, _ name: String, _ instructions: String) -> NativSkill {
         guard let id = UUID(uuidString: identifier) else {
             preconditionFailure("Invalid built-in Kit skill identifier: \(identifier)")
         }
         return NativSkill(id: id, name: name, instructions: instructions, isEnabled: true)
     }
+
+    static let engineeringKitSkill = kit(
+        "A1000000-0000-4000-8000-000000000001",
+        "Working in a codebase",
+        """
+        You're helping with software. Ground every answer in the actual repository, not assumptions.
+
+        - Use the Git and filesystem tools to read real files, history, and diffs before proposing changes; cite concrete paths and symbols.
+        - When you touch GitHub, prefer read-only queries and summarize findings precisely.
+        - Match the project's existing style and conventions. Keep changes minimal and explain the reasoning.
+        - Fetch documentation when an API or library detail is uncertain rather than guessing.
+        """
+    )
+
+    static let researchKitSkill = kit(
+        "A2000000-0000-4000-8000-000000000002",
+        "Researching with sources",
+        """
+        You're doing careful research. Prioritize accuracy and traceability.
+
+        - Use the fetch tool to read primary sources and link each claim to its source.
+        - Record durable findings in the memory tool and recall them before re-fetching.
+        - Query the SQLite tool for the user's dataset instead of estimating.
+        - Separate what sources say from inference, and flag uncertainty plainly.
+        """
+    )
+
+    static let kitDefinitions = [engineeringKitSkill, researchKitSkill]
 }
 
 private extension NativKit {
-    /// Built-in examples that ship in Nativ's Kit catalog.
     static let bundledDefinitions: [NativKit] = [
         NativKit(
             id: "engineering",
@@ -173,29 +348,11 @@ private extension NativKit {
             symbol: "chevron.left.forwardslash.chevron.right",
             tintName: "indigo",
             components: [
-                .mcpServer(catalogID: "git"),
-                .mcpServer(catalogID: "github"),
-                .mcpServer(catalogID: "filesystem"),
-                .mcpServer(catalogID: "fetch"),
-                .skill(
-                    .kit(
-                        "A1000000-0000-4000-8000-000000000001",
-                        "Working in a codebase",
-                        """
-                        You're helping with software. Ground every answer in the actual \
-                        repository, not assumptions.
-
-                        - Use the Git and filesystem tools to read real files, history, and \
-                        diffs before proposing changes; cite concrete paths and symbols.
-                        - When you touch GitHub, prefer read-only queries (issues, PRs, code \
-                        search) and summarize findings precisely.
-                        - Match the project's existing style and conventions. Keep changes \
-                        minimal and explain the reasoning.
-                        - Fetch documentation when an API or library detail is uncertain \
-                        rather than guessing.
-                        """
-                    )
-                ),
+                .mcpServer(.catalog(id: "git")),
+                .mcpServer(.catalog(id: "github")),
+                .mcpServer(.catalog(id: "filesystem")),
+                .mcpServer(.catalog(id: "fetch")),
+                .skill(id: NativSkill.engineeringKitSkill.id),
             ]
         ),
         NativKit(
@@ -205,35 +362,15 @@ private extension NativKit {
             symbol: "magnifyingglass",
             tintName: "purple",
             components: [
-                .mcpServer(catalogID: "fetch"),
-                .mcpServer(catalogID: "memory"),
-                .mcpServer(catalogID: "sqlite"),
-                .skill(
-                    .kit(
-                        "A2000000-0000-4000-8000-000000000002",
-                        "Researching with sources",
-                        """
-                        You're doing careful research. Prioritize accuracy and traceability.
-
-                        - Use the fetch tool to read primary sources; quote or paraphrase \
-                        with a link back to where each claim came from.
-                        - Record durable findings in the memory tool so they carry across \
-                        the conversation, and recall them before re-fetching.
-                        - Query the SQLite tool for anything in the user's own dataset \
-                        instead of estimating.
-                        - Separate what the sources say from your own inference, and flag \
-                        uncertainty plainly.
-                        """
-                    )
-                ),
+                .mcpServer(.catalog(id: "fetch")),
+                .mcpServer(.catalog(id: "memory")),
+                .mcpServer(.catalog(id: "sqlite")),
+                .skill(id: NativSkill.researchKitSkill.id),
             ]
         ),
     ]
 }
 
-// MARK: - Activation
-
-/// How much of a Kit is currently active, derived from its live components.
 enum NativKitState: Equatable {
     case off
     case partial
@@ -248,72 +385,92 @@ struct NativKitActivationSnapshot: Equatable {
 /// Additively enables Kit components and derives status from their live state.
 @MainActor
 enum NativKitActivation {
-    /// Enables every missing component without disabling or taking ownership of shared components.
     static func enableMissing(
         in kit: NativKit,
         model: NativModel,
+        kitCatalog: NativKitCatalog? = nil,
         mcpCatalog: MCPServerCatalog = .bundled,
         isExtensionEnabled: (String) -> Bool,
         enableExtension: (String) -> Void
     ) {
         var settings = model.settings
-        let extensionIDs = enableMissing(in: kit, settings: &settings, mcpCatalog: mcpCatalog)
+        let extensionIDs = enableMissing(
+            in: kit,
+            settings: &settings,
+            kitCatalog: kitCatalog ?? model.kitLibrary.catalog,
+            mcpCatalog: mcpCatalog
+        )
         if settings != model.settings {
             model.settings = settings
         }
-
         for extensionID in extensionIDs where !isExtensionEnabled(extensionID) {
             enableExtension(extensionID)
         }
     }
 
-    /// Enables settings-backed components and returns extension identifiers to enable.
     @discardableResult
     static func enableMissing(
         in kit: NativKit,
         settings: inout NativSettings,
+        kitCatalog: NativKitCatalog = .bundled,
         mcpCatalog: MCPServerCatalog
     ) -> [String] {
-        for catalogID in kit.mcpServerIDs {
-            guard let entry = mcpCatalog.entry(id: catalogID) else { continue }
-            mcpCatalog.setEnabled(true, for: entry, in: &settings.mcpServers)
-        }
-
-        for skill in kit.skills {
-            if let index = settings.skills.firstIndex(where: { $0.id == skill.id }) {
-                settings.skills[index].isEnabled = true
-            } else {
-                settings.skills.append(skill)
+        var extensionIDs: [String] = []
+        for component in kit.components {
+            switch component {
+            case .mcpServer(.catalog(let id)):
+                guard let entry = mcpCatalog.entry(id: id) else { continue }
+                mcpCatalog.setEnabled(true, for: entry, in: &settings.mcpServers)
+            case .mcpServer(.configured(let id)):
+                if let index = settings.mcpServers.firstIndex(where: { $0.id == id }) {
+                    settings.mcpServers[index].isEnabled = true
+                }
+            case .nativeTool(let name):
+                settings.setToolEnabled(true, toolName: name)
+            case .customTool(let id):
+                guard let tool = settings.customTools.first(where: { $0.id == id }) else { continue }
+                settings.setToolEnabled(true, toolName: tool.toolName)
+            case .skill(let id):
+                if let index = settings.skills.firstIndex(where: { $0.id == id }) {
+                    settings.skills[index].isEnabled = true
+                } else if let definition = kitCatalog.skillDefinition(id: id) {
+                    settings.skills.append(definition)
+                }
+            case .extensionPackage(let id):
+                extensionIDs.append(id)
             }
         }
-
-        return kit.extensionIDs
+        return extensionIDs
     }
 
     static func state(
         of kit: NativKit,
         model: NativModel,
+        kitCatalog: NativKitCatalog? = nil,
         mcpCatalog: MCPServerCatalog = .bundled,
         isExtensionEnabled: (String) -> Bool
     ) -> NativKitState {
         snapshot(
             of: kit,
-            settings: model.settings,
+            model: model,
+            kitCatalog: kitCatalog,
+            mcpCatalog: mcpCatalog,
             extensionName: { $0 },
-            isExtensionEnabled: isExtensionEnabled,
-            mcpCatalog: mcpCatalog
+            isExtensionEnabled: isExtensionEnabled
         ).state
     }
 
     static func state(
         of kit: NativKit,
         settings: NativSettings,
+        kitCatalog: NativKitCatalog = .bundled,
         isExtensionEnabled: (String) -> Bool,
         mcpCatalog: MCPServerCatalog
     ) -> NativKitState {
         snapshot(
             of: kit,
             settings: settings,
+            kitCatalog: kitCatalog,
             extensionName: { $0 },
             isExtensionEnabled: isExtensionEnabled,
             mcpCatalog: mcpCatalog
@@ -323,6 +480,7 @@ enum NativKitActivation {
     static func snapshot(
         of kit: NativKit,
         model: NativModel,
+        kitCatalog: NativKitCatalog? = nil,
         mcpCatalog: MCPServerCatalog = .bundled,
         extensionName: (String) -> String,
         isExtensionEnabled: (String) -> Bool
@@ -330,6 +488,7 @@ enum NativKitActivation {
         snapshot(
             of: kit,
             settings: model.settings,
+            kitCatalog: kitCatalog ?? model.kitLibrary.catalog,
             extensionName: extensionName,
             isExtensionEnabled: isExtensionEnabled,
             mcpCatalog: mcpCatalog
@@ -339,18 +498,32 @@ enum NativKitActivation {
     static func snapshot(
         of kit: NativKit,
         settings: NativSettings,
+        kitCatalog: NativKitCatalog = .bundled,
         extensionName: (String) -> String,
         isExtensionEnabled: (String) -> Bool,
         mcpCatalog: MCPServerCatalog
     ) -> NativKitActivationSnapshot {
-        let inactivePartNames = kit.components.compactMap { component in
+        let inactive = kit.components.compactMap { component -> String? in
             switch component {
-            case .mcpServer(let catalogID):
-                guard let entry = mcpCatalog.entry(id: catalogID) else { return catalogID }
+            case .mcpServer(.catalog(let id)):
+                guard let entry = mcpCatalog.entry(id: id) else { return id }
                 return mcpCatalog.isEnabled(entry, in: settings.mcpServers) ? nil : entry.name
-            case .skill(let skill):
-                let isEnabled = settings.skills.first(where: { $0.id == skill.id })?.isEnabled == true
-                return isEnabled ? nil : skill.name
+            case .mcpServer(.configured(let id)):
+                guard let server = settings.mcpServers.first(where: { $0.id == id }) else {
+                    return "MCP server \(id.uuidString)"
+                }
+                return server.isEnabled ? nil : (server.name.isEmpty ? "MCP server" : server.name)
+            case .nativeTool(let name):
+                return settings.isToolEnabled(name) ? nil : humanized(name)
+            case .customTool(let id):
+                guard let tool = settings.customTools.first(where: { $0.id == id }) else {
+                    return "Custom tool \(id.uuidString)"
+                }
+                return settings.isToolEnabled(tool.toolName) ? nil : tool.name
+            case .skill(let id):
+                let skill = settings.skills.first(where: { $0.id == id })
+                let name = skill?.name ?? kitCatalog.skillDefinition(id: id)?.name ?? "Skill \(id.uuidString)"
+                return skill?.isEnabled == true ? nil : name
             case .extensionPackage(let id):
                 return isExtensionEnabled(id) ? nil : extensionName(id)
             }
@@ -358,16 +531,17 @@ enum NativKitActivation {
         let state: NativKitState
         if kit.components.isEmpty {
             state = .off
-        } else if inactivePartNames.isEmpty {
+        } else if inactive.isEmpty {
             state = .enabled
-        } else if inactivePartNames.count == kit.components.count {
+        } else if inactive.count == kit.components.count {
             state = .off
         } else {
             state = .partial
         }
-        return NativKitActivationSnapshot(
-            state: state,
-            inactivePartNames: inactivePartNames
-        )
+        return NativKitActivationSnapshot(state: state, inactivePartNames: inactive)
+    }
+
+    private static func humanized(_ name: String) -> String {
+        name.split(separator: "_").map { String($0).capitalized }.joined(separator: " ")
     }
 }

--- a/Sources/Nativ/Features/Extensions/NativKitLibrary.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitLibrary.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Observation
+
+enum NativKitLibraryError: LocalizedError, Equatable {
+    case unsupportedVersion(Int)
+    case invalidIdentifier
+    case invalidName
+    case emptyKit
+    case bundledKitCannotBeChanged
+    case unresolvedLoadError
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedVersion(let version):
+            "This Kits file uses unsupported format version \(version)."
+        case .invalidIdentifier:
+            "The Kit has an invalid identifier."
+        case .invalidName:
+            "Enter a name for this Kit."
+        case .emptyKit:
+            "Select at least one capability for this Kit."
+        case .bundledKitCannotBeChanged:
+            "Built-in Kits cannot be edited or deleted."
+        case .unresolvedLoadError:
+            "Custom Kits can’t be changed until their saved file loads successfully."
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class NativKitLibrary {
+    private struct Payload: Codable {
+        static let currentVersion = 1
+
+        let version: Int
+        let kits: [NativKit]
+
+        private enum CodingKeys: String, CodingKey {
+            case version
+            case kits
+        }
+
+        init(kits: [NativKit]) {
+            version = Self.currentVersion
+            self.kits = kits
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            version = try container.decode(Int.self, forKey: .version)
+            guard version == Self.currentVersion else {
+                throw NativKitLibraryError.unsupportedVersion(version)
+            }
+            kits = try container.decode([NativKit].self, forKey: .kits)
+        }
+    }
+
+    private(set) var userKits: [NativKit] = []
+    private(set) var lastErrorMessage: String?
+    private var permitsWrites = true
+
+    private let storageURL: URL
+    private let fileManager: FileManager
+
+    init(
+        storageURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        self.fileManager = fileManager
+        self.storageURL = storageURL ?? Self.defaultStorageURL(fileManager: fileManager)
+        reload()
+    }
+
+    var catalog: NativKitCatalog {
+        do {
+            return try NativKitCatalog.bundled.merging(userKits: userKits)
+        } catch {
+            assertionFailure("Invalid in-memory Kit catalog: \(error)")
+            return .bundled
+        }
+    }
+
+    func reload() {
+        guard fileManager.fileExists(atPath: storageURL.path) else {
+            userKits = []
+            lastErrorMessage = nil
+            permitsWrites = true
+            return
+        }
+        do {
+            let data = try Data(contentsOf: storageURL)
+            let payload = try JSONDecoder().decode(Payload.self, from: data)
+            let kits = try payload.kits.map(normalized)
+            _ = try NativKitCatalog.bundled.merging(userKits: kits)
+            userKits = kits
+            lastErrorMessage = nil
+            permitsWrites = true
+        } catch {
+            lastErrorMessage = "Couldn’t load custom Kits: \(error.localizedDescription)"
+            permitsWrites = false
+        }
+    }
+
+    func upsert(_ kit: NativKit) throws {
+        guard permitsWrites else { throw NativKitLibraryError.unresolvedLoadError }
+        let kit = try normalized(kit)
+        guard !NativKitCatalog.bundled.isBundled(kitID: kit.id) else {
+            throw NativKitLibraryError.bundledKitCannotBeChanged
+        }
+
+        var candidate = userKits
+        if let index = candidate.firstIndex(where: { $0.id == kit.id }) {
+            candidate[index] = kit
+        } else {
+            candidate.append(kit)
+        }
+        _ = try NativKitCatalog.bundled.merging(userKits: candidate)
+        try persist(candidate)
+        userKits = candidate
+        lastErrorMessage = nil
+    }
+
+    func delete(kitID: String) throws {
+        guard permitsWrites else { throw NativKitLibraryError.unresolvedLoadError }
+        guard !NativKitCatalog.bundled.isBundled(kitID: kitID) else {
+            throw NativKitLibraryError.bundledKitCannotBeChanged
+        }
+        let candidate = userKits.filter { $0.id != kitID }
+        guard candidate.count != userKits.count else { return }
+        try persist(candidate)
+        userKits = candidate
+        lastErrorMessage = nil
+    }
+
+    private func normalized(_ kit: NativKit) throws -> NativKit {
+        let identifier = kit.id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !identifier.isEmpty else { throw NativKitLibraryError.invalidIdentifier }
+        let name = kit.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { throw NativKitLibraryError.invalidName }
+        guard !kit.components.isEmpty else { throw NativKitLibraryError.emptyKit }
+
+        var normalized = kit
+        normalized.name = name
+        normalized.summary = kit.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized
+    }
+
+    private func persist(_ kits: [NativKit]) throws {
+        try fileManager.createDirectory(
+            at: storageURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(Payload(kits: kits))
+        try data.write(to: storageURL, options: .atomic)
+    }
+
+    private static func defaultStorageURL(fileManager: FileManager) -> URL {
+        let applicationSupport = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? fileManager.homeDirectoryForCurrentUser
+        return applicationSupport
+            .appendingPathComponent("Nativ", isDirectory: true)
+            .appendingPathComponent("Kits.json")
+    }
+}

--- a/Sources/Nativ/Features/Extensions/NativKitRuntimeResolver.swift
+++ b/Sources/Nativ/Features/Extensions/NativKitRuntimeResolver.swift
@@ -4,6 +4,7 @@ import NativServerKit
 /// The settings-backed capabilities selected Kits can supply to a routine.
 struct NativKitRuntimeResolution: Equatable, Sendable {
     let mcpServers: [MCPServerConfig]
+    let tools: [ScheduledTool]
     let skills: [NativSkill]
     let unavailableCapabilities: [String]
 }
@@ -18,9 +19,20 @@ enum NativKitRuntimeResolver {
     ) -> NativKitRuntimeResolution {
         var serverIDs = Set<UUID>()
         var servers: [MCPServerConfig] = []
+        var toolIDs = Set<String>()
+        var tools: [ScheduledTool] = []
         var skillIDs = Set<UUID>()
         var skills: [NativSkill] = []
         var unavailable = Set<String>()
+
+        func appendServer(_ server: MCPServerConfig, kitName: String) {
+            guard server.isEnabled else {
+                unavailable.insert("\(kitName): \(server.name.isEmpty ? "MCP server" : server.name) (disabled)")
+                return
+            }
+            guard serverIDs.insert(server.id).inserted else { return }
+            servers.append(server)
+        }
 
         for kitID in kitIDs {
             guard let kit = kitCatalog.kit(id: kitID) else {
@@ -30,7 +42,7 @@ enum NativKitRuntimeResolver {
 
             for component in kit.components {
                 switch component {
-                case .mcpServer(let catalogID):
+                case .mcpServer(.catalog(let catalogID)):
                     guard let entry = mcpCatalog.entry(id: catalogID) else {
                         unavailable.insert("\(kit.name): \(catalogID) (unavailable)")
                         continue
@@ -42,20 +54,44 @@ enum NativKitRuntimeResolver {
                         unavailable.insert("\(kit.name): \(entry.name) (not configured)")
                         continue
                     }
-                    guard server.isEnabled else {
-                        unavailable.insert("\(kit.name): \(entry.name) (disabled)")
+                    appendServer(server, kitName: kit.name)
+
+                case .mcpServer(.configured(let id)):
+                    guard let server = settings.mcpServers.first(where: { $0.id == id }) else {
+                        unavailable.insert("\(kit.name): MCP server \(id.uuidString) (not configured)")
                         continue
                     }
-                    guard serverIDs.insert(server.id).inserted else { continue }
-                    servers.append(server)
+                    appendServer(server, kitName: kit.name)
 
-                case .skill(let definition):
-                    guard let skill = settings.skills.first(where: { $0.id == definition.id }) else {
-                        unavailable.insert("\(kit.name): \(definition.name) (not configured)")
+                case .nativeTool(let name):
+                    guard settings.isToolEnabled(name) else {
+                        unavailable.insert("\(kit.name): \(name) (disabled)")
+                        continue
+                    }
+                    guard toolIDs.insert(component.id).inserted else { continue }
+                    tools.append(ScheduledTool(provider: .builtIn, name: name))
+
+                case .customTool(let id):
+                    guard let tool = settings.customTools.first(where: { $0.id == id }) else {
+                        unavailable.insert("\(kit.name): Custom tool \(id.uuidString) (not configured)")
+                        continue
+                    }
+                    guard settings.isToolEnabled(tool.toolName) else {
+                        unavailable.insert("\(kit.name): \(tool.name) (disabled)")
+                        continue
+                    }
+                    guard toolIDs.insert(component.id).inserted else { continue }
+                    tools.append(ScheduledTool(provider: .custom(id), name: tool.toolName))
+
+                case .skill(let id):
+                    let definition = kitCatalog.skillDefinition(id: id)
+                    guard let skill = settings.skills.first(where: { $0.id == id }) else {
+                        let name = definition?.name ?? "Skill \(id.uuidString)"
+                        unavailable.insert("\(kit.name): \(name) (not configured)")
                         continue
                     }
                     guard skill.isEnabled else {
-                        let name = skill.name.isEmpty ? definition.name : skill.name
+                        let name = skill.name.isEmpty ? definition?.name ?? "Skill \(id.uuidString)" : skill.name
                         unavailable.insert("\(kit.name): \(name) (disabled)")
                         continue
                     }
@@ -70,6 +106,7 @@ enum NativKitRuntimeResolver {
 
         return NativKitRuntimeResolution(
             mcpServers: servers,
+            tools: tools,
             skills: skills,
             unavailableCapabilities: unavailable.sorted()
         )

--- a/Sources/Nativ/Features/Routines/RoutineEditorView.swift
+++ b/Sources/Nativ/Features/Routines/RoutineEditorView.swift
@@ -67,7 +67,8 @@ struct RoutineEditor: View {
             case .skill:
                 return false
             case .kit(let id):
-                return NativKitCatalog.bundled.kit(id: id)?.mcpServerIDs.isEmpty == false
+                guard let kit = model.kitLibrary.catalog.kit(id: id) else { return false }
+                return !kit.mcpReferences.isEmpty || kit.toolCount > 0
             case .mcpServer, .tool:
                 return true
             }
@@ -75,7 +76,7 @@ struct RoutineEditor: View {
     }
 
     private var capabilityOptions: [ScheduledCapabilityOption] {
-        var options = NativKitCatalog.bundled.kits.map { kit in
+        var options = model.kitLibrary.catalog.kits.map { kit in
             ScheduledCapabilityOption(
                 capability: .kit(kit.id),
                 section: .kits,

--- a/Sources/Nativ/Features/Routines/RoutineRunner.swift
+++ b/Sources/Nativ/Features/Routines/RoutineRunner.swift
@@ -84,7 +84,8 @@ final class RoutineRunner {
                 guard case .kit(let id) = capability else { return nil }
                 return id
             },
-            settings: settings
+            settings: settings,
+            kitCatalog: model.kitLibrary.catalog
         )
         guard kitResolution.unavailableCapabilities.isEmpty else {
             finishUnavailableCapabilities(
@@ -514,7 +515,7 @@ final class RoutineRunner {
         var skillsByID: [UUID: NativSkill] = [:]
         var unavailable = kitResolution.unavailableCapabilities
         var wholeMCPServers = Set(kitResolution.mcpServers.map(\.id))
-        var selectedTools: [ScheduledTool] = []
+        var selectedTools = kitResolution.tools
 
         for skill in kitResolution.skills {
             skillsByID[skill.id] = skill

--- a/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTasksView.swift
@@ -298,7 +298,7 @@ struct ScheduledTasksView: View {
         for capability in task.capabilities {
             guard case .kit(let id) = capability,
                   !previousKitIDs.contains(id),
-                  let kit = NativKitCatalog.bundled.kit(id: id)
+                  let kit = model.kitLibrary.catalog.kit(id: id)
             else { continue }
             NativKitActivation.enableMissing(
                 in: kit,

--- a/Sources/Nativ/NativModel.swift
+++ b/Sources/Nativ/NativModel.swift
@@ -61,6 +61,7 @@ final class ServerLogStore {
 @MainActor
 @Observable
 final class NativModel: ChatModelSwitchingSurface {
+    let kitLibrary: NativKitLibrary
     private(set) var isRunning = false
     let serverLogs = ServerLogStore()
     private(set) var metrics: NativMetrics?
@@ -113,7 +114,8 @@ final class NativModel: ChatModelSwitchingSurface {
     private let maxCurrentServerOutputCharacters = 50_000
     private let maxSessionActivitySamples = 120
 
-    init() {
+    init(kitLibrary: NativKitLibrary? = nil) {
+        self.kitLibrary = kitLibrary ?? NativKitLibrary()
         NativAllTimeStats.removeLegacyStorage()
         configureServerCallbacks()
         isRunning = server.isRunning

--- a/Tests/NativTests/NativKitTests.swift
+++ b/Tests/NativTests/NativKitTests.swift
@@ -29,15 +29,15 @@ struct NativKitTests {
         let kit = makeKit(
             id: "example",
             components: [
-                .mcpServer(catalogID: "fetch"),
-                .mcpServer(catalogID: "fetch"),
+                .mcpServer(.catalog(id: "fetch")),
+                .mcpServer(.catalog(id: "fetch")),
             ]
         )
 
         #expect(
             throws: NativKitCatalogError.duplicateComponent(
                 kitID: "example",
-                componentID: "mcp:fetch"
+                componentID: "mcp-catalog:fetch"
             )
         ) {
             try NativKitCatalog(kits: [kit], mcpCatalog: try makeMCPCatalog())
@@ -48,7 +48,7 @@ struct NativKitTests {
     func unknownMCPServer() {
         let kit = makeKit(
             id: "example",
-            components: [.mcpServer(catalogID: "missing")]
+            components: [.mcpServer(.catalog(id: "missing"))]
         )
 
         #expect(
@@ -73,19 +73,34 @@ struct NativKitTests {
         )
         let first = makeKit(
             id: "first",
-            components: [.mcpServer(catalogID: "fetch")]
+            components: [.mcpServer(.catalog(id: "fetch"))]
         )
         let second = makeKit(
             id: "second",
             components: [
-                .mcpServer(catalogID: "fetch"),
-                .skill(skill),
+                .mcpServer(.catalog(id: "fetch")),
+                .skill(id: skill.id),
             ]
         )
         var settings = NativSettings()
 
-        NativKitActivation.enableMissing(in: first, settings: &settings, mcpCatalog: mcpCatalog)
-        NativKitActivation.enableMissing(in: second, settings: &settings, mcpCatalog: mcpCatalog)
+        let kitCatalog = try NativKitCatalog(
+            kits: [first, second],
+            mcpCatalog: mcpCatalog,
+            skillDefinitions: [skill]
+        )
+        NativKitActivation.enableMissing(
+            in: first,
+            settings: &settings,
+            kitCatalog: kitCatalog,
+            mcpCatalog: mcpCatalog
+        )
+        NativKitActivation.enableMissing(
+            in: second,
+            settings: &settings,
+            kitCatalog: kitCatalog,
+            mcpCatalog: mcpCatalog
+        )
 
         #expect(settings.mcpServers.count == 1)
         #expect(settings.mcpServers.first?.catalogID == "fetch")
@@ -95,6 +110,7 @@ struct NativKitTests {
             NativKitActivation.state(
                 of: first,
                 settings: settings,
+                kitCatalog: kitCatalog,
                 isExtensionEnabled: { _ in false },
                 mcpCatalog: mcpCatalog
             ) == .enabled
@@ -103,6 +119,7 @@ struct NativKitTests {
             NativKitActivation.state(
                 of: second,
                 settings: settings,
+                kitCatalog: kitCatalog,
                 isExtensionEnabled: { _ in false },
                 mcpCatalog: mcpCatalog
             ) == .enabled
@@ -124,10 +141,20 @@ struct NativKitTests {
             instructions: "My instructions",
             isEnabled: false
         )
-        let kit = makeKit(id: "example", components: [.skill(bundledSkill)])
+        let kit = makeKit(id: "example", components: [.skill(id: bundledSkill.id)])
+        let kitCatalog = try NativKitCatalog(
+            kits: [kit],
+            mcpCatalog: .empty,
+            skillDefinitions: [bundledSkill]
+        )
         var settings = NativSettings(skills: [editedSkill])
 
-        NativKitActivation.enableMissing(in: kit, settings: &settings, mcpCatalog: .empty)
+        NativKitActivation.enableMissing(
+            in: kit,
+            settings: &settings,
+            kitCatalog: kitCatalog,
+            mcpCatalog: .empty
+        )
 
         #expect(settings.skills == [
             NativSkill(
@@ -152,8 +179,8 @@ struct NativKitTests {
         let kit = makeKit(
             id: "example",
             components: [
-                .mcpServer(catalogID: "fetch"),
-                .skill(skill),
+                .mcpServer(.catalog(id: "fetch")),
+                .skill(id: skill.id),
             ]
         )
         var settings = NativSettings()
@@ -163,6 +190,11 @@ struct NativKitTests {
         let snapshot = NativKitActivation.snapshot(
             of: kit,
             settings: settings,
+            kitCatalog: try NativKitCatalog(
+                kits: [kit],
+                mcpCatalog: mcpCatalog,
+                skillDefinitions: [skill]
+            ),
             extensionName: { $0 },
             isExtensionEnabled: { _ in false },
             mcpCatalog: mcpCatalog
@@ -185,12 +217,16 @@ struct NativKitTests {
         let kit = makeKit(
             id: "example",
             components: [
-                .mcpServer(catalogID: "fetch"),
-                .skill(skill),
+                .mcpServer(.catalog(id: "fetch")),
+                .skill(id: skill.id),
                 .extensionPackage(id: "com.nativ.example"),
             ]
         )
-        let kitCatalog = try NativKitCatalog(kits: [kit], mcpCatalog: mcpCatalog)
+        let kitCatalog = try NativKitCatalog(
+            kits: [kit],
+            mcpCatalog: mcpCatalog,
+            skillDefinitions: [skill]
+        )
         let entry = try #require(mcpCatalog.entry(id: "fetch"))
         var settings = NativSettings(
             mcpServers: [entry.makeConfiguration(isEnabled: false)]
@@ -228,6 +264,7 @@ struct NativKitTests {
         NativKitActivation.enableMissing(
             in: kit,
             settings: &settings,
+            kitCatalog: kitCatalog,
             mcpCatalog: mcpCatalog
         )
         resolution = NativKitRuntimeResolver.resolve(
@@ -255,15 +292,16 @@ struct NativKitTests {
         )
         let first = makeKit(
             id: "first",
-            components: [.mcpServer(catalogID: "fetch"), .skill(skill)]
+            components: [.mcpServer(.catalog(id: "fetch")), .skill(id: skill.id)]
         )
         let second = makeKit(
             id: "second",
-            components: [.mcpServer(catalogID: "fetch"), .skill(skill)]
+            components: [.mcpServer(.catalog(id: "fetch")), .skill(id: skill.id)]
         )
         let kitCatalog = try NativKitCatalog(
             kits: [first, second],
-            mcpCatalog: mcpCatalog
+            mcpCatalog: mcpCatalog,
+            skillDefinitions: [skill]
         )
         let server = entry.makeConfiguration()
         let settings = NativSettings(mcpServers: [server], skills: [skill])
@@ -278,6 +316,118 @@ struct NativKitTests {
         #expect(resolution.mcpServers == [server])
         #expect(resolution.skills == [skill])
         #expect(resolution.unavailableCapabilities == ["Kit missing (unavailable)"])
+    }
+
+    @Test("Kit components use a stable tagged Codable format")
+    func componentCodableFormat() throws {
+        let configuredID = UUID()
+        let customID = UUID()
+        let skillID = UUID()
+        let components: [NativKitComponent] = [
+            .mcpServer(.catalog(id: "fetch")),
+            .mcpServer(.configured(id: configuredID)),
+            .nativeTool(name: "web_search"),
+            .customTool(id: customID),
+            .skill(id: skillID),
+            .extensionPackage(id: "com.nativ.example"),
+        ]
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(components)
+        let json = String(decoding: data, as: UTF8.self)
+
+        #expect(json.contains(#""type":"mcpCatalog""#))
+        #expect(json.contains(#""type":"mcpConfigured""#))
+        #expect(json.contains(#""type":"nativeTool""#))
+        #expect(try JSONDecoder().decode([NativKitComponent].self, from: data) == components)
+    }
+
+    @Test("Unknown Kit component discriminators fail decoding")
+    func unknownComponentTypeFails() {
+        let data = Data(#"{"type":"futureCapability","id":"example"}"#.utf8)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(NativKitComponent.self, from: data)
+        }
+    }
+
+    @Test("User Kit library persists updates and deletion")
+    func libraryRoundTrip() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nativ-kit-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("Kits.json")
+        let kit = makeKit(
+            id: UUID().uuidString,
+            components: [.nativeTool(name: "web_search")]
+        )
+
+        let library = NativKitLibrary(storageURL: url)
+        try library.upsert(kit)
+        #expect(library.userKits == [kit])
+        #expect(NativKitLibrary(storageURL: url).userKits == [kit])
+
+        try library.delete(kitID: kit.id)
+        #expect(NativKitLibrary(storageURL: url).userKits.isEmpty)
+    }
+
+    @Test("Corrupt Kit files are reported and not overwritten")
+    func corruptLibraryIsPreserved() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nativ-kit-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("Kits.json")
+        let corrupt = Data("not-json".utf8)
+        try corrupt.write(to: url)
+
+        let library = NativKitLibrary(storageURL: url)
+
+        #expect(library.userKits.isEmpty)
+        #expect(library.lastErrorMessage != nil)
+        #expect(try Data(contentsOf: url) == corrupt)
+    }
+
+    @Test("Tool references activate and resolve without copying tool definitions")
+    func toolReferencesActivateAndResolve() throws {
+        let custom = try CustomTool.make(
+            name: "Example Tool",
+            summary: "Example",
+            kind: .script,
+            script: "print('{}')",
+            parametersJSON: CustomTool.defaultParametersJSON
+        )
+        let kit = makeKit(
+            id: "tools",
+            components: [
+                .nativeTool(name: "web_search"),
+                .customTool(id: custom.id),
+            ]
+        )
+        let catalog = try NativKitCatalog.bundled.merging(userKits: [kit])
+        var settings = NativSettings(
+            customTools: [custom],
+            disabledToolNames: ["web_search", custom.toolName]
+        )
+
+        NativKitActivation.enableMissing(
+            in: kit,
+            settings: &settings,
+            kitCatalog: catalog,
+            mcpCatalog: .empty
+        )
+        let resolution = NativKitRuntimeResolver.resolve(
+            kitIDs: [kit.id],
+            settings: settings,
+            kitCatalog: catalog,
+            mcpCatalog: .empty
+        )
+
+        #expect(settings.isToolEnabled("web_search"))
+        #expect(settings.isToolEnabled(custom.toolName))
+        #expect(resolution.tools == [
+            ScheduledTool(provider: .builtIn, name: "web_search"),
+            ScheduledTool(provider: .custom(custom.id), name: custom.toolName),
+        ])
     }
 
     private func makeKit(

--- a/project.yml
+++ b/project.yml
@@ -174,6 +174,7 @@ targets:
       - path: Sources/Nativ/NativSettings.swift
       - path: Sources/Nativ/Features/Extensions/NativSkill.swift
       - path: Sources/Nativ/Features/Extensions/NativKit.swift
+      - path: Sources/Nativ/Features/Extensions/NativKitLibrary.swift
       - path: Sources/Nativ/Features/Extensions/NativKitRuntimeResolver.swift
       - path: Sources/Nativ/Features/Extensions/CustomTool.swift
       - path: Sources/Nativ/Features/Routines/Routine.swift


### PR DESCRIPTION
Adds persistent custom Kits that users can create, edit, and delete from the Kits screen.

Lets each Kit combine MCP servers, tools, skills, and extensions through one searchable editor.

Resolves custom Kit capabilities consistently across chat and scheduled routines.

This builds on #397 and supersedes the remaining custom-Kits work from #251.