### PR TITLE
Condense skill previews in Kits

### DIFF
--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -912,7 +912,7 @@ private enum KitComponentInventory {
                 component: component,
                 section: .skills,
                 title: skill.name,
-                subtitle: skill.instructions,
+                subtitle: skillSummary(skill.instructions),
                 symbol: "sparkles",
                 tint: .purple,
                 logoAssetName: nil,
@@ -957,5 +957,13 @@ private enum KitComponentInventory {
 
     private static func humanized(_ name: String) -> String {
         name.split(separator: "_").map { String($0).capitalized }.joined(separator: " ")
+    }
+
+    private static func skillSummary(_ instructions: String) -> String? {
+        instructions
+            .components(separatedBy: "\n\n")
+            .lazy
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty }
     }
 }


### PR DESCRIPTION
Kit skill rows now show only the opening summary paragraph instead of the entire instruction body. The full skill remains unchanged and is still provided to the model.

Before:

<img width="729" height="671" alt="Screenshot 2026-09-04 at 12 33 22 PM" src="https://github.com/user-attachments/assets/9b2be0a3-08e3-4fad-981e-caf6ffce7b47" />
