### PR TITLE
Add model pinning

### DIFF
--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -590,6 +590,8 @@ struct ModelsView: View {
     private func installedRows(showsResultsHeader: Bool) -> some View {
         let visibleModels = filteredLocalModels
         let normalizedSettings = modelState.settings.normalized()
+        let pinnedIDs = Set(normalizedSettings.pinnedModelIDs)
+            .intersection(visibleModels.lazy.map(\.repoID))
 
         if let error = localLibrary.error {
             ModelsNotice(
@@ -623,7 +625,15 @@ struct ModelsView: View {
                     .modelsListRow(top: 0)
             }
 
-            ForEach(visibleModels) { localModel in
+            ForEach(Array(visibleModels.enumerated()), id: \.element.id) { index, localModel in
+                if shouldShowPinnedHeading(at: index, in: visibleModels, pinnedIDs: pinnedIDs) {
+                    ModelsPinnedSectionHeader(title: "Pinned", systemImage: "pin.fill")
+                        .modelsListRow(top: 8, bottom: 2)
+                }
+                if shouldShowOtherModelsHeading(at: index, in: visibleModels, pinnedIDs: pinnedIDs) {
+                    ModelsPinnedSectionHeader(title: "All models", systemImage: "square.stack.3d.up")
+                        .modelsListRow(top: 12, bottom: 2)
+                }
                 let preloadSlots = preloadSlots(for: localModel)
                 let selectedSlots = Set(
                     ModelPreloadSlot.allCases.filter {
@@ -649,6 +659,7 @@ struct ModelsView: View {
                         && !isModelInUse(localModel.repoID),
                     isSelecting: installedModelSelection.isActive,
                     isSelectedForDeletion: installedModelSelection.contains(localModel.repoID),
+                    isPinned: pinnedIDs.contains(localModel.repoID),
                     onSetPreload: { slot, isEnabled in
                         if isEnabled {
                             model.requestPreloadedModelSwitch(
@@ -668,6 +679,7 @@ struct ModelsView: View {
                         )
                     },
                     onToggleSelection: { toggleInstalledModelSelection(localModel) },
+                    onTogglePin: { togglePin(for: localModel.repoID) },
                     onDelete: { deleteInstalledModel(localModel) }
                 )
                 .equatable()
@@ -1025,6 +1037,7 @@ struct ModelsView: View {
             if settings.speechToTextModelID == localModel.repoID {
                 settings.speechToTextModelID = nil
             }
+            settings.pinnedModelIDs.removeAll { $0 == localModel.repoID }
             model.settings = settings
             NotificationCenter.default.post(name: .localModelLibraryDidChange, object: nil)
         }
@@ -1052,6 +1065,34 @@ struct ModelsView: View {
         installedModelSelection.finish()
     }
 
+    private func togglePin(for modelID: String) {
+        var settings = model.settings
+        if settings.pinnedModelIDs.contains(modelID) {
+            settings.pinnedModelIDs.removeAll { $0 == modelID }
+        } else {
+            settings.pinnedModelIDs.insert(modelID, at: 0)
+        }
+        model.settings = settings.normalized()
+    }
+
+    private func shouldShowPinnedHeading(
+        at index: Int,
+        in models: [LocalModel],
+        pinnedIDs: Set<String>
+    ) -> Bool {
+        index == 0 && pinnedIDs.contains(models[index].repoID)
+    }
+
+    private func shouldShowOtherModelsHeading(
+        at index: Int,
+        in models: [LocalModel],
+        pinnedIDs: Set<String>
+    ) -> Bool {
+        !pinnedIDs.isEmpty
+            && !pinnedIDs.contains(models[index].repoID)
+            && (index == 0 || pinnedIDs.contains(models[index - 1].repoID))
+    }
+
     private var filteredLocalModels: [LocalModel] {
         let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         var models =
@@ -1066,11 +1107,22 @@ struct ModelsView: View {
         models = models.filter { typeFilter.matches($0.capabilities) }
 
         let settings = modelState.settings.normalized()
+        let pinOrder = Dictionary(
+            uniqueKeysWithValues: settings.pinnedModelIDs.enumerated().map { ($1, $0) }
+        )
         let selectedModelIDs = Set(
             ModelPreloadSlot.allCases.compactMap {
                 settings.modelID(for: $0)
             })
         return models.enumerated().sorted { lhs, rhs in
+            let lhsPinIndex = pinOrder[lhs.element.repoID]
+            let rhsPinIndex = pinOrder[rhs.element.repoID]
+            if lhsPinIndex != nil || rhsPinIndex != nil {
+                if let lhsPinIndex, let rhsPinIndex {
+                    return lhsPinIndex < rhsPinIndex
+                }
+                return lhsPinIndex != nil
+            }
             let lhsIsSelected = selectedModelIDs.contains(lhs.element.repoID)
             let rhsIsSelected = selectedModelIDs.contains(rhs.element.repoID)
             if lhsIsSelected != rhsIsSelected {
@@ -1633,9 +1685,11 @@ private struct InstalledModelRow: View, @MainActor Equatable {
     let canDelete: Bool
     let isSelecting: Bool
     let isSelectedForDeletion: Bool
+    let isPinned: Bool
     let onSetPreload: (ModelPreloadSlot, Bool) -> Void
     let onShowReadme: () -> Void
     let onToggleSelection: () -> Void
+    let onTogglePin: () -> Void
     let onDelete: () -> Void
 
     @State private var showsDeleteConfirmation = false
@@ -1654,6 +1708,7 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             && lhs.canDelete == rhs.canDelete
             && lhs.isSelecting == rhs.isSelecting
             && lhs.isSelectedForDeletion == rhs.isSelectedForDeletion
+            && lhs.isPinned == rhs.isPinned
     }
 
     private var isSelected: Bool {
@@ -1687,6 +1742,13 @@ private struct InstalledModelRow: View, @MainActor Equatable {
                             Text(modelName(localModel.displayName))
                                 .font(.body.weight(.semibold))
                                 .lineLimit(1)
+                            if isPinned {
+                                ModelPill(
+                                    title: "Pinned",
+                                    systemImage: "pin.fill",
+                                    color: .accentColor
+                                )
+                            }
                             if let sourceLabel = localModel.source.badgeLabel {
                                 ModelPill(
                                     title: sourceLabel,
@@ -1778,6 +1840,7 @@ private struct InstalledModelRow: View, @MainActor Equatable {
 
             if !isSelecting {
                 loadButton
+                pinButton
                 modelActionsMenu
             }
         }
@@ -1791,6 +1854,13 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             accessibilityLabel: "Select \(localModel.repoID)",
             action: onToggleSelection
         )
+        .contextMenu {
+            Button(
+                isPinned ? "Unpin Model" : "Pin Model",
+                systemImage: isPinned ? "pin.slash" : "pin",
+                action: onTogglePin
+            )
+        }
         .alert("Model isn’t supported", isPresented: $showsUnsupportedModelInformation) {
             Button("OK", role: .cancel) {}
                 .keyboardShortcut(.defaultAction)
@@ -1817,6 +1887,14 @@ private struct InstalledModelRow: View, @MainActor Equatable {
                 .help("Deleting model")
         } else {
             Menu {
+                Button(
+                    isPinned ? "Unpin Model" : "Pin Model",
+                    systemImage: isPinned ? "pin.slash" : "pin",
+                    action: onTogglePin
+                )
+
+                Divider()
+
                 if let snapshotURL = localModel.snapshotURL {
                     Button {
                         NSWorkspace.shared.activateFileViewerSelecting([snapshotURL])
@@ -1849,6 +1927,21 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             )
             .accessibilityLabel("Actions for \(localModel.repoID)")
         }
+    }
+
+    private var pinButton: some View {
+        Button(
+            isPinned ? "Unpin Model" : "Pin Model",
+            systemImage: isPinned ? "pin.fill" : "pin",
+            action: onTogglePin
+        )
+        .labelStyle(.iconOnly)
+        .buttonStyle(.borderless)
+        .foregroundStyle(isPinned ? Color.accentColor : Color.secondary)
+        .frame(width: 30, height: 30)
+        .contentShape(Rectangle())
+        .help(isPinned ? "Unpin from the top of the model list" : "Pin to the top of the model list")
+        .accessibilityValue(isPinned ? "Pinned" : "Not pinned")
     }
 
     @ViewBuilder
@@ -1904,6 +1997,20 @@ private struct InstalledModelRow: View, @MainActor Equatable {
             return "Preload \(localModel.repoID) for \(preferredPreloadSlot.displayName)"
         }
         return "\(localModel.repoID) has no supported preload role"
+    }
+}
+
+private struct ModelsPinnedSectionHeader: View {
+    let title: String
+    let systemImage: String
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .textCase(.uppercase)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityAddTraits(.isHeader)
     }
 }
 

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -419,6 +419,7 @@ struct NativSettings: Codable, Equatable {
     var modelSearchPath: String
     var externalModelCache: ExternalModelCacheReference?
     var additionalModelSearchPaths: [String]
+    var pinnedModelIDs: [String]
     var languageModelID: String?
     var mcpServers: [MCPServerConfig]
     var customTools: [CustomTool]
@@ -475,6 +476,7 @@ struct NativSettings: Codable, Equatable {
         modelSearchPath: String = Self.defaultModelSearchPath,
         externalModelCache: ExternalModelCacheReference? = nil,
         additionalModelSearchPaths: [String] = [],
+        pinnedModelIDs: [String] = [],
         languageModelID: String? = nil,
         mcpServers: [MCPServerConfig] = [],
         customTools: [CustomTool] = [],
@@ -530,6 +532,7 @@ struct NativSettings: Codable, Equatable {
         self.modelSearchPath = modelSearchPath
         self.externalModelCache = externalModelCache
         self.additionalModelSearchPaths = additionalModelSearchPaths
+        self.pinnedModelIDs = pinnedModelIDs
         self.languageModelID = languageModelID
         self.mcpServers = mcpServers
         self.customTools = customTools
@@ -587,6 +590,7 @@ struct NativSettings: Codable, Equatable {
         case modelSearchPath
         case externalModelCache
         case additionalModelSearchPaths
+        case pinnedModelIDs
         case languageModelID
         case mcpServers
         case customTools
@@ -656,6 +660,9 @@ struct NativSettings: Codable, Equatable {
         additionalModelSearchPaths =
             try container.decodeIfPresent([String].self, forKey: .additionalModelSearchPaths)
             ?? defaults.additionalModelSearchPaths
+        pinnedModelIDs =
+            try container.decodeIfPresent([String].self, forKey: .pinnedModelIDs)
+            ?? defaults.pinnedModelIDs
         languageModelID =
             try container.decodeIfPresent(String.self, forKey: .languageModelID)
             ?? legacySelectedModelID ?? defaults.languageModelID
@@ -800,6 +807,7 @@ struct NativSettings: Codable, Equatable {
         try container.encode(modelSearchPath, forKey: .modelSearchPath)
         try container.encodeIfPresent(externalModelCache, forKey: .externalModelCache)
         try container.encode(additionalModelSearchPaths, forKey: .additionalModelSearchPaths)
+        try container.encode(pinnedModelIDs, forKey: .pinnedModelIDs)
         try container.encodeIfPresent(languageModelID, forKey: .languageModelID)
         try container.encode(mcpServers, forKey: .mcpServers)
         try container.encode(customTools, forKey: .customTools)
@@ -985,6 +993,10 @@ struct NativSettings: Codable, Equatable {
         settings.additionalModelSearchPaths = settings.additionalModelSearchPaths
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty && seenAdditionalPaths.insert($0).inserted }
+        var seenPinnedModelIDs = Set<String>()
+        settings.pinnedModelIDs = settings.pinnedModelIDs
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seenPinnedModelIDs.insert($0).inserted }
         let trimmedFileReadRoot =
             settings.fileReadRootPath?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -4,6 +4,38 @@ import XCTest
 @testable import NativServerKit
 
 final class NativSettingsTests: XCTestCase {
+    func testPinnedModelsRoundTripInOrder() throws {
+        let settings = NativSettings(
+            pinnedModelIDs: ["org/most-used", "org/second"]
+        )
+
+        let data = try PropertyListEncoder().encode(settings)
+        let decoded = try PropertyListDecoder().decode(NativSettings.self, from: data)
+
+        XCTAssertEqual(decoded.pinnedModelIDs, ["org/most-used", "org/second"])
+    }
+
+    func testPinnedModelsNormalizeWhitespaceAndDuplicates() {
+        let settings = NativSettings(
+            pinnedModelIDs: [" org/model ", "", "org/model", "org/other"]
+        ).normalized()
+
+        XCTAssertEqual(settings.pinnedModelIDs, ["org/model", "org/other"])
+    }
+
+    func testMissingPinnedModelsDecodeAsEmptyForBackwardCompatibility() throws {
+        let settings = try PropertyListDecoder().decode(
+            NativSettings.self,
+            from: PropertyListSerialization.data(
+                fromPropertyList: ["modelSearchPath": NativSettings.defaultModelSearchPath],
+                format: .xml,
+                options: 0
+            )
+        )
+
+        XCTAssertTrue(settings.pinnedModelIDs.isEmpty)
+    }
+
     func testDisablingLegacyReadFileAlsoDisablesGroupedSearchTool() {
         let settings = NativSettings(disabledToolNames: ["read_file"]).normalized()
 


### PR DESCRIPTION
This PR adds model pinning to the installed models list.

Pinned models appear in a separate section at the top of the list. Models can be pinned or unpinned using the pin button, context menu, or actions menu. Pins are stored with the existing app settings and removed when a pinned model is deleted.

<img width="859" height="968" alt="image" src="https://github.com/user-attachments/assets/762a2c2b-6a6b-40c6-86cf-0514965cec06" />
