### PR TITLE
Use lazy stack for chat transcript

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -127,7 +127,7 @@ private struct ChatTranscriptView: View {
         let latestUserMessageID = chat.latestUserMessageID
 
         ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+            LazyVStack(alignment: .leading, spacing: 12) {
                 if chat.visibleMessages.isEmpty {
                     if chat.messages.isEmpty {
                         ChatEmptyTranscriptView(


### PR DESCRIPTION
The chat view is basically unusable in long sessions when scrolling/rendering responses. Inference takes about 20 seconds but rendering the same response takes up to 11 minutes with VStack 

Changed from VStask to LazyVStack. 


My biggest PR yet lol :)