### PR TITLE
Remove mlx-lm from bundled runtime

### DIFF
--- a/PythonDistribution/Requirements/mlx-vlm-server-macos-arm64.txt
+++ b/PythonDistribution/Requirements/mlx-vlm-server-macos-arm64.txt
@@ -27,8 +27,7 @@ llguidance==1.7.5
 markdown-it-py==4.2.0
 mdurl==0.1.2
 miniaudio==1.71
-mlx-audio>=0.4.7
-mlx-lm==0.31.3
+mlx-audio>=0.5.0
 mlx-metal>=0.32.0
 mlx-vlm>=0.6.10
 mlx>=0.32.0

--- a/PythonDistribution/Scripts/generate_model_capabilities_manifest.py
+++ b/PythonDistribution/Scripts/generate_model_capabilities_manifest.py
@@ -21,7 +21,7 @@ CAPABILITY_NAMES = (
     "embeddings",
     "reranking",
 )
-PACKAGE_NAMES = ("mlx-lm", "mlx-vlm", "mlx-audio")
+PACKAGE_NAMES = ("mlx-vlm", "mlx-audio")
 
 
 def _parse_module(path: Path) -> ast.Module:

--- a/Sources/NativServerKit/NativModelTypeRegistry.swift
+++ b/Sources/NativServerKit/NativModelTypeRegistry.swift
@@ -33,7 +33,7 @@ public struct NativModelTypeRegistry: Equatable, Sendable {
             )
         }
 
-        for package in ["mlx-lm", "mlx-vlm", "mlx-audio"] {
+        for package in ["mlx-vlm", "mlx-audio"] {
             guard let version = manifest.packageVersions[package],
                   !version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             else {


### PR DESCRIPTION
Removes mlx-lm from Nativ's bundled Python runtime and raises the minimum mlx-audio version to 0.5.0, which no longer requires it for core STT/TTS support. Updates capability-manifest validation and adds a build-time guard that rejects distributions where mlx_lm remains importable.