### PR TITLE
Fix model picker tooltip clipping

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -1283,15 +1283,15 @@ struct ComposerModelPicker: View {
         }
         .fixedSize()
         .frame(height: 32)
-        .overlay(alignment: .top) {
-            if isPickerHovered && !isMenuOpen {
+        .background {
+            NativArrowlessPopoverPresenter(
+                isPresented: tooltipPresentation,
+                gap: 10
+            ) {
                 ComposerModelPickerTooltip(
                     title: pickerTooltip,
                     shortcutLabel: isDisabled ? nil : shortcutLabel
                 )
-                    .offset(y: -50)
-                    .transition(.opacity.combined(with: .scale(scale: 0.98, anchor: .bottom)))
-                    .allowsHitTesting(false)
             }
         }
         .contentShape(Capsule())
@@ -1318,6 +1318,13 @@ struct ComposerModelPicker: View {
 
     private var pickerTooltip: String {
         isDisabled ? helpText : "Choose Model"
+    }
+
+    private var tooltipPresentation: Binding<Bool> {
+        Binding(
+            get: { isPickerHovered && !isMenuOpen },
+            set: { isPickerHovered = $0 }
+        )
     }
 
     private var isPickerActive: Bool {
@@ -1798,12 +1805,6 @@ private struct ComposerModelPickerTooltip: View {
         .padding(.leading, 12)
         .padding(.trailing, 8)
         .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color(nsColor: .separatorColor).opacity(0.8), lineWidth: 0.75)
-        }
-        .shadow(color: .black.opacity(0.16), radius: 8, y: 3)
         .fixedSize()
     }
 }


### PR DESCRIPTION

- present the composer model picker tooltip through the shared arrowless popover
- keep long disabled-state guidance visible outside the composer's clipped bounds
- reuse the same behavior for chat and image model pickers

before:
<img width="1180" height="320" alt="image" src="https://github.com/user-attachments/assets/3ed2db65-9249-4f4c-a82e-1df227f2c52b" />


after:

<img width="1068" height="236" alt="image" src="https://github.com/user-attachments/assets/85637786-dba6-4c65-bbd3-8e77f75d7c66" />
