### PR TITLE
Fix latest prompt editing without branching

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -1082,7 +1082,7 @@ struct ChatComposer: View {
             return blockingNotice.message
         }
         if viewModel.promptEditContext != nil {
-            return "Fork and regenerate (Return)"
+            return "Save and regenerate (Return)"
         }
         return "Send (Return)"
     }
@@ -1131,7 +1131,7 @@ private struct ChatPromptEditBanner: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Editing prompt")
                     .fontWeight(.medium)
-                Text("Sending will create a new chat branch.")
+                Text("Sending will replace the latest response.")
                     .foregroundStyle(.secondary)
             }
 

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -889,26 +889,26 @@ final class ChatViewModel: ObservableObject {
 
         if let promptEditContext {
             guard canEditUserMessage(promptEditContext.messageID),
-                let sourceSession = currentSessionSnapshot,
                 let revision = ChatPromptRevision.make(
                     messageID: promptEditContext.messageID,
                     content: prompt,
                     attachments: imageAttachments,
                     modelID: modelID,
-                    in: sourceSession.messages
+                    in: messages
                 )
             else {
                 return
             }
 
-            let branch = ChatConversationBranch.make(
-                from: sourceSession,
-                messages: revision.messages
-            )
-            activateBranch(branch, restoring: composerSnapshot)
+            let editedMessageID = promptEditContext.messageID
+            messages = revision.messages
+            draft = composerSnapshot?.draft ?? ""
+            pendingImageAttachments = composerSnapshot?.attachments ?? []
+            discardPromptEditing()
+            persistCurrentSession(updateTimestamp: true)
             enqueueGeneration(
-                for: promptEditContext.messageID,
-                in: branch.id,
+                for: editedMessageID,
+                in: currentSession.id,
                 settings: settings,
                 languageModelSupportsTools: languageModelSupportsTools,
                 languageModelSupportsVision: languageModelSupportsVision,

--- a/Tests/NativTests/ChatConversationBranchTests.swift
+++ b/Tests/NativTests/ChatConversationBranchTests.swift
@@ -1,6 +1,38 @@
 import XCTest
 
 final class ChatConversationBranchTests: XCTestCase {
+    func testRevisingLatestPromptReplacesItsResponseHistoryWithoutChangingSession() throws {
+        let firstUser = ChatTranscriptMessage(role: .user, content: "First prompt")
+        let firstAssistant = ChatTranscriptMessage(role: .assistant, content: "First response")
+        let latestUser = ChatTranscriptMessage(role: .user, content: "Original prompt")
+        let latestAssistant = ChatTranscriptMessage(role: .assistant, content: "Old response")
+        let sessionID = UUID()
+        var session = ChatSession(
+            id: sessionID,
+            title: "First prompt",
+            createdAt: .now,
+            updatedAt: .now,
+            messages: [firstUser, firstAssistant, latestUser, latestAssistant]
+        )
+
+        let revision = try XCTUnwrap(
+            ChatPromptRevision.make(
+                messageID: latestUser.id,
+                content: "Edited prompt",
+                attachments: [],
+                modelID: "test/model",
+                in: session.messages
+            )
+        )
+        session.messages = revision.messages
+
+        XCTAssertEqual(session.id, sessionID)
+        XCTAssertEqual(session.messages.map(\.id), [firstUser.id, firstAssistant.id, latestUser.id])
+        XCTAssertEqual(session.messages.last?.content, "Edited prompt")
+        XCTAssertEqual(session.messages.last?.modelID, "test/model")
+        XCTAssertFalse(session.messages.contains(where: { $0.id == latestAssistant.id }))
+    }
+
     func testCompletedAssistantResponsesAreForkable() {
         let firstUser = ChatTranscriptMessage(role: .user, content: "First prompt")
         let firstAssistant = ChatTranscriptMessage(role: .assistant, content: "First response")


### PR DESCRIPTION
Closes #487 

This pr fixes editing so that editing the latest user message updates the current chat and regenerates the model’s response without creating a new branch