### PR TITLE
Improved draft model discovery

### DIFF
--- a/PythonDistribution/Scripts/generate_model_capabilities_manifest.py
+++ b/PythonDistribution/Scripts/generate_model_capabilities_manifest.py
@@ -195,12 +195,17 @@ def _validate_mapping_targets(
 
 
 def _entry(
-    model_types: set[str], aliases: dict[str, str] | None = None
+    model_types: set[str],
+    aliases: dict[str, str] | None = None,
+    kinds: dict[str, str] | None = None,
 ) -> dict[str, object]:
-    return {
+    entry: dict[str, object] = {
         "model_types": sorted(model_types),
         "aliases": dict(sorted((aliases or {}).items())),
     }
+    if kinds is not None:
+        entry["kinds"] = dict(sorted(kinds.items()))
+    return entry
 
 
 def model_capabilities(site_packages: Path) -> dict[str, object]:
@@ -209,11 +214,40 @@ def model_capabilities(site_packages: Path) -> dict[str, object]:
     vlm_models_root = mlx_vlm_root / "models"
 
     language_types = _loader_packages(vlm_models_root)
-    drafter_types = _loader_packages(mlx_vlm_root / "speculative" / "drafters")
+    drafters_root = mlx_vlm_root / "speculative" / "drafters"
+    drafter_types = _loader_packages(drafters_root)
+    drafter_initializer = drafters_root / "__init__.py"
+    explicit_drafter_kinds = _string_mapping(
+        drafter_initializer, "DRAFTER_KIND_BY_MODEL_TYPE"
+    )
+    default_drafter_kind = _literal_assignment(
+        _parse_module(drafter_initializer), "DEFAULT_DRAFTER_KIND"
+    )
+    known_drafter_kinds = _literal_assignment(
+        _parse_module(drafter_initializer), "KNOWN_DRAFTER_KINDS"
+    )
+    if (
+        not isinstance(default_drafter_kind, str)
+        or not isinstance(known_drafter_kinds, set)
+        or default_drafter_kind not in known_drafter_kinds
+        or any(not isinstance(kind, str) for kind in known_drafter_kinds)
+    ):
+        raise RuntimeError(f"{drafter_initializer} has invalid drafter kind metadata")
     vlm_alias_mapping = _string_mapping(mlx_vlm_root / "utils.py", "MODEL_REMAPPING")
     _validate_mapping_targets(vlm_alias_mapping, language_types | drafter_types)
     language_types = _apply_alias_precedence(language_types, vlm_alias_mapping)
     drafter_types = _apply_alias_precedence(drafter_types, vlm_alias_mapping)
+    resolved_drafter_kinds: dict[str, str] = {}
+    for model_type, kind in explicit_drafter_kinds.items():
+        loader = vlm_alias_mapping.get(model_type, model_type)
+        existing_kind = resolved_drafter_kinds.get(loader)
+        if existing_kind is not None and existing_kind != kind:
+            raise RuntimeError(f"Conflicting drafter kinds for loader {loader}")
+        resolved_drafter_kinds[loader] = kind
+    drafter_kinds = {
+        model_type: resolved_drafter_kinds.get(model_type, default_drafter_kind)
+        for model_type in drafter_types
+    }
 
     image_generation_types, image_editing_types = _image_model_types(vlm_models_root)
 
@@ -257,6 +291,7 @@ def model_capabilities(site_packages: Path) -> dict[str, object]:
         "speculative_drafters": _entry(
             drafter_types,
             _aliases_for(vlm_alias_mapping, drafter_types),
+            drafter_kinds,
         ),
         "image_generation": _entry(
             image_generation_types,
@@ -307,6 +342,7 @@ def validate_manifest(manifest: object) -> None:
             raise RuntimeError(f"Invalid {capability_name} capability entry")
         model_types = entry.get("model_types")
         aliases = entry.get("aliases")
+        kinds = entry.get("kinds")
         if (
             not isinstance(model_types, list)
             or not model_types
@@ -331,6 +367,19 @@ def validate_manifest(manifest: object) -> None:
             for alias, target in aliases.items()
         ):
             raise RuntimeError(f"Invalid {capability_name} aliases")
+        if capability_name == "speculative_drafters":
+            if (
+                not isinstance(kinds, dict)
+                or set(kinds) != set(model_types)
+                or any(
+                    not isinstance(kind, str)
+                    or kind not in {"dflash", "eagle3", "mtp"}
+                    for kind in kinds.values()
+                )
+            ):
+                raise RuntimeError("Invalid speculative drafter kinds")
+        elif kinds is not None:
+            raise RuntimeError(f"Unexpected {capability_name} model kinds")
 
 
 def generate_model_capabilities_manifest(site_packages: Path, output: Path) -> Path:

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -73,6 +73,16 @@ enum HuggingFaceSortDirection: Int, CaseIterable, Hashable, Identifiable, Sendab
 }
 
 enum HuggingFaceCapabilityFilter {
+    /// `draft-model` is the emerging convention, but older and vendor-specific
+    /// repositories use these aliases. `speculative-decoding` is deliberately
+    /// only a search candidate: config metadata must still identify a drafter.
+    static let drafterCandidateTags = [
+        "draft-model",
+        "drafter",
+        "speculative-decoding-draft",
+        "speculative-decoding",
+    ]
+
     /// Reasoning, tool calling, and drafter are Hub model tags rather than pipeline tasks.
     /// Apply them to the API request so Discover searches the full matching
     /// catalog instead of filtering a small window of unrelated trending models.
@@ -88,6 +98,17 @@ enum HuggingFaceCapabilityFilter {
             tags.append("draft-model")
         }
         return tags
+    }
+
+    static func hubTagSets(
+        for capabilities: Set<LocalModelCapability>
+    ) -> [[String]] {
+        let canonicalTags = hubTags(for: capabilities)
+        guard capabilities.contains(.drafter) else {
+            return [canonicalTags]
+        }
+        let commonTags = canonicalTags.filter { $0 != "draft-model" }
+        return drafterCandidateTags.map { commonTags + [$0] }
     }
 
     /// Select the canonical Hub task for a single Nativ model capability.
@@ -151,6 +172,8 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
     let id: String
     let downloads: Int
     let likes: Int
+    let trendingScore: Double
+    let lastModified: String?
     let pipelineTag: String?
     let libraryName: String?
     let tags: [String]
@@ -164,17 +187,21 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
     let sizeBytes: Int64?
     let capabilities: Set<LocalModelCapability>
     let memoryEstimate: LocalModelMemoryEstimate?
+    let drafterKind: String?
 
     enum CodingKeys: String, CodingKey {
         case id
         case downloads
         case likes
+        case trendingScore
+        case lastModified
         case pipelineTag = "pipeline_tag"
         case libraryName = "library_name"
         case tags
         case isPrivate = "private"
         case gated
         case safetensors
+        case modelConfiguration = "config"
     }
 
     init(from decoder: Decoder) throws {
@@ -182,11 +209,18 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         id = try container.decode(String.self, forKey: .id)
         downloads = try container.decodeIfPresent(Int.self, forKey: .downloads) ?? 0
         likes = try container.decodeIfPresent(Int.self, forKey: .likes) ?? 0
+        trendingScore =
+            try container.decodeIfPresent(Double.self, forKey: .trendingScore) ?? 0
+        lastModified = try container.decodeIfPresent(String.self, forKey: .lastModified)
         pipelineTag = try container.decodeIfPresent(String.self, forKey: .pipelineTag)
         libraryName = try container.decodeIfPresent(String.self, forKey: .libraryName)
         tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
         isPrivate = try container.decodeIfPresent(Bool.self, forKey: .isPrivate) ?? false
         safetensors = try container.decodeIfPresent(HuggingFaceSafetensors.self, forKey: .safetensors)
+        let modelConfiguration = try? container.decode(
+            DrafterModelConfiguration.self,
+            forKey: .modelConfiguration
+        )
 
         if let value = try? container.decode(Bool.self, forKey: .gated) {
             isGated = value
@@ -198,10 +232,15 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
 
         provider = LocalModelProviderResolver.resolve(repoID: id, modelType: nil, architectures: [])
         sizeBytes = safetensors?.sizeBytes
+        drafterKind =
+            MLXDrafterModelResolver.shared.metadata(
+                for: modelConfiguration
+            )?.kind
         capabilities = Self.resolveCapabilities(
             pipelineTag: pipelineTag,
             libraryName: libraryName,
-            tags: tags
+            tags: tags,
+            configIdentifiesDrafter: drafterKind != nil
         )
         memoryEstimate = Self.resolveMemoryEstimate(
             repoID: id,
@@ -293,7 +332,8 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
     private static func resolveCapabilities(
         pipelineTag: String?,
         libraryName: String?,
-        tags: [String]
+        tags: [String],
+        configIdentifiesDrafter: Bool
     ) -> Set<LocalModelCapability> {
         let pipeline = pipelineTag?.lowercased() ?? ""
         let descriptors = ([pipelineTag, libraryName].compactMap { $0 } + tags)
@@ -383,6 +423,9 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
             "draft-model", "drafter", "speculative-decoding-draft",
         ]
         if !normalizedTags.isDisjoint(with: drafterTags) {
+            result.insert(.drafter)
+        }
+        if configIdentifiesDrafter {
             result.insert(.drafter)
         }
         return result
@@ -519,39 +562,44 @@ private struct HuggingFaceHubClient: Sendable {
         capabilities: Set<LocalModelCapability>,
         token: String?
     ) async throws -> HuggingFaceModelPage {
-        var components = URLComponents()
-        components.scheme = "https"
-        components.host = "huggingface.co"
-        components.path = "/api/models"
-
-        let hubFilters = ["safetensors"]
-            + HuggingFaceCapabilityFilter.hubTags(for: capabilities)
-        var queryItems = [
-            URLQueryItem(name: "filter", value: hubFilters.joined(separator: ",")),
-            URLQueryItem(name: "sort", value: sort.apiSortValue),
-            // The Hub API currently rejects ascending requests for every sort.
-            // Ascending results are prepared locally by the library below.
-            URLQueryItem(name: "direction", value: HuggingFaceSortDirection.descending.apiValue),
-            URLQueryItem(name: "limit", value: "50")
-        ]
-        if let pipelineTag = HuggingFaceCapabilityFilter.pipelineTag(for: capabilities) {
-            queryItems.append(URLQueryItem(name: "pipeline_tag", value: pipelineTag))
-        }
-        queryItems.append(contentsOf: [
-            "downloads", "likes", "pipeline_tag", "library_name", "tags",
-            "private", "gated", "safetensors"
-        ].map { URLQueryItem(name: "expand[]", value: $0) })
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedQuery.isEmpty {
-            queryItems.append(URLQueryItem(name: "search", value: trimmedQuery))
-        }
-        components.queryItems = queryItems
+        let urls = try HuggingFaceCapabilityFilter.hubTagSets(for: capabilities).map {
+            hubTags in
+            var components = URLComponents()
+            components.scheme = "https"
+            components.host = "huggingface.co"
+            components.path = "/api/models"
 
-        guard let url = components.url else {
-            throw HuggingFaceHubError.invalidResponse
-        }
+            let hubFilters = ["safetensors"] + hubTags
+            var queryItems = [
+                URLQueryItem(name: "filter", value: hubFilters.joined(separator: ",")),
+                URLQueryItem(name: "sort", value: sort.apiSortValue),
+                // The Hub API currently rejects ascending requests for every sort.
+                // Ascending results are prepared locally by the library below.
+                URLQueryItem(
+                    name: "direction",
+                    value: HuggingFaceSortDirection.descending.apiValue
+                ),
+                URLQueryItem(name: "limit", value: "50"),
+            ]
+            if let pipelineTag = HuggingFaceCapabilityFilter.pipelineTag(for: capabilities) {
+                queryItems.append(URLQueryItem(name: "pipeline_tag", value: pipelineTag))
+            }
+            queryItems.append(
+                contentsOf: Self.expandedFields.map {
+                    URLQueryItem(name: "expand[]", value: $0)
+                })
+            if !trimmedQuery.isEmpty {
+                queryItems.append(URLQueryItem(name: "search", value: trimmedQuery))
+            }
+            components.queryItems = queryItems
 
-        return try await page(at: url, token: token)
+            guard let url = components.url else {
+                throw HuggingFaceHubError.invalidResponse
+            }
+            return url
+        }
+        return try await pages(at: urls, token: token)
     }
 
     func modelData(id: String, token: String?) async throws -> Data {
@@ -559,10 +607,9 @@ private struct HuggingFaceHubClient: Sendable {
         components.scheme = "https"
         components.host = "huggingface.co"
         components.path = "/api/models/\(id)"
-        components.queryItems = [
-            "downloads", "likes", "pipeline_tag", "library_name", "tags",
-            "private", "gated", "safetensors"
-        ].map { URLQueryItem(name: "expand[]", value: $0) }
+        components.queryItems = Self.expandedFields.map {
+            URLQueryItem(name: "expand[]", value: $0)
+        }
 
         guard let url = components.url else {
             throw HuggingFaceHubError.invalidResponse
@@ -584,7 +631,6 @@ private struct HuggingFaceHubClient: Sendable {
     }
 
     func page(at url: URL, token: String?) async throws -> HuggingFaceModelPage {
-
         var request = URLRequest(url: url)
         request.timeoutInterval = 20
         request.setValue("MLXPlatform/1.0", forHTTPHeaderField: "User-Agent")
@@ -604,7 +650,37 @@ private struct HuggingFaceHubClient: Sendable {
             }
         return HuggingFaceModelPage(
             models: models,
-            nextPageURL: nextPageURL(from: httpResponse.value(forHTTPHeaderField: "Link"))
+            nextPageURLs: [
+                nextPageURL(from: httpResponse.value(forHTTPHeaderField: "Link"))
+            ].compactMap { $0 }
+        )
+    }
+
+    func pages(at urls: [URL], token: String?) async throws -> HuggingFaceModelPage {
+        let indexedPages = try await withThrowingTaskGroup(
+            of: (Int, HuggingFaceModelPage).self,
+            returning: [(Int, HuggingFaceModelPage)].self
+        ) { group in
+            for (index, url) in urls.enumerated() {
+                group.addTask {
+                    (index, try await page(at: url, token: token))
+                }
+            }
+
+            var pages: [(Int, HuggingFaceModelPage)] = []
+            for try await page in group {
+                pages.append(page)
+            }
+            return pages.sorted { $0.0 < $1.0 }
+        }
+
+        var seenIDs = Set<String>()
+        let models = indexedPages.flatMap(\.1.models).filter {
+            seenIDs.insert($0.id).inserted
+        }
+        return HuggingFaceModelPage(
+            models: models,
+            nextPageURLs: indexedPages.flatMap(\.1.nextPageURLs)
         )
     }
 
@@ -619,11 +695,16 @@ private struct HuggingFaceHubClient: Sendable {
         }
         return URL(string: String(nextLink[nextLink.index(after: start)..<end]))
     }
+
+    private static let expandedFields = [
+        "downloads", "likes", "trendingScore", "lastModified", "pipeline_tag",
+        "library_name", "tags", "private", "gated", "safetensors", "config",
+    ]
 }
 
 private struct HuggingFaceModelPage: Sendable {
     let models: [HuggingFaceModel]
-    let nextPageURL: URL?
+    let nextPageURLs: [URL]
 }
 
 struct HuggingFaceCuratedModelLoader: Sendable {
@@ -728,7 +809,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
     private var activeSort: HuggingFaceModelSort = .downloads
     private var activeDirection: HuggingFaceSortDirection = .descending
     private var visibilityPredicate: (HuggingFaceModel) -> Bool = { _ in true }
-    private var nextPageURL: URL?
+    private var nextPageURLs: [URL] = []
     private let pageSize = 24
     private let maximumPageCount = 5
     private let maximumFillFetches = 8
@@ -750,7 +831,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
         error = nil
         models = []
         buffer = []
-        nextPageURL = nil
+        nextPageURLs = []
         pageNumber = 1
         activeSort = sort
         activeDirection = direction
@@ -766,8 +847,8 @@ final class HuggingFaceModelLibrary: ObservableObject {
                     token: token
                 )
                 try Task.checkCancellation()
-                self.buffer = page.models
-                self.nextPageURL = page.nextPageURL
+                self.mergeIntoBuffer(page.models)
+                self.nextPageURLs = page.nextPageURLs
                 let needsStableLocalOrdering = sort.sortsBySize || direction == .ascending
                 let targetCount = needsStableLocalOrdering
                     ? self.maximumPageCount * self.pageSize : self.pageSize
@@ -775,7 +856,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
                 if needsStableLocalOrdering {
                     // Local ordering spans Nativ's complete five-page window.
                     // Stop here so later pagination cannot reshuffle earlier pages.
-                    self.nextPageURL = nil
+                    self.nextPageURLs = []
                 }
                 try Task.checkCancellation()
                 self.models = self.slice(forPage: 1)
@@ -799,7 +880,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
         error = nil
         models = []
         buffer = []
-        nextPageURL = nil
+        nextPageURLs = []
         pageNumber = 1
         activeSort = .downloads
         activeDirection = .descending
@@ -828,7 +909,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
 
     var canGoToNextPage: Bool {
         guard !isSearching, pageNumber < maximumPageCount else { return false }
-        return orderedVisible.count > pageNumber * pageSize || nextPageURL != nil
+        return orderedVisible.count > pageNumber * pageSize || !nextPageURLs.isEmpty
     }
 
     func goToPreviousPage() {
@@ -842,7 +923,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
         guard canGoToNextPage else { return }
         let target = pageNumber + 1
 
-        if orderedVisible.count >= target * pageSize || nextPageURL == nil {
+        if orderedVisible.count >= target * pageSize || nextPageURLs.isEmpty {
             pageNumber = target
             models = slice(forPage: target)
             error = nil
@@ -876,14 +957,22 @@ final class HuggingFaceModelLibrary: ObservableObject {
     }
 
     private func fillBuffer(upTo count: Int, token: String?) async throws {
-        var fetches = 0
-        while orderedVisible.count < count, let url = nextPageURL, fetches < maximumFillFetches {
-            let nextPage = try await client.page(at: url, token: token)
+        var fetchRounds = 0
+        while orderedVisible.count < count,
+            !nextPageURLs.isEmpty,
+            fetchRounds < maximumFillFetches
+        {
+            let nextPage = try await client.pages(at: nextPageURLs, token: token)
             try Task.checkCancellation()
-            buffer.append(contentsOf: nextPage.models)
-            nextPageURL = nextPage.nextPageURL
-            fetches += 1
+            mergeIntoBuffer(nextPage.models)
+            nextPageURLs = nextPage.nextPageURLs
+            fetchRounds += 1
         }
+    }
+
+    private func mergeIntoBuffer(_ models: [HuggingFaceModel]) {
+        var knownIDs = Set(buffer.map(\.id))
+        buffer.append(contentsOf: models.filter { knownIDs.insert($0.id).inserted })
     }
 
     private func slice(forPage number: Int) -> [HuggingFaceModel] {
@@ -893,21 +982,56 @@ final class HuggingFaceModelLibrary: ObservableObject {
         return Array(ordered[start..<min(start + pageSize, ordered.count)])
     }
 
-    /// Buffered results in display order. The Hub only provides descending
-    /// server-side results, so ascending and size ordering are applied locally
-    /// after the complete app-sized result window has been fetched.
+    /// Buffered results in display order. Drafter discovery merges several Hub
+    /// tag searches, so every sort is applied locally after de-duplication.
     private var orderedBuffer: [HuggingFaceModel] {
-        if activeSort.sortsBySize {
-            return buffer.sorted { lhs, rhs in
-                switch (lhs.sizeBytes, rhs.sizeBytes) {
-                case let (lhsSize?, rhsSize?):
-                    return activeDirection == .ascending ? lhsSize < rhsSize : lhsSize > rhsSize
-                case (nil, _): return false
-                case (_, nil): return true
+        buffer.sorted { lhs, rhs in
+            let isAscending = activeDirection == .ascending
+            switch activeSort {
+            case .downloads:
+                if lhs.downloads != rhs.downloads {
+                    return isAscending
+                        ? lhs.downloads < rhs.downloads : lhs.downloads > rhs.downloads
+                }
+            case .trending:
+                if lhs.trendingScore != rhs.trendingScore {
+                    return isAscending
+                        ? lhs.trendingScore < rhs.trendingScore
+                        : lhs.trendingScore > rhs.trendingScore
+                }
+            case .likes:
+                if lhs.likes != rhs.likes {
+                    return isAscending ? lhs.likes < rhs.likes : lhs.likes > rhs.likes
+                }
+            case .recentlyUpdated:
+                if lhs.lastModified != rhs.lastModified {
+                    switch (lhs.lastModified, rhs.lastModified) {
+                    case (let lhsDate?, let rhsDate?):
+                        return isAscending ? lhsDate < rhsDate : lhsDate > rhsDate
+                    case (nil, _):
+                        return false
+                    case (_, nil):
+                        return true
+                    }
+                }
+            case .size:
+                if lhs.sizeBytes != rhs.sizeBytes {
+                    switch (lhs.sizeBytes, rhs.sizeBytes) {
+                    case (let lhsSize?, let rhsSize?):
+                        return isAscending ? lhsSize < rhsSize : lhsSize > rhsSize
+                    case (nil, _):
+                        return false
+                    case (_, nil):
+                        return true
+                    }
                 }
             }
+            let comparison = lhs.id.localizedCaseInsensitiveCompare(rhs.id)
+            if comparison != .orderedSame {
+                return comparison == .orderedAscending
+            }
+            return lhs.id < rhs.id
         }
-        return activeDirection == .ascending ? Array(buffer.reversed()) : buffer
     }
 
     private var orderedVisible: [HuggingFaceModel] {

--- a/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
+++ b/Sources/Nativ/Features/Models/LocalModelDiscovery.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NativServerKit
 
 extension Notification.Name {
     static let localModelLibraryDidChange = Notification.Name("LocalModelLibraryDidChange")
@@ -274,6 +275,220 @@ struct LocalModelConfigurationMetadata: Equatable, Sendable {
     let contextSize: Int?
     let defaultSystemPrompt: String?
     let hiddenSize: Int?
+}
+
+struct DrafterModelConfiguration: Decodable, Equatable, Sendable {
+    struct DFlashConfiguration: Decodable, Equatable, Sendable {
+        let projectorType: String?
+        let markovRank: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case projectorType = "projector_type"
+            case markovRank = "markov_rank"
+        }
+
+        init(projectorType: String?, markovRank: Int?) {
+            self.projectorType = projectorType
+            self.markovRank = markovRank
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            projectorType = try? container.decode(String.self, forKey: .projectorType)
+            markovRank = try? container.decode(Int.self, forKey: .markovRank)
+        }
+    }
+
+    let modelType: String?
+    let speculatorsModelType: String?
+    let architectures: [String]
+    let dflashConfiguration: DFlashConfiguration?
+    let markovRank: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case speculatorsModelType = "speculators_model_type"
+        case architectures
+        case dflashConfiguration = "dflash_config"
+        case markovRank = "markov_rank"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try? container.decode(String.self, forKey: .modelType)
+        speculatorsModelType = try? container.decode(
+            String.self,
+            forKey: .speculatorsModelType
+        )
+        architectures = (try? container.decode(
+            [String].self,
+            forKey: .architectures
+        )) ?? []
+        dflashConfiguration = try? container.decode(
+            DFlashConfiguration.self,
+            forKey: .dflashConfiguration
+        )
+        markovRank = try? container.decode(Int.self, forKey: .markovRank)
+    }
+
+    init(config: [String: Any]) {
+        modelType = config["model_type"] as? String
+        speculatorsModelType = config["speculators_model_type"] as? String
+        architectures = config["architectures"] as? [String] ?? []
+        markovRank = (config["markov_rank"] as? NSNumber)?.intValue
+
+        if let dflashConfig = config["dflash_config"] as? [String: Any] {
+            dflashConfiguration = DFlashConfiguration(
+                projectorType: dflashConfig["projector_type"] as? String,
+                markovRank: (dflashConfig["markov_rank"] as? NSNumber)?.intValue
+            )
+        } else {
+            dflashConfiguration = nil
+        }
+    }
+}
+
+struct MLXDrafterMetadata: Equatable, Sendable {
+    let loaderModelType: String
+    let kind: String
+}
+
+/// Resolves config metadata to a speculative drafter loader bundled with Nativ.
+/// Repository names are intentionally not considered.
+struct MLXDrafterModelResolver: Sendable {
+    static let shared = Self(
+        registry: try? Nativ.modelTypeRegistry(),
+        fallbackKinds: [:]
+    )
+
+    private let registry: NativModelTypeRegistry?
+    private let fallbackKinds: [String: String]
+
+    private init(
+        registry: NativModelTypeRegistry?,
+        fallbackKinds: [String: String]
+    ) {
+        self.registry = registry
+        self.fallbackKinds = fallbackKinds
+    }
+
+    init(supportedDrafterKinds: [String: String]) {
+        registry = nil
+        fallbackKinds = supportedDrafterKinds
+    }
+
+    func metadata(for configuration: DrafterModelConfiguration?) -> MLXDrafterMetadata? {
+        guard let configuration else {
+            return nil
+        }
+
+        for candidate in candidateModelTypes(for: configuration) {
+            let loader: String
+            if let registry {
+                guard
+                    let bundledLoader = registry.loader(
+                        for: candidate,
+                        capability: .speculativeDrafters
+                    )
+                else {
+                    continue
+                }
+                loader = bundledLoader
+            } else {
+                guard fallbackKinds[candidate] != nil else {
+                    continue
+                }
+                loader = candidate
+            }
+
+            let kind =
+                registry?.drafterKind(for: candidate)
+                ?? fallbackKinds[loader]
+            if let kind {
+                return MLXDrafterMetadata(loaderModelType: loader, kind: kind)
+            }
+        }
+        return nil
+    }
+
+    static func inferredKind(fromModelType modelType: String?) -> String? {
+        guard let modelType = normalized(modelType) else {
+            return nil
+        }
+        let explicitKinds: [String: String] = [
+            "gemma4_assistant": "mtp",
+            "gemma4_unified_assistant": "mtp",
+            "inkling_mtp": "mtp",
+            "laguna": "dflash",
+            "muse_glimmer_assistant": "dflash",
+        ]
+        if let kind = explicitKinds[modelType] {
+            return kind
+        }
+        if modelType.contains("mtp") {
+            return "mtp"
+        }
+        if modelType.contains("dflash") || modelType.contains("dspark") {
+            return "dflash"
+        }
+        if modelType.contains("eagle") {
+            return "eagle3"
+        }
+        return nil
+    }
+
+    private func candidateModelTypes(
+        for configuration: DrafterModelConfiguration
+    ) -> [String] {
+        let modelType = Self.normalized(configuration.modelType)
+        let speculatorsModelType = Self.normalized(configuration.speculatorsModelType)
+        let architectures = configuration.architectures.map { $0.lowercased() }
+        var candidates: [String] = []
+
+        func append(_ candidate: String?) {
+            guard let candidate, !candidates.contains(candidate) else {
+                return
+            }
+            candidates.append(candidate)
+        }
+
+        if architectures.contains(where: { $0.contains("dflash2") }) {
+            append("dflash2")
+        } else if architectures.contains(where: { $0.contains("gemma4dspark") }) {
+            append("gemma4_dspark")
+        } else if architectures.contains(where: { $0.contains("dspark") }) {
+            append("dspark")
+        } else if architectures.contains(where: { $0.contains("eagle3") }) {
+            append("eagle3")
+        } else if let baseModelType = modelType,
+            architectures.contains(where: { $0.contains("dflash") })
+        {
+            append("\(baseModelType)_dflash")
+        }
+
+        if configuration.dflashConfiguration != nil {
+            if isDSpark(configuration) {
+                append("dspark")
+            } else if let baseModelType = modelType ?? speculatorsModelType {
+                append("\(baseModelType)_dflash")
+            }
+        }
+
+        append(modelType ?? speculatorsModelType)
+        return candidates
+    }
+
+    private func isDSpark(_ configuration: DrafterModelConfiguration) -> Bool {
+        configuration.dflashConfiguration?.projectorType?.lowercased() == "dspark"
+            || (configuration.markovRank ?? 0) > 0
+            || (configuration.dflashConfiguration?.markovRank ?? 0) > 0
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return normalized?.isEmpty == false ? normalized : nil
+    }
 }
 
 enum LocalModelDiscovery {
@@ -1276,7 +1491,8 @@ enum LocalModelDiscovery {
         )
         var capabilities = Set<LocalModelCapability>()
 
-        if drafterKind(fromModelType: drafterModelType(in: config)) != nil {
+        let drafterConfiguration = DrafterModelConfiguration(config: config)
+        if MLXDrafterModelResolver.shared.metadata(for: drafterConfiguration) != nil {
             capabilities.insert(.drafter)
         }
 
@@ -1528,35 +1744,7 @@ enum LocalModelDiscovery {
     }
 
     static func drafterKind(fromModelType modelType: String?) -> String? {
-        guard let modelType = modelType?.lowercased(), !modelType.isEmpty else {
-            return nil
-        }
-        let exactKinds: [String: String] = [
-            "deepseek_v4_mtp": "mtp",
-            "eagle3": "eagle3",
-            "gemma4_assistant": "mtp",
-            "gemma4_unified_assistant": "mtp",
-            "glm4_moe_lite_mtp": "mtp",
-            "inkling_mtp": "mtp",
-            "qwen3_5_mtp": "mtp"
-        ]
-        if let kind = exactKinds[modelType] {
-            return kind
-        }
-        if modelType.contains("mtp") {
-            return "mtp"
-        }
-        if modelType.contains("dflash") {
-            return "dflash"
-        }
-        if modelType.contains("eagle") {
-            return "eagle3"
-        }
-        return nil
-    }
-
-    private static func drafterModelType(in config: [String: Any]) -> String? {
-        (config["model_type"] as? String) ?? (config["speculators_model_type"] as? String)
+        MLXDrafterModelResolver.inferredKind(fromModelType: modelType)
     }
 
     private static func hiddenSize(in config: [String: Any]) -> Int? {
@@ -1590,7 +1778,9 @@ enum LocalModelDiscovery {
             return (nil, nil)
         }
         return (
-            drafterKind(fromModelType: drafterModelType(in: config)),
+            MLXDrafterModelResolver.shared.metadata(
+                for: DrafterModelConfiguration(config: config)
+            )?.kind,
             hiddenSize(in: config)
         )
     }

--- a/Sources/NativServerKit/NativModelTypeRegistry.swift
+++ b/Sources/NativServerKit/NativModelTypeRegistry.swift
@@ -19,6 +19,8 @@ public enum NativModelTypeRegistryError: Error, Equatable, Sendable {
     case emptyCapability(NativModelCapability)
     case invalidModelType(String, NativModelCapability)
     case invalidAlias(String, String, NativModelCapability)
+    case invalidModelKinds(NativModelCapability)
+    case invalidModelKind(String, String, NativModelCapability)
 }
 
 /// A validated view of the loaders shipped inside Nativ's bundled MLX runtime.
@@ -91,9 +93,36 @@ public struct NativModelTypeRegistry: Equatable, Sendable {
                 aliases[normalizedAlias] = normalizedLoader
             }
 
+            if let manifestKinds = manifestEntry.kinds {
+                guard capability == .speculativeDrafters,
+                      Set(manifestKinds.keys) == modelTypes
+                else {
+                    throw NativModelTypeRegistryError.invalidModelKinds(capability)
+                }
+            }
+
+            var kinds: [String: String] = [:]
+            for (modelType, kind) in manifestEntry.kinds ?? [:] {
+                guard let normalizedModelType = Self.normalized(modelType),
+                    let normalizedKind = Self.normalized(kind),
+                    normalizedModelType == modelType,
+                    normalizedKind == kind,
+                    modelTypes.contains(normalizedModelType),
+                    Self.knownDrafterKinds.contains(normalizedKind)
+                else {
+                    throw NativModelTypeRegistryError.invalidModelKind(
+                        modelType,
+                        kind,
+                        capability
+                    )
+                }
+                kinds[normalizedModelType] = normalizedKind
+            }
+
             validatedEntries[capability] = Entry(
                 modelTypes: modelTypes,
-                aliases: aliases
+                aliases: aliases,
+                kinds: kinds
             )
         }
 
@@ -129,17 +158,34 @@ public struct NativModelTypeRegistry: Equatable, Sendable {
         )
     }
 
+    /// The speculative round-loop kind assigned by the bundled mlx-vlm
+    /// runtime. Aliases are resolved through the same loader table first.
+    public func drafterKind(for modelType: String) -> String? {
+        guard
+            let loader = loader(
+                for: modelType,
+                capability: .speculativeDrafters
+            )
+        else {
+            return nil
+        }
+        return entries[.speculativeDrafters]?.kinds[loader]
+    }
+
     private static func normalized(_ modelType: String) -> String? {
         let value = modelType.trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         return value.isEmpty ? nil : value
     }
+
+    private static let knownDrafterKinds: Set<String> = ["dflash", "eagle3", "mtp"]
 }
 
 private extension NativModelTypeRegistry {
     struct Entry: Equatable, Sendable {
         let modelTypes: Set<String>
         let aliases: [String: String]
+        let kinds: [String: String]
     }
 
     struct Manifest: Decodable {
@@ -157,10 +203,12 @@ private extension NativModelTypeRegistry {
     struct ManifestEntry: Decodable {
         let modelTypes: [String]
         let aliases: [String: String]
+        let kinds: [String: String]?
 
         enum CodingKeys: String, CodingKey {
             case modelTypes = "model_types"
             case aliases
+            case kinds
         }
     }
 }

--- a/Tests/NativTests/LocalModelDiscoveryTests.swift
+++ b/Tests/NativTests/LocalModelDiscoveryTests.swift
@@ -562,6 +562,101 @@ final class LocalModelDiscoveryTests: XCTestCase {
         XCTAssertNil(LocalModelDiscovery.drafterKind(fromModelType: ""))
     }
 
+    func testDrafterMetadataResolverUsesConfigInsteadOfRepositoryNames() throws {
+        let resolver = MLXDrafterModelResolver(
+            supportedDrafterKinds: [
+                "qwen3_5_mtp": "mtp",
+                "qwen3_dflash": "dflash",
+                "dspark": "dflash",
+                "eagle3": "eagle3",
+            ]
+        )
+        let fixtures: [([String: Any], MLXDrafterMetadata)] = [
+            (
+                ["model_type": "qwen3_5_mtp"],
+                MLXDrafterMetadata(loaderModelType: "qwen3_5_mtp", kind: "mtp")
+            ),
+            (
+                [
+                    "model_type": "qwen3",
+                    "architectures": ["DFlashDraftModel"],
+                    "dflash_config": [:],
+                ],
+                MLXDrafterMetadata(loaderModelType: "qwen3_dflash", kind: "dflash")
+            ),
+            (
+                [
+                    "model_type": "qwen3",
+                    "architectures": ["DSparkDraftModel"],
+                    "dflash_config": ["projector_type": "dspark"],
+                    "markov_rank": 512,
+                ],
+                MLXDrafterMetadata(loaderModelType: "dspark", kind: "dflash")
+            ),
+            (
+                ["architectures": ["Eagle3DraftModel"]],
+                MLXDrafterMetadata(loaderModelType: "eagle3", kind: "eagle3")
+            ),
+        ]
+
+        for (config, expected) in fixtures {
+            let data = try JSONSerialization.data(withJSONObject: config)
+            let decoded = try JSONDecoder().decode(DrafterModelConfiguration.self, from: data)
+            XCTAssertEqual(resolver.metadata(for: decoded), expected)
+        }
+
+        let targetConfig = try JSONDecoder().decode(
+            DrafterModelConfiguration.self,
+            from: JSONSerialization.data(withJSONObject: [
+                "model_type": "qwen3",
+                "speculators_model_type": "eagle3",
+                "num_nextn_predict_layers": 1,
+            ])
+        )
+        XCTAssertNil(resolver.metadata(for: targetConfig))
+    }
+
+    func testScanClassifiesSupportedDrafterConfigFamilies() async throws {
+        let fixtures: [(String, [String: Any], String)] = [
+            ("org/mtp", ["model_type": "qwen3_5_mtp"], "mtp"),
+            (
+                "org/dflash",
+                [
+                    "model_type": "qwen3",
+                    "architectures": ["DFlashDraftModel"],
+                    "dflash_config": [:],
+                ],
+                "dflash"
+            ),
+            (
+                "org/dspark",
+                [
+                    "model_type": "qwen3",
+                    "architectures": ["DSparkDraftModel"],
+                    "dflash_config": ["projector_type": "dspark"],
+                    "markov_rank": 512,
+                ],
+                "dflash"
+            ),
+            (
+                "org/eagle3",
+                ["architectures": ["Eagle3DraftModel"]],
+                "eagle3"
+            ),
+        ]
+        for (repoID, config, _) in fixtures {
+            try makeDrafterSnapshot(repoID: repoID, config: config)
+        }
+
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+
+        for (repoID, _, expectedKind) in fixtures {
+            let model = try XCTUnwrap(models.first { $0.repoID == repoID })
+            XCTAssertTrue(model.capabilities.contains(.drafter), repoID)
+            XCTAssertEqual(model.drafterKind, expectedKind, repoID)
+        }
+    }
+
     func testDrafterExcludedFromLanguageModelPicker() {
         let drafter = makeModel(
             repoID: "mlx-community/Qwen3.5-4B-MTP-4bit",
@@ -595,6 +690,20 @@ final class LocalModelDiscoveryTests: XCTestCase {
             withIntermediateDirectories: true
         )
         try Data(string.utf8).write(to: url)
+    }
+
+    private func makeDrafterSnapshot(
+        repoID: String,
+        config: [String: Any]
+    ) throws {
+        let snapshot = snapshotURL(repoID: repoID)
+        let repository =
+            snapshot
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        try write(snapshot.lastPathComponent, to: repository.appendingPathComponent("refs/main"))
+        try writeJSON(config, to: snapshot.appendingPathComponent("config.json"))
+        try write("weights", to: snapshot.appendingPathComponent("model.safetensors"))
     }
 
     private func makeModel(

--- a/Tests/NativTests/LocalModelProviderTests.swift
+++ b/Tests/NativTests/LocalModelProviderTests.swift
@@ -1,3 +1,4 @@
+import NativServerKit
 import XCTest
 
 final class LocalModelProviderTests: XCTestCase {
@@ -167,6 +168,18 @@ final class HuggingFaceCapabilityFilterTests: XCTestCase {
         )
     }
 
+    func testDrafterDiscoverySearchesKnownTagVariants() {
+        XCTAssertEqual(
+            HuggingFaceCapabilityFilter.hubTagSets(for: [.drafter]),
+            [
+                ["draft-model"],
+                ["drafter"],
+                ["speculative-decoding-draft"],
+                ["speculative-decoding"],
+            ]
+        )
+    }
+
     func testSupportedCapabilitiesUseCanonicalPipelineTasks() {
         XCTAssertEqual(
             HuggingFaceCapabilityFilter.pipelineTag(for: [.text]),
@@ -249,6 +262,37 @@ final class HuggingFaceCapabilityFilterTests: XCTestCase {
         )
     }
 
+    func testBroadSpeculativeDecodingCandidateUsesConfigMetadata() throws {
+        let model = try decodeModel(
+            pipelineTag: "text-generation",
+            tags: ["speculative-decoding"],
+            config: [
+                "model_type": "qwen3",
+                "architectures": ["DFlashDraftModel"],
+                "dflash_config": [:],
+            ]
+        )
+
+        XCTAssertTrue(model.capabilities.contains(.drafter))
+        XCTAssertEqual(model.drafterKind, "dflash")
+    }
+
+    func testMalformedDrafterConfigDoesNotBreakHubModelDecoding() throws {
+        let model = try decodeModel(
+            pipelineTag: "text-generation",
+            tags: ["draft-model"],
+            config: [
+                "model_type": 42,
+                "architectures": "DFlashDraftModel",
+                "dflash_config": "invalid",
+                "markov_rank": "invalid",
+            ]
+        )
+
+        XCTAssertTrue(model.capabilities.contains(.drafter))
+        XCTAssertNil(model.drafterKind)
+    }
+
     func testGGUFTaggedSafetensorsRepositoryRemainsVisible() throws {
         let model = try decodeModel(
             id: "test/model-GGUF",
@@ -285,7 +329,8 @@ final class HuggingFaceCapabilityFilterTests: XCTestCase {
         id: String = "test/model",
         pipelineTag: String,
         tags: [String] = [],
-        safetensors: [String: Any]? = nil
+        safetensors: [String: Any]? = nil,
+        config: [String: Any]? = nil
     ) throws -> HuggingFaceModel {
         var payload: [String: Any] = [
             "id": id,
@@ -293,8 +338,68 @@ final class HuggingFaceCapabilityFilterTests: XCTestCase {
             "tags": tags,
         ]
         payload["safetensors"] = safetensors
+        payload["config"] = config
         let data = try JSONSerialization.data(withJSONObject: payload)
         return try JSONDecoder().decode(HuggingFaceModel.self, from: data)
+    }
+}
+
+final class NativModelTypeRegistryDrafterTests: XCTestCase {
+    func testDrafterKindsFollowCanonicalLoaderAndAliases() throws {
+        var capabilities: [String: Any] = [:]
+        for capability in NativModelCapability.allCases {
+            capabilities[capability.rawValue] = [
+                "model_types": ["test_\(capability.rawValue)"],
+                "aliases": [:],
+            ]
+        }
+        capabilities[NativModelCapability.speculativeDrafters.rawValue] = [
+            "model_types": ["qwen3_dflash"],
+            "aliases": ["qwen3-dflash": "qwen3_dflash"],
+            "kinds": ["qwen3_dflash": "dflash"],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: [
+            "schema_version": 1,
+            "package_versions": ["mlx-vlm": "1.0", "mlx-audio": "1.0"],
+            "capabilities": capabilities,
+        ])
+
+        let registry = try NativModelTypeRegistry(data: data)
+
+        XCTAssertEqual(registry.drafterKind(for: "qwen3_dflash"), "dflash")
+        XCTAssertEqual(registry.drafterKind(for: "qwen3-dflash"), "dflash")
+        XCTAssertNil(registry.drafterKind(for: "qwen3"))
+    }
+
+    func testDrafterKindsRejectUnknownRuntimeKinds() throws {
+        var capabilities: [String: Any] = [:]
+        for capability in NativModelCapability.allCases {
+            capabilities[capability.rawValue] = [
+                "model_types": ["test_\(capability.rawValue)"],
+                "aliases": [:],
+            ]
+        }
+        capabilities[NativModelCapability.speculativeDrafters.rawValue] = [
+            "model_types": ["future_drafter"],
+            "aliases": [:],
+            "kinds": ["future_drafter": "unknown"],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: [
+            "schema_version": 1,
+            "package_versions": ["mlx-vlm": "1.0", "mlx-audio": "1.0"],
+            "capabilities": capabilities,
+        ])
+
+        XCTAssertThrowsError(try NativModelTypeRegistry(data: data)) { error in
+            XCTAssertEqual(
+                error as? NativModelTypeRegistryError,
+                .invalidModelKind(
+                    "future_drafter",
+                    "unknown",
+                    .speculativeDrafters
+                )
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This updates the heuristics for draft model discovery to match `mlx-vlm`, and significantly improves our ability to detect draft models of all types (MTP, DFlash, DSpark, etc)