### PR TITLE
rebuild chat message rendering

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		1DCBC70AA972310D3FBC22CC /* ChatSwitchModelTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */; };
 		1EBCB9482DABA02FD039A795 /* Routine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F067B3DB861CF232820136 /* Routine.swift */; };
 		1F81CA41D2A065763C784DC0 /* ControlPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FCFAB2E7C5BC1AC0A5D9BB /* ControlPanelView.swift */; };
+		2024C3DBE60A54C0DA7EF5A9 /* ChatRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED337312E3F6206B56477D2 /* ChatRenderingTests.swift */; };
 		203E0B78BCFCA71DFFB8B48B /* WebSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB3FA30F4803017685118E3 /* WebSearchService.swift */; };
 		2042F97FFB6520AC2CF63514 /* ChatFileWriteTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F98763452E5A3BED006155 /* ChatFileWriteTools.swift */; };
 		2043243F627AFA7A2239BB8E /* ChatCapabilitiesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2AACD0A419316AD0099E20 /* ChatCapabilitiesSheet.swift */; };
@@ -84,9 +85,11 @@
 		2C9930764FCB1AF6B4C66363 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
 		2C9DFB15B06C56CB650FC9A6 /* WebBrowsingTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB497800D0F8B237A1891EE1 /* WebBrowsingTransport.swift */; };
 		2CA1076EA0874C55E7BB14B2 /* RealtimeAudioMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5682AEE2C7DF8C9A3AFAC3DF /* RealtimeAudioMeter.swift */; };
+		2D00D7A5F23F9250577351F7 /* ChatMathPreprocessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096CE626C3ECC066E4D735C7 /* ChatMathPreprocessor.swift */; };
 		2D2E2AE0FB5D588884E86BFB /* OfficeArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE82B4EBA796206F12005498 /* OfficeArchive.swift */; };
 		2D445C948687EAF45C707C83 /* MCPServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */; };
 		2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
+		308D702D90DECE44C62375CD /* SwaTexRender in Frameworks */ = {isa = PBXBuildFile; productRef = 7C44F2BDEB36AE1669F3B4C5 /* SwaTexRender */; };
 		31C08C22828567AEB0F8BC0E /* NativKitLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE65855FB48CA89F7A0DDA8 /* NativKitLibrary.swift */; };
 		31D67AFE2E2CD864C37D6CFA /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		326C969CB7D0F41F38467DFE /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
@@ -126,6 +129,7 @@
 		455662EBEFC2C805F0223541 /* ControlPanelSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B9207F7063BEC112E5CAB /* ControlPanelSidebarView.swift */; };
 		4572BDBE09CB7D688B8838CA /* MCPServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */; };
 		463870509178CCD59287E1BE /* VoiceTranscriptInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23155DB5E733D8887D83AFD0 /* VoiceTranscriptInserter.swift */; };
+		467A79817882057E60D2E4ED /* Highlightr in Frameworks */ = {isa = PBXBuildFile; productRef = 0771E5ACBAEB27CD4A733935 /* Highlightr */; };
 		4681766DBDD49200E3A90BF0 /* ScheduledTasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5C104E12EEB90C4108DD86 /* ScheduledTasksView.swift */; };
 		4751D7C9F392C341E8921F58 /* ChatPromptRevision.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */; };
 		482E08D2A8EFADD566FFDC4D /* LocalModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CD53CDD71732DE956F55DC /* LocalModelProvider.swift */; };
@@ -165,6 +169,7 @@
 		589A3D1D88F2768F7D0FE974 /* NativExtensionManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD61E02ECEEF3C00ECF238A8 /* NativExtensionManifest.swift */; };
 		58AEDA213E27344F01AE5A6B /* NativServerKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		59841D5E65EFAF5E513C502D /* SystemMonitorObservationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE94F230299FF8E794099BB4 /* SystemMonitorObservationPolicyTests.swift */; };
+		59F063A85DE0A1DFA681282F /* ChatMathPreprocessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096CE626C3ECC066E4D735C7 /* ChatMathPreprocessor.swift */; };
 		5BA95DA067DA56BBAC83EC14 /* ChatAttachmentValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */; };
 		5C64F06C8BE83F8E0E589B78 /* NativBulkSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6964F9653F9E59196C2EDACB /* NativBulkSelectionTests.swift */; };
 		5DD093567BA5EFF33F68C302 /* ChatArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F299F04205B8F438A9A9FF12 /* ChatArchiveTests.swift */; };
@@ -243,13 +248,14 @@
 		95711758521BCF469B48481E /* PerplexityBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F316824C4C3D36A94717A62 /* PerplexityBrowsingProvider.swift */; };
 		9593586AAFCA2B97C6A7438B /* ChatFileWriteTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F98763452E5A3BED006155 /* ChatFileWriteTools.swift */; };
 		95BB08DDD07C02F4E3976931 /* FileWriteConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740FC3907FB149A3D184EBF9 /* FileWriteConfigurationView.swift */; };
+		96A319074CB28B885E031213 /* ChatMarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432F8E84739652B2546DC7B7 /* ChatMarkdownRenderer.swift */; };
 		96AE764D2F938395E9B76C9E /* ChatServerStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */; };
 		97EEA29CCD874048A8CE9D54 /* VoiceShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */; };
 		98086CE0CF71463BDF07F8A8 /* RoutineLaunchAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34FBE730C051EFF28B1323B /* RoutineLaunchAgent.swift */; };
 		9954F8086FE0A7A9B3378EC9 /* NativComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EE1CE9AAE5A3B9A2D4669C /* NativComponents.swift */; };
 		99CBBEE3F1E0092E70D172D4 /* Firecrawl.png in Resources */ = {isa = PBXBuildFile; fileRef = EEF71E7A328DFB6E2E741999 /* Firecrawl.png */; };
 		9A1E1FD2D597C682F4A8D2A9 /* AudioInputLevelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DDA5274474AC8D54DFDF71 /* AudioInputLevelMonitor.swift */; };
-		9A57C70528785257DF9CEAAE /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 66E307AA0AD0D089ED4F2AB5 /* ZIPFoundation */; };
+		9A57C70528785257DF9CEAAE /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 93C7D7CFC10C12D282013C7E /* MarkdownUI */; };
 		9DF353990BDA6B9319A226F4 /* LocalModelProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */; };
 		9E55354F76C4EA175A492263 /* DocumentTextExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6BDF659A46F028B6203144 /* DocumentTextExtraction.swift */; };
 		9E5AB6D42F995E0A78C4EA79 /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
@@ -270,6 +276,7 @@
 		A9B82EFAD4FD8C57E045721B /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB9D1D0FC24AC771442B628 /* Artifact.swift */; };
 		AA4FD64FCA38FCA61BC4A490 /* SafeLocalFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7A0A31B4307E2520BCD4F2 /* SafeLocalFileReader.swift */; };
 		AA938EB357E47BE2077567E2 /* ControlPanelSidebarRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF298015C5DDB04B72C29A9 /* ControlPanelSidebarRows.swift */; };
+		AB05CE341967E073E10EF420 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = F1322868F0F169F28BE6D797 /* MarkdownUI */; };
 		AB1C4B8494B46754E6E8BE24 /* AudioAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0BD007DAD141D50E1BAA4 /* AudioAnalyticsStore.swift */; };
 		AB4C49A5BFDAA9352BD257B7 /* CustomToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB72E13D688936495CBA7C8 /* CustomToolTests.swift */; };
 		ABB0814F3990772A1BEF7D0C /* NativExtensionStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F42CEC1B39477AC13352E3 /* NativExtensionStateStore.swift */; };
@@ -288,6 +295,7 @@
 		B47F34B1273BEEAA4D5DD314 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553434CA19B929108FF740F /* ChatView.swift */; };
 		B4846F63E99C06434507B047 /* FileEditEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35141B7390F1FF36B462CEA /* FileEditEngine.swift */; };
 		B4A42954CF10D792F499DD96 /* ControlPanelSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD04BD7013C8285E3533B66 /* ControlPanelSupportViews.swift */; };
+		B53F0BCBE1C538AB55D8D62F /* ChatFontScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */; };
 		B55A6BE5C7B03181E2CD03D6 /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
 		B580FFA54780AE54DFC27957 /* NativSystemPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E2A903D604A57696674510 /* NativSystemPermissionController.swift */; };
 		B5C7C76E37B11FF2A0A8F584 /* FnControlShortcutMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D63523BA62CC95FDD8D51E /* FnControlShortcutMonitor.swift */; };
@@ -297,7 +305,9 @@
 		B6FAA495B9166FE42AAD9478 /* NativSkill.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDB4C89F8DD338E9209E7FF /* NativSkill.swift */; };
 		B71FD641DAB1197C15F4D9B7 /* VoiceAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0952EC469768D8775A2D188 /* VoiceAudioRecorder.swift */; };
 		B7811385D69D03D4AF80C3AC /* ChatWebReadToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D56A7BC388C8D6DEAEFA18 /* ChatWebReadToolTests.swift */; };
+		B8025D46E56B130B785F7EBE /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 66E307AA0AD0D089ED4F2AB5 /* ZIPFoundation */; };
 		B951641CCDDFF5C718078D99 /* FileSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5668DEC01979A9C0F082682C /* FileSearchEngine.swift */; };
+		BA7876C934E43E103899E70E /* SwaTexRender in Frameworks */ = {isa = PBXBuildFile; productRef = CB3602F4C9B417450A9FAA0B /* SwaTexRender */; };
 		BC0753B567DC8935199FCDFB /* ImageGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239C5B241E83468B75C43E5A /* ImageGenerationViewModel.swift */; };
 		BD65446445E57FFE4E717F42 /* SystemMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF7F0D894C4EB6521F21D4D /* SystemMonitorView.swift */; };
 		BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */; };
@@ -313,6 +323,7 @@
 		C22170FAE93CAF0FCEF39675 /* GitHubOAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711EAE65183E78E000DD3253 /* GitHubOAuthTests.swift */; };
 		C3D251E72388C59FFEA7E9C4 /* ChatAttachmentNoticesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51539FFC3A9D763AA1746318 /* ChatAttachmentNoticesView.swift */; };
 		C4381191592EC7C3B97E2C35 /* FilePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C9FECAED1FB3E2D43716FF /* FilePreview.swift */; };
+		C43BABF794329C2C1D03F869 /* Highlightr in Frameworks */ = {isa = PBXBuildFile; productRef = B47FB8D68E53A933ACF71A58 /* Highlightr */; };
 		C4A766A43FD62815D056BD93 /* ParallelBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8347D15B2595FF7819F7C /* ParallelBrowsingProvider.swift */; };
 		C5CE4EBDB988CF611FB2D6DA /* SystemMenuBarPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE1E26171E964D9769E65CB /* SystemMenuBarPreferences.swift */; };
 		C6DFA4F348008EDB924A3FC1 /* WebReadContentSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F15F7E180170C5FA55BD38F /* WebReadContentSelector.swift */; };
@@ -334,6 +345,7 @@
 		D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */; };
 		D74F92EBE05FADCD813CD8B9 /* AudioAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0BD007DAD141D50E1BAA4 /* AudioAnalyticsStore.swift */; };
 		D76DC0072E523E6409DF1176 /* Textual in Frameworks */ = {isa = PBXBuildFile; productRef = 730B64747E8A780CD14AF88F /* Textual */; };
+		D835C99B486C3FE352A27039 /* ChatMarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432F8E84739652B2546DC7B7 /* ChatMarkdownRenderer.swift */; };
 		D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7F610FC8739BA80227DB26 /* NativKit.swift */; };
 		D8838254D03112C2EABE37AC /* ModelPrimaryTaskResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */; };
 		D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
@@ -487,6 +499,7 @@
 		06F067B3DB861CF232820136 /* Routine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routine.swift; sourceTree = "<group>"; };
 		07D656FC00686C187E004C5B /* LICENSE.phosphor-icons.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "LICENSE.phosphor-icons.txt"; sourceTree = "<group>"; };
 		087534BC45A233134507ED19 /* ControlPanelSidebarDragAndDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarDragAndDrop.swift; sourceTree = "<group>"; };
+		096CE626C3ECC066E4D735C7 /* ChatMathPreprocessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMathPreprocessor.swift; sourceTree = "<group>"; };
 		0990D460FC714AC74F1565B3 /* SearXNG.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SearXNG.png; sourceTree = "<group>"; };
 		0DBC23C0369758C056A8182D /* ScheduledTaskChatLinkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTaskChatLinkerTests.swift; sourceTree = "<group>"; };
 		0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCLIProfile.swift; sourceTree = "<group>"; };
@@ -539,6 +552,7 @@
 		41417C210BF817681A8C6D87 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
 		4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperView.swift; sourceTree = "<group>"; };
 		42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
+		432F8E84739652B2546DC7B7 /* ChatMarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMarkdownRenderer.swift; sourceTree = "<group>"; };
 		44C9FECAED1FB3E2D43716FF /* FilePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreview.swift; sourceTree = "<group>"; };
 		44E1CF05FF502F41036F9958 /* ChatTerminalTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTerminalTool.swift; sourceTree = "<group>"; };
 		44FCFAB2E7C5BC1AC0A5D9BB /* ControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelView.swift; sourceTree = "<group>"; };
@@ -709,6 +723,7 @@
 		DE575DB2DCD07A1864311714 /* Nativ.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nativ.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE77E6246A3E3A186C3E8F54 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		DE94F230299FF8E794099BB4 /* SystemMonitorObservationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorObservationPolicyTests.swift; sourceTree = "<group>"; };
+		DED337312E3F6206B56477D2 /* ChatRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRenderingTests.swift; sourceTree = "<group>"; };
 		E0DA5C4D0B6B5A094E13CCC8 /* NativExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativExtensionTests.swift; sourceTree = "<group>"; };
 		E295CCB27C6CBD1025E62D11 /* WebSearchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSearchSettingsView.swift; sourceTree = "<group>"; };
 		E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineStore.swift; sourceTree = "<group>"; };
@@ -761,6 +776,9 @@
 				488BBCB7C0182ABB1FBADAD1 /* NativServerKit.framework in Frameworks */,
 				361D948B1B76F41B63A0B832 /* NativExtensionSDK.framework in Frameworks */,
 				E9CD4ED9C227090EFE23EB03 /* ZIPFoundation in Frameworks */,
+				AB05CE341967E073E10EF420 /* MarkdownUI in Frameworks */,
+				C43BABF794329C2C1D03F869 /* Highlightr in Frameworks */,
+				BA7876C934E43E103899E70E /* SwaTexRender in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -772,7 +790,10 @@
 				F32A65A75BCD6911505114F4 /* NativExtensionSDK.framework in Frameworks */,
 				4882FE7E8C689152D428AB2E /* Sparkle in Frameworks */,
 				D76DC0072E523E6409DF1176 /* Textual in Frameworks */,
-				9A57C70528785257DF9CEAAE /* ZIPFoundation in Frameworks */,
+				9A57C70528785257DF9CEAAE /* MarkdownUI in Frameworks */,
+				467A79817882057E60D2E4ED /* Highlightr in Frameworks */,
+				308D702D90DECE44C62375CD /* SwaTexRender in Frameworks */,
+				B8025D46E56B130B785F7EBE /* ZIPFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -787,6 +808,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		07AA5BEA8DD43664FA37A14E /* Rendering */ = {
+			isa = PBXGroup;
+			children = (
+				432F8E84739652B2546DC7B7 /* ChatMarkdownRenderer.swift */,
+				096CE626C3ECC066E4D735C7 /* ChatMathPreprocessor.swift */,
+			);
+			path = Rendering;
+			sourceTree = "<group>";
+		};
 		0A9385475502902D1AC774D5 /* Routines */ = {
 			isa = PBXGroup;
 			children = (
@@ -1331,8 +1361,8 @@
 				8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */,
 				5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */,
 				7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */,
-				C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */,
 				F9988535384E783847070506 /* ChatImportAlert.swift */,
+				C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */,
 				F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */,
 				8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */,
 				530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */,
@@ -1340,6 +1370,7 @@
 				F553434CA19B929108FF740F /* ChatView.swift */,
 				2A1B515ECDF21B3616E5A3D1 /* ChatViewModel.swift */,
 				39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */,
+				07AA5BEA8DD43664FA37A14E /* Rendering */,
 				967B3678137E2B152FAC9838 /* Tools */,
 			);
 			path = Chat;
@@ -1368,6 +1399,7 @@
 				BC9BAAC27515691F6C7950B4 /* ChatFileWriteToolTests.swift */,
 				23682FBD5DC3FC2517ABF397 /* ChatProjectStoreTests.swift */,
 				D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */,
+				DED337312E3F6206B56477D2 /* ChatRenderingTests.swift */,
 				2A1E6ED5DB03C63851E6AAE2 /* ChatSearchFilesToolTests.swift */,
 				97D987724FB28974BA95CF29 /* ChatTerminalToolTests.swift */,
 				C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */,
@@ -1454,6 +1486,9 @@
 			packageProductDependencies = (
 				0D3574097911A448F62ED273 /* Sparkle */,
 				730B64747E8A780CD14AF88F /* Textual */,
+				93C7D7CFC10C12D282013C7E /* MarkdownUI */,
+				0771E5ACBAEB27CD4A733935 /* Highlightr */,
+				7C44F2BDEB36AE1669F3B4C5 /* SwaTexRender */,
 				66E307AA0AD0D089ED4F2AB5 /* ZIPFoundation */,
 			);
 			productName = Nativ;
@@ -1478,6 +1513,9 @@
 			name = NativTests;
 			packageProductDependencies = (
 				7916EF3A0446EB624D66C33F /* ZIPFoundation */,
+				F1322868F0F169F28BE6D797 /* MarkdownUI */,
+				B47FB8D68E53A933ACF71A58 /* Highlightr */,
+				CB3602F4C9B417450A9FAA0B /* SwaTexRender */,
 			);
 			productName = NativTests;
 			productReference = 879B4B75CA9BE0A82C259451 /* NativTests.xctest */;
@@ -1557,7 +1595,10 @@
 			mainGroup = 78E0E819BEDF0A48F9ED67A5;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				0A53C94509BEA58DC6EB1A8A /* XCRemoteSwiftPackageReference "Highlightr" */,
+				125E13F2D3CF4137B2E027C1 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				0FB7E2D2B22FC46D3462C47A /* XCRemoteSwiftPackageReference "Sparkle" */,
+				F0DF26FE39829DA66FD81C62 /* XCRemoteSwiftPackageReference "SwaTex" */,
 				5409D05039F3337AF74DB4F3 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 				4AEDB4F2A39BE67B1DF710AE /* XCRemoteSwiftPackageReference "swift-sdk" */,
 				07F80B12D683EBF42228393D /* XCRemoteSwiftPackageReference "textual" */,
@@ -1567,11 +1608,11 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				ED4CB78AB93E015D0BE21F7B /* NativExtensionSDK */,
 				1622B274F4DF5A85C2FDB081 /* NativServerKit */,
-				51AD42FA29E71F2450386688 /* NativTests */,
+				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				7082E254E8272A5E8D13E6F0 /* VoiceDictationExtensionRuntime */,
+				51AD42FA29E71F2450386688 /* NativTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1714,6 +1755,8 @@
 				B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */,
 				D96122BA0806CCE96CC145E0 /* ChatImportAlert.swift in Sources */,
 				04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */,
+				96A319074CB28B885E031213 /* ChatMarkdownRenderer.swift in Sources */,
+				59F063A85DE0A1DFA681282F /* ChatMathPreprocessor.swift in Sources */,
 				7CBAB6DA0F1FB81208ED41FD /* ChatProjectStore.swift in Sources */,
 				902CD676AA3002459DF7ACAE /* ChatPromptRevision.swift in Sources */,
 				B6E24E55015CB5A98973B993 /* ChatReadFileTool.swift in Sources */,
@@ -1891,14 +1934,18 @@
 				4E81E2CBA8DBB61035A07C86 /* ChatDocumentExtractionCache.swift in Sources */,
 				5EE99710A57A2413EAEA93A7 /* ChatFileWriteToolTests.swift in Sources */,
 				2042F97FFB6520AC2CF63514 /* ChatFileWriteTools.swift in Sources */,
+				B53F0BCBE1C538AB55D8D62F /* ChatFontScale.swift in Sources */,
 				76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */,
 				D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */,
 				39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */,
+				D835C99B486C3FE352A27039 /* ChatMarkdownRenderer.swift in Sources */,
+				2D00D7A5F23F9250577351F7 /* ChatMathPreprocessor.swift in Sources */,
 				F7F573F15C7DC5CD17061EB9 /* ChatProjectStore.swift in Sources */,
 				4FF939720FFF6FCEEFFC7018 /* ChatProjectStoreTests.swift in Sources */,
 				4751D7C9F392C341E8921F58 /* ChatPromptRevision.swift in Sources */,
 				7719AEDEE627A29CA30D6FE3 /* ChatReadFileTool.swift in Sources */,
 				F9B4AAA3C467240C00807753 /* ChatReadFileToolTests.swift in Sources */,
+				2024C3DBE60A54C0DA7EF5A9 /* ChatRenderingTests.swift in Sources */,
 				A0D30C905A2788C3BD2149BF /* ChatScreenCapture.swift in Sources */,
 				70620E92994E9828794445D8 /* ChatSearchFilesTool.swift in Sources */,
 				7775550C303776DF9AE6030E /* ChatSearchFilesToolTests.swift in Sources */,
@@ -2503,12 +2550,28 @@
 				version = 0.5.0;
 			};
 		};
+		0A53C94509BEA58DC6EB1A8A /* XCRemoteSwiftPackageReference "Highlightr" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/raspu/Highlightr";
+			requirement = {
+				kind = exactVersion;
+				version = 2.3.0;
+			};
+		};
 		0FB7E2D2B22FC46D3462C47A /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = exactVersion;
 				version = 2.9.4;
+			};
+		};
+		125E13F2D3CF4137B2E027C1 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = exactVersion;
+				version = 2.4.1;
 			};
 		};
 		4AEDB4F2A39BE67B1DF710AE /* XCRemoteSwiftPackageReference "swift-sdk" */ = {
@@ -2527,9 +2590,22 @@
 				version = 0.9.20;
 			};
 		};
+		F0DF26FE39829DA66FD81C62 /* XCRemoteSwiftPackageReference "SwaTex" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/PhraseHQ/SwaTex.git";
+			requirement = {
+				kind = exactVersion;
+				version = 0.5.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0771E5ACBAEB27CD4A733935 /* Highlightr */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0A53C94509BEA58DC6EB1A8A /* XCRemoteSwiftPackageReference "Highlightr" */;
+			productName = Highlightr;
+		};
 		0D3574097911A448F62ED273 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0FB7E2D2B22FC46D3462C47A /* XCRemoteSwiftPackageReference "Sparkle" */;
@@ -2550,10 +2626,35 @@
 			package = 5409D05039F3337AF74DB4F3 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
 			productName = ZIPFoundation;
 		};
+		7C44F2BDEB36AE1669F3B4C5 /* SwaTexRender */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F0DF26FE39829DA66FD81C62 /* XCRemoteSwiftPackageReference "SwaTex" */;
+			productName = SwaTexRender;
+		};
 		8DD1E187A7659D46CDC76CF9 /* MCP */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4AEDB4F2A39BE67B1DF710AE /* XCRemoteSwiftPackageReference "swift-sdk" */;
 			productName = MCP;
+		};
+		93C7D7CFC10C12D282013C7E /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 125E13F2D3CF4137B2E027C1 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
+		B47FB8D68E53A933ACF71A58 /* Highlightr */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0A53C94509BEA58DC6EB1A8A /* XCRemoteSwiftPackageReference "Highlightr" */;
+			productName = Highlightr;
+		};
+		CB3602F4C9B417450A9FAA0B /* SwaTexRender */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F0DF26FE39829DA66FD81C62 /* XCRemoteSwiftPackageReference "SwaTex" */;
+			productName = SwaTexRender;
+		};
+		F1322868F0F169F28BE6D797 /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 125E13F2D3CF4137B2E027C1 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -3,7 +3,6 @@ import Foundation
 import NativServerKit
 import QuickLookThumbnailing
 import SwiftUI
-import Textual
 import UniformTypeIdentifiers
 
 struct ChatView: View {
@@ -548,6 +547,7 @@ private struct ChatMessageRow: View, @MainActor Equatable {
         Group {
             if usesCompactBubble {
                 ChatMessageText(
+                    messageID: message.id,
                     content: displayContent,
                     rendersMarkdown: rendersMarkdown,
                     isStreaming: message.isStreaming,
@@ -557,6 +557,7 @@ private struct ChatMessageRow: View, @MainActor Equatable {
                 .fixedSize(horizontal: true, vertical: false)
             } else {
                 ChatMessageText(
+                    messageID: message.id,
                     content: displayContent,
                     rendersMarkdown: rendersMarkdown,
                     isStreaming: message.isStreaming,
@@ -1740,6 +1741,7 @@ private struct ChatImageAttachmentView: View {
 }
 
 private struct ChatMessageText: View {
+    var messageID: UUID? = nil
     let content: String
     let rendersMarkdown: Bool
     let isStreaming: Bool
@@ -1752,85 +1754,18 @@ private struct ChatMessageText: View {
             Text(verbatim: content)
                 .textSelection(.enabled)
                 .font(ChatFontMetrics.bodyFont(scale: chatFontScale))
-        } else if rendersMarkdown && isStreaming {
-            ChatStreamingMarkdownText(
+        } else if rendersMarkdown {
+            ChatMarkdownRenderer(
+                messageID: messageID,
                 content: content,
+                isStreaming: isStreaming,
                 fontScale: chatFontScale
             )
-        } else if rendersMarkdown {
-            StructuredText(
-                markdown: NativMarkdownFormatting.normalizedMathDelimiters(in: content),
-                syntaxExtensions: [.math]
-            )
-            .textual.structuredTextStyle(.gitHub)
-            .textual.textSelection(.enabled)
-            .font(ChatFontMetrics.bodyFont(scale: chatFontScale))
         } else {
-            renderedText
+            Text(verbatim: content)
                 .textSelection(.enabled)
                 .font(ChatFontMetrics.bodyFont(scale: chatFontScale))
         }
-    }
-
-    private var renderedText: Text {
-        guard rendersMarkdown,
-            let attributed = try? AttributedString(
-                markdown: content,
-                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-            )
-        else {
-            return Text(content)
-        }
-
-        return Text(attributed)
-    }
-}
-
-private struct ChatStreamingMarkdownText: View {
-    private static let chunkSpacing: CGFloat = 16
-
-    let document: NativStreamingMarkdownDocument
-    let fontScale: Double
-
-    init(content: String, fontScale: Double) {
-        document = NativMarkdownFormatting.streamingDocument(in: content)
-        self.fontScale = fontScale
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Self.chunkSpacing) {
-            ForEach(document.completedChunks) { chunk in
-                ChatStreamingMarkdownChunk(chunk: chunk)
-                    .equatable()
-            }
-
-            if !document.tail.isEmpty {
-                InlineText(
-                    markdown: NativMarkdownFormatting.normalizedMathDelimiters(
-                        in: document.tail
-                    ),
-                    syntaxExtensions: [.math]
-                )
-                .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .textual.structuredTextStyle(.gitHub)
-        .textual.textSelection(.enabled)
-        .font(ChatFontMetrics.bodyFont(scale: fontScale))
-    }
-}
-
-private struct ChatStreamingMarkdownChunk: View, Equatable {
-    let chunk: NativStreamingMarkdownDocument.Chunk
-
-    var body: some View {
-        StructuredText(
-            markdown: NativMarkdownFormatting.normalizedMathDelimiters(
-                in: chunk.markdown
-            ),
-            syntaxExtensions: [.math]
-        )
-        .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/Sources/Nativ/Features/Chat/Rendering/ChatMarkdownRenderer.swift
+++ b/Sources/Nativ/Features/Chat/Rendering/ChatMarkdownRenderer.swift
@@ -1,0 +1,321 @@
+import AppKit
+import Highlightr
+import MarkdownUI
+import SwaTex
+import SwaTexRender
+import SwiftUI
+
+struct ChatMarkdownRenderer: View {
+  let messageID: UUID?
+  let content: String
+  let isStreaming: Bool
+  let fontScale: Double
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    let renderedContent = ChatMarkdownCache.shared.renderedContent(
+      for: messageID,
+      content: content,
+      isStreaming: isStreaming
+    )
+    let markdown = Markdown(MarkdownContent(renderedContent))
+      .markdownTheme(.nativChat)
+      .markdownCodeSyntaxHighlighter(ChatCodeHighlighter.forScheme(colorScheme))
+      .markdownInlineImageProvider(
+        MathInlineProvider(
+          fontSize: ChatFontMetrics.baseBodyPointSize * fontScale,
+          color: mathColor
+        )
+      )
+      .markdownImageProvider(
+        MathBlockProvider(
+          fontSize: (ChatFontMetrics.baseBodyPointSize + 2) * fontScale,
+          color: mathColor
+        )
+      )
+      .textSelection(.enabled)
+      .font(ChatFontMetrics.bodyFont(scale: fontScale))
+
+    if isStreaming {
+      markdown
+        .geometryGroup()
+        .transaction { transaction in
+          transaction.animation = nil
+        }
+    } else {
+      markdown
+    }
+  }
+
+  private var mathColor: NSColor {
+    colorScheme == .dark
+      ? NSColor(white: 0.92, alpha: 1)
+      : NSColor(white: 0.12, alpha: 1)
+  }
+}
+
+extension MarkdownUI.Theme {
+  static var nativChat: MarkdownUI.Theme {
+    MarkdownUI.Theme.gitHub
+      .text {
+        BackgroundColor(nil)
+        FontSize(16)
+      }
+  }
+}
+
+@MainActor
+final class ChatMarkdownCache {
+  static let shared = ChatMarkdownCache()
+
+  private struct Entry {
+    let content: String
+    let renderedContent: String
+  }
+
+  private var entries: [UUID: Entry] = [:]
+  private var order: [UUID] = []
+  private let capacity: Int
+
+  init(capacity: Int = 256) {
+    self.capacity = capacity
+  }
+
+  func renderedContent(
+    for id: UUID?,
+    content: String,
+    isStreaming: Bool
+  ) -> String {
+    if isStreaming {
+      return Self.preprocessStreamingFlush(content)
+    }
+
+    guard let id else {
+      return MathPreprocessor.preprocess(content)
+    }
+    if let entry = entries[id], entry.content == content {
+      touch(id)
+      return entry.renderedContent
+    }
+
+    let renderedContent = MathPreprocessor.preprocess(content)
+    entries[id] = Entry(content: content, renderedContent: renderedContent)
+    touch(id)
+    evictIfNeeded()
+    return renderedContent
+  }
+
+  private static func preprocessStreamingFlush(_ text: String) -> String {
+    let dollarCount = text.reduce(into: 0) { count, character in
+      if character == "$" {
+        count += 1
+      }
+    }
+    guard !dollarCount.isMultiple(of: 2),
+      let lastDollar = text.lastIndex(of: "$")
+    else {
+      return MathPreprocessor.preprocess(text)
+    }
+
+    let stable = String(text[..<lastDollar])
+    let held = String(text[lastDollar...])
+    return MathPreprocessor.preprocess(stable) + held
+  }
+
+  private func touch(_ id: UUID) {
+    if let index = order.firstIndex(of: id) {
+      order.remove(at: index)
+    }
+    order.append(id)
+  }
+
+  private func evictIfNeeded() {
+    while order.count > capacity {
+      entries.removeValue(forKey: order.removeFirst())
+    }
+  }
+}
+
+final class ChatCodeHighlighter: CodeSyntaxHighlighter, @unchecked Sendable {
+  static let light = ChatCodeHighlighter(theme: "xcode")
+  static let dark = ChatCodeHighlighter(theme: "atom-one-dark")
+
+  static func forScheme(_ scheme: ColorScheme) -> ChatCodeHighlighter {
+    scheme == .dark ? .dark : .light
+  }
+
+  private let highlightr: Highlightr?
+  private var cache: [String: Text] = [:]
+
+  private init(theme: String) {
+    let highlightr = Highlightr()
+    highlightr?.setTheme(to: theme)
+    self.highlightr = highlightr
+  }
+
+  func highlightCode(_ code: String, language: String?) -> Text {
+    let key = (language ?? "") + "\u{0}" + code
+    if let cached = cache[key] {
+      return cached
+    }
+
+    guard let highlightr,
+      let highlighted = highlightr.highlight(
+        code,
+        as: normalized(language),
+        fastRender: true
+      ),
+      let attributed = try? AttributedString(highlighted, including: \.appKit)
+    else {
+      return Text(code)
+    }
+
+    let text = Text(attributed)
+    if cache.count > 300 {
+      cache.removeAll(keepingCapacity: true)
+    }
+    cache[key] = text
+    return text
+  }
+
+  private func normalized(_ language: String?) -> String? {
+    guard let language = language?.lowercased(), !language.isEmpty else {
+      return nil
+    }
+    switch language {
+    case "js":
+      return "javascript"
+    case "ts":
+      return "typescript"
+    case "py":
+      return "python"
+    case "sh", "zsh", "shell":
+      return "bash"
+    case "yml":
+      return "yaml"
+    default:
+      return language
+    }
+  }
+}
+
+enum MathRenderer {
+  nonisolated(unsafe) private static let cache = NSCache<NSString, NSImage>()
+  private static let retinaScale: CGFloat = 2
+
+  static func render(
+    base64URL encoded: String,
+    display: Bool,
+    fontSize: CGFloat,
+    color: NSColor
+  ) -> NSImage {
+    let key = "\(display ? "d" : "i")|\(fontSize)|\(color.description)|\(encoded)" as NSString
+    if let cached = cache.object(forKey: key) {
+      return cached
+    }
+
+    let latex = MathPreprocessor.decodeBase64URL(encoded) ?? ""
+    let options = RenderOptions(fontSize: fontSize, padding: display ? 6 : 1)
+    let style: MathStyle = display ? .display : .text
+    let ink = swatexColor(from: color)
+
+    let final: NSImage
+    if let cgImage = try? ImageRenderer.image(
+      latex: latex,
+      style: style,
+      color: ink,
+      options: options,
+      displayScale: retinaScale
+    ) {
+      let pointSize = NSSize(
+        width: CGFloat(cgImage.width) / retinaScale,
+        height: CGFloat(cgImage.height) / retinaScale
+      )
+      final = NSImage(cgImage: cgImage, size: pointSize)
+    } else {
+      final = literalImage(text: latex.isEmpty ? "math" : latex, color: color)
+    }
+    cache.setObject(final, forKey: key)
+    return final
+  }
+
+  private static func swatexColor(from color: NSColor) -> SwaTex.Color {
+    let rgb = color.usingColorSpace(.sRGB) ?? color
+    return SwaTex.Color(
+      r: Float(rgb.redComponent),
+      g: Float(rgb.greenComponent),
+      b: Float(rgb.blueComponent),
+      a: Float(rgb.alphaComponent)
+    )
+  }
+
+  private static func literalImage(text: String, color: NSColor) -> NSImage {
+    let attributed = NSAttributedString(
+      string: text,
+      attributes: [
+        .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular),
+        .foregroundColor: color,
+      ]
+    )
+    var size = attributed.size()
+    size.width = max(size.width, 4)
+    size.height = max(size.height, 4)
+    return NSImage(size: size, flipped: false) { rect in
+      attributed.draw(in: rect)
+      return true
+    }
+  }
+}
+
+struct MathInlineProvider: InlineImageProvider {
+  let fontSize: CGFloat
+  let color: NSColor
+
+  struct UnsupportedURL: Error {}
+
+  func image(with url: URL, label: String) async throws -> Image {
+    guard url.scheme == "swiftmath" else {
+      throw UnsupportedURL()
+    }
+    let encoded = String(url.path.dropFirst())
+    let nsImage = MathRenderer.render(
+      base64URL: encoded,
+      display: (url.host ?? "") == "d",
+      fontSize: fontSize,
+      color: color
+    )
+    return Image(nsImage: nsImage)
+  }
+}
+
+struct MathBlockProvider: ImageProvider {
+  let fontSize: CGFloat
+  let color: NSColor
+
+  @ViewBuilder
+  func makeImage(url: URL?) -> some View {
+    if let url, url.scheme == "swiftmath" {
+      let nsImage = MathRenderer.render(
+        base64URL: String(url.path.dropFirst()),
+        display: (url.host ?? "") == "d",
+        fontSize: fontSize,
+        color: color
+      )
+      if nsImage.size.width > 720 {
+        ScrollView(.horizontal, showsIndicators: true) {
+          Image(nsImage: nsImage)
+            .padding(.vertical, 4)
+        }
+      } else {
+        Image(nsImage: nsImage)
+          .frame(maxWidth: .infinity, alignment: .center)
+          .padding(.vertical, 4)
+      }
+    } else if let url {
+      Link(url.absoluteString, destination: url)
+    } else {
+      EmptyView()
+    }
+  }
+}

--- a/Sources/Nativ/Features/Chat/Rendering/ChatMathPreprocessor.swift
+++ b/Sources/Nativ/Features/Chat/Rendering/ChatMathPreprocessor.swift
@@ -1,0 +1,445 @@
+import Foundation
+
+enum MathPreprocessor {
+  static func preprocess(_ markdown: String) -> String {
+    let markdown = repairAccidentalIndentedMath(
+      convertMathFences(markdown))
+    return transformOutsideCodeBlocks(markdown)
+  }
+
+  private static func transformOutsideCodeBlocks(_ markdown: String) -> String {
+    guard hasPotentialCodeBlock(markdown) else {
+      return transformOutsideInlineCode(markdown)
+    }
+    var result = ""
+    var cursor = markdown.startIndex
+    for range in protectedCodeBlockRanges(in: markdown) {
+      result += transformOutsideInlineCode(String(markdown[cursor..<range.lowerBound]))
+      result += markdown[range]
+      cursor = range.upperBound
+    }
+    result += transformOutsideInlineCode(String(markdown[cursor...]))
+    return result
+  }
+
+  private static func hasPotentialCodeBlock(_ text: String) -> Bool {
+    text.contains("```")
+      || text.contains("~~~")
+      || hasPotentialIndentedLine(text)
+  }
+
+  private static func hasPotentialIndentedLine(_ text: String) -> Bool {
+    text.hasPrefix("    ")
+      || text.hasPrefix("\t")
+      || text.contains("\n    ")
+      || text.contains("\n\t")
+  }
+
+  private static func transformOutsideInlineCode(_ markdown: String) -> String {
+    let codeSpan = /(`{1,3})[^`]*?\1/
+    var result = ""
+    var cursor = markdown.startIndex
+    for match in markdown.matches(of: codeSpan) {
+      result += transform(String(markdown[cursor..<match.range.lowerBound]))
+      result += markdown[match.range]
+      cursor = match.range.upperBound
+    }
+    result += transform(String(markdown[cursor...]))
+    return result
+  }
+
+  private struct LineSlice {
+    let contentRange: Range<String.Index>
+    let fullRange: Range<String.Index>
+  }
+
+  private struct OpenFence {
+    let marker: Character
+    let minimumLength: Int
+    let start: String.Index
+  }
+
+  private static func protectedCodeBlockRanges(in text: String) -> [Range<String.Index>] {
+    var ranges: [Range<String.Index>] = []
+    var fence: OpenFence?
+    var indentedStart: String.Index?
+    var indentedEnd: String.Index?
+
+    for line in lineSlices(in: text) {
+      let content = text[line.contentRange]
+
+      if let currentFence = fence {
+        if isClosingFence(
+          content,
+          marker: currentFence.marker,
+          minimumLength: currentFence.minimumLength)
+        {
+          ranges.append(currentFence.start..<line.fullRange.upperBound)
+          fence = nil
+        }
+        continue
+      }
+
+      if let start = indentedStart {
+        if content.trimmingCharacters(in: .whitespaces).isEmpty
+          || isIndentedCodeLine(content)
+        {
+          indentedEnd = line.fullRange.upperBound
+          continue
+        }
+        ranges.append(start..<(indentedEnd ?? line.fullRange.lowerBound))
+        indentedStart = nil
+        indentedEnd = nil
+      }
+
+      if let opening = openingFence(in: content) {
+        fence = OpenFence(
+          marker: opening.marker,
+          minimumLength: opening.length,
+          start: line.fullRange.lowerBound)
+      } else if !content.trimmingCharacters(in: .whitespaces).isEmpty,
+        isIndentedCodeLine(content)
+      {
+        indentedStart = line.fullRange.lowerBound
+        indentedEnd = line.fullRange.upperBound
+      }
+    }
+
+    if let fence {
+      ranges.append(fence.start..<text.endIndex)
+    } else if let indentedStart {
+      ranges.append(indentedStart..<(indentedEnd ?? text.endIndex))
+    }
+    return ranges
+  }
+
+  private static func lineSlices(in text: String) -> [LineSlice] {
+    var lines: [LineSlice] = []
+    var start = text.startIndex
+    while start < text.endIndex {
+      let newline = text[start...].firstIndex(of: "\n")
+      let contentEnd = newline ?? text.endIndex
+      let fullEnd = newline.map { text.index(after: $0) } ?? text.endIndex
+      lines.append(
+        LineSlice(
+          contentRange: start..<contentEnd,
+          fullRange: start..<fullEnd))
+      start = fullEnd
+    }
+    return lines
+  }
+
+  private static func openingFence(
+    in line: Substring
+  ) -> (marker: Character, length: Int)? {
+    var index = line.startIndex
+    var spaces = 0
+    while index < line.endIndex, line[index] == " ", spaces < 4 {
+      spaces += 1
+      index = line.index(after: index)
+    }
+    guard spaces <= 3, index < line.endIndex else { return nil }
+    let marker = line[index]
+    guard marker == "`" || marker == "~" else { return nil }
+    var length = 0
+    while index < line.endIndex, line[index] == marker {
+      length += 1
+      index = line.index(after: index)
+    }
+    guard length >= 3 else { return nil }
+    if marker == "`", line[index...].contains("`") { return nil }
+    return (marker, length)
+  }
+
+  private static func isClosingFence(
+    _ line: Substring,
+    marker: Character,
+    minimumLength: Int
+  ) -> Bool {
+    var index = line.startIndex
+    var spaces = 0
+    while index < line.endIndex, line[index] == " ", spaces < 4 {
+      spaces += 1
+      index = line.index(after: index)
+    }
+    guard spaces <= 3 else { return false }
+    var length = 0
+    while index < line.endIndex, line[index] == marker {
+      length += 1
+      index = line.index(after: index)
+    }
+    guard length >= minimumLength else { return false }
+    return line[index...].allSatisfy { $0 == " " || $0 == "\t" }
+  }
+
+  private static func isIndentedCodeLine(_ line: Substring) -> Bool {
+    let remainder: Substring
+    if line.first == "\t" {
+      remainder = line.dropFirst()
+    } else if line.hasPrefix("    ") {
+      remainder = line.dropFirst(4)
+    } else {
+      return false
+    }
+    if remainder.prefixMatch(of: /^[ \t]*(?:[-+*]|[0-9]+[.)])[ \t]+/) != nil {
+      return false
+    }
+    return true
+  }
+
+  private static func repairAccidentalIndentedMath(_ markdown: String) -> String {
+    guard hasPotentialIndentedLine(markdown) else { return markdown }
+    var lines = markdown.components(separatedBy: "\n")
+    var previousNonblank: String?
+    var fence: (marker: Character, minimumLength: Int)?
+
+    for index in lines.indices {
+      let original = lines[index]
+      let line = Substring(original)
+      if let currentFence = fence {
+        if isClosingFence(
+          line,
+          marker: currentFence.marker,
+          minimumLength: currentFence.minimumLength)
+        {
+          fence = nil
+        }
+        continue
+      }
+      if let opening = openingFence(in: line) {
+        fence = (opening.marker, opening.length)
+        continue
+      }
+
+      let originalTrimmed = original.trimmingCharacters(in: .whitespaces)
+      defer {
+        if !originalTrimmed.isEmpty { previousNonblank = originalTrimmed }
+      }
+
+      guard let dedented = removeSingleCodeIndent(from: original),
+        previousNonblank?.wholeMatch(
+          of: /(?:[-+*]|[0-9]+[.)])[ \t]+.*/
+        ) == nil
+      else { continue }
+
+      let candidate = dedented.trimmingCharacters(in: .whitespaces)
+      guard !candidate.isEmpty, !looksLikeSourceCode(candidate) else { continue }
+
+      if transform(candidate) != candidate {
+        lines[index] = dedented
+      } else if looksLikeBareLatexEquation(candidate) {
+        lines[index] = "$$\(candidate)$$"
+      }
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  private static func removeSingleCodeIndent(from line: String) -> String? {
+    if line.hasPrefix("\t") {
+      let result = String(line.dropFirst())
+      return result.first == "\t" || result.hasPrefix("    ") ? nil : result
+    }
+    guard line.hasPrefix("    ") else { return nil }
+    let result = String(line.dropFirst(4))
+    return result.first == " " || result.first == "\t" ? nil : result
+  }
+
+  private static func looksLikeSourceCode(_ line: String) -> Bool {
+    let prefixes = [
+      "let ", "var ", "func ", "class ", "struct ", "enum ",
+      "import ", "return ", "if ", "for ", "while ", "switch ",
+      "case ", "print(", "#", "//", "/*", "<",
+    ]
+    return prefixes.contains { line.hasPrefix($0) }
+      || line.contains("\"")
+      || line.contains("`")
+      || line.hasSuffix(";")
+  }
+
+  private static func looksLikeBareLatexEquation(_ line: String) -> Bool {
+    let commands = [
+      "\\frac", "\\sum", "\\prod", "\\int", "\\lim", "\\left",
+      "\\right", "\\sqrt", "\\infty", "\\to", "\\cdot", "\\times",
+      "\\nabla", "\\epsilon", "\\theta", "\\mathbb", "\\mathrm",
+      "\\begin", "\\end", "\\tfrac", "\\dfrac", "\\text",
+    ]
+    guard commands.contains(where: { line.contains($0) }) else { return false }
+    return line.contains("=") || line.first == "\\"
+  }
+
+  private static func convertMathFences(_ text: String) -> String {
+    var output = text
+    output = output.replacing(
+      /(?m)^```[ \t]*(?:math|latex|tex)[ \t]*\n([\s\S]{1,2000}?)\n```[ \t]*$/
+    ) { match in
+      var latex = String(match.1).trimmingCharacters(in: .whitespacesAndNewlines)
+      latex = latex.trimmingCharacters(in: CharacterSet(charactersIn: "$"))
+      return displayImage(latex)
+    }
+    output = output.replacing(
+      /(?m)^```[ \t]*(?:text)?[ \t]*\n[ \t]*\$\$?([^$\n]{1,300}?)\$\$?[ \t]*\n```[ \t]*$/
+    ) { match in
+      displayImage(String(match.1))
+    }
+    return output
+  }
+
+  private static func transform(_ text: String) -> String {
+    var output = text
+
+    output = output.replacing(/(?s)\$\$(.{1,2000}?)\$\$/) { match in
+      math(String(match.1), display: isStandalone(output, match.range))
+    }
+    output = output.replacing(/(?s)\\\[(.{1,2000}?)\\\]/) { match in
+      math(String(match.1), display: isStandalone(output, match.range))
+    }
+    output = output.replacing(/(?s)\\\((.{1,300}?)\\\)/) { match in
+      inlineMath(String(match.1))
+    }
+    output = output.replacing(/\$[ \t]*([^\s$][^$\n]{0,118}?[^\s$]|[^\s$])[ \t]*\$/) { match in
+      let latex = String(match.1)
+      if latex.wholeMatch(of: /[A-Za-z0-9'\[\](),=+\-*\/×·. ]{1,60}/) != nil,
+        latex.contains(/[A-Za-z]/),
+        !(latex.contains(" ") && latex.wholeMatch(of: /.*[=+\-*\/×·].*/) == nil)
+      {
+        return mathItalic(latex)
+      }
+      if looksLikePairedPipeAbs(latex) {
+        return inlineImage(latex)
+      }
+      if containsMathUnicode(latex) {
+        return inlineImage(latex)
+      }
+      guard latex.contains(/[\\^_{}<>]/) else { return String(match.0) }
+      return inlineImage(latex)
+    }
+    output = wrapUnicodeBigOperators(output)
+    output = convertBareBoxed(output)
+    return output
+  }
+
+  private static func containsMathUnicode(_ text: String) -> Bool {
+    text.unicodeScalars.contains { $0.properties.isMath && $0.value > 0x7F }
+  }
+
+  private static func wrapUnicodeBigOperators(_ text: String) -> String {
+    text.replacing(
+      /([Σ∑Π∏∫])(_\{[^}\n]{1,80}\}(?:\^\{[^}\n]{1,40}\})?|\^\{[^}\n]{1,40}\}(?:_\{[^}\n]{1,80}\})?)/
+    ) { match in
+      let command: String
+      switch String(match.1) {
+      case "Σ", "∑": command = "\\sum"
+      case "Π", "∏": command = "\\prod"
+      default: command = "\\int"
+      }
+      return inlineImage(command + String(match.2))
+    }
+  }
+
+  private static func looksLikePairedPipeAbs(_ latex: String) -> Bool {
+    let pipeCount = latex.reduce(into: 0) { count, character in
+      if character == "|" { count += 1 }
+    }
+    guard pipeCount >= 2, pipeCount.isMultiple(of: 2) else { return false }
+    if latex.contains(/[=+\-*\/^_{}\\<>]/) || latex.contains(/[A-Za-z]\(/) {
+      return true
+    }
+    return pipeCount == 2 && latex.contains(/\|[A-Za-z0-9'\[\](),. ]+\|/)
+  }
+
+  private static func math(_ latex: String, display: Bool) -> String {
+    display ? displayMath(latex) : inlineMath(latex)
+  }
+
+  private static func isStandalone(_ text: String, _ range: Range<String.Index>) -> Bool {
+    let lineStart =
+      text[..<range.lowerBound].lastIndex(of: "\n")
+      .map { text.index(after: $0) } ?? text.startIndex
+    let lineEnd = text[range.upperBound...].firstIndex(of: "\n") ?? text.endIndex
+    return text[lineStart..<range.lowerBound].allSatisfy(" \t".contains)
+      && text[range.upperBound..<lineEnd].allSatisfy(" \t".contains)
+  }
+
+  private static func displayMath(_ latex: String) -> String {
+    displayImage(latex)
+  }
+
+  private static func inlineMath(_ latex: String) -> String {
+    inlineImage(latex)
+  }
+
+  private static func convertBareBoxed(_ text: String) -> String {
+    var rest = text
+    var result = ""
+    while let (_, range) = firstBoxed(in: rest) {
+      result += rest[..<range.lowerBound] + inlineImage(String(rest[range]))
+      rest = String(rest[range.upperBound...])
+    }
+    return result + rest
+  }
+
+  private static func firstBoxed(in text: String) -> (inner: String, range: Range<String.Index>)? {
+    guard let start = text.range(of: #"\boxed{"#) else { return nil }
+    var depth = 1
+    var index = start.upperBound
+    while index < text.endIndex, depth > 0 {
+      switch text[index] {
+      case "{": depth += 1
+      case "}": depth -= 1
+      default: break
+      }
+      if depth == 0 { break }
+      index = text.index(after: index)
+    }
+    guard depth == 0 else { return nil }
+    return (String(text[start.upperBound..<index]), start.lowerBound..<text.index(after: index))
+  }
+
+  private static func mathItalic(_ text: String) -> String {
+    String(
+      text.flatMap { char -> [Character] in
+        guard let scalar = char.unicodeScalars.first, char.unicodeScalars.count == 1 else {
+          return [char]
+        }
+        let value: UInt32
+        switch scalar.value {
+        case 0x27:
+          value = 0x2032
+        case 0x68:
+          value = 0x210E
+        case 0x41...0x5A:
+          value = 0x1D434 + (scalar.value - 0x41)
+        case 0x61...0x7A:
+          value = 0x1D44E + (scalar.value - 0x61)
+        default:
+          return [char]
+        }
+        return [Character(UnicodeScalar(value)!)]
+      })
+  }
+
+  private static func displayImage(_ latex: String) -> String {
+    "\n\n![math](swiftmath://d/\(base64URL(latex)))\n\n"
+  }
+
+  private static func inlineImage(_ latex: String) -> String {
+    "![math](swiftmath://i/\(base64URL(latex)))"
+  }
+
+  static func base64URL(_ text: String) -> String {
+    Data(text.utf8).base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+
+  static func decodeBase64URL(_ encoded: String) -> String? {
+    var base64 =
+      encoded
+      .replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+    while base64.count % 4 != 0 { base64 += "=" }
+    guard let data = Data(base64Encoded: base64) else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+}

--- a/Tests/NativTests/ChatRenderingTests.swift
+++ b/Tests/NativTests/ChatRenderingTests.swift
@@ -1,0 +1,73 @@
+import MarkdownUI
+import SwiftUI
+import XCTest
+
+final class ChatMarkdownRendererTests: XCTestCase {
+  func testChatThemeDoesNotPaintASeparateDocumentCanvas() {
+    XCTAssertNil(Theme.nativChat.textBackgroundColor)
+  }
+
+  @MainActor
+  func testLongMarkdownUsesItsCompleteIntrinsicHeight() throws {
+    let section = """
+      ## Efficient streaming
+
+      This paragraph contains **bold text**, `inline code`, and a [link](https://example.com).
+
+      - First item with enough text to wrap naturally across the available width.
+      - Second item with more content and an inline expression $x^2 + y^2$.
+
+      ```swift
+      struct Message: Identifiable {
+          let id: UUID
+          let content: String
+      }
+      ```
+
+      """
+    let markdown = Array(repeating: section, count: 80).joined(separator: "\n")
+    let renderer = ImageRenderer(
+      content: ChatMarkdownRenderer(
+        messageID: UUID(),
+        content: markdown,
+        isStreaming: false,
+        fontScale: 1
+      )
+      .frame(width: 560)
+      .fixedSize(horizontal: false, vertical: true)
+    )
+    renderer.proposedSize = ProposedViewSize(width: 560, height: nil)
+
+    let image = try XCTUnwrap(renderer.nsImage)
+    XCTAssertGreaterThan(image.size.height, 8_000)
+    XCTAssertGreaterThan(markdown.count, 25_000)
+  }
+
+  @MainActor
+  func testStreamingAndCompletedMarkdownBothRender() throws {
+    let content = """
+      # Streaming
+
+      Content grows without assigning a fixed row height.
+
+      $$E = mc^2$$
+      """
+
+    for isStreaming in [true, false] {
+      let renderer = ImageRenderer(
+        content: ChatMarkdownRenderer(
+          messageID: UUID(),
+          content: content,
+          isStreaming: isStreaming,
+          fontScale: 1
+        )
+        .frame(width: 560)
+        .fixedSize(horizontal: false, vertical: true)
+      )
+      renderer.proposedSize = ProposedViewSize(width: 560, height: nil)
+
+      let image = try XCTUnwrap(renderer.nsImage)
+      XCTAssertGreaterThan(image.size.height, 40)
+    }
+  }
+}

--- a/project.yml
+++ b/project.yml
@@ -18,6 +18,15 @@ packages:
   textual:
     url: https://github.com/gonzalezreal/textual.git
     exactVersion: 0.5.0
+  MarkdownUI:
+    url: https://github.com/gonzalezreal/swift-markdown-ui
+    exactVersion: 2.4.1
+  Highlightr:
+    url: https://github.com/raspu/Highlightr
+    exactVersion: 2.3.0
+  SwaTex:
+    url: https://github.com/PhraseHQ/SwaTex.git
+    exactVersion: 0.5.0
   mcp-swift-sdk:
     url: https://github.com/modelcontextprotocol/swift-sdk
     exactVersion: 0.12.1
@@ -118,6 +127,12 @@ targets:
         product: Sparkle
       - package: textual
         product: Textual
+      - package: MarkdownUI
+        product: MarkdownUI
+      - package: Highlightr
+        product: Highlightr
+      - package: SwaTex
+        product: SwaTexRender
       - package: ZIPFoundation
         product: ZIPFoundation
     postBuildScripts:
@@ -210,6 +225,8 @@ targets:
       - path: Sources/Nativ/Features/Chat/ChatToolRegistry.swift
       - path: Sources/Nativ/Features/Chat/ChatProjectStore.swift
       - path: Sources/Nativ/Features/Chat/ChatViewModel.swift
+      - path: Sources/Nativ/Features/Chat/ChatFontScale.swift
+      - path: Sources/Nativ/Features/Chat/Rendering
       - path: Sources/Nativ/Features/Chat/ChatConversationBranch.swift
       - path: Sources/Nativ/Features/Chat/ChatPromptRevision.swift
       - path: Sources/Nativ/Features/Chat/Tools/ChatImageTool.swift
@@ -285,6 +302,12 @@ targets:
       - target: NativExtensionSDK
       - package: ZIPFoundation
         product: ZIPFoundation
+      - package: MarkdownUI
+        product: MarkdownUI
+      - package: Highlightr
+        product: Highlightr
+      - package: SwaTex
+        product: SwaTexRender
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.local.NativTests


### PR DESCRIPTION
This replaces the previous textual and chunk based chat renderer with a dedicated SwiftUI rendering pipeline built on MarkdownUI. Streaming and completed responses now use the same rendering path, which prevents messages from changing structure when generation finishes.

The renderer supports Markdown, syntax highlighted code, inline and block mathematics, links, tables, lists, and the existing text scaling behavior. Parsed content and highlighted code are cached to avoid repeating expensive work while scrolling or streaming.

Message views retain their natural intrinsic height, allowing very long responses to render completely without clipping. 

This also adds tests covering long response height, streaming and completed rendering, and protection against an additional Markdown document background. Existing message actions and chat functionality are unchanged.