### PR TITLE
Add Granite Speech 5.0 to STT model resolver

### DIFF
--- a/Sources/Nativ/Features/Models/ModelPrimaryTaskResolver.swift
+++ b/Sources/Nativ/Features/Models/ModelPrimaryTaskResolver.swift
@@ -161,6 +161,7 @@ enum ModelPrimaryTaskResolver {
         "fireredasr2",
         "glmasr",
         "granite_speech",
+        "granite_speech5_ctc",
         "lasr",
         "lasr_ctc",
         "moonshine",

--- a/Tests/NativTests/LocalModelDiscoveryTests.swift
+++ b/Tests/NativTests/LocalModelDiscoveryTests.swift
@@ -100,6 +100,22 @@ final class LocalModelDiscoveryTests: XCTestCase {
         XCTAssertTrue(model.capabilities.contains(.text))
     }
 
+    func testClassifiesGraniteSpeech5CTCAsSpeechToText() async throws {
+        try makeTextModelSnapshot(
+            repoID: "ibm-granite/granite-speech-5.0-470m-turboctc",
+            modelType: "granite_speech5_ctc",
+            architectures: ["GraniteSpeech5ForCTC"],
+            sentenceTransformer: false
+        )
+
+        let models = try await LocalModelDiscovery.scan(searchPaths: searchPaths)
+        let model = try XCTUnwrap(models.first)
+
+        XCTAssertTrue(model.capabilities.contains(.audio))
+        XCTAssertTrue(model.capabilities.contains(.speechToText))
+        XCTAssertFalse(model.capabilities.contains(.text))
+    }
+
     func testClassifiesLLMBasedEmbedderWithPoolingAsEmbeddingModel() async throws {
         try makeTextModelSnapshot(
             repoID: "org/qwen3-embedding",

--- a/Tests/NativTests/ModelPrimaryTaskResolverTests.swift
+++ b/Tests/NativTests/ModelPrimaryTaskResolverTests.swift
@@ -25,6 +25,18 @@ final class ModelPrimaryTaskResolverTests: XCTestCase {
         XCTAssertFalse(task.includesLanguageCapability(fallbackMatch: true))
     }
 
+    func testGraniteSpeech5CTCIsSpeechToText() {
+        let task = resolve(
+            model: "ibm-granite/granite-speech-5.0-470m-turboctc",
+            modelType: "granite_speech5_ctc",
+            architecture: "GraniteSpeech5ForCTC"
+        )
+
+        XCTAssertEqual(task, .speechToText)
+        XCTAssertFalse(task.isLanguageCapable)
+        XCTAssertFalse(task.includesLanguageCapability(fallbackMatch: true))
+    }
+
     func testQwenTTSIsNotLanguageModel() {
         let task = resolve(
             model: "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit",


### PR DESCRIPTION
This is a new model arch so it needs to be added to the resolver to be used for STT in-app.