### PR TITLE
Add Hugging Face link to model details

### DIFF
--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1516,6 +1516,7 @@ private struct ModelReadmePanel: View {
     let selection: ModelReadmeSelection
     @ObservedObject var store: HuggingFaceModelReadmeStore
     let onClose: () -> Void
+    @State private var isHubLinkHovered = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1533,9 +1534,32 @@ private struct ModelReadmePanel: View {
             ModelProviderBadge(provider: selection.provider)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(modelName(selection.repoID))
-                    .font(.headline)
-                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(modelName(selection.repoID))
+                        .font(.headline)
+                        .lineLimit(1)
+
+                    if let hubURL {
+                        Link(destination: hubURL) {
+                            Label("Open on Hugging Face", systemImage: "arrow.up.right")
+                        }
+                        .labelStyle(.iconOnly)
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(isHubLinkHovered ? Color.accentColor : Color.secondary)
+                        .frame(width: 24, height: 24)
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(
+                                    isHubLinkHovered
+                                        ? Color.accentColor.opacity(0.12) : Color.clear
+                                )
+                        )
+                        .contentShape(Rectangle())
+                        .onHover { isHubLinkHovered = $0 }
+                        .animation(.easeOut(duration: 0.12), value: isHubLinkHovered)
+                        .help("Open \(selection.repoID) on Hugging Face")
+                    }
+                }
                 Text(selection.repoID)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -1974,7 +1998,7 @@ private struct ActiveDownloadBannerRow: View {
 
                 Spacer()
 
-                HStack(spacing: 10) {
+                HStack(spacing: 6) {
                     Button(pauseResumeTitle, systemImage: pauseResumeSymbol, action: onPauseResume)
                         .help(pauseResumeTitle)
 


### PR DESCRIPTION
This PR adds an external link icon next to the model title in the details card. The icon opens the model’s Hugging Face repository and includes hover and accessibility states.

<img width="592" height="913" alt="Screenshot 2026-09-03 at 11 43 43 AM" src="https://github.com/user-attachments/assets/983e9668-bc46-4cd8-85f1-19d3f0ce120e" />
<img width="598" height="923" alt="Screenshot 2026-09-03 at 11 43 52 AM" src="https://github.com/user-attachments/assets/bd4a2ca3-999d-4a47-bc42-a7687f91c927" />
