### PR TITLE
Confirm model config reset

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -175,6 +175,7 @@ struct ModelConfigurationView: View {
     @State private var modelConfiguration: LocalModelConfigurationMetadata?
     @State private var isLoadingModelConfiguration = false
     @State private var modelConfigurationRevision = 0
+    @State private var isConfirmingReset = false
     @StateObject private var draftModelLibrary = LocalModelLibrary()
 
     var body: some View {
@@ -231,11 +232,22 @@ struct ModelConfigurationView: View {
 
                 Spacer(minLength: 0)
 
-                Button(action: onReset) {
-                    Image(systemName: "arrow.counterclockwise")
+                Button("Reset model configuration", systemImage: "arrow.counterclockwise") {
+                    isConfirmingReset = true
                 }
+                .labelStyle(.iconOnly)
                 .buttonStyle(.borderless)
                 .help("Reset model configuration")
+                .confirmationDialog(
+                    "Reset model configuration?",
+                    isPresented: $isConfirmingReset,
+                    titleVisibility: .visible
+                ) {
+                    Button("Reset", role: .destructive, action: onReset)
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This will restore all model configuration settings to their defaults.")
+                }
             }
 
             if settingsRequireRestart {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -1516,6 +1516,7 @@ private struct ModelReadmePanel: View {
     let selection: ModelReadmeSelection
     @ObservedObject var store: HuggingFaceModelReadmeStore
     let onClose: () -> Void
+    @State private var isHubLinkHovered = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1533,9 +1534,32 @@ private struct ModelReadmePanel: View {
             ModelProviderBadge(provider: selection.provider)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(modelName(selection.repoID))
-                    .font(.headline)
-                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(modelName(selection.repoID))
+                        .font(.headline)
+                        .lineLimit(1)
+
+                    if let hubURL {
+                        Link(destination: hubURL) {
+                            Label("Open on Hugging Face", systemImage: "arrow.up.right")
+                        }
+                        .labelStyle(.iconOnly)
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(isHubLinkHovered ? Color.accentColor : Color.secondary)
+                        .frame(width: 24, height: 24)
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(
+                                    isHubLinkHovered
+                                        ? Color.accentColor.opacity(0.12) : Color.clear
+                                )
+                        )
+                        .contentShape(Rectangle())
+                        .onHover { isHubLinkHovered = $0 }
+                        .animation(.easeOut(duration: 0.12), value: isHubLinkHovered)
+                        .help("Open \(selection.repoID) on Hugging Face")
+                    }
+                }
                 Text(selection.repoID)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -1974,7 +1998,7 @@ private struct ActiveDownloadBannerRow: View {
 
                 Spacer()
 
-                HStack(spacing: 10) {
+                HStack(spacing: 6) {
                     Button(pauseResumeTitle, systemImage: pauseResumeSymbol, action: onPauseResume)
                         .help(pauseResumeTitle)
 


### PR DESCRIPTION
This PR adds a confirmation dialog when resetting the model configuration. Users can confirm the reset or cancel without changing their settings.

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/f2afd3df-c3f4-4ce0-90de-75e8296230a4" />
