### PR TITLE
add semantic color and typography system

### DIFF
--- a/Sources/Nativ/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0x7A","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0x91","red":"0x00"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativAccentEmphasis.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativAccentEmphasis.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.450","blue":"0xFF","green":"0x7A","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.450","blue":"0xFF","green":"0x91","red":"0x00"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativAccentFocusRing.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativAccentFocusRing.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.500","blue":"0xF4","green":"0x67","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.500","blue":"0xFF","green":"0x91","red":"0x00"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativAccentHover.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativAccentHover.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.080","blue":"0xFF","green":"0x7A","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.080","blue":"0xFF","green":"0x91","red":"0x00"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativAccentSelected.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativAccentSelected.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.180","blue":"0xFF","green":"0x7A","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.180","blue":"0xFF","green":"0x91","red":"0x00"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativAccentSubtle.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativAccentSubtle.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.120","blue":"0xFF","green":"0x7A","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.120","blue":"0xFF","green":"0x91","red":"0x00"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativBorderPrimary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativBorderPrimary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.100","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.100","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativBorderSecondary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativBorderSecondary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.050","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.050","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativChartGrid.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativChartGrid.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.070","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.070","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativChartPanelStroke.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativChartPanelStroke.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.060","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.060","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativChartSeries1.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativChartSeries1.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xE8","green":"0x97","red":"0x47"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xE8","green":"0x97","red":"0x47"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativChartSeries2.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativChartSeries2.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xEA","green":"0x69","red":"0x77"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xEA","green":"0x69","red":"0x77"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativChartSeries3.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativChartSeries3.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xCF","green":"0xAE","red":"0x47"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xCF","green":"0xAE","red":"0x47"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativChartSeries4.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativChartSeries4.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x83","green":"0xB3","red":"0x3E"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x83","green":"0xB3","red":"0x3E"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativChartSeries5.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativChartSeries5.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x65","green":"0x5B","red":"0xE1"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x65","green":"0x5B","red":"0xE1"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativChartSeries6.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativChartSeries6.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x41","green":"0x97","red":"0xE8"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x41","green":"0x97","red":"0xE8"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativContentOnAccentPrimary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativContentOnAccentPrimary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativContentOnAccentSecondary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativContentOnAccentSecondary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.500","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.500","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativContentPlaceholder.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativContentPlaceholder.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.500","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.550","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativContentPrimary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativContentPrimary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x1C","green":"0x1A","red":"0x19"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xE9","green":"0xE9","red":"0xE9"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativContentQuaternary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativContentQuaternary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.100","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.100","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativContentSecondary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativContentSecondary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.500","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.550","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativContentStrong.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativContentStrong.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x1C","green":"0x1A","red":"0x19"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativContentTertiary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativContentTertiary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.260","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.250","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativFillPrimary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativFillPrimary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.100","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.180","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativFillQuaternary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativFillQuaternary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.030","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.070","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativFillQuinary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativFillQuinary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.010","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.030","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativFillSecondary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativFillSecondary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.080","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.150","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativFillTertiary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativFillTertiary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.060","blue":"0x00","green":"0x00","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"0.100","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativStatusDanger.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativStatusDanger.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x3C","green":"0x38","red":"0xFF"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x45","green":"0x42","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativStatusSuccess.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativStatusSuccess.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x59","green":"0xC7","red":"0x34"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x58","green":"0xD1","red":"0x30"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativStatusWarning.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativStatusWarning.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x28","green":"0x8D","red":"0xFF"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x30","green":"0x92","red":"0xFF"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfacePrimary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfacePrimary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x17","green":"0x17","red":"0x17"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfaceSecondary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfaceSecondary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x1C","green":"0x1C","red":"0x1C"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfaceSelected.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfaceSelected.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xE1","green":"0x64","red":"0x00"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xD1","green":"0x59","red":"0x00"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfaceSelectedQuiet.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfaceSelectedQuiet.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xDC","green":"0xDC","red":"0xDC"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x46","green":"0x46","red":"0x46"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfaceSidebarMaterial.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfaceSidebarMaterial.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xF2","green":"0xE6","red":"0xDA"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x17","green":"0x15","red":"0x14"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfaceStrong.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfaceStrong.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x08","green":"0x0A","red":"0x0B"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfaceTertiary.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfaceTertiary.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xF5","green":"0xF5","red":"0xF5"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x17","green":"0x17","red":"0x17"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfaceUnderPage.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfaceUnderPage.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"0.900","blue":"0x96","green":"0x96","red":"0x96"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x28","green":"0x28","red":"0x28"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/Assets.xcassets/NativSurfaceWindow.colorset/Contents.json
+++ b/Sources/Nativ/Assets.xcassets/NativSurfaceWindow.colorset/Contents.json
@@ -1,0 +1,1 @@
+{"colors":[{"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0xFF","green":"0xFF","red":"0xFF"}},"idiom":"universal"},{"appearances":[{"appearance":"luminosity","value":"dark"}],"color":{"color-space":"srgb","components":{"alpha":"1.000","blue":"0x17","green":"0x17","red":"0x17"}},"idiom":"universal"}],"info":{"author":"xcode","version":1}}

--- a/Sources/Nativ/DesignSystem/NativColor.swift
+++ b/Sources/Nativ/DesignSystem/NativColor.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+/// Nativ's semantic color contract.
+///
+/// Every concrete value is stored in `Assets.xcassets` with Light and Dark
+/// appearances that match the Figma `Appearance` collection. Aliases stay as
+/// aliases here so the same relationships exist in design and production.
+enum NativColor {
+    enum Surface {
+        static let window = Color(.nativSurfaceWindow)
+        static let primary = Color(.nativSurfacePrimary)
+        static let secondary = Color(.nativSurfaceSecondary)
+        static let tertiary = Color(.nativSurfaceTertiary)
+        static let strong = Color(.nativSurfaceStrong)
+        static let underPage = Color(.nativSurfaceUnderPage)
+        static let selected = Color(.nativSurfaceSelected)
+        static let selectedQuiet = Color(.nativSurfaceSelectedQuiet)
+
+        /// Preview fallback only. Production sidebars should use system material.
+        static let sidebarMaterialFallback = Color(.nativSurfaceSidebarMaterial)
+    }
+
+    enum Content {
+        static let strong = Color(.nativContentStrong)
+        static let primary = Color(.nativContentPrimary)
+        static let secondary = Color(.nativContentSecondary)
+        static let tertiary = Color(.nativContentTertiary)
+        static let quaternary = Color(.nativContentQuaternary)
+        static let placeholder = Color(.nativContentPlaceholder)
+        static let onAccentPrimary = Color(.nativContentOnAccentPrimary)
+        static let onAccentSecondary = Color(.nativContentOnAccentSecondary)
+
+        /// Figma alias: `content/danger-primary` → `status/danger`.
+        static var dangerPrimary: Color { Status.danger }
+    }
+
+    enum Border {
+        static let primary = Color(.nativBorderPrimary)
+        static let secondary = Color(.nativBorderSecondary)
+    }
+
+    enum Fill {
+        static let primary = Color(.nativFillPrimary)
+        static let secondary = Color(.nativFillSecondary)
+        static let tertiary = Color(.nativFillTertiary)
+        static let quaternary = Color(.nativFillQuaternary)
+        static let quinary = Color(.nativFillQuinary)
+    }
+
+    enum Accent {
+        static let base = Color(.accent)
+        static let hover = Color(.nativAccentHover)
+        static let subtle = Color(.nativAccentSubtle)
+        static let selected = Color(.nativAccentSelected)
+        static let emphasis = Color(.nativAccentEmphasis)
+        static let focusRing = Color(.nativAccentFocusRing)
+    }
+
+    enum Status {
+        static let success = Color(.nativStatusSuccess)
+        static let warning = Color(.nativStatusWarning)
+        static let danger = Color(.nativStatusDanger)
+
+        /// Figma alias: `status/active` → `accent/base`.
+        static var active: Color { Accent.base }
+
+        /// Figma alias: `status/neutral` → `content/secondary`.
+        static var neutral: Color { Content.secondary }
+    }
+
+    enum Chart {
+        static let series1 = Color(.nativChartSeries1)
+        static let series2 = Color(.nativChartSeries2)
+        static let series3 = Color(.nativChartSeries3)
+        static let series4 = Color(.nativChartSeries4)
+        static let series5 = Color(.nativChartSeries5)
+        static let series6 = Color(.nativChartSeries6)
+
+        /// Figma alias: `chart/panel` → `surface/primary`.
+        static var panel: Color { Surface.primary }
+
+        /// Figma alias: `chart/axis-text` → `content/secondary`.
+        static var axisText: Color { Content.secondary }
+
+        /// Figma alias: `chart/axis-label` → `content/tertiary`.
+        static var axisLabel: Color { Content.tertiary }
+
+        static let panelStroke = Color(.nativChartPanelStroke)
+        static let grid = Color(.nativChartGrid)
+    }
+}

--- a/Sources/Nativ/DesignSystem/NativTypography.swift
+++ b/Sources/Nativ/DesignSystem/NativTypography.swift
@@ -1,0 +1,286 @@
+import SwiftUI
+
+/// The Figma typography ramp expressed once, independently of view-specific meaning.
+/// Application views should consume `NativTypography.Style` rather than these tokens.
+private enum NativTypeScale {
+    struct Token {
+        let font: Font
+        let lineHeight: CGFloat
+        let lineSpacing: CGFloat
+    }
+
+    // The Figma letter-spacing values mirror SF Pro's optical metrics. SwiftUI's
+    // system font supplies those metrics; applying `.tracking` again would add a
+    // second adjustment. Line spacing is only added where SwiftUI's native
+    // baseline distance is smaller than the Figma style's line height.
+    static let titleExtraLargeMedium = system(size: 38, lineHeight: 44, nativeLineHeight: 45, weight: .medium)
+    static let titleLargeMedium = system(size: 26, lineHeight: 32, nativeLineHeight: 30, weight: .medium)
+    static let titleLargeBold = system(size: 26, lineHeight: 32, nativeLineHeight: 30, weight: .bold)
+    static let titleMediumMedium = system(size: 22, lineHeight: 26, nativeLineHeight: 26, weight: .medium)
+    static let titleMediumBold = system(size: 22, lineHeight: 26, nativeLineHeight: 26, weight: .bold)
+    static let titleSmallMedium = system(size: 17, lineHeight: 22, nativeLineHeight: 20, weight: .medium)
+    static let titleSmallBold = system(size: 17, lineHeight: 22, nativeLineHeight: 20, weight: .bold)
+
+    static let textLargeRegular = system(size: 17, lineHeight: 22, nativeLineHeight: 20, weight: .regular)
+    static let textLargeMedium = system(size: 17, lineHeight: 22, nativeLineHeight: 20, weight: .medium)
+    static let textLargeSemibold = system(size: 17, lineHeight: 22, nativeLineHeight: 20, weight: .semibold)
+    static let textLargeBold = system(size: 17, lineHeight: 22, nativeLineHeight: 20, weight: .bold)
+
+    static let textMediumRegular = system(size: 15, lineHeight: 20, nativeLineHeight: 19, weight: .regular)
+    static let textMediumMedium = system(size: 15, lineHeight: 20, nativeLineHeight: 19, weight: .medium)
+    static let textMediumSemibold = system(size: 15, lineHeight: 20, nativeLineHeight: 19, weight: .semibold)
+    static let textMediumBold = system(size: 15, lineHeight: 20, nativeLineHeight: 19, weight: .bold)
+
+    static let textSmallRegular = system(size: 13, lineHeight: 16, nativeLineHeight: 16, weight: .regular)
+    static let textSmallMedium = system(size: 13, lineHeight: 16, nativeLineHeight: 16, weight: .medium)
+    static let textSmallSemibold = system(size: 13, lineHeight: 16, nativeLineHeight: 16, weight: .semibold)
+    static let textSmallBold = system(size: 13, lineHeight: 16, nativeLineHeight: 16, weight: .bold)
+
+    static let textExtraSmallRegular = system(size: 11, lineHeight: 14, nativeLineHeight: 14, weight: .regular)
+    static let textExtraSmallMedium = system(size: 11, lineHeight: 14, nativeLineHeight: 14, weight: .medium)
+    static let textExtraSmallSemibold = system(size: 11, lineHeight: 14, nativeLineHeight: 14, weight: .semibold)
+    static let textExtraSmallBold = system(size: 11, lineHeight: 14, nativeLineHeight: 14, weight: .bold)
+
+    static let metadataNumeric = Token(
+        font: textExtraSmallRegular.font.monospacedDigit(),
+        lineHeight: textExtraSmallRegular.lineHeight,
+        lineSpacing: textExtraSmallRegular.lineSpacing
+    )
+
+    static let technicalDisplay = monospaced(size: 17, lineHeight: 22, nativeLineHeight: 20, weight: .semibold)
+    static let technicalTitle = monospaced(size: 15, lineHeight: 20, nativeLineHeight: 19, weight: .semibold)
+    static let technicalLabel = monospaced(size: 13, lineHeight: 16, nativeLineHeight: 16, weight: .medium)
+    static let code = monospaced(size: 13, lineHeight: 16, nativeLineHeight: 16, weight: .regular)
+    static let codeEmphasized = monospaced(size: 13, lineHeight: 16, nativeLineHeight: 16, weight: .semibold)
+
+    private static func system(
+        size: CGFloat,
+        lineHeight: CGFloat,
+        nativeLineHeight: CGFloat,
+        weight: Font.Weight
+    ) -> Token {
+        Token(
+            font: .system(size: size, weight: weight),
+            lineHeight: lineHeight,
+            lineSpacing: max(0, lineHeight - nativeLineHeight)
+        )
+    }
+
+    private static func monospaced(
+        size: CGFloat,
+        lineHeight: CGFloat,
+        nativeLineHeight: CGFloat,
+        weight: Font.Weight
+    ) -> Token {
+        Token(
+            font: .system(size: size, weight: weight, design: .monospaced),
+            lineHeight: lineHeight,
+            lineSpacing: max(0, lineHeight - nativeLineHeight)
+        )
+    }
+}
+
+/// Stable, semantic typography roles used by Nativ views.
+/// Figma scale changes are mapped here without renaming application call sites.
+enum NativTypography {
+    enum Style {
+        case displayTitle
+        case heroSubtitle
+        case pageTitle
+        case brandTitle
+        case sheetTitle
+        case detailTitle
+        case cardTitle
+        case compactCardTitle
+        case emptyStateTitle
+        case sidebarSectionTitle
+        case sidebarItem
+        case subsectionTitle
+        case sectionTitle
+        case rowTitleEmphasized
+        case rowTitle
+        case body
+        case supporting
+        case supportingEmphasized
+        case metadata
+        case metadataNumeric
+        case badge
+        case badgeMuted
+        case badgeStrong
+        case actionLabel
+        case prominentActionLabel
+        case statusBadge
+        case chartLabel
+        case technicalDisplayTitle
+        case technicalTitle
+        case technicalLabel
+        case code
+        case codeEmphasized
+
+        fileprivate var token: NativTypeScale.Token {
+            switch self {
+            case .displayTitle:
+                NativTypeScale.titleExtraLargeMedium
+            case .heroSubtitle:
+                NativTypeScale.textLargeRegular
+            case .pageTitle:
+                NativTypeScale.titleLargeMedium
+            case .brandTitle:
+                NativTypeScale.titleMediumMedium
+            case .sheetTitle:
+                NativTypeScale.titleSmallBold
+            case .detailTitle:
+                NativTypeScale.titleSmallMedium
+            case .cardTitle:
+                NativTypeScale.textMediumSemibold
+            case .compactCardTitle:
+                NativTypeScale.textSmallSemibold
+            case .emptyStateTitle:
+                NativTypeScale.textMediumMedium
+            case .sidebarSectionTitle:
+                NativTypeScale.textMediumSemibold
+            case .sidebarItem:
+                NativTypeScale.textMediumRegular
+            case .subsectionTitle, .sectionTitle, .rowTitleEmphasized:
+                NativTypeScale.textSmallSemibold
+            case .rowTitle:
+                NativTypeScale.textSmallMedium
+            case .body:
+                NativTypeScale.textMediumRegular
+            case .supporting:
+                NativTypeScale.textSmallRegular
+            case .supportingEmphasized:
+                NativTypeScale.textSmallMedium
+            case .metadata:
+                NativTypeScale.textExtraSmallRegular
+            case .metadataNumeric:
+                NativTypeScale.metadataNumeric
+            case .badge, .statusBadge:
+                NativTypeScale.textExtraSmallSemibold
+            case .badgeMuted, .actionLabel:
+                NativTypeScale.textExtraSmallMedium
+            case .prominentActionLabel:
+                NativTypeScale.textLargeMedium
+            case .badgeStrong:
+                NativTypeScale.textExtraSmallBold
+            case .chartLabel:
+                NativTypeScale.textExtraSmallRegular
+            case .technicalDisplayTitle:
+                NativTypeScale.technicalDisplay
+            case .technicalTitle:
+                NativTypeScale.technicalTitle
+            case .technicalLabel:
+                NativTypeScale.technicalLabel
+            case .code:
+                NativTypeScale.code
+            case .codeEmphasized:
+                NativTypeScale.codeEmphasized
+            }
+        }
+    }
+}
+
+private struct NativTypographyModifier: ViewModifier {
+    let style: NativTypography.Style
+
+    func body(content: Content) -> some View {
+        let token = style.token
+        content
+            .font(token.font)
+            .lineSpacing(token.lineSpacing)
+    }
+}
+
+extension View {
+    /// Applies one of Nativ's application-wide semantic typography roles.
+    func nativTextStyle(_ style: NativTypography.Style) -> some View {
+        modifier(NativTypographyModifier(style: style))
+    }
+}
+
+private struct NativTypographyPreview: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                previewSection("Titles") {
+                    previewRow("Display title", sample: "Welcome to Nativ", style: .displayTitle)
+                    previewRow("Hero subtitle", sample: "Let’s get you set up", style: .heroSubtitle)
+                    previewRow("Page title", sample: "Extensions", style: .pageTitle)
+                    previewRow("Brand title", sample: "Nativ", style: .brandTitle)
+                    previewRow("Sheet title", sample: "Edit Tool", style: .sheetTitle)
+                    previewRow("Detail title", sample: "Featured Kit", style: .detailTitle)
+                    previewRow("Card title", sample: "Scheduled Task", style: .cardTitle)
+                    previewRow("Compact card title", sample: "Artifact.jpg", style: .compactCardTitle)
+                    previewRow("Empty-state title", sample: "Drop files here", style: .emptyStateTitle)
+                }
+
+                previewSection("Navigation and content") {
+                    previewRow("Sidebar section", sample: "Chats", style: .sidebarSectionTitle)
+                    previewRow("Sidebar item", sample: "Recent conversation", style: .sidebarItem)
+                    previewRow("Subsection title", sample: "Custom Servers", style: .subsectionTitle)
+                    previewRow("Section title", sample: "Capabilities", style: .sectionTitle)
+                    previewRow("Emphasized row", sample: "Image Generation", style: .rowTitleEmphasized)
+                    previewRow("Row title", sample: "Web Search", style: .rowTitle)
+                    previewRow("Body", sample: "Primary interface content", style: .body)
+                    previewRow("Supporting", sample: "Additional context and guidance", style: .supporting)
+                    previewRow("Supporting emphasized", sample: "Field or control label", style: .supportingEmphasized)
+                }
+
+                previewSection("Metadata and labels") {
+                    previewRow("Metadata", sample: "Updated today", style: .metadata)
+                    previewRow("Numeric metadata", sample: "12 of 48", style: .metadataNumeric)
+                    previewRow("Badge", sample: "BUILT-IN", style: .badge)
+                    previewRow("Muted badge", sample: "Optional", style: .badgeMuted)
+                    previewRow("Strong badge", sample: "PDF", style: .badgeStrong)
+                    previewRow("Action label", sample: "Enable", style: .actionLabel)
+                    previewRow("Prominent action", sample: "Continue", style: .prominentActionLabel)
+                    previewRow("Status badge", sample: "Connected", style: .statusBadge)
+                    previewRow("Chart label", sample: "12 AM", style: .chartLabel)
+                }
+
+                previewSection("Technical") {
+                    previewRow("Technical display", sample: "web_search", style: .technicalDisplayTitle)
+                    previewRow("Technical title", sample: "read_file", style: .technicalTitle)
+                    previewRow("Technical label", sample: "POST", style: .technicalLabel)
+                    previewRow("Code", sample: #"{"query":"Nativ"}"#, style: .code)
+                    previewRow("Code emphasized", sample: "GET /v1/models", style: .codeEmphasized)
+                }
+            }
+            .padding(24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(NativColor.Surface.window)
+    }
+
+    private func previewSection<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .nativTextStyle(.sectionTitle)
+            content()
+        }
+    }
+
+    private func previewRow(
+        _ name: String,
+        sample: String,
+        style: NativTypography.Style
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 16) {
+            Text(name)
+                .nativTextStyle(.metadata)
+                .foregroundStyle(NativColor.Content.secondary)
+                .frame(width: 150, alignment: .leading)
+            Text(sample)
+                .nativTextStyle(style)
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+#Preview("Typography") {
+    NativTypographyPreview()
+        .frame(width: 520, height: 760)
+}

--- a/Sources/Nativ/Features/Shared/NativComponents.swift
+++ b/Sources/Nativ/Features/Shared/NativComponents.swift
@@ -164,11 +164,11 @@ private struct ArrowlessPopoverSurface: View {
 
     var body: some View {
         content
-            .background(Color(nsColor: .textBackgroundColor))
+            .background(NativColor.Surface.secondary)
             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.75)
+                    .stroke(NativColor.Border.primary, lineWidth: 0.75)
             }
     }
 }
@@ -196,115 +196,6 @@ extension Color {
 // Shared, flat UI primitives used across Nativ. These favor whitespace and a
 // single tint over nested filled tiles, so a surface reads as one calm plane
 // rather than a stack of boxes. Prefer these over re-rolling a pill/badge/dot.
-
-/// The application-wide typography roles used by Nativ interface chrome.
-enum NativTypography {
-    enum Style {
-        case displayTitle
-        case pageTitle
-        case brandTitle
-        case sheetTitle
-        case detailTitle
-        case cardTitle
-        case compactCardTitle
-        case emptyStateTitle
-        case sidebarSectionTitle
-        case sidebarItem
-        case subsectionTitle
-        case sectionTitle
-        case rowTitleEmphasized
-        case rowTitle
-        case body
-        case supporting
-        case supportingEmphasized
-        case metadata
-        case metadataNumeric
-        case badge
-        case badgeMuted
-        case badgeStrong
-        case actionLabel
-        case statusBadge
-        case chartLabel
-        case technicalDisplayTitle
-        case technicalTitle
-        case technicalLabel
-        case code
-        case codeEmphasized
-
-        fileprivate var font: Font {
-            switch self {
-            case .displayTitle:
-                .system(size: 32, weight: .semibold)
-            case .pageTitle:
-                .system(size: 20, weight: .semibold)
-            case .brandTitle:
-                .system(size: 18, weight: .semibold)
-            case .sheetTitle:
-                .system(size: 18, weight: .semibold)
-            case .detailTitle:
-                .system(size: 17, weight: .semibold)
-            case .cardTitle:
-                .system(size: 15, weight: .semibold)
-            case .compactCardTitle:
-                .system(size: 14, weight: .semibold)
-            case .emptyStateTitle:
-                .system(size: 15, weight: .medium)
-            case .sidebarSectionTitle:
-                .system(size: 15, weight: .semibold)
-            case .sidebarItem:
-                .system(size: 15)
-            case .subsectionTitle:
-                .system(size: 14, weight: .semibold)
-            case .sectionTitle:
-                .system(size: 13, weight: .semibold)
-            case .rowTitleEmphasized:
-                .system(size: 13, weight: .semibold)
-            case .rowTitle:
-                .system(size: 13, weight: .medium)
-            case .body:
-                .system(size: 13)
-            case .supporting:
-                .system(size: 12)
-            case .supportingEmphasized:
-                .system(size: 12, weight: .medium)
-            case .metadata:
-                .system(size: 11)
-            case .metadataNumeric:
-                .system(size: 11).monospacedDigit()
-            case .badge:
-                .system(size: 10, weight: .semibold)
-            case .badgeMuted:
-                .system(size: 10, weight: .medium)
-            case .badgeStrong:
-                .system(size: 10, weight: .bold)
-            case .actionLabel:
-                .system(size: 11, weight: .medium)
-            case .statusBadge:
-                .system(size: 11, weight: .semibold)
-            case .chartLabel:
-                .system(size: 9)
-            case .technicalDisplayTitle:
-                .system(size: 16, weight: .semibold, design: .monospaced)
-            case .technicalTitle:
-                .system(size: 15, weight: .semibold, design: .monospaced)
-            case .technicalLabel:
-                .system(size: 12, weight: .medium, design: .monospaced)
-            case .code:
-                .system(size: 12, design: .monospaced)
-            case .codeEmphasized:
-                .system(size: 12, weight: .semibold, design: .monospaced)
-            }
-        }
-    }
-}
-
-private struct NativTypographyModifier: ViewModifier {
-    let style: NativTypography.Style
-
-    func body(content: Content) -> some View {
-        content.font(style.font)
-    }
-}
 
 /// The supported corner-radius roles for shared panel surfaces.
 enum NativPanelCornerRadius {
@@ -334,10 +225,10 @@ private struct NativPanelSurfaceModifier: ViewModifier {
         content
             .background {
                 shape
-                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .fill(NativColor.Surface.primary)
                     .overlay {
                         if isHighlighted {
-                            Color.primary.opacity(0.045)
+                            NativColor.Accent.hover
                         }
                     }
                     .clipShape(shape)
@@ -345,8 +236,8 @@ private struct NativPanelSurfaceModifier: ViewModifier {
             .overlay {
                 shape.stroke(
                     isHighlighted
-                        ? Color.primary.opacity(0.16)
-                        : Color(nsColor: .separatorColor),
+                        ? NativColor.Accent.emphasis
+                        : NativColor.Border.primary,
                     lineWidth: 0.5
                 )
             }
@@ -354,11 +245,6 @@ private struct NativPanelSurfaceModifier: ViewModifier {
 }
 
 extension View {
-    /// Applies one of Nativ's application-wide typography roles.
-    func nativTextStyle(_ style: NativTypography.Style) -> some View {
-        modifier(NativTypographyModifier(style: style))
-    }
-
     /// Applies Nativ's standard semantic panel surface.
     func nativPanelStyle(
         cornerRadius: NativPanelCornerRadius = .standard,
@@ -373,91 +259,6 @@ extension View {
     }
 }
 
-private struct NativTypographyPreview: View {
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                previewSection("Titles") {
-                    previewRow("Display title", sample: "Welcome to Nativ", style: .displayTitle)
-                    previewRow("Page title", sample: "Extensions", style: .pageTitle)
-                    previewRow("Brand title", sample: "Nativ", style: .brandTitle)
-                    previewRow("Sheet title", sample: "Edit Tool", style: .sheetTitle)
-                    previewRow("Detail title", sample: "Featured Kit", style: .detailTitle)
-                    previewRow("Card title", sample: "Scheduled Task", style: .cardTitle)
-                    previewRow("Compact card title", sample: "Artifact.jpg", style: .compactCardTitle)
-                    previewRow("Empty-state title", sample: "Drop files here", style: .emptyStateTitle)
-                }
-
-                previewSection("Navigation and content") {
-                    previewRow("Sidebar section", sample: "Chats", style: .sidebarSectionTitle)
-                    previewRow("Sidebar item", sample: "Recent conversation", style: .sidebarItem)
-                    previewRow("Subsection title", sample: "Custom Servers", style: .subsectionTitle)
-                    previewRow("Section title", sample: "Capabilities", style: .sectionTitle)
-                    previewRow("Emphasized row", sample: "Image Generation", style: .rowTitleEmphasized)
-                    previewRow("Row title", sample: "Web Search", style: .rowTitle)
-                    previewRow("Body", sample: "Primary interface content", style: .body)
-                    previewRow("Supporting", sample: "Additional context and guidance", style: .supporting)
-                    previewRow("Supporting emphasized", sample: "Field or control label", style: .supportingEmphasized)
-                }
-
-                previewSection("Metadata and labels") {
-                    previewRow("Metadata", sample: "Updated today", style: .metadata)
-                    previewRow("Numeric metadata", sample: "12 of 48", style: .metadataNumeric)
-                    previewRow("Badge", sample: "BUILT-IN", style: .badge)
-                    previewRow("Muted badge", sample: "Optional", style: .badgeMuted)
-                    previewRow("Strong badge", sample: "PDF", style: .badgeStrong)
-                    previewRow("Action label", sample: "Enable", style: .actionLabel)
-                    previewRow("Status badge", sample: "Connected", style: .statusBadge)
-                    previewRow("Chart label", sample: "12 AM", style: .chartLabel)
-                }
-
-                previewSection("Technical") {
-                    previewRow("Technical display", sample: "web_search", style: .technicalDisplayTitle)
-                    previewRow("Technical title", sample: "read_file", style: .technicalTitle)
-                    previewRow("Technical label", sample: "POST", style: .technicalLabel)
-                    previewRow("Code", sample: #"{"query":"Nativ"}"#, style: .code)
-                    previewRow("Code emphasized", sample: "GET /v1/models", style: .codeEmphasized)
-                }
-            }
-            .padding(24)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .windowBackgroundColor))
-    }
-
-    private func previewSection<Content: View>(
-        _ title: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text(title)
-                .nativTextStyle(.sectionTitle)
-            content()
-        }
-    }
-
-    private func previewRow(
-        _ name: String,
-        sample: String,
-        style: NativTypography.Style
-    ) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 16) {
-            Text(name)
-                .nativTextStyle(.metadata)
-                .foregroundStyle(.secondary)
-                .frame(width: 150, alignment: .leading)
-            Text(sample)
-                .nativTextStyle(style)
-            Spacer(minLength: 0)
-        }
-    }
-}
-
-#Preview("Typography") {
-    NativTypographyPreview()
-        .frame(width: 520, height: 760)
-}
-
 /// A semantic status color, shared by dots, badges, and tool states.
 enum NativStatusTone {
     case neutral
@@ -468,11 +269,11 @@ enum NativStatusTone {
 
     var color: Color {
         switch self {
-        case .neutral: return .secondary
-        case .active: return .accentColor
-        case .success: return .green
-        case .warning: return .orange
-        case .danger: return .red
+        case .neutral: return NativColor.Status.neutral
+        case .active: return NativColor.Status.active
+        case .success: return NativColor.Status.success
+        case .warning: return NativColor.Status.warning
+        case .danger: return NativColor.Status.danger
         }
     }
 }
@@ -574,13 +375,13 @@ struct NativCodeBlock: View {
     var body: some View {
         Text(display)
             .font(.system(.caption, design: .monospaced))
-            .foregroundStyle(.secondary)
+            .foregroundStyle(NativColor.Content.secondary)
             .textSelection(.enabled)
             .lineLimit(lineLimit)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(8)
             .background(
-                Color.primary.opacity(0.04),
+                NativColor.Fill.quaternary,
                 in: RoundedRectangle(cornerRadius: 6, style: .continuous)
             )
     }
@@ -648,9 +449,9 @@ struct NativHoverCloseButton: View {
         Button(action: action) {
             Image(systemName: "xmark")
                 .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(NativColor.Content.secondary)
                 .frame(width: 26, height: 26)
-                .background(Circle().fill(Color.primary.opacity(hovering ? 0.10 : 0)))
+                .background(Circle().fill(hovering ? NativColor.Fill.primary : .clear))
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)

--- a/project.yml
+++ b/project.yml
@@ -146,6 +146,7 @@ targets:
       base:
         ARCHS: arm64
         ASSETCATALOG_COMPILER_APPICON_NAME: ""
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         MACOSX_DEPLOYMENT_TARGET: "26.0"
         ENABLE_HARDENED_RUNTIME: YES
         PRODUCT_BUNDLE_IDENTIFIER: $(NATIV_BUNDLE_IDENTIFIER)
@@ -207,6 +208,10 @@ targets:
       - path: Sources/Nativ/Features/Models/MLXImageModelResolver.swift
       - path: Sources/Nativ/Features/Models/ModelPrimaryTaskResolver.swift
       - path: Sources/Nativ/Features/Shared/NativBulkSelection.swift
+      - path: Sources/Nativ/DesignSystem/NativColor.swift
+      - path: Sources/Nativ/DesignSystem/NativTypography.swift
+      - path: Sources/Nativ/Assets.xcassets
+        buildPhase: resources
       - path: Sources/Nativ/Features/Developer/LogTextStorageMutation.swift
       - path: Sources/Nativ/Features/Integrations/CodexCLIProfile.swift
       - path: Sources/Nativ/Features/Integrations/IntegrationServices.swift


### PR DESCRIPTION
Adds centralized semantic color and typography systems based on the Figma design system, including light and dark mode support. 

@Lazarus-931 the pr also updates your typography-based components to use the revised design tokens.