### PR TITLE
Bulk Selection for the Installed Models Page

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1691371327569F6FA1634DE5 /* FormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F39043C3E9B07A5EC3B7688 /* FormattingTests.swift */; };
 		184CEAB6FBA72EB5BF2A319D /* BraveBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6D2D7280064648E0EFC847 /* BraveBrowsingProvider.swift */; };
 		1890C306E4861079C4CA34AB /* FileReadAccessPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0425C365C50DD040161226 /* FileReadAccessPolicy.swift */; };
+		18BA08A2DD4C4CAD2DC6B0E3 /* NativBulkSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7069F17AAC82BF3F1FD1C95E /* NativBulkSelection.swift */; };
 		197EBBED5CC651E6364617B5 /* VoiceCaptureOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C93856381B1D89C4DE61DCC /* VoiceCaptureOverlay.swift */; };
 		1A6F5207528E44EA9FF8F831 /* NativChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E6FD97A66F91B3B667B3FE /* NativChatClient.swift */; };
 		1A82A76742BFEEBE881659BD /* TavilyBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90AC464C5C04FB14A3C789 /* TavilyBrowsingProvider.swift */; };
@@ -164,6 +165,7 @@
 		58AEDA213E27344F01AE5A6B /* NativServerKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		59841D5E65EFAF5E513C502D /* SystemMonitorObservationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE94F230299FF8E794099BB4 /* SystemMonitorObservationPolicyTests.swift */; };
 		5BA95DA067DA56BBAC83EC14 /* ChatAttachmentValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */; };
+		5C64F06C8BE83F8E0E589B78 /* NativBulkSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6964F9653F9E59196C2EDACB /* NativBulkSelectionTests.swift */; };
 		5DD093567BA5EFF33F68C302 /* ChatArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F299F04205B8F438A9A9FF12 /* ChatArchiveTests.swift */; };
 		5EE99710A57A2413EAEA93A7 /* ChatFileWriteToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9BAAC27515691F6C7950B4 /* ChatFileWriteToolTests.swift */; };
 		5FAB8159D1D05E7CD75F56D2 /* WebSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB3FA30F4803017685118E3 /* WebSearchService.swift */; };
@@ -335,6 +337,7 @@
 		D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
 		D94A6B329A8D7D3285147914 /* MarkdownFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */; };
 		D96122BA0806CCE96CC145E0 /* ChatImportAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9988535384E783847070506 /* ChatImportAlert.swift */; };
+		D963B49FA9E1E766B9081104 /* NativBulkSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7069F17AAC82BF3F1FD1C95E /* NativBulkSelection.swift */; };
 		D9CA77A603AF02C2C70BC9FF /* MCPServerCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */; };
 		DC1ED6C1A11081FB70F1F019 /* NativImageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */; };
 		DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677360D86DDAFAB194A995E7 /* Main.swift */; };
@@ -570,11 +573,13 @@
 		677258B04E9BB7CA8B89E11E /* FileTypeIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIcon.swift; sourceTree = "<group>"; };
 		677360D86DDAFAB194A995E7 /* Main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Main.swift; sourceTree = "<group>"; };
 		67855F86F63BC3BD40D008C8 /* Tools */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Tools; path = ThirdParty/ripgrep/Tools; sourceTree = SOURCE_ROOT; };
+		6964F9653F9E59196C2EDACB /* NativBulkSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativBulkSelectionTests.swift; sourceTree = "<group>"; };
 		6ABC782FB29B8C76EC8B60E6 /* NotificationAppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = NotificationAppIcon.icns; sourceTree = "<group>"; };
 		6BB0CD839020E3F5FF4F8DED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6BF298015C5DDB04B72C29A9 /* ControlPanelSidebarRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarRows.swift; sourceTree = "<group>"; };
 		6CDD9C3FE179B2E8D76FC769 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		6D4ED7BDFBC000148E13EA19 /* PowerPointDocumentTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerPointDocumentTextExtractor.swift; sourceTree = "<group>"; };
+		7069F17AAC82BF3F1FD1C95E /* NativBulkSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativBulkSelection.swift; sourceTree = "<group>"; };
 		711EAE65183E78E000DD3253 /* GitHubOAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubOAuthTests.swift; sourceTree = "<group>"; };
 		7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceShortcut.swift; sourceTree = "<group>"; };
 		740FC3907FB149A3D184EBF9 /* FileWriteConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileWriteConfigurationView.swift; sourceTree = "<group>"; };
@@ -1338,6 +1343,7 @@
 			isa = PBXGroup;
 			children = (
 				7A2C827258CAD4269D2428AD /* InferenceActivityCoordinator.swift */,
+				7069F17AAC82BF3F1FD1C95E /* NativBulkSelection.swift */,
 				20EE1CE9AAE5A3B9A2D4669C /* NativComponents.swift */,
 				C8B94192425D46A59F516118 /* PersistedDataChangeHub.swift */,
 			);
@@ -1378,6 +1384,7 @@
 				B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */,
 				3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */,
 				2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */,
+				6964F9653F9E59196C2EDACB /* NativBulkSelectionTests.swift */,
 				E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */,
 				780A9582305FC184F6C68D12 /* NativKitTests.swift */,
 				982F3BB563023885587DC860 /* NativNotificationTests.swift */,
@@ -1778,6 +1785,7 @@
 				C84FA1A269F12B130EAEB57B /* ModelsView.swift in Sources */,
 				692EA024371CB249BE53DB86 /* NativAnalyticsStore.swift in Sources */,
 				D635FD9C6938DC35CC56CAD7 /* NativApplicationCommands.swift in Sources */,
+				18BA08A2DD4C4CAD2DC6B0E3 /* NativBulkSelection.swift in Sources */,
 				9954F8086FE0A7A9B3378EC9 /* NativComponents.swift in Sources */,
 				39ADE4524CF22ED36D505546 /* NativExtensionHostBroker.swift in Sources */,
 				F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */,
@@ -1951,6 +1959,8 @@
 				F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */,
 				D8838254D03112C2EABE37AC /* ModelPrimaryTaskResolverTests.swift in Sources */,
 				252ABC474FF17BAFE5BFD3CE /* NativAnalyticsStore.swift in Sources */,
+				D963B49FA9E1E766B9081104 /* NativBulkSelection.swift in Sources */,
+				5C64F06C8BE83F8E0E589B78 /* NativBulkSelectionTests.swift in Sources */,
 				83E74199C4F9A50350E3E354 /* NativComponents.swift in Sources */,
 				ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */,
 				0E326825AE5A1A5EEA33D928 /* NativExtensionTests.swift in Sources */,

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -674,10 +674,11 @@ struct ModelsView: View {
             }
             installedModelSelection.toggleMode()
         } label: {
-            Label(
-                installedModelSelection.isActive ? "Done" : "Select",
-                systemImage: installedModelSelection.isActive ? "checkmark" : "checkmark.circle"
-            )
+            if installedModelSelection.isActive {
+                Label("Done", systemImage: "checkmark")
+            } else {
+                Text("Select")
+            }
         }
         .buttonStyle(.bordered)
         .disabled(

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -675,8 +675,8 @@ struct ModelsView: View {
             installedModelSelection.toggleMode()
         } label: {
             Label(
-                installedModelSelection.isActive ? "Done" : "Delete Models…",
-                systemImage: installedModelSelection.isActive ? "checkmark" : "trash"
+                installedModelSelection.isActive ? "Done" : "Select",
+                systemImage: installedModelSelection.isActive ? "checkmark" : "checkmark.circle"
             )
         }
         .buttonStyle(.bordered)
@@ -687,7 +687,7 @@ struct ModelsView: View {
         .help(
             installedModelSelection.isActive
                 ? "Finish selecting installed models"
-                : "Select multiple installed models to delete"
+                : "Select multiple installed models"
         )
     }
 

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -272,7 +272,6 @@ struct ModelsView: View {
         ) {
             VStack(spacing: 0) {
                 pageHeader
-                Divider()
                 activeDownloadBanner
                 modelLoadFailureBanner
 
@@ -505,6 +504,13 @@ struct ModelsView: View {
                     debounceMilliseconds: renderedSection == .installed ? 100 : 350
                 )
                 .frame(height: 32)
+                .overlay {
+                    if renderedSection == .installed {
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .strokeBorder(Color.primary.opacity(0.16), lineWidth: 1)
+                            .allowsHitTesting(false)
+                    }
+                }
 
                 if renderedSection == .discover, hubLibrary.isSearching {
                     ProgressView()

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -238,6 +238,9 @@ struct ModelsView: View {
     @State private var handledModelDiscoveryRequest = 0
     @State private var lastStartedHubSearchTaskID: HubSearchTaskID?
     @State private var readmeSelection: ModelReadmeSelection?
+    @State private var installedModelSelection = NativBulkSelection<String>()
+    @State private var pendingInstalledModelDeletion: [LocalModel] = []
+    @State private var isConfirmingInstalledModelDeletion = false
 
     init(
         model: NativModel,
@@ -276,6 +279,24 @@ struct ModelsView: View {
                 modelsPage
             }
         }
+        .alert(
+            "Delete \(pendingInstalledModelDeletion.count) \(pendingInstalledModelDeletion.count == 1 ? "model" : "models")?",
+            isPresented: $isConfirmingInstalledModelDeletion
+        ) {
+            Button(
+                pendingInstalledModelDeletion.count == 1 ? "Delete Model" : "Delete Models",
+                role: .destructive
+            ) {
+                deleteInstalledModels(pendingInstalledModelDeletion)
+                pendingInstalledModelDeletion = []
+            }
+            .keyboardShortcut(.defaultAction)
+            Button("Cancel", role: .cancel) {
+                pendingInstalledModelDeletion = []
+            }
+        } message: {
+            Text("The selected models will be permanently removed from the local Hugging Face cache.")
+        }
         .background(Color.nativMainContentBackground)
         .task(id: modelScanPath) {
             rescanLocalModels()
@@ -298,6 +319,12 @@ struct ModelsView: View {
             openModelDiscoveryIfRequested()
         }
         .onChange(of: section) { _, newSection in
+            if newSection != .installed {
+                installedModelSelection.finish()
+                pendingInstalledModelDeletion = []
+                isConfirmingInstalledModelDeletion = false
+            }
+
             // Let the segmented control commit before replacing the toolbar
             // and active rows. This queues one main-loop turn with no fixed
             // delay and keeps only one section's content mounted at a time.
@@ -489,6 +516,9 @@ struct ModelsView: View {
             switch renderedSection {
             case .installed:
                 installedFilterBar
+                if installedModelSelection.isActive {
+                    installedSelectionBar(for: filteredLocalModels)
+                }
             case .discover:
                 discoverFilterBar
             }
@@ -584,6 +614,8 @@ struct ModelsView: View {
                         localModel.repoID),
                     canDelete: localModel.isDeletable && !modelState.modelSwitchInProgress
                         && !isModelInUse(localModel.repoID),
+                    isSelecting: installedModelSelection.isActive,
+                    isSelectedForDeletion: installedModelSelection.contains(localModel.repoID),
                     onSetPreload: { slot, isEnabled in
                         if isEnabled {
                             model.requestPreloadedModelSwitch(
@@ -602,6 +634,7 @@ struct ModelsView: View {
                             localSnapshotURL: localModel.snapshotURL
                         )
                     },
+                    onToggleSelection: { toggleInstalledModelSelection(localModel) },
                     onDelete: { deleteInstalledModel(localModel) }
                 )
                 .equatable()
@@ -629,8 +662,52 @@ struct ModelsView: View {
             sourcesMenu
             Spacer(minLength: 0)
             refreshButton
+            installedBulkSelectionButton
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var installedBulkSelectionButton: some View {
+        Button {
+            if !installedModelSelection.isActive {
+                readmeSelection = nil
+            }
+            installedModelSelection.toggleMode()
+        } label: {
+            Label(
+                installedModelSelection.isActive ? "Done" : "Delete Models…",
+                systemImage: installedModelSelection.isActive ? "checkmark" : "trash"
+            )
+        }
+        .buttonStyle(.bordered)
+        .disabled(
+            !installedModelSelection.isActive
+                && !localLibrary.models.contains(where: canSelectForDeletion)
+        )
+        .help(
+            installedModelSelection.isActive
+                ? "Finish selecting installed models"
+                : "Select multiple installed models to delete"
+        )
+    }
+
+    private func installedSelectionBar(for visibleModels: [LocalModel]) -> some View {
+        let eligibleVisibleModels = visibleModels.filter(canSelectForDeletion)
+        let eligibleIDs = Set(eligibleVisibleModels.map(\.repoID))
+        let selectedModels = selectedInstalledModels
+
+        return NativBulkSelectionToolbar(
+            selectedCount: selectedModels.count,
+            allSelected: installedModelSelection.includesAll(eligibleIDs),
+            isSelectAllEnabled: !eligibleVisibleModels.isEmpty,
+            onToggleAll: {
+                installedModelSelection.toggleAll(eligibleIDs)
+            },
+            onDelete: {
+                pendingInstalledModelDeletion = selectedModels
+                isConfirmingInstalledModelDeletion = true
+            }
+        )
     }
 
     private var refreshButton: some View {
@@ -893,12 +970,12 @@ struct ModelsView: View {
     }
 
     private func deleteInstalledModel(_ localModel: LocalModel) {
-        guard localModel.isDeletable else { return }
+        guard canSelectForDeletion(localModel) else { return }
         localLibrary.delete(
             model: localModel,
             path: modelState.settings.modelSearchPath
         ) {
-            var settings = modelState.settings
+            var settings = model.settings
             if settings.languageModelID == localModel.repoID {
                 settings.languageModelID = nil
             }
@@ -914,6 +991,28 @@ struct ModelsView: View {
             model.settings = settings
             NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
         }
+    }
+
+    private var selectedInstalledModels: [LocalModel] {
+        localLibrary.models.filter {
+            installedModelSelection.contains($0.repoID) && canSelectForDeletion($0)
+        }
+    }
+
+    private func canSelectForDeletion(_ localModel: LocalModel) -> Bool {
+        localModel.isDeletable
+            && !modelState.modelSwitchInProgress
+            && !isModelInUse(localModel.repoID)
+    }
+
+    private func toggleInstalledModelSelection(_ localModel: LocalModel) {
+        guard canSelectForDeletion(localModel) else { return }
+        installedModelSelection.toggle(localModel.repoID)
+    }
+
+    private func deleteInstalledModels(_ localModels: [LocalModel]) {
+        localModels.forEach(deleteInstalledModel)
+        installedModelSelection.finish()
     }
 
     private var filteredLocalModels: [LocalModel] {
@@ -1508,8 +1607,11 @@ private struct InstalledModelRow: View, @MainActor Equatable {
     let isReadmeSelected: Bool
     let isDeleting: Bool
     let canDelete: Bool
+    let isSelecting: Bool
+    let isSelectedForDeletion: Bool
     let onSetPreload: (ModelPreloadSlot, Bool) -> Void
     let onShowReadme: () -> Void
+    let onToggleSelection: () -> Void
     let onDelete: () -> Void
 
     @State private var showsDeleteConfirmation = false
@@ -1526,6 +1628,8 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             && lhs.isReadmeSelected == rhs.isReadmeSelected
             && lhs.isDeleting == rhs.isDeleting
             && lhs.canDelete == rhs.canDelete
+            && lhs.isSelecting == rhs.isSelecting
+            && lhs.isSelectedForDeletion == rhs.isSelectedForDeletion
     }
 
     private var isSelected: Bool {
@@ -1538,6 +1642,18 @@ private struct InstalledModelRow: View, @MainActor Equatable {
 
     var body: some View {
         HStack(spacing: 10) {
+            if isSelecting {
+                NativBulkSelectionCheckbox(
+                    isSelected: isSelectedForDeletion,
+                    isEnabled: canDelete
+                )
+                .help(
+                    canDelete
+                        ? "Select \(localModel.repoID)"
+                        : "This model can’t be deleted while it is in use"
+                )
+            }
+
             Button(action: onShowReadme) {
                 HStack(spacing: 14) {
                     ModelProviderBadge(provider: localModel.provider)
@@ -1636,13 +1752,21 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             .help("Show README for \(localModel.repoID)")
             .accessibilityLabel("Show details for \(localModel.repoID)")
 
-            loadButton
-
-            modelActionsMenu
+            if !isSelecting {
+                loadButton
+                modelActionsMenu
+            }
         }
         .padding(14)
         .contentShape(RoundedRectangle(cornerRadius: 12))
         .modelRowBackground(isHighlighted: isReadmeSelected)
+        .nativBulkSelectable(
+            isSelecting: isSelecting,
+            isSelected: isSelectedForDeletion,
+            isEnabled: canDelete,
+            accessibilityLabel: "Select \(localModel.repoID)",
+            action: onToggleSelection
+        )
         .alert("Model isn’t supported", isPresented: $showsUnsupportedModelInformation) {
             Button("OK", role: .cancel) {}
                 .keyboardShortcut(.defaultAction)

--- a/Sources/Nativ/Features/Shared/NativBulkSelection.swift
+++ b/Sources/Nativ/Features/Shared/NativBulkSelection.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+/// Selection state shared by component-scoped bulk-management flows.
+struct NativBulkSelection<ID: Hashable> {
+    private(set) var isActive = false
+    private(set) var ids = Set<ID>()
+
+    func contains(_ id: ID) -> Bool {
+        ids.contains(id)
+    }
+
+    func includesAll(_ candidateIDs: Set<ID>) -> Bool {
+        !candidateIDs.isEmpty && ids.isSuperset(of: candidateIDs)
+    }
+
+    mutating func toggleMode() {
+        isActive.toggle()
+        if !isActive {
+            ids.removeAll()
+        }
+    }
+
+    mutating func toggle(_ id: ID) {
+        if ids.contains(id) {
+            ids.remove(id)
+        } else {
+            ids.insert(id)
+        }
+    }
+
+    mutating func toggleAll(_ candidateIDs: Set<ID>) {
+        guard !candidateIDs.isEmpty else { return }
+        if includesAll(candidateIDs) {
+            ids.subtract(candidateIDs)
+        } else {
+            ids.formUnion(candidateIDs)
+        }
+    }
+
+    mutating func finish() {
+        isActive = false
+        ids.removeAll()
+    }
+}
+
+/// The shared selection affordance for bulk-management lists.
+struct NativBulkSelectionCheckbox: View {
+    let isSelected: Bool
+    var isEnabled = true
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                .fill(isSelected ? Color.accentColor : Color.clear)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .stroke(
+                            isSelected ? Color.accentColor : Color.secondary.opacity(0.55),
+                            lineWidth: 1.25
+                        )
+                }
+
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+        }
+        .frame(width: 18, height: 18)
+        .opacity(isEnabled ? 1 : 0.45)
+        .animation(.easeInOut(duration: 0.12), value: isSelected)
+        .accessibilityHidden(true)
+    }
+}
+
+private struct NativBulkSelectionSurface: ViewModifier {
+    let isSelecting: Bool
+    let isSelected: Bool
+    let isEnabled: Bool
+    let cornerRadius: CGFloat
+    let accessibilityLabel: String
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        content.overlay {
+            if isSelecting {
+                Button(action: action) {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
+                        .overlay {
+                            if isSelected {
+                                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                                    .stroke(Color.accentColor.opacity(0.55), lineWidth: 1)
+                            }
+                        }
+                        .contentShape(
+                            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(!isEnabled)
+                .accessibilityLabel(accessibilityLabel)
+                .accessibilityValue(isSelected ? "Selected" : "Not selected")
+            }
+        }
+    }
+}
+
+extension View {
+    /// Makes an entire row or card the selection control while bulk selection is active.
+    func nativBulkSelectable(
+        isSelecting: Bool,
+        isSelected: Bool,
+        isEnabled: Bool = true,
+        cornerRadius: CGFloat = 12,
+        accessibilityLabel: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            NativBulkSelectionSurface(
+                isSelecting: isSelecting,
+                isSelected: isSelected,
+                isEnabled: isEnabled,
+                cornerRadius: cornerRadius,
+                accessibilityLabel: accessibilityLabel,
+                action: action
+            )
+        )
+    }
+}
+
+/// Shared controls for selecting every visible item and performing bulk deletion.
+struct NativBulkSelectionToolbar: View {
+    let selectedCount: Int
+    let allSelected: Bool
+    var isSelectAllEnabled = true
+    let onToggleAll: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("\(selectedCount) selected")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+
+            Button(allSelected ? "Deselect All" : "Select All", action: onToggleAll)
+                .disabled(!isSelectAllEnabled)
+
+            Spacer(minLength: 0)
+
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete Selected", systemImage: "trash")
+            }
+            .disabled(selectedCount == 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            Color.primary.opacity(0.04),
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+    }
+}

--- a/Tests/NativTests/NativBulkSelectionTests.swift
+++ b/Tests/NativTests/NativBulkSelectionTests.swift
@@ -1,0 +1,55 @@
+import Testing
+
+@Suite("Bulk selection")
+struct NativBulkSelectionTests {
+    @Test("Leaving selection mode clears the selection")
+    func leavingSelectionModeClearsSelection() {
+        var selection = NativBulkSelection<String>()
+
+        selection.toggleMode()
+        selection.toggle("first")
+        selection.toggleMode()
+
+        #expect(!selection.isActive)
+        #expect(selection.ids.isEmpty)
+    }
+
+    @Test("Toggling an item selects and deselects it")
+    func togglingAnItemUpdatesSelection() {
+        var selection = NativBulkSelection<String>()
+
+        selection.toggle("first")
+        #expect(selection.contains("first"))
+
+        selection.toggle("first")
+        #expect(!selection.contains("first"))
+    }
+
+    @Test("Select All only changes the supplied candidates")
+    func selectAllOnlyChangesCandidates() {
+        var selection = NativBulkSelection<String>()
+        selection.toggle("hidden")
+        let visible = Set(["first", "second"])
+
+        selection.toggleAll(visible)
+        #expect(selection.includesAll(visible))
+        #expect(selection.contains("hidden"))
+
+        selection.toggleAll(visible)
+        #expect(!selection.contains("first"))
+        #expect(!selection.contains("second"))
+        #expect(selection.contains("hidden"))
+    }
+
+    @Test("Finishing selection clears mode and selected items")
+    func finishingSelectionResetsState() {
+        var selection = NativBulkSelection<String>()
+        selection.toggleMode()
+        selection.toggle("first")
+
+        selection.finish()
+
+        #expect(!selection.isActive)
+        #expect(selection.ids.isEmpty)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -191,6 +191,7 @@ targets:
       - path: Sources/Nativ/Features/Models/LocalModelProvider.swift
       - path: Sources/Nativ/Features/Models/MLXImageModelResolver.swift
       - path: Sources/Nativ/Features/Models/ModelPrimaryTaskResolver.swift
+      - path: Sources/Nativ/Features/Shared/NativBulkSelection.swift
       - path: Sources/Nativ/Features/Integrations/CodexCLIProfile.swift
       - path: Sources/Nativ/Features/Integrations/IntegrationServices.swift
       - path: Sources/Nativ/Features/Integrations/IntegrationTypes.swift


### PR DESCRIPTION
## Summary

- Add an explicit **Select** action beside Refresh on the Installed Models page.
- Keep bulk-selection controls pinned above the model list so they remain visible while scrolling.
- Support full-row selection, Select All/Deselect All, and confirmed bulk deletion.
- Introduce reusable bulk-selection state and controls for later component-scoped PRs.

Also made search outline slightly darker and removed the divider above it

https://github.com/user-attachments/assets/d005708f-0efb-4747-9c12-7ee3b9ac83ab

