### PR TITLE
Move model reset below panel toggle

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -10,7 +10,6 @@ private enum ModelConfigurationLayoutMetrics {
     static let topInset: CGFloat = 32
     static let transitionDuration: TimeInterval = 0.3
     static let resizeHandleWidth: CGFloat = 9
-    static let headerTrailingControlClearance: CGFloat = 52
 }
 
 struct ModelConfigurationLayout<Content: View>: View {
@@ -232,12 +231,27 @@ struct ModelConfigurationView: View {
                     .font(.title3.weight(.semibold))
 
                 Spacer(minLength: 0)
+            }
+
+            HStack(spacing: 8) {
+                if settingsRequireRestart {
+                    Label("Server restart required", systemImage: "arrow.clockwise")
+                        .font(.footnote)
+                        .foregroundStyle(.orange)
+                } else {
+                    Text("Request settings apply to the next message.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
 
                 Button("Reset model configuration", systemImage: "arrow.counterclockwise") {
                     isConfirmingReset = true
                 }
                 .labelStyle(.iconOnly)
                 .buttonStyle(.borderless)
+                .frame(width: ControlPanelLayout.topControlSize)
                 .help("Reset model configuration")
                 .confirmationDialog(
                     "Reset model configuration?",
@@ -250,19 +264,9 @@ struct ModelConfigurationView: View {
                     Text("This will restore all model configuration settings to their defaults.")
                 }
             }
-
-            if settingsRequireRestart {
-                Label("Server restart required", systemImage: "arrow.clockwise")
-                    .font(.footnote)
-                    .foregroundStyle(.orange)
-            } else {
-                Text("Request settings apply to the next message.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
         }
         .padding(.leading, 16)
-        .padding(.trailing, ModelConfigurationLayoutMetrics.headerTrailingControlClearance)
+        .padding(.trailing, ControlPanelLayout.topControlsTrailingPadding)
         .padding(.top, 13)
         .padding(.bottom, 16)
     }

--- a/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
+++ b/Sources/Nativ/Features/Chat/ChatConfigurationView.swift
@@ -10,6 +10,11 @@ private enum ModelConfigurationLayoutMetrics {
     static let topInset: CGFloat = 32
     static let transitionDuration: TimeInterval = 0.3
     static let resizeHandleWidth: CGFloat = 9
+    /// The panel toggle is drawn over this panel's top-trailing corner with the
+    /// safe area ignored, so ``topInset`` has to clear its band in every window
+    /// state -- not just full screen -- for the header's own trailing control to
+    /// sit under it rather than on it.
+    static let headerTopPadding: CGFloat = 4
 }
 
 struct ModelConfigurationLayout<Content: View>: View {
@@ -41,7 +46,6 @@ struct ModelConfigurationLayout<Content: View>: View {
 
 struct ModelConfigurationLayoutContent<Content: View>: View {
     @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.controlPanelIsFullScreen) private var isFullScreen
     @Environment(\.displayScale) private var displayScale
     @Binding var settings: NativSettings
     let settingsRequireRestart: Bool
@@ -105,7 +109,7 @@ struct ModelConfigurationLayoutContent<Content: View>: View {
                 settingsRequireRestart: settingsRequireRestart,
                 onReset: onReset
             )
-            .padding(.top, isFullScreen ? ModelConfigurationLayoutMetrics.topInset : 0)
+            .padding(.top, ModelConfigurationLayoutMetrics.topInset)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -229,20 +233,8 @@ struct ModelConfigurationView: View {
             HStack(spacing: 8) {
                 Label("Model Configuration", systemImage: "slider.horizontal.3")
                     .font(.title3.weight(.semibold))
-
-                Spacer(minLength: 0)
-            }
-
-            HStack(spacing: 8) {
-                if settingsRequireRestart {
-                    Label("Server restart required", systemImage: "arrow.clockwise")
-                        .font(.footnote)
-                        .foregroundStyle(.orange)
-                } else {
-                    Text("Request settings apply to the next message.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
 
                 Spacer(minLength: 0)
 
@@ -264,10 +256,20 @@ struct ModelConfigurationView: View {
                     Text("This will restore all model configuration settings to their defaults.")
                 }
             }
+
+            if settingsRequireRestart {
+                Label("Server restart required", systemImage: "arrow.clockwise")
+                    .font(.footnote)
+                    .foregroundStyle(.orange)
+            } else {
+                Text("Request settings apply to the next message.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding(.leading, 16)
         .padding(.trailing, ControlPanelLayout.topControlsTrailingPadding)
-        .padding(.top, 13)
+        .padding(.top, ModelConfigurationLayoutMetrics.headerTopPadding)
         .padding(.bottom, 16)
     }
 


### PR DESCRIPTION
## Summary

- move the model-configuration reset control into the status row
- align it directly beneath the right-panel visibility toggle
- preserve the existing reset confirmation and accessibility behavior


I had a fix for this merged but still was off:

After https://github.com/Blaizzy/nativ/pull/496 (which is now main):

<img width="296" height="176" alt="image" src="https://github.com/user-attachments/assets/77d6ddaa-0951-43f6-939d-0a538a4e8aee" />


After this pr:

<img width="323" height="77" alt="Screenshot 2026-09-11 at 10 16 41 AM" src="https://github.com/user-attachments/assets/7ff8bea7-8769-4e95-8425-790cd877c99d" />


