### PR TITLE
Stabilize live server log scrolling

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */; };
 		051790A7801DEB8772911289 /* ExternalModelCacheReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = F605E5C42FC442A37E4946BD /* ExternalModelCacheReference.swift */; };
 		052BF04D854F36CDA740635F /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0259C7C842DE5ADC12B367 /* MarkdownFormatting.swift */; };
+		05A777931F6CE20BB1420C16 /* LogTextStorageMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B0E640985EEB0E4E0AEE79 /* LogTextStorageMutation.swift */; };
 		060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */; };
 		06C8B891576DC3051282D367 /* NativKitRuntimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */; };
 		07E17841B388FBBD8C8A28EF /* NativSystemPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E2A903D604A57696674510 /* NativSystemPermissionController.swift */; };
@@ -176,6 +177,7 @@
 		62CAD81D603FF4AC296279CB /* ChatToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */; };
 		63D4D3774994EAE5F5ABB7E9 /* AudioInputVolumeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A118DF27AE0EF852DC458BB7 /* AudioInputVolumeController.swift */; };
 		63FEFD395756E19E4C9E9A24 /* ExternalModelCacheReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = F605E5C42FC442A37E4946BD /* ExternalModelCacheReference.swift */; };
+		655916FBFE8CD4AF713ABCB9 /* LogTextStorageMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEAD8583687ABA95FF4986E /* LogTextStorageMutationTests.swift */; };
 		657DFF151F7E54EA66CC36F8 /* SystemSensorSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653E58FFA38742CD4D5D41F5 /* SystemSensorSampler.swift */; };
 		65D6016C8BB7D8445C4627E3 /* SearXNG.png in Resources */ = {isa = PBXBuildFile; fileRef = 0990D460FC714AC74F1565B3 /* SearXNG.png */; };
 		66745D5BB4D1454479FF6C9C /* RoutineScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C1220F03EC60874920E0CE /* RoutineScheduler.swift */; };
@@ -225,6 +227,7 @@
 		823D9E08D7818B714E75C7D3 /* ControlPanelSidebarModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F460CC6B734041A8C60AAE /* ControlPanelSidebarModels.swift */; };
 		826AB68248F3DD8952284745 /* AppleSpeechTranscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219898F64D1B7C28FA4A1B38 /* AppleSpeechTranscriber.swift */; };
 		83E74199C4F9A50350E3E354 /* NativComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EE1CE9AAE5A3B9A2D4669C /* NativComponents.swift */; };
+		859706E482A5B1BF77CFBECA /* LogTextStorageMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B0E640985EEB0E4E0AEE79 /* LogTextStorageMutation.swift */; };
 		86C75AF5CF63104E397339FB /* ArtifactsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3387C33E274E567979F013 /* ArtifactsView.swift */; };
 		872CB62F2CB2A0C716A60654 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1B515ECDF21B3616E5A3D1 /* ChatViewModel.swift */; };
 		87C7CE62B090DCE2F9CF0A4F /* NativNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982F3BB563023885587DC860 /* NativNotificationTests.swift */; };
@@ -542,6 +545,7 @@
 		46B469F1D62E2DB0DE8CFAF1 /* NativPermissionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativPermissionsCard.swift; sourceTree = "<group>"; };
 		46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSemanticSearch.swift; sourceTree = "<group>"; };
 		49B4556627CCB5BD1D3DE5F8 /* VoiceDictationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtension.swift; sourceTree = "<group>"; };
+		4BEAD8583687ABA95FF4986E /* LogTextStorageMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextStorageMutationTests.swift; sourceTree = "<group>"; };
 		4C93856381B1D89C4DE61DCC /* VoiceCaptureOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureOverlay.swift; sourceTree = "<group>"; };
 		4DCD9D4118F0B3580590998F /* ScheduledTaskChatLinker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTaskChatLinker.swift; sourceTree = "<group>"; };
 		4DEE7582DCB286B9D878E28E /* ChatAttachmentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentKind.swift; sourceTree = "<group>"; };
@@ -553,6 +557,7 @@
 		530CA8743FEBF843F79321A7 /* Parallel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Parallel.png; sourceTree = "<group>"; };
 		530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionStore.swift; sourceTree = "<group>"; };
 		5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDocumentExtractionCache.swift; sourceTree = "<group>"; };
+		54B0E640985EEB0E4E0AEE79 /* LogTextStorageMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextStorageMutation.swift; sourceTree = "<group>"; };
 		5668DEC01979A9C0F082682C /* FileSearchEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchEngine.swift; sourceTree = "<group>"; };
 		5682AEE2C7DF8C9A3AFAC3DF /* RealtimeAudioMeter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeAudioMeter.swift; sourceTree = "<group>"; };
 		577B24B3B022E78F7664C76E /* NativNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativNotificationService.swift; sourceTree = "<group>"; };
@@ -844,6 +849,7 @@
 			children = (
 				4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */,
 				E646A2A68BB20D0CD4933E2A /* DevHubView.swift */,
+				54B0E640985EEB0E4E0AEE79 /* LogTextStorageMutation.swift */,
 			);
 			path = Developer;
 			sourceTree = "<group>";
@@ -1379,6 +1385,7 @@
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
 				C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */,
 				8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */,
+				4BEAD8583687ABA95FF4986E /* LogTextStorageMutationTests.swift */,
 				A5380B4B598D5FE350F8B75F /* MarkdownFormattingTests.swift */,
 				45F373627C4A522AF78E2A17 /* MCPClientTests.swift */,
 				B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */,
@@ -1775,6 +1782,7 @@
 				BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */,
 				1423FD497A75A14770FCA9E1 /* LocalModelDiscovery.swift in Sources */,
 				482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */,
+				05A777931F6CE20BB1420C16 /* LogTextStorageMutation.swift in Sources */,
 				2452C5D7B24CA5FF6FAA36E2 /* MCPHostManager.swift in Sources */,
 				6C872B0124611E3D0297E2FD /* MCPSectionView.swift in Sources */,
 				4572BDBE09CB7D688B8838CA /* MCPServerCatalog.swift in Sources */,
@@ -1948,6 +1956,8 @@
 				4DFD3E48E28FEF1D17A53B71 /* LocalModelDiscoveryTests.swift in Sources */,
 				4B554D4DBAD0F0EE6CCDB4B2 /* LocalModelProvider.swift in Sources */,
 				9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */,
+				859706E482A5B1BF77CFBECA /* LogTextStorageMutation.swift in Sources */,
+				655916FBFE8CD4AF713ABCB9 /* LogTextStorageMutationTests.swift in Sources */,
 				0394DEE40DF5A06244F72794 /* MCPClientTests.swift in Sources */,
 				3583BC09DCAFC37BBB94749D /* MCPHostManager.swift in Sources */,
 				2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */,

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -2154,7 +2154,7 @@ private struct LogTextView: NSViewRepresentable {
         textView.usesFindPanel = true
         textView.backgroundColor = NSColor.textBackgroundColor
         textView.textContainerInset = NSSize(width: 12, height: 12)
-        render(text, searchQuery: searchQuery, in: textView)
+        replaceAllText(text, searchQuery: searchQuery, in: textView)
         context.coordinator.renderedText = text
         context.coordinator.renderedQuery = searchQuery
 
@@ -2164,7 +2164,8 @@ private struct LogTextView: NSViewRepresentable {
         scrollView.borderType = .noBorder
 
         DispatchQueue.main.async { [weak textView] in
-            textView?.scrollToEndOfDocument(nil)
+            guard let textView else { return }
+            Self.scrollToBottom(textView)
         }
         return scrollView
     }
@@ -2180,18 +2181,67 @@ private struct LogTextView: NSViewRepresentable {
         }
 
         let shouldFollowOutput = isNearBottom(scrollView)
-        render(text, searchQuery: searchQuery, in: textView)
+        updateText(
+            text,
+            searchQuery: searchQuery,
+            previousText: context.coordinator.renderedText,
+            previousQuery: context.coordinator.renderedQuery,
+            in: textView
+        )
         context.coordinator.renderedText = text
         context.coordinator.renderedQuery = searchQuery
         if shouldFollowOutput {
-            textView.scrollToEndOfDocument(nil)
+            Self.scrollToBottom(textView)
         }
     }
 
-    private func render(_ text: String, searchQuery: String, in textView: NSTextView) {
+    private func replaceAllText(
+        _ text: String,
+        searchQuery: String,
+        in textView: NSTextView
+    ) {
         textView.textStorage?.setAttributedString(
             LogTextStyler.attributedString(text, searchQuery: searchQuery)
         )
+    }
+
+    private func updateText(
+        _ text: String,
+        searchQuery: String,
+        previousText: String,
+        previousQuery: String,
+        in textView: NSTextView
+    ) {
+        guard let textStorage = textView.textStorage else { return }
+        let mutation = LogTextStorageMutation.plan(
+            previousText: previousText,
+            previousQuery: previousQuery,
+            newText: text,
+            newQuery: searchQuery
+        )
+
+        switch mutation {
+        case .replaceAll:
+            replaceAllText(text, searchQuery: searchQuery, in: textView)
+        case .replaceSuffix(let offset):
+            let suffix = (text as NSString).substring(from: offset)
+            let existingSuffix = NSRange(
+                location: offset,
+                length: textStorage.length - offset
+            )
+            textStorage.replaceCharacters(
+                in: existingSuffix,
+                with: LogTextStyler.attributedString(
+                    suffix,
+                    searchQuery: searchQuery
+                )
+            )
+        }
+    }
+
+    private static func scrollToBottom(_ textView: NSTextView) {
+        let end = NSRange(location: textView.textStorage?.length ?? 0, length: 0)
+        textView.scrollRangeToVisible(end)
     }
 
     private func isNearBottom(_ scrollView: NSScrollView) -> Bool {

--- a/Sources/Nativ/Features/Developer/LogTextStorageMutation.swift
+++ b/Sources/Nativ/Features/Developer/LogTextStorageMutation.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum LogTextStorageMutation: Equatable {
+    case replaceAll
+    case replaceSuffix(fromUTF16Offset: Int)
+
+    static func plan(
+        previousText: String,
+        previousQuery: String,
+        newText: String,
+        newQuery: String
+    ) -> LogTextStorageMutation {
+        guard previousQuery == newQuery,
+              newText.utf16.starts(with: previousText.utf16)
+        else {
+            return .replaceAll
+        }
+
+        let previousNSString = previousText as NSString
+        let lastNewline = previousNSString.range(
+            of: "\n",
+            options: .backwards
+        )
+        let offset = lastNewline.location == NSNotFound
+            ? 0
+            : NSMaxRange(lastNewline)
+        return .replaceSuffix(fromUTF16Offset: offset)
+    }
+}

--- a/Tests/NativTests/LogTextStorageMutationTests.swift
+++ b/Tests/NativTests/LogTextStorageMutationTests.swift
@@ -1,0 +1,95 @@
+import Testing
+
+@Suite("Log text storage updates")
+struct LogTextStorageMutationTests {
+    @Test("Appending complete lines only replaces the appended suffix")
+    func appendingCompleteLinesReplacesAppendedSuffix() {
+        let previousText = "first\nsecond\n"
+
+        let mutation = LogTextStorageMutation.plan(
+            previousText: previousText,
+            previousQuery: "",
+            newText: previousText + "third\n",
+            newQuery: ""
+        )
+
+        #expect(
+            mutation == .replaceSuffix(
+                fromUTF16Offset: previousText.utf16.count
+            )
+        )
+    }
+
+    @Test("Appending to a partial line restyles that entire line")
+    func appendingToPartialLineRestylesTheLine() {
+        let previousText = "first\n2026-09-01 - INF"
+
+        let mutation = LogTextStorageMutation.plan(
+            previousText: previousText,
+            previousQuery: "",
+            newText: previousText + "O - Decode progress\n",
+            newQuery: ""
+        )
+
+        #expect(
+            mutation == .replaceSuffix(
+                fromUTF16Offset: "first\n".utf16.count
+            )
+        )
+    }
+
+    @Test("UTF-16 offsets match attributed string ranges")
+    func mutationUsesUTF16Offsets() {
+        let previousText = "status 🚀\nnext"
+
+        let mutation = LogTextStorageMutation.plan(
+            previousText: previousText,
+            previousQuery: "",
+            newText: previousText + " line",
+            newQuery: ""
+        )
+
+        #expect(
+            mutation == .replaceSuffix(
+                fromUTF16Offset: "status 🚀\n".utf16.count
+            )
+        )
+    }
+
+    @Test("Trimming the log replaces the full document")
+    func trimmingLogReplacesAllText() {
+        let mutation = LogTextStorageMutation.plan(
+            previousText: "first\nsecond\nthird\n",
+            previousQuery: "",
+            newText: "second\nthird\nfourth\n",
+            newQuery: ""
+        )
+
+        #expect(mutation == .replaceAll)
+    }
+
+    @Test("Changing the search query replaces all attributes")
+    func changingSearchQueryReplacesAllText() {
+        let text = "first\nsecond\n"
+        let mutation = LogTextStorageMutation.plan(
+            previousText: text,
+            previousQuery: "first",
+            newText: text,
+            newQuery: "second"
+        )
+
+        #expect(mutation == .replaceAll)
+    }
+
+    @Test("Canonically equivalent text with different storage replaces the document")
+    func canonicallyEquivalentTextReplacesAllText() {
+        let mutation = LogTextStorageMutation.plan(
+            previousText: "é",
+            previousQuery: "",
+            newText: "e\u{301} continued",
+            newQuery: ""
+        )
+
+        #expect(mutation == .replaceAll)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -192,6 +192,7 @@ targets:
       - path: Sources/Nativ/Features/Models/MLXImageModelResolver.swift
       - path: Sources/Nativ/Features/Models/ModelPrimaryTaskResolver.swift
       - path: Sources/Nativ/Features/Shared/NativBulkSelection.swift
+      - path: Sources/Nativ/Features/Developer/LogTextStorageMutation.swift
       - path: Sources/Nativ/Features/Integrations/CodexCLIProfile.swift
       - path: Sources/Nativ/Features/Integrations/IntegrationServices.swift
       - path: Sources/Nativ/Features/Integrations/IntegrationTypes.swift


### PR DESCRIPTION
Fixes #453 by updating only the changed tail of the live server log instead of rebuilding the entire attributed document for every output chunk. Keeps the view pinned when following the latest output, preserves manual scroll position, and adds regression coverage for partial lines, truncation, filters, and UTF-16 ranges.