### PR TITLE
Keep bulk selection scoped to visible items

### DIFF
--- a/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
@@ -89,8 +89,7 @@ struct ArtifactsView: View {
     @State private var sort: ArtifactSort = .newest
     @State private var layout: ArtifactLayout = .grid
     @State private var previewID: Artifact.ID?
-    @State private var isSelecting = false
-    @State private var selection: Set<Artifact.ID> = []
+    @State private var artifactSelection = NativBulkSelection<Artifact.ID>()
     @State private var pendingDelete: [Artifact] = []
     @State private var isConfirmingDelete = false
     @State private var inspectorArtifact: Artifact?
@@ -165,6 +164,10 @@ struct ArtifactsView: View {
         }
         let lowered = query.lowercased()
         return result.filter { $0.searchText.contains(lowered) }.sorted(by: sort.comparator)
+    }
+
+    private var visibleArtifactIDs: Set<Artifact.ID> {
+        Set(filtered.map(\.id))
     }
 
     private var groups: [ArtifactGroup] {
@@ -465,7 +468,7 @@ struct ArtifactsView: View {
             semanticBanner
             filterBar
             Divider()
-            if isSelecting {
+            if artifactSelection.isActive {
                 selectionBar
             }
             contentView
@@ -490,6 +493,9 @@ struct ArtifactsView: View {
         .onChange(of: searchIndex.indexedCount) { _, _ in
             scheduleSemanticSearch()
         }
+        .onChange(of: visibleArtifactIDs) { _, visibleIDs in
+            artifactSelection.retain(visibleIDs)
+        }
         .overlay {
             if previewID != nil {
                 ArtifactPreview(
@@ -507,10 +513,10 @@ struct ArtifactsView: View {
         .alert("Delete \(pendingDelete.count) \(pendingDelete.count == 1 ? "item" : "items")?", isPresented: $isConfirmingDelete) {
             Button("Delete", role: .destructive) {
                 let deletedIDs = store.delete(pendingDelete)
-                selection.subtract(deletedIDs)
+                artifactSelection.remove(deletedIDs)
                 pendingDelete = []
-                if selection.isEmpty {
-                    isSelecting = false
+                if artifactSelection.isEmpty {
+                    artifactSelection.finish()
                 }
             }
             .keyboardShortcut(.defaultAction)
@@ -658,16 +664,16 @@ struct ArtifactsView: View {
                 ArtifactTile(
                     artifact: artifact,
                     store: store,
-                    isSelecting: isSelecting,
-                    isSelected: selection.contains(artifact.id),
+                    isSelecting: artifactSelection.isActive,
+                    isSelected: artifactSelection.contains(artifact.id),
                     isFavorite: store.isFavorite(artifact),
                     onInspect: { inspectorArtifact = artifact },
                     onToggleFavorite: { store.toggleFavorite(artifact) }
                 )
                 .onTapGesture { activate(artifact) }
-                .modifier(ArtifactDrag(store: store, artifact: artifact, enabled: !isSelecting))
+                .modifier(ArtifactDrag(store: store, artifact: artifact, enabled: !artifactSelection.isActive))
                 .overlay {
-                    if isSelecting {
+                    if artifactSelection.isActive {
                         SelectionDrag(
                             onToggle: { activate(artifact) },
                             fileURLs: { selectedFileURLs(including: artifact) }
@@ -675,7 +681,7 @@ struct ArtifactsView: View {
                     }
                 }
                 .overlay {
-                    if cursorID == artifact.id, !isSelecting {
+                    if cursorID == artifact.id, !artifactSelection.isActive {
                         RoundedRectangle(cornerRadius: 10, style: .continuous)
                             .stroke(Color.accentColor.opacity(0.9), lineWidth: 2.5)
                     }
@@ -691,11 +697,11 @@ struct ArtifactsView: View {
                 ArtifactRow(
                     artifact: artifact,
                     store: store,
-                    isSelecting: isSelecting,
-                    isSelected: selection.contains(artifact.id)
+                    isSelecting: artifactSelection.isActive,
+                    isSelected: artifactSelection.contains(artifact.id)
                 )
                 .onTapGesture { activate(artifact) }
-                .modifier(ArtifactDrag(store: store, artifact: artifact, enabled: !isSelecting))
+                .modifier(ArtifactDrag(store: store, artifact: artifact, enabled: !artifactSelection.isActive))
                 .contextMenu { menu(for: artifact) }
                 Divider()
             }
@@ -735,50 +741,37 @@ struct ArtifactsView: View {
     }
 
     private var selectionBar: some View {
-        HStack(spacing: 10) {
-            Text("\(selection.count) selected")
-                .nativTextStyle(.supportingEmphasized)
-                .foregroundStyle(.secondary)
-
-            Button(selection.count == filtered.count ? "Deselect All" : "Select All") {
-                if selection.count == filtered.count {
-                    selection.removeAll()
-                } else {
-                    selection = Set(filtered.map(\.id))
-                }
+        let artifacts = selectedArtifacts
+        return NativBulkSelectionToolbar(
+            selectedCount: artifacts.count,
+            allSelected: artifactSelection.includesAll(visibleArtifactIDs),
+            isSelectAllEnabled: !visibleArtifactIDs.isEmpty,
+            onToggleAll: {
+                artifactSelection.toggleAll(visibleArtifactIDs)
+            },
+            onDelete: {
+                pendingDelete = artifacts
+                isConfirmingDelete = true
             }
-            .nativTextStyle(.supporting)
-
-            Spacer(minLength: 0)
-
+        ) {
             Button {
-                ArtifactShare.present(urls: selectedArtifacts.map { store.fileURL(for: $0) })
+                ArtifactShare.present(urls: artifacts.map { store.fileURL(for: $0) })
             } label: {
                 Image(systemName: "square.and.arrow.up")
             }
             .help("Share")
-            .disabled(selection.isEmpty)
+            .disabled(artifacts.isEmpty)
 
             Button {
-                store.exportToDirectory(selectedArtifacts)
+                store.exportToDirectory(artifacts)
             } label: {
                 Image(systemName: "square.and.arrow.down")
             }
             .help("Export")
-            .disabled(selection.isEmpty)
-
-            Button(role: .destructive) {
-                pendingDelete = selectedArtifacts
-                isConfirmingDelete = true
-            } label: {
-                Image(systemName: "trash")
-            }
-            .help("Delete")
-            .disabled(selection.isEmpty)
+            .disabled(artifacts.isEmpty)
         }
-        .padding(.horizontal, 24)
+        .padding(.horizontal, 14)
         .padding(.vertical, 8)
-        .background(Color(nsColor: .controlBackgroundColor))
     }
 
     private var filterBar: some View {
@@ -805,11 +798,8 @@ struct ArtifactsView: View {
 
                 Spacer(minLength: 16)
 
-                Button(isSelecting ? "Done" : "Select") {
-                    isSelecting.toggle()
-                    if !isSelecting {
-                        selection.removeAll()
-                    }
+                Button(artifactSelection.isActive ? "Done" : "Select") {
+                    artifactSelection.toggleMode()
                 }
 
                 Menu {
@@ -992,8 +982,10 @@ struct ArtifactsView: View {
     }
 
     private func selectedFileURLs(including artifact: Artifact) -> [URL] {
-        let ids = selection.contains(artifact.id) && !selection.isEmpty ? selection : [artifact.id]
-        return store.artifacts
+        let ids = artifactSelection.contains(artifact.id) && !artifactSelection.isEmpty
+            ? artifactSelection.ids
+            : [artifact.id]
+        return filtered
             .filter { ids.contains($0.id) }
             .map { store.fileURL(for: $0) }
     }
@@ -1005,8 +997,7 @@ struct ArtifactsView: View {
         let index = cursorID.flatMap { id in items.firstIndex { $0.id == id } }
 
         if press.modifiers.contains(.command), press.characters.lowercased() == "a" {
-            isSelecting = true
-            selection = Set(items.map(\.id))
+            artifactSelection.selectAll(Set(items.map(\.id)))
             return .handled
         }
 
@@ -1073,16 +1064,12 @@ struct ArtifactsView: View {
     }
 
     private var selectedArtifacts: [Artifact] {
-        store.artifacts.filter { selection.contains($0.id) }
+        filtered.filter { artifactSelection.contains($0.id) }
     }
 
     private func activate(_ artifact: Artifact) {
-        if isSelecting {
-            if selection.contains(artifact.id) {
-                selection.remove(artifact.id)
-            } else {
-                selection.insert(artifact.id)
-            }
+        if artifactSelection.isActive {
+            artifactSelection.toggle(artifact.id)
         } else {
             previewID = artifact.id
         }

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -356,6 +356,9 @@ struct ModelsView: View {
         .onChange(of: localLibrary.models.map(\.repoID)) { _, _ in
             selectFirstVisibleReadmeIfNeeded(in: .installed)
         }
+        .onChange(of: eligibleVisibleModelIDs) { _, visibleIDs in
+            installedModelSelection.retain(visibleIDs)
+        }
         .onChange(of: hubLibrary.models.map(\.id)) { _, _ in
             selectFirstVisibleReadmeIfNeeded(in: .discover)
         }
@@ -1031,9 +1034,13 @@ struct ModelsView: View {
     }
 
     private var selectedInstalledModels: [LocalModel] {
-        localLibrary.models.filter {
+        filteredLocalModels.filter {
             installedModelSelection.contains($0.repoID) && canSelectForDeletion($0)
         }
+    }
+
+    private var eligibleVisibleModelIDs: Set<String> {
+        Set(filteredLocalModels.filter(canSelectForDeletion).map(\.repoID))
     }
 
     private func canSelectForDeletion(_ localModel: LocalModel) -> Bool {

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -356,9 +356,6 @@ struct ModelsView: View {
         .onChange(of: localLibrary.models.map(\.repoID)) { _, _ in
             selectFirstVisibleReadmeIfNeeded(in: .installed)
         }
-        .onChange(of: eligibleVisibleModelIDs) { _, visibleIDs in
-            installedModelSelection.retain(visibleIDs)
-        }
         .onChange(of: hubLibrary.models.map(\.id)) { _, _ in
             selectFirstVisibleReadmeIfNeeded(in: .discover)
         }
@@ -552,6 +549,9 @@ struct ModelsView: View {
             switch renderedSection {
             case .installed:
                 installedFilterBar
+                    .onChange(of: eligibleVisibleModelIDs) { _, visibleIDs in
+                        installedModelSelection.retain(visibleIDs)
+                    }
                 if installedModelSelection.isActive {
                     installedSelectionBar(for: filteredLocalModels)
                 }

--- a/Sources/Nativ/Features/Shared/NativBulkSelection.swift
+++ b/Sources/Nativ/Features/Shared/NativBulkSelection.swift
@@ -5,6 +5,8 @@ struct NativBulkSelection<ID: Hashable> {
     private(set) var isActive = false
     private(set) var ids = Set<ID>()
 
+    var isEmpty: Bool { ids.isEmpty }
+
     func contains(_ id: ID) -> Bool {
         ids.contains(id)
     }
@@ -35,6 +37,19 @@ struct NativBulkSelection<ID: Hashable> {
         } else {
             ids.formUnion(candidateIDs)
         }
+    }
+
+    mutating func selectAll(_ candidateIDs: Set<ID>) {
+        isActive = true
+        ids = candidateIDs
+    }
+
+    mutating func retain(_ candidateIDs: Set<ID>) {
+        ids.formIntersection(candidateIDs)
+    }
+
+    mutating func remove<S: Sequence>(_ removedIDs: S) where S.Element == ID {
+        ids.subtract(removedIDs)
     }
 
     mutating func finish() {
@@ -130,12 +145,29 @@ extension View {
 }
 
 /// Shared controls for selecting every visible item and performing bulk deletion.
-struct NativBulkSelectionToolbar: View {
+struct NativBulkSelectionToolbar<Actions: View>: View {
     let selectedCount: Int
     let allSelected: Bool
     var isSelectAllEnabled = true
     let onToggleAll: () -> Void
     let onDelete: () -> Void
+    let actions: Actions
+
+    init(
+        selectedCount: Int,
+        allSelected: Bool,
+        isSelectAllEnabled: Bool = true,
+        onToggleAll: @escaping () -> Void,
+        onDelete: @escaping () -> Void,
+        @ViewBuilder actions: () -> Actions
+    ) {
+        self.selectedCount = selectedCount
+        self.allSelected = allSelected
+        self.isSelectAllEnabled = isSelectAllEnabled
+        self.onToggleAll = onToggleAll
+        self.onDelete = onDelete
+        self.actions = actions()
+    }
 
     var body: some View {
         HStack(spacing: 10) {
@@ -148,6 +180,8 @@ struct NativBulkSelectionToolbar: View {
 
             Spacer(minLength: 0)
 
+            actions
+
             Button(role: .destructive, action: onDelete) {
                 Label("Delete Selected", systemImage: "trash")
             }
@@ -159,5 +193,25 @@ struct NativBulkSelectionToolbar: View {
             Color.primary.opacity(0.04),
             in: RoundedRectangle(cornerRadius: 8, style: .continuous)
         )
+    }
+}
+
+extension NativBulkSelectionToolbar where Actions == EmptyView {
+    init(
+        selectedCount: Int,
+        allSelected: Bool,
+        isSelectAllEnabled: Bool = true,
+        onToggleAll: @escaping () -> Void,
+        onDelete: @escaping () -> Void
+    ) {
+        self.init(
+            selectedCount: selectedCount,
+            allSelected: allSelected,
+            isSelectAllEnabled: isSelectAllEnabled,
+            onToggleAll: onToggleAll,
+            onDelete: onDelete
+        ) {
+            EmptyView()
+        }
     }
 }

--- a/Tests/NativTests/NativBulkSelectionTests.swift
+++ b/Tests/NativTests/NativBulkSelectionTests.swift
@@ -41,6 +41,28 @@ struct NativBulkSelectionTests {
         #expect(selection.contains("hidden"))
     }
 
+    @Test("Selecting all activates selection mode and replaces hidden items")
+    func selectingAllReplacesSelection() {
+        var selection = NativBulkSelection<String>()
+        selection.toggle("hidden")
+
+        selection.selectAll(["first", "second"])
+
+        #expect(selection.isActive)
+        #expect(selection.ids == ["first", "second"])
+    }
+
+    @Test("Retaining visible items removes hidden selections")
+    func retainingVisibleItemsRemovesHiddenSelections() {
+        var selection = NativBulkSelection<String>()
+        selection.toggle("visible")
+        selection.toggle("hidden")
+
+        selection.retain(["visible"])
+
+        #expect(selection.ids == ["visible"])
+    }
+
     @Test("Finishing selection clears mode and selected items")
     func finishingSelectionResetsState() {
         var selection = NativBulkSelection<String>()


### PR DESCRIPTION
Keeps Models and Artifacts bulk actions scoped to visible filtered items while moving Artifacts onto the shared selection state and toolbar.

For consistency, why have two separate select states