### PR TITLE
Reorder navigation in the sidebar

### DIFF
--- a/Sources/Nativ/Features/ControlPanel/ControlPanelNavigation.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelNavigation.swift
@@ -19,11 +19,11 @@ enum ControlPanelTab: String, CaseIterable, Identifiable {
     static var allCases: [ControlPanelTab] {
         [
             .chat,
-            .scheduled,
+            .models,
             .artifacts,
+            .scheduled,
             .dashboard,
             .system,
-            .models,
             .extensions,
             .dev,
         ]

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
@@ -236,7 +236,7 @@ extension ControlPanelView {
             ForEach(ControlPanelTab.allCases) { tab in
                 sidebarTabButton(tab)
 
-                if tab == .chat {
+                if tab == .models {
                     ForEach(contentState.extensionSidebarContributions) { contribution in
                         extensionSidebarButton(contribution)
                     }


### PR DESCRIPTION
This is based on what I think would be frequency of use for each section, but open to alternative viewpoints.

<img width="259" height="317" alt="Screenshot 2026-09-02 at 11 21 00 AM" src="https://github.com/user-attachments/assets/15d1e7cf-fa62-47a0-9778-d1358711786c" />
