### PR TITLE
Improve chat streaming cadence

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -20,12 +20,34 @@ private struct ChatSessionBootstrap {
     let sessions: [ChatSession]
 }
 
+enum ChatStreamingRenderPolicy {
+    static func updatesPerSecond(characterCount: Int) -> Double {
+        switch characterCount {
+        case ..<2_000:
+            10
+        case ..<8_000:
+            9
+        case ..<20_000:
+            8.5
+        default:
+            8
+        }
+    }
+
+    static func flushIntervalSeconds(characterCount: Int) -> TimeInterval {
+        1 / updatesPerSecond(characterCount: characterCount)
+    }
+
+    static func flushInterval(characterCount: Int) -> Duration {
+        .seconds(flushIntervalSeconds(characterCount: characterCount))
+    }
+}
+
 @MainActor
 final class ChatViewModel: ObservableObject {
     /// MCP tool host, set by ChatView. Provides MCP tool definitions + execution.
     weak var mcpHost: MCPHostManager?
     private static let liveDecodeRateRefreshInterval: TimeInterval = 0.25
-    private static let streamFlushInterval: TimeInterval = 1.0 / 15.0
 
     private struct QueuedChatRequest {
         let id: UUID
@@ -2452,12 +2474,21 @@ final class ChatViewModel: ObservableObject {
             return
         }
 
-        let now = Date()
-        if let lastFlush = streamFlushDates[id],
-            now.timeIntervalSince(lastFlush) < Self.streamFlushInterval
-        {
-            scheduleStreamFlush(id, in: sessionID)
-            return
+        let now = Date.now
+        let characterCount = streamingCharacterCount(id, in: sessionID)
+        let flushInterval = ChatStreamingRenderPolicy.flushIntervalSeconds(
+            characterCount: characterCount
+        )
+        if let lastFlush = streamFlushDates[id] {
+            let elapsed = now.timeIntervalSince(lastFlush)
+            if elapsed < flushInterval {
+                scheduleStreamFlush(
+                    id,
+                    in: sessionID,
+                    delay: flushInterval - elapsed
+                )
+                return
+            }
         }
         flushStream(id, in: sessionID)
     }
@@ -2468,12 +2499,16 @@ final class ChatViewModel: ObservableObject {
             || pendingStreamMetrics[id] != nil
     }
 
-    private func scheduleStreamFlush(_ id: UUID, in sessionID: UUID) {
+    private func scheduleStreamFlush(
+        _ id: UUID,
+        in sessionID: UUID,
+        delay: TimeInterval
+    ) {
         guard streamFlushTasks[id] == nil else {
             return
         }
         streamFlushTasks[id] = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(Self.streamFlushInterval * 1_000_000_000))
+            try? await Task.sleep(for: .seconds(delay))
             guard let self, !Task.isCancelled else {
                 return
             }
@@ -2515,7 +2550,7 @@ final class ChatViewModel: ObservableObject {
                 )
             }
         }
-        streamFlushDates[id] = Date()
+        streamFlushDates[id] = .now
         if !content.isEmpty || !reasoning.isEmpty, currentSessionID == sessionID {
             bumpScroll()
         }
@@ -2528,6 +2563,15 @@ final class ChatViewModel: ObservableObject {
         pendingStreamReasoning.removeValue(forKey: id)
         pendingStreamMetrics.removeValue(forKey: id)
         streamFlushDates.removeValue(forKey: id)
+    }
+
+    private func streamingCharacterCount(_ id: UUID, in sessionID: UUID) -> Int {
+        let message = message(id, in: sessionID)
+        let contentCount = (message?.content.count ?? 0)
+            + (pendingStreamContent[id]?.count ?? 0)
+        let reasoningCount = (message?.reasoningContent.count ?? 0)
+            + (pendingStreamReasoning[id]?.count ?? 0)
+        return max(contentCount, reasoningCount)
     }
 
     private func shouldRefreshLiveMetrics(

--- a/Tests/NativTests/ChatRenderingTests.swift
+++ b/Tests/NativTests/ChatRenderingTests.swift
@@ -115,3 +115,46 @@ final class ChatMarkdownRendererTests: XCTestCase {
     return try XCTUnwrap(renderer.nsImage).size.height
   }
 }
+
+final class ChatStreamingRenderPolicyTests: XCTestCase {
+  func testAdaptiveIntervalsUseNativSmoothCadence() {
+    XCTAssertEqual(
+      ChatStreamingRenderPolicy.updatesPerSecond(characterCount: 0),
+      10
+    )
+    XCTAssertEqual(
+      ChatStreamingRenderPolicy.updatesPerSecond(characterCount: 1_999),
+      10
+    )
+    XCTAssertEqual(
+      ChatStreamingRenderPolicy.updatesPerSecond(characterCount: 2_000),
+      9
+    )
+    XCTAssertEqual(
+      ChatStreamingRenderPolicy.updatesPerSecond(characterCount: 8_000),
+      8.5
+    )
+    XCTAssertEqual(
+      ChatStreamingRenderPolicy.updatesPerSecond(characterCount: 20_000),
+      8
+    )
+  }
+
+  func testCadenceNeverDropsBelowEightUpdatesPerSecond() {
+    for characterCount in [0, 2_000, 8_000, 20_000, 100_000, 1_000_000] {
+      XCTAssertGreaterThanOrEqual(
+        ChatStreamingRenderPolicy.updatesPerSecond(characterCount: characterCount),
+        8
+      )
+    }
+  }
+
+  func testCadenceNeverAcceleratesAsContentGrows() {
+    let counts = [0, 1_999, 2_000, 7_999, 8_000, 19_999, 20_000, 100_000]
+    let intervals = counts.map {
+      ChatStreamingRenderPolicy.flushIntervalSeconds(characterCount: $0)
+    }
+
+    XCTAssertEqual(intervals, intervals.sorted())
+  }
+}


### PR DESCRIPTION
This replaces the fixed streaming update interval with an adaptive cadence based on the current response length. Short responses update ten times per second, while progressively longer responses update at nine, eight and a half, or eight times per second.
The character count includes both published and pending answer and reasoning content. Each update is scheduled using the remaining time since the previous flush, which avoids redundant refresh tasks and keeps streaming visually consistent.
The lower update frequency for very large responses reduces repeated Markdown parsing, layout work, and main thread pressure while maintaining a minimum of eight visible updates per second. This keeps generation smooth without allowing long responses to consume unnecessary processing time.
Tests verify every cadence threshold, ensure the cadence does not accelerate as content grows, and guarantee that it never falls below eight updates per second.
