### PR TITLE
Feature/chat import export

### DIFF
--- a/Docs/features/chat.md
+++ b/Docs/features/chat.md
@@ -27,6 +27,17 @@ carries its title, messages, timestamps, pin state, and an optional folder assig
   session (`folderID`) and the folder list persists alongside sessions.
 - Empty, redundant sessions are pruned automatically.
 
+### Import and export
+
+The action menu for a chat exports a versioned JSON file containing its messages,
+attachments, model repository ID, system prompt, and basic session metadata. Use the import
+button above the sidebar to add one of these files as a new local session.
+
+Imported tool calls are kept as history and are never run automatically. Nativ offers to
+switch to the original model when it is installed and links to Models when it is missing.
+Users can instead continue with any downloaded language model. A chat remains read-only when
+its recorded token count exceeds the selected model's context window.
+
 ## Chat tools
 
 A tool-calling model can invoke host capabilities mid-conversation. The registry is

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 		D8838254D03112C2EABE37AC /* ModelPrimaryTaskResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */; };
 		D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
 		D94A6B329A8D7D3285147914 /* MarkdownFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */; };
+		D96122BA0806CCE96CC145E0 /* ChatImportAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9988535384E783847070506 /* ChatImportAlert.swift */; };
 		D9CA77A603AF02C2C70BC9FF /* MCPServerCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */; };
 		DC1ED6C1A11081FB70F1F019 /* NativImageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */; };
 		DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677360D86DDAFAB194A995E7 /* Main.swift */; };
@@ -713,6 +714,7 @@
 		F553434CA19B929108FF740F /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDocumentContextBuilderTests.swift; sourceTree = "<group>"; };
 		F84C7B764CE1B6F63746E3BB /* Perplexity.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Perplexity.png; sourceTree = "<group>"; };
+		F9988535384E783847070506 /* ChatImportAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatImportAlert.swift; sourceTree = "<group>"; };
 		FB10CC03A96A3EA80EF9343B /* ScheduledCapabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledCapabilityTests.swift; sourceTree = "<group>"; };
 		FB497800D0F8B237A1891EE1 /* WebBrowsingTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingTransport.swift; sourceTree = "<group>"; };
 		FD296E4B5897E7E46606B697 /* ControlPanelActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelActions.swift; sourceTree = "<group>"; };
@@ -1304,6 +1306,7 @@
 				8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */,
 				5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */,
 				7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */,
+				F9988535384E783847070506 /* ChatImportAlert.swift */,
 				F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */,
 				8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */,
 				530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */,
@@ -1679,6 +1682,7 @@
 				E1A4AA0C4AA32599FF2D54E7 /* ChatFontScale.swift in Sources */,
 				2BF78B0A20ED752102326A38 /* ChatImageModelSelection.swift in Sources */,
 				B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */,
+				D96122BA0806CCE96CC145E0 /* ChatImportAlert.swift in Sources */,
 				04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */,
 				902CD676AA3002459DF7ACAE /* ChatPromptRevision.swift in Sources */,
 				B6E24E55015CB5A98973B993 /* ChatReadFileTool.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		145464A2B098437667795AFB /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB9D1D0FC24AC771442B628 /* Artifact.swift */; };
 		14CEDB8ACA6EB7BCF8A3430C /* SystemSensorSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653E58FFA38742CD4D5D41F5 /* SystemSensorSampler.swift */; };
 		1523799A41450A96269D097C /* ControlPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028A6EB95776995CFF6F82A9 /* ControlPanelState.swift */; };
+		16572E3E7F6B92652B6A441E /* ChatArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDC9AFB58899E777CFF3BCD /* ChatArchive.swift */; };
 		16734A0FEAEBB574FEBFE9AE /* NativModelTypeRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D3285EDFAE3C2C1A6D4920 /* NativModelTypeRegistry.swift */; };
 		1691371327569F6FA1634DE5 /* FormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F39043C3E9B07A5EC3B7688 /* FormattingTests.swift */; };
 		184CEAB6FBA72EB5BF2A319D /* BraveBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6D2D7280064648E0EFC847 /* BraveBrowsingProvider.swift */; };
@@ -63,6 +64,7 @@
 		2452C5D7B24CA5FF6FAA36E2 /* MCPHostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5D77458EF56DD1B8F4AE17 /* MCPHostManager.swift */; };
 		252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
 		256B07A9158557D2E3AD2A35 /* Manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AF8F6359E4523814FB0EFDA /* Manifest.json */; };
+		2586E842357D9C0567C2572F /* ChatArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDC9AFB58899E777CFF3BCD /* ChatArchive.swift */; };
 		25A5064ED5552EA7DC8A562F /* SafeLocalFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E56BA346D88CC58DE21D448 /* SafeLocalFileWriter.swift */; };
 		276CD3A0BBC5127714E407CA /* ControlPanelDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90494E1AE30EF515482DDBE7 /* ControlPanelDependencies.swift */; };
 		28197A70541BE1F1F482BCF4 /* PDFDocumentTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB2C50E190D5DBA2E237FB2 /* PDFDocumentTextExtractor.swift */; };
@@ -159,6 +161,7 @@
 		58AEDA213E27344F01AE5A6B /* NativServerKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		59841D5E65EFAF5E513C502D /* SystemMonitorObservationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE94F230299FF8E794099BB4 /* SystemMonitorObservationPolicyTests.swift */; };
 		5BA95DA067DA56BBAC83EC14 /* ChatAttachmentValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */; };
+		5DD093567BA5EFF33F68C302 /* ChatArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F299F04205B8F438A9A9FF12 /* ChatArchiveTests.swift */; };
 		5EE99710A57A2413EAEA93A7 /* ChatFileWriteToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9BAAC27515691F6C7950B4 /* ChatFileWriteToolTests.swift */; };
 		5FAB8159D1D05E7CD75F56D2 /* WebSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB3FA30F4803017685118E3 /* WebSearchService.swift */; };
 		5FE38D5A9D40E133EC25BA20 /* ArtifactSearchIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55A33BE26A6AF77B69C0430 /* ArtifactSearchIndex.swift */; };
@@ -495,6 +498,7 @@
 		2A1B515ECDF21B3616E5A3D1 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		2A1E6ED5DB03C63851E6AAE2 /* ChatSearchFilesToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSearchFilesToolTests.swift; sourceTree = "<group>"; };
 		2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPrimaryTaskResolverTests.swift; sourceTree = "<group>"; };
+		2BDC9AFB58899E777CFF3BCD /* ChatArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatArchive.swift; sourceTree = "<group>"; };
 		2CF9F903E2609C4A522C19CF /* ChatConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatConfigurationView.swift; sourceTree = "<group>"; };
 		2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelReadmeTests.swift; sourceTree = "<group>"; };
 		2FF1D2267F5230F7692BC886 /* FileMutationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMutationState.swift; sourceTree = "<group>"; };
@@ -704,6 +708,7 @@
 		EEF71E7A328DFB6E2E741999 /* Firecrawl.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Firecrawl.png; sourceTree = "<group>"; };
 		EF7AE3F3DB48E640950CCDB4 /* SystemAudioMeetingRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioMeetingRecorder.swift; sourceTree = "<group>"; };
 		F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProvider.swift; sourceTree = "<group>"; };
+		F299F04205B8F438A9A9FF12 /* ChatArchiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatArchiveTests.swift; sourceTree = "<group>"; };
 		F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatPromptRevision.swift; sourceTree = "<group>"; };
 		F553434CA19B929108FF740F /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDocumentContextBuilderTests.swift; sourceTree = "<group>"; };
@@ -1288,6 +1293,7 @@
 		ED33631B7BBA892EB4B78808 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
+				2BDC9AFB58899E777CFF3BCD /* ChatArchive.swift */,
 				4DEE7582DCB286B9D878E28E /* ChatAttachmentKind.swift */,
 				51539FFC3A9D763AA1746318 /* ChatAttachmentNoticesView.swift */,
 				9483127E124DE562AFFFAC94 /* ChatAttachmentValidator.swift */,
@@ -1325,6 +1331,7 @@
 			children = (
 				FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */,
 				3B965B701714787B0A85AE6B /* AudioTests.swift */,
+				F299F04205B8F438A9A9FF12 /* ChatArchiveTests.swift */,
 				C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */,
 				B059AF48F10F1B0502DC5E6F /* ChatConversationBranchTests.swift */,
 				F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */,
@@ -1658,6 +1665,7 @@
 				63D4D3774994EAE5F5ABB7E9 /* AudioInputVolumeController.swift in Sources */,
 				ADDF36ABE66D5ACE3D765589 /* AudioView.swift in Sources */,
 				184CEAB6FBA72EB5BF2A319D /* BraveBrowsingProvider.swift in Sources */,
+				2586E842357D9C0567C2572F /* ChatArchive.swift in Sources */,
 				76DA7BB4EB87C407B55D5E05 /* ChatAttachmentKind.swift in Sources */,
 				C3D251E72388C59FFEA7E9C4 /* ChatAttachmentNoticesView.swift in Sources */,
 				FF9252FDCB6E44F672B53452 /* ChatAttachmentValidator.swift in Sources */,
@@ -1832,6 +1840,8 @@
 				393DC62E524B83E0216268B8 /* AudioInputLevelMonitor.swift in Sources */,
 				4B66E72A9DCB833D700F7612 /* AudioTests.swift in Sources */,
 				B3DE35DF177BB2B7A9D7690B /* BraveBrowsingProvider.swift in Sources */,
+				16572E3E7F6B92652B6A441E /* ChatArchive.swift in Sources */,
+				5DD093567BA5EFF33F68C302 /* ChatArchiveTests.swift in Sources */,
 				7ACEF87EDC19CB862FCF8840 /* ChatAttachmentKind.swift in Sources */,
 				6128B35157BF004E8A9E73F0 /* ChatAttachmentValidator.swift in Sources */,
 				5BA95DA067DA56BBAC83EC14 /* ChatAttachmentValidatorTests.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatArchive.swift
+++ b/Sources/Nativ/Features/Chat/ChatArchive.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+struct ChatArchive: Codable, Equatable {
+    static let format = "nativ-chat"
+    static let currentVersion = 1
+
+    let format: String
+    let version: Int
+    let exportedAt: Date
+    let modelRepositoryID: String
+    let systemPrompt: String
+    let chat: ChatArchiveConversation
+
+    init(
+        chat: ChatSession,
+        modelRepositoryID: String,
+        systemPrompt: String,
+        exportedAt: Date = .now
+    ) {
+        format = Self.format
+        version = Self.currentVersion
+        self.exportedAt = exportedAt
+        self.modelRepositoryID = modelRepositoryID
+        self.systemPrompt = systemPrompt
+        self.chat = ChatArchiveConversation(chat)
+    }
+}
+
+struct ChatArchiveConversation: Codable, Equatable {
+    let title: String
+    let customTitle: String?
+    let createdAt: Date
+    let updatedAt: Date
+    let messages: [ChatTranscriptMessage]
+    let imageGenerationModelID: String?
+
+    init(_ chat: ChatSession) {
+        title = chat.title
+        customTitle = chat.customTitle
+        createdAt = chat.createdAt
+        updatedAt = chat.updatedAt
+        messages = chat.messages
+        imageGenerationModelID = chat.imageGenerationModelID
+    }
+}
+
+enum ChatArchiveError: Error, Equatable, LocalizedError {
+    case invalidFormat
+    case unsupportedVersion(Int)
+    case missingModelRepositoryID
+    case invalidAttachment(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidFormat:
+            "This is not a Nativ chat export."
+        case let .unsupportedVersion(version):
+            "This chat export uses unsupported version \(version)."
+        case .missingModelRepositoryID:
+            "The chat export does not identify its model."
+        case let .invalidAttachment(filename):
+            "The attachment “\(filename)” contains invalid data."
+        }
+    }
+}
+
+enum ChatContinuationAvailability: Equatable {
+    case ready(requiresModelSwitch: Bool)
+    case modelMissing
+    case contextExceeded(tokenCount: Int, contextWindow: Int)
+}
+
+enum ChatArchiveCodec {
+    static func encode(_ archive: ChatArchive) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(archive)
+    }
+
+    static func decode(_ data: Data) throws -> ChatArchive {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let archive = try decoder.decode(ChatArchive.self, from: data)
+        try validate(archive)
+        return archive
+    }
+
+    static func importedSession(from archive: ChatArchive, now: Date = .now) throws -> ChatSession {
+        try validate(archive)
+
+        let messages = archive.chat.messages.map { message in
+            ChatTranscriptMessage(
+                role: message.role,
+                content: message.content,
+                reasoningContent: message.reasoningContent,
+                modelID: message.modelID,
+                createdAt: message.createdAt,
+                isThinkingEnabled: message.isThinkingEnabled,
+                thinkingDuration: message.thinkingDuration,
+                imageAttachments: message.imageAttachments.map {
+                    ChatImageAttachment(
+                        filename: $0.filename,
+                        mimeType: $0.mimeType,
+                        base64Data: $0.base64Data
+                    )
+                },
+                responseMetrics: message.responseMetrics,
+                toolCalls: message.toolCalls,
+                toolCallID: message.toolCallID,
+                toolName: message.toolName,
+                toolStatus: historicalStatus(message.toolStatus),
+                toolArguments: message.toolArguments
+            )
+        }
+
+        return ChatSession(
+            id: UUID(),
+            title: archive.chat.title,
+            customTitle: archive.chat.customTitle,
+            createdAt: archive.chat.createdAt,
+            updatedAt: now,
+            messages: messages,
+            imageGenerationModelID: archive.chat.imageGenerationModelID,
+            importedModelRepositoryID: archive.modelRepositoryID,
+            importedSystemPrompt: archive.systemPrompt
+        )
+    }
+
+    static func continuationAvailability(
+        for archive: ChatArchive,
+        installedModels: [LocalModel],
+        currentModelID: String?,
+        promptTokenCount: Int? = nil
+    ) -> ChatContinuationAvailability {
+        guard let model = installedModels.first(where: {
+            $0.repoID == archive.modelRepositoryID
+        }) else {
+            return .modelMissing
+        }
+
+        if let promptTokenCount,
+           let contextWindow = model.contextSize,
+           promptTokenCount > contextWindow {
+            return .contextExceeded(
+                tokenCount: promptTokenCount,
+                contextWindow: contextWindow
+            )
+        }
+
+        return .ready(requiresModelSwitch: currentModelID != archive.modelRepositoryID)
+    }
+
+    private static func validate(_ archive: ChatArchive) throws {
+        guard archive.format == ChatArchive.format else {
+            throw ChatArchiveError.invalidFormat
+        }
+        guard archive.version == ChatArchive.currentVersion else {
+            throw ChatArchiveError.unsupportedVersion(archive.version)
+        }
+        guard !archive.modelRepositoryID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ChatArchiveError.missingModelRepositoryID
+        }
+
+        for attachment in archive.chat.messages.flatMap(\.imageAttachments) {
+            guard Data(base64Encoded: attachment.base64Data) != nil else {
+                throw ChatArchiveError.invalidAttachment(attachment.filename)
+            }
+        }
+    }
+
+    private static func historicalStatus(
+        _ status: ChatTranscriptMessage.ToolStatus?
+    ) -> ChatTranscriptMessage.ToolStatus? {
+        switch status {
+        case .preparing, .awaitingImageModelSelection, .running, .awaitingConsent:
+            .cancelled
+        default:
+            status
+        }
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatArchive.swift
+++ b/Sources/Nativ/Features/Chat/ChatArchive.swift
@@ -151,6 +151,15 @@ enum ChatArchiveCodec {
         return .ready(requiresModelSwitch: currentModelID != archive.modelRepositoryID)
     }
 
+    static func promptTokenCount(in archive: ChatArchive) -> Int? {
+        archive.chat.messages.reversed().compactMap { message -> Int? in
+            guard message.role == .assistant else {
+                return nil
+            }
+            return message.responseMetrics?.totalTokens
+        }.first
+    }
+
     private static func validate(_ archive: ChatArchive) throws {
         guard archive.format == ChatArchive.format else {
             throw ChatArchiveError.invalidFormat

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -457,11 +457,14 @@ struct ChatComposer: View {
     }
 
     private var effectiveCanSend: Bool {
-        canSend && !hasVisionRejectedAttachment
+        canSend && !hasVisionRejectedAttachment && importedContinuationIsAvailable
     }
 
     private var attachmentNotices: [ChatAttachmentNotice] {
         var notices: [ChatAttachmentNotice] = []
+        if let importedContinuationNotice {
+            notices.append(importedContinuationNotice)
+        }
         let rejectedImages = modelLacksVision
             ? viewModel.pendingImageAttachments.filter { $0.chatAttachmentKind == .image }
             : []
@@ -536,6 +539,40 @@ struct ChatComposer: View {
             ))
         }
         return notices
+    }
+
+    private var importedContinuationIsAvailable: Bool {
+        guard viewModel.importedModelRepositoryID != nil else {
+            return true
+        }
+        guard let selectedLocalModel
+        else {
+            return true
+        }
+        guard let tokenCount = viewModel.importedPromptTokenCount,
+            let contextWindow = selectedLocalModel.contextSize
+        else {
+            return true
+        }
+        return tokenCount <= contextWindow
+    }
+
+    private var importedContinuationNotice: ChatAttachmentNotice? {
+        guard viewModel.importedModelRepositoryID != nil else {
+            return nil
+        }
+        if let tokenCount = viewModel.importedPromptTokenCount,
+           let contextWindow = selectedLocalModel?.contextSize,
+           tokenCount > contextWindow {
+            return ChatAttachmentNotice(
+                id: "imported-chat-context-limit",
+                severity: .error,
+                title: "This chat can’t be continued",
+                message: "Its \(tokenCount)-token history exceeds the selected model’s "
+                    + "\(contextWindow)-token context window."
+            )
+        }
+        return nil
     }
 
     private func documentContextWarningMessage(

--- a/Sources/Nativ/Features/Chat/ChatImportAlert.swift
+++ b/Sources/Nativ/Features/Chat/ChatImportAlert.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum ChatImportAlert: Identifiable, Equatable {
+    case originalModel(String)
+    case switchModel(String)
+    case modelMissing(String)
+    case contextExceeded(modelID: String, tokenCount: Int, contextWindow: Int)
+    case failed(String)
+
+    var id: String {
+        switch self {
+        case .originalModel:
+            "original-model"
+        case .switchModel:
+            "switch-model"
+        case .modelMissing:
+            "model-missing"
+        case .contextExceeded:
+            "context-exceeded"
+        case .failed:
+            "failed"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .originalModel:
+            "Original model"
+        case .switchModel:
+            "Switch models?"
+        case .modelMissing:
+            "Model required"
+        case .contextExceeded:
+            "Chat is too long to continue"
+        case .failed:
+            "Couldn’t import chat"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case let .originalModel(modelID):
+            "This chat was created with \(modelID). You can continue with it or choose another downloaded model."
+        case let .switchModel(modelID):
+            "This chat was created with \(modelID). You can switch to it or continue with any downloaded model."
+        case let .modelMissing(modelID):
+            "This chat was created with \(modelID), which is not downloaded. You can find it in Models or continue with another downloaded model."
+        case let .contextExceeded(modelID, tokenCount, contextWindow):
+            "This chat uses \(tokenCount) tokens, which exceeds \(modelID)’s \(contextWindow)-token context window. You can view it, but not continue it."
+        case let .failed(message):
+            message
+        }
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -23,6 +23,8 @@ struct ChatSession: Identifiable, Equatable, Codable {
     var folderID: UUID?
     var imageGenerationModelID: String?
     var scheduledTaskID: String?
+    var importedModelRepositoryID: String? = nil
+    var importedSystemPrompt: String? = nil
 
     var summary: ChatSessionSummary {
         ChatSessionSummary(

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -244,6 +244,19 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
+    var importedModelRepositoryID: String? {
+        currentSession?.importedModelRepositoryID
+    }
+
+    var importedPromptTokenCount: Int? {
+        messages.reversed().compactMap { message -> Int? in
+            guard message.role == .assistant else {
+                return nil
+            }
+            return message.responseMetrics?.totalTokens
+        }.first
+    }
+
     func attachmentValidation(for attachmentID: UUID) -> ChatAttachmentValidation? {
         attachmentValidations[attachmentID]
     }
@@ -369,6 +382,48 @@ final class ChatViewModel: ObservableObject {
         draft = ""
         pendingImageAttachments.removeAll()
         applyCurrentSession(session)
+    }
+
+    func archive(
+        for sessionID: UUID,
+        selectedModelID: String?,
+        systemPrompt: String
+    ) -> ChatArchive? {
+        let session: ChatSession?
+        if sessionID == currentSessionID {
+            session = currentSessionSnapshot
+        } else {
+            session = storedSessions.first(where: { $0.id == sessionID })
+                ?? sessionStore.loadSession(id: sessionID)
+        }
+
+        guard let session,
+            let modelRepositoryID = session.importedModelRepositoryID
+                ?? session.messages.reversed().compactMap(\.modelID).first
+                ?? selectedModelID
+        else {
+            return nil
+        }
+
+        return ChatArchive(
+            chat: session,
+            modelRepositoryID: modelRepositoryID,
+            systemPrompt: session.importedSystemPrompt ?? systemPrompt
+        )
+    }
+
+    func importArchive(_ archive: ChatArchive) throws -> UUID? {
+        let session = try ChatArchiveCodec.importedSession(from: archive)
+        persistCurrentSession(updateTimestamp: false)
+        guard saveSession(session) else {
+            return nil
+        }
+        upsertStoredSession(session)
+        discardPromptEditing()
+        draft = ""
+        pendingImageAttachments.removeAll()
+        applyCurrentSession(session)
+        return session.id
     }
 
     func stageAttachment(_ attachment: ChatImageAttachment) {
@@ -752,7 +807,10 @@ final class ChatViewModel: ObservableObject {
         languageModelSupportsTools: Bool,
         languageModelSupportsVision: Bool
     ) {
-        let settings = appModel.settings.normalized()
+        var settings = appModel.settings.normalized()
+        if let importedSystemPrompt = currentSession?.importedSystemPrompt {
+            settings.systemPrompt = importedSystemPrompt
+        }
         guard canSend(isRunning: appModel.isRunning, selectedModelID: settings.languageModelID),
             languageModelSupportsVision || !hasPendingImageAttachments,
             let modelID = settings.languageModelID,

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelActions.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelActions.swift
@@ -55,17 +55,91 @@ extension ControlPanelView {
 
     func exportRecentConversation(_ recent: ControlPanelRecentSession) {
         guard case .chat(let sessionID) = recent.selection,
-            let text = chat.conversationText(for: sessionID)
+            let archive = chat.archive(
+                for: sessionID,
+                selectedModelID: model.settings.normalized().languageModelID,
+                systemPrompt: model.settings.systemPrompt
+            )
         else {
             return
         }
         let panel = NSSavePanel()
-        panel.nameFieldStringValue = "\(recent.title).txt"
-        panel.allowedContentTypes = [.plainText]
+        panel.nameFieldStringValue = chatExportFileName(for: recent.title)
+        panel.allowedContentTypes = [.json]
         guard panel.runModal() == .OK, let url = panel.url else {
             return
         }
-        try? text.write(to: url, atomically: true, encoding: .utf8)
+        do {
+            try ChatArchiveCodec.encode(archive).write(to: url, options: .atomic)
+        } catch {
+            chatImportAlert = .failed("The chat could not be exported: \(error.localizedDescription)")
+        }
+    }
+
+    func importChat() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.prompt = "Import"
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+
+        do {
+            let archive = try ChatArchiveCodec.decode(Data(contentsOf: url))
+            Task {
+                await importChat(archive)
+            }
+        } catch {
+            chatImportAlert = .failed(error.localizedDescription)
+        }
+    }
+
+    func importChat(_ archive: ChatArchive) async {
+        do {
+            guard let sessionID = try chat.importArchive(archive) else {
+                chatImportAlert = .failed("Nativ could not save the imported chat.")
+                return
+            }
+            showChatWorkspace()
+            applySidebarSelection(.chat(sessionID))
+        } catch {
+            chatImportAlert = .failed(error.localizedDescription)
+            return
+        }
+
+        do {
+            let models = try await LocalModelDiscovery.scan(
+                searchPaths: model.settings.localModelSearchPaths
+            )
+            guard let originalModel = models.first(where: {
+                $0.repoID == archive.modelRepositoryID
+            }) else {
+                chatImportAlert = .modelMissing(archive.modelRepositoryID)
+                return
+            }
+
+            let selectedModelID = model.settings.normalized().languageModelID
+            if selectedModelID != archive.modelRepositoryID {
+                chatImportAlert = .switchModel(archive.modelRepositoryID)
+            } else if let tokenCount = ChatArchiveCodec.promptTokenCount(in: archive),
+                      let contextWindow = originalModel.contextSize,
+                      tokenCount > contextWindow {
+                chatImportAlert = .contextExceeded(
+                    modelID: archive.modelRepositoryID,
+                    tokenCount: tokenCount,
+                    contextWindow: contextWindow
+                )
+            } else {
+                chatImportAlert = .originalModel(archive.modelRepositoryID)
+            }
+        } catch {
+            chatImportAlert = .failed(
+                "The chat was imported, but Nativ could not check the local model library: "
+                    + error.localizedDescription
+            )
+        }
     }
 
     func exportFolder(_ folder: ChatFolder) {
@@ -110,6 +184,15 @@ extension ControlPanelView {
         let cleaned = name.components(separatedBy: invalid).joined(separator: "-")
         let trimmed = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "Untitled" : trimmed
+    }
+
+    func chatExportFileName(for title: String) -> String {
+        var name = sanitizedFileName(title)
+        if name.lowercased().hasSuffix(".json") {
+            name.removeLast(5)
+        }
+        name = String(name.prefix(80)).trimmingCharacters(in: .whitespacesAndNewlines)
+        return "\(name.isEmpty ? "Chat" : name).json"
     }
 
     func revealRecentSession(_ recent: ControlPanelRecentSession) {

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelDetail.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelDetail.swift
@@ -122,7 +122,9 @@ extension ControlPanelView {
                 titleLeadingInset: 0,
                 speechModelDiscoveryRequest: speechModelDiscoveryRequest,
                 imageModelDiscoveryRequest: imageModelDiscoveryRequest,
-                imageModelDiscoveryCapability: imageModelDiscoveryCapability
+                imageModelDiscoveryCapability: imageModelDiscoveryCapability,
+                modelDiscoveryRequest: modelDiscoveryRequest,
+                modelDiscoveryRepositoryID: modelDiscoveryRepositoryID
             )
             .equatable()
         case .extensions:

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelNavigation.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelNavigation.swift
@@ -66,6 +66,8 @@ final class ControlPanelNavigation: ObservableObject {
     @Published private(set) var imageModelDiscoveryRequest = 0
     @Published private(set) var imageModelDiscoveryCapability: LocalModelCapability =
         .imageGeneration
+    @Published private(set) var modelDiscoveryRequest = 0
+    @Published private(set) var modelDiscoveryRepositoryID: String?
     @Published private(set) var collapseAllSectionsRequest = 0
     private var consumedNewChatRequest = 0
     private var consumedToggleSidebarRequest = 0
@@ -96,6 +98,12 @@ final class ControlPanelNavigation: ObservableObject {
     func openImageModelDiscovery(for operation: ChatImageOperation) {
         imageModelDiscoveryCapability = operation.requiredCapability
         imageModelDiscoveryRequest += 1
+        requestedTab = .models
+    }
+
+    func openModelDiscovery(repoID: String) {
+        modelDiscoveryRepositoryID = repoID
+        modelDiscoveryRequest += 1
         requestedTab = .models
     }
 

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarToolbar.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarToolbar.swift
@@ -10,6 +10,13 @@ extension ControlPanelView {
         HStack(spacing: 8) {
             Spacer(minLength: 0)
 
+            Button("Import Chat", systemImage: "square.and.arrow.down", action: importChat)
+                .labelStyle(.iconOnly)
+                .buttonStyle(.plain)
+                .frame(width: 26, height: 28)
+                .foregroundStyle(Color.secondary.opacity(0.7))
+                .help("Import chat")
+
             Button {
                 withAnimation(.snappy(duration: 0.2)) {
                     enterSelectMode()

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelView.swift
@@ -29,6 +29,8 @@ struct ControlPanelView: View {
     @State var speechModelDiscoveryRequest: Int
     @State var imageModelDiscoveryRequest: Int
     @State var imageModelDiscoveryCapability: LocalModelCapability
+    @State var modelDiscoveryRequest: Int
+    @State var modelDiscoveryRepositoryID: String?
     @State var hoveredFooterControl: FooterControl?
     @State var isSidebarVisible = true
     @State var sidebarWidth = ControlPanelLayout.sidebarIdealWidth
@@ -47,6 +49,7 @@ struct ControlPanelView: View {
     @State var pendingDeleteRecent: ControlPanelRecentSession?
     @State var pendingDeleteFolder: ChatFolder?
     @State var isConfirmingBulkDelete = false
+    @State var chatImportAlert: ChatImportAlert?
 
     var chat: ChatViewModel { dependencies.chat }
     var mcpHost: MCPHostManager { dependencies.mcpHost }
@@ -94,6 +97,10 @@ struct ControlPanelView: View {
         )
         _imageModelDiscoveryCapability = State(
             initialValue: navigation.imageModelDiscoveryCapability
+        )
+        _modelDiscoveryRequest = State(initialValue: navigation.modelDiscoveryRequest)
+        _modelDiscoveryRepositoryID = State(
+            initialValue: navigation.modelDiscoveryRepositoryID
         )
     }
 
@@ -161,6 +168,35 @@ struct ControlPanelView: View {
             ControlPanelWindowStateReader(isFullScreen: $isFullScreen)
                 .frame(width: 0, height: 0)
         }
+        .alert(
+            chatImportAlert?.title ?? "Import Chat",
+            isPresented: Binding(
+                get: { chatImportAlert != nil },
+                set: { if !$0 { chatImportAlert = nil } }
+            ),
+            presenting: chatImportAlert
+        ) { alert in
+            switch alert {
+            case .originalModel:
+                Button("OK", role: .cancel) {}
+            case let .switchModel(modelID):
+                Button("Switch Model") {
+                    model.switchLanguageModel(to: modelID)
+                }
+                .keyboardShortcut(.defaultAction)
+                Button("Use Another Model", role: .cancel) {}
+            case let .modelMissing(modelID):
+                Button("Open Models") {
+                    navigation.openModelDiscovery(repoID: modelID)
+                }
+                .keyboardShortcut(.defaultAction)
+                Button("Use Another Model", role: .cancel) {}
+            case .contextExceeded, .failed:
+                Button("OK", role: .cancel) {}
+            }
+        } message: { alert in
+            Text(alert.message)
+        }
         .onAppear {
             applySidebarSelection(
                 navigation.requestedTab.map(ControlPanelSidebarSelection.tab) ?? sidebarSelection)
@@ -207,6 +243,12 @@ struct ControlPanelView: View {
         }
         .onReceive(navigation.$imageModelDiscoveryCapability) { capability in
             imageModelDiscoveryCapability = capability
+        }
+        .onReceive(navigation.$modelDiscoveryRepositoryID) { repoID in
+            modelDiscoveryRepositoryID = repoID
+        }
+        .onReceive(navigation.$modelDiscoveryRequest) { request in
+            modelDiscoveryRequest = request
         }
         .onReceive(
             NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -179,6 +179,8 @@ struct ModelsViewHost: View, @MainActor Equatable {
     var speechModelDiscoveryRequest = 0
     var imageModelDiscoveryRequest = 0
     var imageModelDiscoveryCapability: LocalModelCapability = .imageGeneration
+    var modelDiscoveryRequest = 0
+    var modelDiscoveryRepositoryID: String?
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.model === rhs.model
@@ -187,6 +189,8 @@ struct ModelsViewHost: View, @MainActor Equatable {
             && lhs.speechModelDiscoveryRequest == rhs.speechModelDiscoveryRequest
             && lhs.imageModelDiscoveryRequest == rhs.imageModelDiscoveryRequest
             && lhs.imageModelDiscoveryCapability == rhs.imageModelDiscoveryCapability
+            && lhs.modelDiscoveryRequest == rhs.modelDiscoveryRequest
+            && lhs.modelDiscoveryRepositoryID == rhs.modelDiscoveryRepositoryID
     }
 
     var body: some View {
@@ -196,7 +200,9 @@ struct ModelsViewHost: View, @MainActor Equatable {
             titleLeadingInset: titleLeadingInset,
             speechModelDiscoveryRequest: speechModelDiscoveryRequest,
             imageModelDiscoveryRequest: imageModelDiscoveryRequest,
-            imageModelDiscoveryCapability: imageModelDiscoveryCapability
+            imageModelDiscoveryCapability: imageModelDiscoveryCapability,
+            modelDiscoveryRequest: modelDiscoveryRequest,
+            modelDiscoveryRepositoryID: modelDiscoveryRepositoryID
         )
     }
 }
@@ -208,6 +214,8 @@ struct ModelsView: View {
     var speechModelDiscoveryRequest = 0
     var imageModelDiscoveryRequest = 0
     var imageModelDiscoveryCapability: LocalModelCapability = .imageGeneration
+    var modelDiscoveryRequest = 0
+    var modelDiscoveryRepositoryID: String?
     @StateObject private var modelState: ModelsNativState
     @StateObject private var localLibrary = LocalModelLibrary()
     @StateObject private var hubLibrary = HuggingFaceModelLibrary()
@@ -227,6 +235,7 @@ struct ModelsView: View {
     @State private var hubAccessFilter: HubAccessFilter = .all
     @State private var handledSpeechModelDiscoveryRequest = 0
     @State private var handledImageModelDiscoveryRequest = 0
+    @State private var handledModelDiscoveryRequest = 0
     @State private var lastStartedHubSearchTaskID: HubSearchTaskID?
     @State private var readmeSelection: ModelReadmeSelection?
 
@@ -236,7 +245,9 @@ struct ModelsView: View {
         titleLeadingInset: CGFloat = 0,
         speechModelDiscoveryRequest: Int = 0,
         imageModelDiscoveryRequest: Int = 0,
-        imageModelDiscoveryCapability: LocalModelCapability = .imageGeneration
+        imageModelDiscoveryCapability: LocalModelCapability = .imageGeneration,
+        modelDiscoveryRequest: Int = 0,
+        modelDiscoveryRepositoryID: String? = nil
     ) {
         self.model = model
         _showsConfiguration = showsConfiguration
@@ -244,6 +255,8 @@ struct ModelsView: View {
         self.speechModelDiscoveryRequest = speechModelDiscoveryRequest
         self.imageModelDiscoveryRequest = imageModelDiscoveryRequest
         self.imageModelDiscoveryCapability = imageModelDiscoveryCapability
+        self.modelDiscoveryRequest = modelDiscoveryRequest
+        self.modelDiscoveryRepositoryID = modelDiscoveryRepositoryID
         _modelState = StateObject(wrappedValue: ModelsNativState(model: model))
     }
 
@@ -273,12 +286,16 @@ struct ModelsView: View {
         .onAppear {
             openSpeechModelDiscoveryIfRequested()
             openImageModelDiscoveryIfRequested()
+            openModelDiscoveryIfRequested()
         }
         .onChange(of: speechModelDiscoveryRequest) { _, _ in
             openSpeechModelDiscoveryIfRequested()
         }
         .onChange(of: imageModelDiscoveryRequest) { _, _ in
             openImageModelDiscoveryIfRequested()
+        }
+        .onChange(of: modelDiscoveryRequest) { _, _ in
+            openModelDiscoveryIfRequested()
         }
         .onChange(of: section) { _, newSection in
             // Let the segmented control commit before replacing the toolbar
@@ -355,6 +372,20 @@ struct ModelsView: View {
         hubSort = .downloads
         hubSortDirection = .descending
         hubCapabilityFilters = [imageModelDiscoveryCapability]
+        hubAccessFilter = .all
+    }
+
+    private func openModelDiscoveryIfRequested() {
+        guard modelDiscoveryRequest > handledModelDiscoveryRequest,
+            let modelDiscoveryRepositoryID
+        else {
+            return
+        }
+        handledModelDiscoveryRequest = modelDiscoveryRequest
+        section = .discover
+        typeFilter = .all
+        hubQuery = modelDiscoveryRepositoryID
+        hubCapabilityFilters = []
         hubAccessFilter = .all
     }
 

--- a/Tests/NativTests/ChatArchiveTests.swift
+++ b/Tests/NativTests/ChatArchiveTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import NativServerKit
+import XCTest
+
+final class ChatArchiveTests: XCTestCase {
+    func testArchiveRoundTrip() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let session = makeSession(date: date)
+        let archive = ChatArchive(
+            chat: session,
+            modelRepositoryID: "mlx-community/Qwen3-4B",
+            systemPrompt: "Be concise.",
+            exportedAt: date
+        )
+
+        let data = try ChatArchiveCodec.encode(archive)
+        let decoded = try ChatArchiveCodec.decode(data)
+
+        XCTAssertEqual(decoded, archive)
+    }
+
+    func testImportAssignsNewLocalIDsAndPreservesToolCallLinks() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let source = makeSession(date: date, isStreaming: true)
+        let archive = ChatArchive(
+            chat: source,
+            modelRepositoryID: "mlx-community/Qwen3-4B",
+            systemPrompt: ""
+        )
+
+        let imported = try ChatArchiveCodec.importedSession(from: archive, now: date)
+
+        XCTAssertNotEqual(imported.id, source.id)
+        XCTAssertEqual(imported.messages.count, source.messages.count)
+        XCTAssertNotEqual(imported.messages[0].id, source.messages[0].id)
+        XCTAssertNotEqual(
+            imported.messages[0].imageAttachments[0].id,
+            source.messages[0].imageAttachments[0].id
+        )
+        XCTAssertEqual(imported.messages[1].toolCalls, source.messages[1].toolCalls)
+        XCTAssertEqual(imported.messages[2].toolCallID, source.messages[2].toolCallID)
+        XCTAssertEqual(imported.messages[2].toolStatus, .cancelled)
+        XCTAssertFalse(imported.messages[2].isStreaming)
+        XCTAssertEqual(imported.importedModelRepositoryID, archive.modelRepositoryID)
+        XCTAssertEqual(imported.importedSystemPrompt, archive.systemPrompt)
+    }
+
+    func testDecodeRejectsAnUnsupportedVersion() throws {
+        let archive = ChatArchive(
+            chat: makeSession(),
+            modelRepositoryID: "mlx-community/Qwen3-4B",
+            systemPrompt: ""
+        )
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: ChatArchiveCodec.encode(archive)) as? [String: Any]
+        )
+        object["version"] = 2
+        let data = try JSONSerialization.data(withJSONObject: object)
+
+        XCTAssertThrowsError(try ChatArchiveCodec.decode(data)) { error in
+            XCTAssertEqual(error as? ChatArchiveError, .unsupportedVersion(2))
+        }
+    }
+
+    func testDecodeRejectsAnInvalidFormat() throws {
+        let archive = ChatArchive(
+            chat: makeSession(),
+            modelRepositoryID: "mlx-community/Qwen3-4B",
+            systemPrompt: ""
+        )
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: ChatArchiveCodec.encode(archive)) as? [String: Any]
+        )
+        object["format"] = "some-other-format"
+        let data = try JSONSerialization.data(withJSONObject: object)
+
+        XCTAssertThrowsError(try ChatArchiveCodec.decode(data)) { error in
+            XCTAssertEqual(error as? ChatArchiveError, .invalidFormat)
+        }
+    }
+
+    func testDecodeRejectsInvalidAttachmentData() throws {
+        let archive = ChatArchive(
+            chat: makeSession(attachmentData: "not base64"),
+            modelRepositoryID: "mlx-community/Qwen3-4B",
+            systemPrompt: ""
+        )
+
+        XCTAssertThrowsError(try ChatArchiveCodec.decode(ChatArchiveCodec.encode(archive))) { error in
+            XCTAssertEqual(
+                error as? ChatArchiveError,
+                .invalidAttachment("notes.txt")
+            )
+        }
+    }
+
+    func testContinuationAvailability() {
+        let archive = ChatArchive(
+            chat: makeSession(),
+            modelRepositoryID: "mlx-community/Qwen3-4B",
+            systemPrompt: ""
+        )
+        let installedModel = LocalModel(
+            repoID: archive.modelRepositoryID,
+            snapshotURL: nil,
+            modifiedAt: nil,
+            sizeBytes: nil,
+            parameterCount: nil,
+            quantizationBits: nil,
+            quantizationGroupSize: nil,
+            contextSize: 4_096,
+            provider: nil,
+            capabilities: [.text],
+            drafterKind: nil,
+            hiddenSize: nil
+        )
+
+        XCTAssertEqual(
+            ChatArchiveCodec.continuationAvailability(
+                for: archive,
+                installedModels: [],
+                currentModelID: nil
+            ),
+            .modelMissing
+        )
+        XCTAssertEqual(
+            ChatArchiveCodec.continuationAvailability(
+                for: archive,
+                installedModels: [installedModel],
+                currentModelID: "another-model"
+            ),
+            .ready(requiresModelSwitch: true)
+        )
+        XCTAssertEqual(
+            ChatArchiveCodec.continuationAvailability(
+                for: archive,
+                installedModels: [installedModel],
+                currentModelID: archive.modelRepositoryID,
+                promptTokenCount: 4_097
+            ),
+            .contextExceeded(tokenCount: 4_097, contextWindow: 4_096)
+        )
+    }
+
+    private func makeSession(
+        date: Date = .now,
+        attachmentData: String = Data("hello".utf8).base64EncodedString(),
+        isStreaming: Bool = false
+    ) -> ChatSession {
+        let toolCallID = "call_1"
+        return ChatSession(
+            id: UUID(),
+            title: "Imported chat",
+            createdAt: date,
+            updatedAt: date,
+            messages: [
+                ChatTranscriptMessage(
+                    role: .user,
+                    content: "Read this",
+                    createdAt: date,
+                    imageAttachments: [
+                        ChatImageAttachment(
+                            filename: "notes.txt",
+                            mimeType: "text/plain",
+                            base64Data: attachmentData
+                        )
+                    ]
+                ),
+                ChatTranscriptMessage(
+                    role: .assistant,
+                    content: "",
+                    createdAt: date,
+                    toolCalls: [
+                        MLXChatToolCall(
+                            index: 0,
+                            id: toolCallID,
+                            type: "function",
+                            function: MLXChatFunctionCall(name: "read_file", arguments: "{}")
+                        )
+                    ]
+                ),
+                ChatTranscriptMessage(
+                    role: .tool,
+                    content: "hello",
+                    createdAt: date,
+                    isStreaming: isStreaming,
+                    toolCallID: toolCallID,
+                    toolName: "read_file",
+                    toolStatus: .running
+                )
+            ]
+        )
+    }
+}

--- a/Tests/NativTests/ChatArchiveTests.swift
+++ b/Tests/NativTests/ChatArchiveTests.swift
@@ -142,6 +142,26 @@ final class ChatArchiveTests: XCTestCase {
         )
     }
 
+    func testPromptTokenCountUsesTheLatestAssistantMetrics() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        var session = makeSession(date: date)
+        session.messages.append(
+            ChatTranscriptMessage(
+                role: .assistant,
+                content: "Done",
+                createdAt: date,
+                responseMetrics: ChatResponseMetrics(totalTokens: 321)
+            )
+        )
+        let archive = ChatArchive(
+            chat: session,
+            modelRepositoryID: "mlx-community/Qwen3-4B",
+            systemPrompt: ""
+        )
+
+        XCTAssertEqual(ChatArchiveCodec.promptTokenCount(in: archive), 321)
+    }
+
     private func makeSession(
         date: Date = .now,
         attachmentData: String = Data("hello".utf8).base64EncodedString(),

--- a/Tests/NativTests/WindowCommandRoutingTests.swift
+++ b/Tests/NativTests/WindowCommandRoutingTests.swift
@@ -32,6 +32,17 @@ final class WindowCommandRoutingTests: XCTestCase {
         XCTAssertTrue(navigation.consumeCollapseAllSectionsRequest())
     }
 
+    func testOpensDiscoveryForAnExactModel() {
+        let navigation = ControlPanelNavigation()
+        let repoID = "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit"
+
+        navigation.openModelDiscovery(repoID: repoID)
+
+        XCTAssertEqual(navigation.requestedTab, .models)
+        XCTAssertEqual(navigation.modelDiscoveryRepositoryID, repoID)
+        XCTAssertEqual(navigation.modelDiscoveryRequest, 1)
+    }
+
     func testActivateDoesNotChangeNavigation() {
         let navigation = ControlPanelNavigation()
 

--- a/project.yml
+++ b/project.yml
@@ -247,6 +247,7 @@ targets:
       - path: Sources/Nativ/Features/Artifacts/Artifact.swift
       - path: Sources/Nativ/Features/Documents
       - path: Sources/Nativ/Features/Chat/ChatSessionStore.swift
+      - path: Sources/Nativ/Features/Chat/ChatArchive.swift
       - path: Sources/Nativ/Features/Chat/ChatAttachmentKind.swift
       - path: Sources/Nativ/Features/Chat/ChatAttachmentValidator.swift
       - path: Sources/Nativ/Features/Chat/ChatDocumentExtractionCache.swift


### PR DESCRIPTION
This is the first v of chat import and export.

Exported chats include messages, attachments, model information, the system prompt, and basic metadata. Imported chats get new local IDs and keep previous tool calls as inactive history.

After importing, Nativ shows which model created the chat. Users can switch to that model, download it from the Models page, or continue with another installed model. Chats that exceed the selected model’s context window remain viewable but cannot be continued.

<img width="1728" height="1117" alt="Screenshot 2026-08-31 at 2 50 04 PM" src="https://github.com/user-attachments/assets/efdcdc77-3ecc-42f2-9a28-807e9914112c" />
<img width="1728" height="1117" alt="Screenshot 2026-08-31 at 2 44 35 PM" src="https://github.com/user-attachments/assets/962d9149-a5a6-4f0e-a1f0-e13a21068602" />
<img width="1728" height="1117" alt="Screenshot 2026-08-31 at 2 44 51 PM" src="https://github.com/user-attachments/assets/c211a379-d941-431a-993c-e05ae72455d3" />