### PR TITLE
Add context window progress ring to chat composer

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -2,6 +2,69 @@ import AppKit
 import Foundation
 import SwiftUI
 
+private struct ChatContextWindowUsage: Equatable {
+    let usedTokens: Int
+    let capacityTokens: Int
+
+    var usedFraction: Double {
+        guard capacityTokens > 0 else { return 0 }
+        return min(max(Double(usedTokens) / Double(capacityTokens), 0), 1)
+    }
+
+    var remainingPercentage: Int {
+        Int(((1 - usedFraction) * 100).rounded())
+    }
+}
+
+private struct ChatContextWindowRing: View {
+    let usage: ChatContextWindowUsage
+    @State private var showsDetails = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(.quaternary, lineWidth: 2)
+
+            Circle()
+                .trim(from: 0, to: usage.usedFraction)
+                .stroke(
+                    ringColor,
+                    style: StrokeStyle(lineWidth: 2, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: 17, height: 17)
+        .contentShape(.circle)
+        .onHover { showsDetails = $0 }
+        .background {
+            NativArrowlessPopoverPresenter(isPresented: $showsDetails, gap: 6) {
+                Text("Context window: \(usage.remainingPercentage)% remaining")
+                    .monospacedDigit()
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Model context window")
+        .accessibilityValue(
+            "\(usage.remainingPercentage) percent remaining, "
+                + "\(usage.usedTokens.formatted()) of \(usage.capacityTokens.formatted()) tokens used"
+        )
+    }
+
+    private var ringColor: Color {
+        switch usage.usedFraction {
+        case ..<0.75:
+            .secondary
+        case ..<0.9:
+            .orange
+        default:
+            .red
+        }
+    }
+
+}
+
 private struct ChatAttachmentThumbnail: View {
     let attachment: ChatImageAttachment
     var width: CGFloat = 120
@@ -226,6 +289,10 @@ struct ChatComposer: View {
 
                     Spacer(minLength: 12)
 
+                    if let contextWindowUsage {
+                        ChatContextWindowRing(usage: contextWindowUsage)
+                    }
+
                     modelPicker
 
                     Button {
@@ -420,6 +487,41 @@ struct ChatComposer: View {
             onSelectModel: select,
             onSwitchModel: { model.switchLanguageModel(to: $0) }
         )
+    }
+
+    private var contextWindowUsage: ChatContextWindowUsage? {
+        guard let capacity = effectiveContextWindowCapacity,
+              capacity > 0 else {
+            return nil
+        }
+
+        let usedTokens = viewModel.visibleMessages
+            .reversed()
+            .lazy
+            .compactMap({ $0.responseMetrics?.totalTokens })
+            .first ?? 0
+
+        return ChatContextWindowUsage(
+            usedTokens: usedTokens,
+            capacityTokens: capacity
+        )
+    }
+
+    private var effectiveContextWindowCapacity: Int? {
+        if let runtimeCapacity = model.metrics?.server.effectiveContextLimit
+            ?? model.metrics?.server.configuredContextLimit
+            ?? model.metrics?.server.loadedContextSize {
+            return runtimeCapacity
+        }
+
+        let advertisedCapacity = selectedLocalModel?.contextSize
+        guard model.settings.maxKVSize > 0 else {
+            return advertisedCapacity
+        }
+        guard let advertisedCapacity else {
+            return model.settings.maxKVSize
+        }
+        return min(advertisedCapacity, model.settings.maxKVSize)
     }
 
     private var languageModels: [LocalModel] {


### PR DESCRIPTION
This adds a context window indicator in chat.

The ring shows how much of the selected model’s context has been used, and hovering over it shows the percentage remaining.

It uses the token count returned by MLX-VLM and the effective context limit already available in Nativ. If runtime metrics aren’t available yet, it falls back to the model’s local metadata.