### PR TITLE
Fix model configuration header overlap

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -10,6 +10,7 @@ private enum ModelConfigurationLayoutMetrics {
     static let topInset: CGFloat = 32
     static let transitionDuration: TimeInterval = 0.3
     static let resizeHandleWidth: CGFloat = 9
+    static let headerTrailingControlClearance: CGFloat = 52
 }
 
 struct ModelConfigurationLayout<Content: View>: View {
@@ -261,7 +262,7 @@ struct ModelConfigurationView: View {
             }
         }
         .padding(.leading, 16)
-        .padding(.trailing, 16)
+        .padding(.trailing, ModelConfigurationLayoutMetrics.headerTrailingControlClearance)
         .padding(.top, 13)
         .padding(.bottom, 16)
     }


### PR DESCRIPTION
Reserve space in the model configuration header so reset and sidebar controls remain visually distinct.

top right here: 
<img width="329" height="69" alt="Screenshot 2026-09-04 at 12 49 44 PM" src="https://github.com/user-attachments/assets/f80f5f57-31cc-47b2-bc61-86a1a6ef9181" />
