### PR TITLE
test: add isolated realtime STT adoption probe

### DIFF
--- a/Docs/realtime-stt-candidate.md
+++ b/Docs/realtime-stt-candidate.md
@@ -1,0 +1,75 @@
+# Candidate live-input STT adoption
+
+The Nativ Python overlay imports the mlx-vlm application, so it automatically
+exposes `/v1/audio/transcriptions/realtime` when the underlying mlx-vlm package
+provides that route. No second mlx-audio app, model registry, or audio worker
+should be mounted in Nativ.
+
+This is a candidate integration, not enabled by changing production pins:
+
+- mlx-audio https://github.com/Blaizzy/mlx-audio/pull/945 adds Nemotron live-input
+  sessions (signed candidate `c706c4b53a149e0696dfa6f9fd3db9bb5bda6261`).
+- mlx-vlm https://github.com/Blaizzy/mlx-vlm/pull/2167 exposes that contract on
+  its existing authenticated router/audio worker
+  (`64295d91a8535d189b0c4528371d75a28470e75a`).
+- Nativ's existing `--mlx-vlm-source` and `--mlx-audio-source` build arguments
+  accept local candidate checkouts. Release requirements remain unchanged until
+  compatible upstream releases are available.
+
+## Reproduce without modifying the installed app
+
+Use a disposable Python environment with the candidate packages and Nativ's
+server dependencies installed. Use an existing local Nemotron model snapshot;
+the probe enforces offline mode. Create non-personal synthetic fixtures, e.g.
+with macOS `say` and `afconvert`, as mono 16-bit little-endian PCM WAV at 16 kHz.
+Use a spoken phrase long enough to observe partial output before it ends.
+
+```sh
+python PythonDistribution/Scripts/probe_realtime_stt.py \
+  --model /absolute/path/to/local/nemotron/snapshot \
+  --wav /absolute/path/to/synthetic-pt.wav \
+  --wav /absolute/path/to/synthetic-en.wav
+```
+
+The probe starts the actual Nativ overlay on a temporary loopback socket,
+redirects analytics to a new temporary directory, disables inherited preloads
+and API-key configuration only inside that process, streams PCM in paced 20 ms
+chunks, asserts partial output before commit and final output afterwards, and
+stops its server. It prints the synthetic transcript and timings as JSON.
+It does not start the installed application or replace its bundle. Temporary
+proof analytics remain under the `nativ-stt-proof-` OS temporary directory prefix
+for inspection.
+
+For a separate disposable distribution build, the existing builder accepts:
+
+```sh
+python PythonDistribution/Scripts/build_mlx_vlm_server.py \
+  --mlx-vlm-source /absolute/path/to/candidate/mlx-vlm \
+  --mlx-audio-source /absolute/path/to/candidate/mlx-audio \
+  --output /absolute/path/to/disposable/output \
+  --cache-dir /absolute/path/to/disposable/cache
+```
+
+That packaging step is distinct from the overlay/socket proof below; it has
+not been certified by that proof.
+
+## Observed proof
+
+On Apple Silicon, the unmodified Nativ overlay at
+`c6b6dbe7539192cb14bc7cdf4da47fd83193804f` with the candidate packages above and
+Nemotron 3.5 0.6B snapshot `e550040c0478027ed679b2b6b0d055502c103663` passed two
+synthetic fixtures using this probe:
+
+| Fixture | Audio duration | First partial | Commit to final |
+| --- | ---: | ---: | ---: |
+| Portuguese | 7.812 s | 2.717 s | 0.249 s |
+| English | 6.753 s | 1.636 s | 0.295 s |
+
+Both produced partials before commit. These are one-run functional observations,
+not latency percentiles, microphone UX proof, sustained-load certification, or
+proof of an updated packaged app. The server's separate suite passed 36 tests.
+
+The candidate endpoint is single-utterance, native-rate PCM16, greedy decoding,
+manual commit only. It has bounded queues and duration limits and exclusively
+reserves the audio worker. There is no automatic VAD, resampling, or full OpenAI
+Realtime compatibility claim. See the mlx-vlm candidate's `docs/realtime-stt.md`.

--- a/PythonDistribution/Scripts/probe_realtime_stt.py
+++ b/PythonDistribution/Scripts/probe_realtime_stt.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Probe live STT through an isolated Nativ Python overlay and loopback socket.
+
+Requires candidate mlx-vlm/mlx-audio packages in the selected interpreter.
+Never modifies the installed application or its analytics database.
+"""
+
+import argparse
+import base64
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+import wave
+from pathlib import Path
+from urllib.parse import quote
+
+
+def probe(ws, pcm):
+    created = json.loads(ws.recv(timeout=120))
+    if created.get("type") != "session.created":
+        raise RuntimeError(f"Session creation failed: {created}")
+    if created["session"]["input_audio_sample_rate"] != 16000:
+        raise ValueError("This probe requires a 16 kHz model")
+    timing = {"start": time.monotonic()}
+    failures = []
+    stop = threading.Event()
+
+    def send():
+        try:
+            for offset in range(0, len(pcm), 640):
+                if stop.is_set():
+                    return
+                ws.send(
+                    json.dumps(
+                        {
+                            "type": "input_audio_buffer.append",
+                            "audio": base64.b64encode(
+                                pcm[offset : offset + 640]
+                            ).decode(),
+                        }
+                    )
+                )
+                stop.wait(0.02)
+            timing["commit"] = time.monotonic()
+            ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
+        except Exception as exc:
+            failures.append(str(exc))
+
+    sender = threading.Thread(target=send, daemon=True)
+    sender.start()
+    first = None
+    partial_before_commit = False
+    try:
+        while True:
+            message = json.loads(ws.recv(timeout=120))
+            if message["type"] == "error":
+                raise RuntimeError(message["error"])
+            if message["type"].endswith(".delta") and first is None:
+                first = time.monotonic()
+                partial_before_commit = "commit" not in timing
+            if message["type"].endswith(".completed"):
+                finished = time.monotonic()
+                break
+        if failures or not partial_before_commit or "commit" not in timing:
+            raise RuntimeError(f"Live partial/final proof failed: {failures}")
+        return {
+            "first_partial_s": round(first - timing["start"], 3),
+            "commit_to_final_s": round(finished - timing["commit"], 3),
+            "partial_before_commit": partial_before_commit,
+            "transcript": message["transcript"],
+            "audio_s": len(pcm) / 32000,
+        }
+    finally:
+        stop.set()
+        ws.close()
+        sender.join(5)
+        if sender.is_alive():
+            raise RuntimeError("Audio sender did not stop")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        required=True,
+        type=Path,
+        help="Existing local model snapshot; no download",
+    )
+    parser.add_argument(
+        "--wav",
+        required=True,
+        action="append",
+        type=Path,
+        help="Synthetic mono PCM16 16 kHz WAV; repeat for more fixtures",
+    )
+    args = parser.parse_args()
+    model = args.model.resolve(strict=True)
+    fixtures = []
+    for path in args.wav:
+        with wave.open(str(path)) as wav:
+            if (wav.getframerate(), wav.getnchannels(), wav.getsampwidth()) != (
+                16000,
+                1,
+                2,
+            ):
+                parser.error("Fixtures must be mono PCM16 at 16000 Hz")
+            fixtures.append((path.name, wav.readframes(wav.getnframes())))
+
+    # These overrides apply only to this disposable process, before import.
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["MLX_PLATFORM_ANALYTICS_DB_PATH"] = str(
+        Path(tempfile.mkdtemp(prefix="nativ-stt-proof-")) / "analytics.sqlite3"
+    )
+    os.environ.pop("MLX_VLM_SERVER_API_KEY", None)
+    for key in tuple(os.environ):
+        if key.startswith("MLX_VLM_PRELOAD_"):
+            os.environ.pop(key)
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "Overlay"))
+    import nativ_server
+    import uvicorn
+    from websockets.sync.client import connect
+
+    route = "/v1/audio/transcriptions/realtime"
+    if not any(
+        getattr(item, "path", None) == route for item in nativ_server.base.app.routes
+    ):
+        raise RuntimeError(
+            "Installed mlx-vlm lacks the live STT route; install candidate dependencies first"
+        )
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    server = uvicorn.Server(
+        uvicorn.Config(
+            nativ_server.base.app,
+            log_level="warning",
+            ws_max_size=128 * 1024,
+            ws_max_queue=64,
+        )
+    )
+    thread = threading.Thread(
+        target=server.run, kwargs={"sockets": [sock]}, daemon=True
+    )
+    thread.start()
+    try:
+        deadline = time.monotonic() + 30
+        while not server.started:
+            if not thread.is_alive() or time.monotonic() > deadline:
+                raise RuntimeError("Nativ overlay failed to start")
+            time.sleep(0.05)
+        for name, pcm in fixtures:
+            with connect(
+                f"ws://127.0.0.1:{port}{route}?model={quote(str(model), safe='')}"
+            ) as ws:
+                print(json.dumps({"fixture": name, **probe(ws, pcm)}), flush=True)
+    finally:
+        server.should_exit = True
+        thread.join(30)
+        sock.close()
+        if thread.is_alive():
+            raise RuntimeError("Nativ overlay failed to stop")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #499. Depends on Blaizzy/mlx-audio#945 and Blaizzy/mlx-vlm#2167.

The existing Nativ Python overlay already exposes the new upstream route once the candidate packages are present. This PR adds a reproducible isolated loopback WebSocket probe and candidate adoption documentation instead of mounting a second server or changing production dependency pins.

Verified the actual Nativ overlay with real local Nemotron 3.5 0.6B weights and paced 20ms synthetic PCM in Portuguese and English. Both produced partial text before commit and final transcripts afterwards. Probe observations: PT first partial 2.717s, commit-to-final 0.249s; EN 1.636s and 0.295s. These are single-run observations, not latency percentiles.

The probe uses an ephemeral loopback port and isolated temporary analytics, offline local weights, and stops its server. No installed app, production configuration or model cache was modified. Full distribution packaging and microphone/UI proof remain separate and unverified. Kept draft pending upstream dependency availability.