### PR TITLE
Show model provider logos in integration picker

### DIFF
--- a/Sources/Nativ/Features/Integrations/IntegrationTypes.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationTypes.swift
@@ -199,6 +199,7 @@ enum IntegrationTool: String, CaseIterable, Hashable, Identifiable, Sendable {
 struct IntegrationModelDescriptor: Identifiable, Equatable, Sendable {
     let id: String
     let displayName: String
+    let provider: LocalModelProvider?
     let contextWindow: Int?
     let supportsVision: Bool
     let supportsReasoning: Bool

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -8,6 +8,7 @@ extension IntegrationModelDescriptor {
         self.init(
             id: localModel.repoID,
             displayName: localModel.repoID.split(separator: "/").last.map(String.init) ?? localModel.repoID,
+            provider: localModel.provider,
             contextWindow: localModel.contextSize,
             supportsVision: localModel.capabilities.contains(.vision),
             supportsReasoning: localModel.capabilities.contains(.reasoning),
@@ -674,7 +675,8 @@ private struct IntegrationDetailView: View {
             } else {
                 Picker("Model", selection: $viewModel.selectedModelID) {
                     ForEach(viewModel.eligibleModels) { model in
-                        Text(model.id).tag(Optional(model.id))
+                        IntegrationModelPickerLabel(model: model)
+                            .tag(Optional(model.id))
                     }
                 }
                 .labelsHidden()
@@ -852,6 +854,43 @@ private struct IntegrationDetailView: View {
 
     private func formatContext(_ count: Int) -> String {
         count >= 1_000 ? "\(count / 1_000)K context" : "\(count) context"
+    }
+}
+
+private struct IntegrationModelPickerLabel: View {
+    let model: IntegrationModelDescriptor
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Label {
+            Text(model.id)
+        } icon: {
+            ZStack {
+                if model.provider?.needsLightIconBackgroundInDarkMode == true,
+                   colorScheme == .dark {
+                    Circle()
+                        .fill(Color.white.opacity(0.94))
+                }
+
+                if let provider = model.provider,
+                   let image = LocalModelProviderIcon.image(for: provider) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .foregroundStyle(Color(nsColor: provider.iconTintColor))
+                } else if let provider = model.provider {
+                    Text(provider.monogram)
+                        .font(.system(size: provider.monogram.count > 2 ? 7 : 9, weight: .bold))
+                        .foregroundStyle(Color(nsColor: provider.iconTintColor))
+                } else {
+                    Image(systemName: "cube.transparent")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 16, height: 16)
+            .accessibilityHidden(true)
+        }
     }
 }
 

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -876,10 +876,7 @@ private struct IntegrationModelPickerLabel: View {
                 if let provider = model.provider,
                    let image = LocalModelProviderIcon.image(for: provider) {
                     Image(nsImage: image)
-                        .resizable()
-                        .scaledToFit()
                         .foregroundStyle(Color(nsColor: provider.iconTintColor))
-                        .frame(width: 15, height: 15)
                 } else if let provider = model.provider {
                     Text(provider.monogram)
                         .font(.system(size: provider.monogram.count > 2 ? 7 : 9, weight: .bold))

--- a/Sources/Nativ/Features/Integrations/IntegrationsView.swift
+++ b/Sources/Nativ/Features/Integrations/IntegrationsView.swift
@@ -870,6 +870,7 @@ private struct IntegrationModelPickerLabel: View {
                    colorScheme == .dark {
                     Circle()
                         .fill(Color.white.opacity(0.94))
+                        .frame(width: 18, height: 18)
                 }
 
                 if let provider = model.provider,
@@ -878,6 +879,7 @@ private struct IntegrationModelPickerLabel: View {
                         .resizable()
                         .scaledToFit()
                         .foregroundStyle(Color(nsColor: provider.iconTintColor))
+                        .frame(width: 15, height: 15)
                 } else if let provider = model.provider {
                     Text(provider.monogram)
                         .font(.system(size: provider.monogram.count > 2 ? 7 : 9, weight: .bold))
@@ -888,7 +890,7 @@ private struct IntegrationModelPickerLabel: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            .frame(width: 16, height: 16)
+            .frame(width: 18, height: 18)
             .accessibilityHidden(true)
         }
     }

--- a/Tests/NativTests/IntegrationServicesTests.swift
+++ b/Tests/NativTests/IntegrationServicesTests.swift
@@ -31,6 +31,7 @@ final class IntegrationServicesTests: XCTestCase {
     private let selectedModel = IntegrationModelDescriptor(
         id: "org/local-model",
         displayName: "Local Model",
+        provider: .qwen,
         contextWindow: 32_768,
         supportsVision: true,
         supportsReasoning: true,
@@ -39,6 +40,7 @@ final class IntegrationServicesTests: XCTestCase {
     private let basicModel = IntegrationModelDescriptor(
         id: "org/basic-model",
         displayName: "Basic Model",
+        provider: nil,
         contextWindow: nil,
         supportsVision: false,
         supportsReasoning: false,


### PR DESCRIPTION
## Summary

- show each installed model’s provider logo in Integration model dropdowns
- preserve the resolved provider from local model discovery
- use a neutral model glyph when the provider is unknown
- keep provider artwork at its intrinsic menu size so native Picker labels cannot stretch it


<img width="1256" height="1043" alt="Screenshot 2026-09-04 at 4 16 22 PM" src="https://github.com/user-attachments/assets/d63a9b87-b05d-4ccf-b493-9d8eb543b77d" />

