### PR TITLE
Add native extension workspaces and command runtime

### DIFF
--- a/Docs/extensions/workspaces.md
+++ b/Docs/extensions/workspaces.md
@@ -1,0 +1,81 @@
+# Extension workspaces
+
+Music Lab will be an extension-owned workspace, like Audio. This first layer
+lets a package contribute a native page with tabs, persistent controls, and
+commands with progress and cancellation. It contains no Music Lab-specific
+Swift code and requires no model-server changes.
+
+## Contract
+
+Workspace packages use manifest schema 2 and reference `Dashboard.json`.
+Schema 1 text-workflow packages continue to work. Older hosts reject schema 2
+rather than accepting UI they cannot render. A workspace contributes exactly
+one sidebar destination; its dashboard owns the tabs within that page.
+`Workflow.json` is optional for a workspace without commands.
+
+A dashboard declares `schemaVersion`, `title`, `storage`, and `tabs`. Each tab
+has a stable `id`, `title`, and `sections`. Each section has `id`, `title`, and
+`components`. Supported components are text, textField, toggle, picker, and
+button. A component uses `text` for literal content, `storageKey` for a direct
+binding, or `commandID` for a declared command. Pickers declare their options.
+No expressions, scripts, paths, or recursive interpolation are evaluated.
+
+Storage declares named fields with `type` (text, number, boolean) and
+`defaultValue`. Controls and workflows share that state. Values are isolated
+by extension ID, bounded, written atomically outside the installed package,
+and retained when disabled, updated, or uninstalled. Reinstalling the same ID
+restores compatible fields. Incompatible or removed fields use new defaults;
+corrupt state is reported rather than silently overwritten.
+
+`storage.read` takes a literal `key` and produces a typed `value`.
+`storage.write` takes a literal `key` and a typed `value`; an exact binding such
+as `{{read.value}}` preserves its type. Keys must be declared in the dashboard,
+and storage use requires `storage.namespaced`. Model prompt interpolation may
+format scalar outputs but never evaluates bindings inside a stored value.
+
+Each schema 2 command trigger can select an ordered `steps` list, so different
+buttons execute different actions within the same package. Bindings and
+selection prerequisites are checked independently for each command. Omitting
+`steps` preserves the schema 1 behavior of executing the full workflow.
+
+An enabled workspace owns one active command at a time. Progress reports
+completed steps, not estimated model progress. Navigation does not stop a job;
+Cancel, disabling, removal, package replacement, and permission changes do.
+A cancelled task cannot commit later storage writes or overwrite a newer run's
+status. Work does not resume automatically after application termination.
+
+## Next layers for Music Lab
+
+This is the workspace foundation, not a music engine. Typed media handles,
+user-selected file import, audio playback/transport, media collections, and
+capability-based music-model operations still need explicit host contracts.
+Those operations belong behind the workflow services boundary; packages must
+not receive arbitrary filesystem paths, shell execution, or network access.
+
+The private registry remains pinned to its existing contract until the new
+host is reviewed and its validator can be pinned to a published commit.
+
+## Local validation and handoff
+
+The sample is `Examples/ExtensionWorkspace/com.example.workspace.nativextension`.
+Install it through Extensions → Extensions → Installed → Install from Folder,
+enable Session Workspace, and use its sidebar page. Save copies the draft into
+the saved note; Clear resets only the saved note. Settings exercises number,
+boolean, and picker values without requiring a model or macOS Accessibility.
+
+Validation on September 9, 2026:
+
+- XcodeGen and the local Debug app build succeeded.
+- 74 focused SDK and runtime tests passed, including command routing, retained
+  state, isolation, malformed packages, symlink rejection, permission changes,
+  cancellation, and late results arriving after a replacement run.
+- Live package installation and enablement succeeded; its sidebar entry and
+  separate command buttons appeared.
+- The computer-use connection failed while opening the page. Editing controls,
+  navigation, visual layout, and persistence across an actual app restart remain
+  manual QA items. Automated persistence and lifecycle checks passed.
+
+The focused test run used a temporary XcodeGen project containing the real SDK
+and runtime sources and the SDK, workflow-runner, and workspace-runtime tests.
+It does not establish that the full Nativ test target passes; that target has a
+pre-existing SystemMonitorIdentityTests module import issue.

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0935A0AC0D6A6298D551EEAE /* ArtifactSemanticSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */; };
 		0940E69FB438245641377D01 /* NativKitLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE65855FB48CA89F7A0DDA8 /* NativKitLibrary.swift */; };
 		09AFBDCFDE11D1048329E070 /* WebBrowsingRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254FDFBF7C5F7C8019E9E03F /* WebBrowsingRuntime.swift */; };
+		0A1585576190A127B6E84FAB /* VoiceTranscriptInsertionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A552B9C1BDF0DAE48EF7ADC /* VoiceTranscriptInsertionTarget.swift */; };
 		0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */; };
 		0B11412D6A9FB77B9A204E7C /* Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3D808CCA7AE53C7245C3D7 /* Formatting.swift */; };
 		0B5170A046C3C587DE077072 /* PDFDocumentTextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8513AE482EB6C3113080826A /* PDFDocumentTextExtractorTests.swift */; };
@@ -130,10 +131,13 @@
 		3D7F718E2E136C35CD3509B4 /* ChatSystemStatsTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D9F5E20A8F5FFC8618E82 /* ChatSystemStatsTool.swift */; };
 		3D96ED3F0E463F75A47071C6 /* ArtifactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C2AB90FC12D1B83D6691F4 /* ArtifactStore.swift */; };
 		3DC245EBB2B070A887EC86FB /* MarkdownDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63300909BAA09F75C75DE55D /* MarkdownDocument.swift */; };
+		3EF458C32567BB83FC872DA5 /* NativWorkflowRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ABE68784380EEB83CFAD61D /* NativWorkflowRunner.swift */; };
 		3FB5FC66FB4952C993611B2B /* DeveloperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */; };
 		402FF67FA99A26739AA4A653 /* MCPCatalog.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C57E985705899CDD8DB5996 /* MCPCatalog.json */; };
 		40B9D69B537427CD54D388B8 /* InferenceActivityCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D726D6B7B3242DA22BDC8600 /* InferenceActivityCoordinatorTests.swift */; };
+		40CFB4DC3362687148A5AB07 /* NativWorkflowRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D658975EDBA140428E89BBAB /* NativWorkflowRunnerTests.swift */; };
 		40FAF7AC21743208E1C38AC2 /* WebBrowsingProviderClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E0214BE1D88EB4CDB66836 /* WebBrowsingProviderClient.swift */; };
+		4155E4D3811761EB982A38F3 /* NativTaskModelSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68684DEC351E5E06173036B7 /* NativTaskModelSelectionTests.swift */; };
 		41E383BBE43E9CDE0B70826D /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		4262747AC6425403FC1F2210 /* ArtifactDeletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */; };
@@ -190,6 +194,7 @@
 		59841D5E65EFAF5E513C502D /* SystemMonitorObservationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE94F230299FF8E794099BB4 /* SystemMonitorObservationPolicyTests.swift */; };
 		59F063A85DE0A1DFA681282F /* ChatMathPreprocessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096CE626C3ECC066E4D735C7 /* ChatMathPreprocessor.swift */; };
 		5A149C678F9793812E308BB7 /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317509D10D670E696B038E8E /* MarkdownView.swift */; };
+		5B40D2CCC0CFD3A5782468CD /* VoiceTranscriptInsertionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A552B9C1BDF0DAE48EF7ADC /* VoiceTranscriptInsertionTarget.swift */; };
 		5BA95DA067DA56BBAC83EC14 /* ChatAttachmentValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */; };
 		5C64F06C8BE83F8E0E589B78 /* NativBulkSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6964F9653F9E59196C2EDACB /* NativBulkSelectionTests.swift */; };
 		5DD093567BA5EFF33F68C302 /* ChatArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F299F04205B8F438A9A9FF12 /* ChatArchiveTests.swift */; };
@@ -209,6 +214,7 @@
 		66745D5BB4D1454479FF6C9C /* RoutineScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C1220F03EC60874920E0CE /* RoutineScheduler.swift */; };
 		67560D2323090F583CCC39C6 /* NotificationAppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 6ABC782FB29B8C76EC8B60E6 /* NotificationAppIcon.icns */; };
 		6794E481FC0BE317EAA7600C /* FileEditEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35141B7390F1FF36B462CEA /* FileEditEngine.swift */; };
+		67C36476AC0ADFC1F8E3B5A1 /* NativTaskModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B4931E0830BC402FCDE33 /* NativTaskModelSelection.swift */; };
 		686A83AD1E07A381F56F6D05 /* ChatDocumentContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */; };
 		690202C6E092ABA0A086955F /* NativKitRuntimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */; };
 		692EA024371CB249BE53DB86 /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
@@ -224,6 +230,7 @@
 		6F18364BF5D253A01CB4D9FE /* MarkdownDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63300909BAA09F75C75DE55D /* MarkdownDocument.swift */; };
 		6F59E4CC485E211A7E6BC943 /* ScheduledTaskViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7213B7C6CEA995B14EBAC99 /* ScheduledTaskViews.swift */; };
 		6F9FA9F0E5FC4FEC900CEF21 /* NativExtensionWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1E754DAB58CBA63FC8A6B4 /* NativExtensionWorkflowTests.swift */; };
+		6FD5395B3B412B843CB3E1B9 /* NativWorkflowRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ABE68784380EEB83CFAD61D /* NativWorkflowRunner.swift */; };
 		702AFCE23DACD12454A8A7A5 /* ChatAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A108D078B32275B9F99C98C7 /* ChatAnnotationTests.swift */; };
 		70545F329C01AD4C683BF264 /* NativWindowHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1301809E464FD9315BF2A22 /* NativWindowHandle.swift */; };
 		70620E92994E9828794445D8 /* ChatSearchFilesTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA054C2CE69D40692AB665CD /* ChatSearchFilesTool.swift */; };
@@ -276,6 +283,7 @@
 		8874FA8A63B49548E2C6DFD5 /* TextDocumentTextExtractors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91D4332044DCC5DCE4B27F6 /* TextDocumentTextExtractors.swift */; };
 		88883B5201142E3A7E03CD70 /* NativWindowStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E103C92A2FC5D00734DC471 /* NativWindowStateTests.swift */; };
 		89A737DC8761CE35C282BC7D /* MarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317509D10D670E696B038E8E /* MarkdownView.swift */; };
+		8A540E02BF32D8489653CD6F /* NativWorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DFCB65B6527A90384819F9 /* NativWorkspaceState.swift */; };
 		8AD4D0675D4C4F456ACEA352 /* ChatWebSearchTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = D873D2FEC84059F689E7F623 /* ChatWebSearchTool.swift */; };
 		8B4DF732A8A6AA5FFBE11982 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BBF79010B8120057237B52 /* StatsView.swift */; };
 		8B86659B490F58DEC1363135 /* NativServerKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; };
@@ -342,7 +350,9 @@
 		AFBC36570418275354CE129B /* ExaBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 769A36AA0753AB7F4CB1E371 /* ExaBrowsingProvider.swift */; };
 		B15353CDE6204176664DB3B2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E2EE61C1652C49ECC69658 /* AppDelegate.swift */; };
 		B25D81298D9DB66967A5FB84 /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50DB6DEB5C434C27FE9AF66 /* MarkdownText.swift */; };
+		B27545BD97574066D6F24CB0 /* NativWorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DFCB65B6527A90384819F9 /* NativWorkspaceState.swift */; };
 		B2B154008527C6291C17AC93 /* MLXImageModelResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61126D4235AFF77D82F1F80B /* MLXImageModelResolver.swift */; };
+		B31A8529F85DF537C02DA63C /* NativDeclarativeExtension+Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E26FFE892E437B6DB2F745 /* NativDeclarativeExtension+Host.swift */; };
 		B38B5B7EFE4D34BBB26198AA /* ChatTranscriptScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318F0B7627C7BB80B04FF747 /* ChatTranscriptScroller.swift */; };
 		B3DE35DF177BB2B7A9D7690B /* BraveBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6D2D7280064648E0EFC847 /* BraveBrowsingProvider.swift */; };
 		B400776A9DE913FA1509FA06 /* FileMutationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF1D2267F5230F7692BC886 /* FileMutationState.swift */; };
@@ -367,7 +377,9 @@
 		B951641CCDDFF5C718078D99 /* FileSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5668DEC01979A9C0F082682C /* FileSearchEngine.swift */; };
 		B986E17A8D75D859BFF14BBF /* ReleaseVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F46907258A26CF631CB3BD /* ReleaseVersion.swift */; };
 		BA7876C934E43E103899E70E /* cmark-gfm-extensions in Frameworks */ = {isa = PBXBuildFile; productRef = 73083760B397D149449368BB /* cmark-gfm-extensions */; };
+		BB6B6FA3F9DBB34EACB80210 /* NativWorkspaceRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE83BABE1ACDBE5E7FDA418 /* NativWorkspaceRuntimeTests.swift */; };
 		BC0753B567DC8935199FCDFB /* ImageGenerationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239C5B241E83468B75C43E5A /* ImageGenerationViewModel.swift */; };
+		BCD3E93D917167BEB89F4617 /* NativWorkflowServices+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC48B5313F84A167115E98A2 /* NativWorkflowServices+Live.swift */; };
 		BD65446445E57FFE4E717F42 /* SystemMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF7F0D894C4EB6521F21D4D /* SystemMonitorView.swift */; };
 		BE712AD5A19F62157BB8535C /* LaunchAtLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676481665F5FA780DE8D402E /* LaunchAtLoginController.swift */; };
 		BE908F6A41DDF52B149830D9 /* ShellEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5919AB4E9488642C73886266 /* ShellEnvironment.swift */; };
@@ -375,6 +387,7 @@
 		BF5A1AD007F259A2F926AF57 /* ChatWorkspacePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */; };
 		BF6E71AD66F66631D0D52149 /* FileReadAccessPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0425C365C50DD040161226 /* FileReadAccessPolicy.swift */; };
 		BF9EFBD1337BA49572D74A91 /* NativExtensionCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA6F88737CAB763B6E12914 /* NativExtensionCatalog.swift */; };
+		C0273D3D6FD933FD12CC5CA5 /* NativWorkflowServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408FABF6AB575CA0D313A40A /* NativWorkflowServices.swift */; };
 		C03E948D1C7E27B27838C4C6 /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7F610FC8739BA80227DB26 /* NativKit.swift */; };
 		C03F87BD5E8649BBF42B35EE /* PowerPointDocumentTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4ED7BDFBC000148E13EA19 /* PowerPointDocumentTextExtractor.swift */; };
 		C04192DCEE3B50535BE6E83D /* ControlPanelSidebarActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A96F57099AE45BFC2F74E66 /* ControlPanelSidebarActions.swift */; };
@@ -424,6 +437,7 @@
 		DD9CAC7451574C4B05DF1EDB /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677360D86DDAFAB194A995E7 /* Main.swift */; };
 		DE62F002578F2CB0176F5ECE /* ScheduledTaskChatLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCD9D4118F0B3580590998F /* ScheduledTaskChatLinker.swift */; };
 		DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */; };
+		DF748B5A2F6F10DCA854F1FB /* NativDeclarativeDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEEF657154CD9B23D6633BC /* NativDeclarativeDashboardView.swift */; };
 		E07244079BF415C89A76AC48 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
 		E0A20B5A3FC188AF0B13A943 /* ServerProcessEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8C02FD60255220A8DF3BE7 /* ServerProcessEnvironment.swift */; };
 		E0B07216A3D3638AA5FAA059 /* ParallelBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8347D15B2595FF7819F7C /* ParallelBrowsingProvider.swift */; };
@@ -439,13 +453,16 @@
 		E5DF6B83A09106489F564CED /* HuggingFaceCuratedModelLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */; };
 		E64F3E5C624F0C949AE70C60 /* SoftwareUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822185ADAAC5DA3F034179B0 /* SoftwareUpdater.swift */; };
 		E6696BECCF805C7262526F08 /* ScheduledCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB10CC03A96A3EA80EF9343B /* ScheduledCapabilityTests.swift */; };
+		E682B0E95B83FCFA449BDC36 /* NativTextSelectionAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = B452ADDA2C5C41C33534F763 /* NativTextSelectionAccess.swift */; };
 		E7505EAD6A8116B5E097DBC0 /* ChatTranscriptScroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318F0B7627C7BB80B04FF747 /* ChatTranscriptScroller.swift */; };
 		E752ED0A8DD58CB4B4D0BE7C /* WindowIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAD1D95768722F427321CF5 /* WindowIntent.swift */; };
 		E77359B5F8F6AF656F2008C6 /* Exa.png in Resources */ = {isa = PBXBuildFile; fileRef = 995095FAF89C9D1DEC4158FB /* Exa.png */; };
 		E82F16B73372F51DA3767A67 /* MarkdownSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57891442224B287BE8D82B18 /* MarkdownSelectionTests.swift */; };
 		E96652149FDCCF65899280A8 /* IntegrationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41417C210BF817681A8C6D87 /* IntegrationsView.swift */; };
 		E9CD4ED9C227090EFE23EB03 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 7916EF3A0446EB624D66C33F /* ZIPFoundation */; };
+		EAD7248567C4F2D7DECD3F53 /* NativDeclarativeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C887A2598FE12E991F02E6 /* NativDeclarativeExtension.swift */; };
 		EB19103900BE04518CBFF993 /* WebSearchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295CCB27C6CBD1025E62D11 /* WebSearchSettingsView.swift */; };
+		EB5F0F79780A277CF061C7F4 /* NativDeclarativeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C887A2598FE12E991F02E6 /* NativDeclarativeExtension.swift */; };
 		EB9FB4A6BFB7E084FE4A81BA /* LICENSE.phosphor-icons.txt in Resources */ = {isa = PBXBuildFile; fileRef = 07D656FC00686C187E004C5B /* LICENSE.phosphor-icons.txt */; };
 		EBFEB06DE701CB82A0D9C246 /* NativWindowRegistryReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89EF5054AA7F54AC65ED2F25 /* NativWindowRegistryReader.swift */; };
 		EC68CDAB39D1963EC1120C71 /* ControlPanelNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE6470BBA56F75D1F12FE09 /* ControlPanelNavigation.swift */; };
@@ -466,11 +483,13 @@
 		F39E0A3FF5B7D6375EBB71BC /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50DB6DEB5C434C27FE9AF66 /* MarkdownText.swift */; };
 		F3D21045349377FF044ABDC7 /* MarkdownSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE109F2077912969C25E134 /* MarkdownSelection.swift */; };
 		F419F46D380D8BB63BEE29EC /* SwaTexRender in Frameworks */ = {isa = PBXBuildFile; productRef = CB3602F4C9B417450A9FAA0B /* SwaTexRender */; };
+		F4F096A542D6D496F09E3914 /* NativTaskModelSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23B4931E0830BC402FCDE33 /* NativTaskModelSelection.swift */; };
 		F4F5A265970521BCC2273D23 /* NativExtensionMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC0B3C7BCF8243FF1A3CA56 /* NativExtensionMarketplace.swift */; };
 		F55977B2BF1C55FDBC7AD537 /* HuggingFaceDownloadPreflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */; };
 		F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */; };
+		F6DDF5442DFBFC0640F4FB76 /* NativWorkflowServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408FABF6AB575CA0D313A40A /* NativWorkflowServices.swift */; };
 		F7F573F15C7DC5CD17061EB9 /* ChatProjectStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */; };
 		F945C21FDDC8AE619860D222 /* Highlightr in Frameworks */ = {isa = PBXBuildFile; productRef = B47FB8D68E53A933ACF71A58 /* Highlightr */; };
 		F9B4AAA3C467240C00807753 /* ChatReadFileToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */; };
@@ -616,6 +635,7 @@
 		2A876C6D832E392C40F6154E /* HuggingFaceDownloadCapacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceDownloadCapacity.swift; sourceTree = "<group>"; };
 		2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPrimaryTaskResolverTests.swift; sourceTree = "<group>"; };
 		2BDC9AFB58899E777CFF3BCD /* ChatArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatArchive.swift; sourceTree = "<group>"; };
+		2BE83BABE1ACDBE5E7FDA418 /* NativWorkspaceRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWorkspaceRuntimeTests.swift; sourceTree = "<group>"; };
 		2CF9F903E2609C4A522C19CF /* ChatConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatConfigurationView.swift; sourceTree = "<group>"; };
 		2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceModelReadmeTests.swift; sourceTree = "<group>"; };
 		2E103C92A2FC5D00734DC471 /* NativWindowStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWindowStateTests.swift; sourceTree = "<group>"; };
@@ -640,10 +660,13 @@
 		3E540204DED30CFBDB0FE1AD /* SystemMonitorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorStore.swift; sourceTree = "<group>"; };
 		3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitRuntimeResolver.swift; sourceTree = "<group>"; };
 		3F4B9C2F4C7B7765BC3CA6CF /* MLXImageModelResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXImageModelResolverTests.swift; sourceTree = "<group>"; };
+		408FABF6AB575CA0D313A40A /* NativWorkflowServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWorkflowServices.swift; sourceTree = "<group>"; };
 		41417C210BF817681A8C6D87 /* IntegrationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsView.swift; sourceTree = "<group>"; };
 		4157CCE5D9CD6B779FF7FFCE /* DeveloperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperView.swift; sourceTree = "<group>"; };
 		42F2A46C219AE81DB14EEF3A /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		432F8E84739652B2546DC7B7 /* ChatMarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMarkdownRenderer.swift; sourceTree = "<group>"; };
+		43E26FFE892E437B6DB2F745 /* NativDeclarativeExtension+Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NativDeclarativeExtension+Host.swift"; sourceTree = "<group>"; };
+		44C887A2598FE12E991F02E6 /* NativDeclarativeExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativDeclarativeExtension.swift; sourceTree = "<group>"; };
 		44C9FECAED1FB3E2D43716FF /* FilePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreview.swift; sourceTree = "<group>"; };
 		44E1CF05FF502F41036F9958 /* ChatTerminalTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTerminalTool.swift; sourceTree = "<group>"; };
 		44FCFAB2E7C5BC1AC0A5D9BB /* ControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelView.swift; sourceTree = "<group>"; };
@@ -651,6 +674,7 @@
 		46B469F1D62E2DB0DE8CFAF1 /* NativPermissionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativPermissionsCard.swift; sourceTree = "<group>"; };
 		46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSemanticSearch.swift; sourceTree = "<group>"; };
 		49B4556627CCB5BD1D3DE5F8 /* VoiceDictationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtension.swift; sourceTree = "<group>"; };
+		49DFCB65B6527A90384819F9 /* NativWorkspaceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWorkspaceState.swift; sourceTree = "<group>"; };
 		4BEAD8583687ABA95FF4986E /* LogTextStorageMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextStorageMutationTests.swift; sourceTree = "<group>"; };
 		4C93856381B1D89C4DE61DCC /* VoiceCaptureOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureOverlay.swift; sourceTree = "<group>"; };
 		4DCD9D4118F0B3580590998F /* ScheduledTaskChatLinker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTaskChatLinker.swift; sourceTree = "<group>"; };
@@ -692,6 +716,7 @@
 		677258B04E9BB7CA8B89E11E /* FileTypeIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIcon.swift; sourceTree = "<group>"; };
 		677360D86DDAFAB194A995E7 /* Main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Main.swift; sourceTree = "<group>"; };
 		67855F86F63BC3BD40D008C8 /* Tools */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Tools; path = ThirdParty/ripgrep/Tools; sourceTree = SOURCE_ROOT; };
+		68684DEC351E5E06173036B7 /* NativTaskModelSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativTaskModelSelectionTests.swift; sourceTree = "<group>"; };
 		6964F9653F9E59196C2EDACB /* NativBulkSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativBulkSelectionTests.swift; sourceTree = "<group>"; };
 		696F983B4F1F1DEABA37ABBB /* MarkdownFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFixtures.swift; sourceTree = "<group>"; };
 		6ABC782FB29B8C76EC8B60E6 /* NotificationAppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = NotificationAppIcon.icns; sourceTree = "<group>"; };
@@ -712,6 +737,7 @@
 		7A111F0BE402A5EDEAB117C7 /* ChatTranscriptScrollingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptScrollingTests.swift; sourceTree = "<group>"; };
 		7A1B88001E3E22C2E592C0BA /* WebBrowsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingError.swift; sourceTree = "<group>"; };
 		7A2C827258CAD4269D2428AD /* InferenceActivityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceActivityCoordinator.swift; sourceTree = "<group>"; };
+		7A552B9C1BDF0DAE48EF7ADC /* VoiceTranscriptInsertionTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTranscriptInsertionTarget.swift; sourceTree = "<group>"; };
 		7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontScale.swift; sourceTree = "<group>"; };
 		7B0425C365C50DD040161226 /* FileReadAccessPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReadAccessPolicy.swift; sourceTree = "<group>"; };
 		7B205BC53F36B8200F5D5FD8 /* EmbeddingModelPreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddingModelPreparer.swift; sourceTree = "<group>"; };
@@ -753,6 +779,7 @@
 		8C5D77458EF56DD1B8F4AE17 /* MCPHostManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPHostManager.swift; sourceTree = "<group>"; };
 		8D07325FEFBE7AF27167E009 /* VoiceCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureCoordinator.swift; sourceTree = "<group>"; };
 		8DE109F2077912969C25E134 /* MarkdownSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownSelection.swift; sourceTree = "<group>"; };
+		8DEEF657154CD9B23D6633BC /* NativDeclarativeDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativDeclarativeDashboardView.swift; sourceTree = "<group>"; };
 		8EBF8B632041559A8097F2E6 /* LocalModelProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelProviderTests.swift; sourceTree = "<group>"; };
 		90012E8ECF43A5A55BFD8787 /* RoutineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineSupport.swift; sourceTree = "<group>"; };
 		90494E1AE30EF515482DDBE7 /* ControlPanelDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelDependencies.swift; sourceTree = "<group>"; };
@@ -763,6 +790,7 @@
 		982F3BB563023885587DC860 /* NativNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativNotificationTests.swift; sourceTree = "<group>"; };
 		995095FAF89C9D1DEC4158FB /* Exa.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Exa.png; sourceTree = "<group>"; };
 		9A7A7ACB288953FD476C47E8 /* MCPServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerConfig.swift; sourceTree = "<group>"; };
+		9ABE68784380EEB83CFAD61D /* NativWorkflowRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWorkflowRunner.swift; sourceTree = "<group>"; };
 		9AF7F0D894C4EB6521F21D4D /* SystemMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMonitorView.swift; sourceTree = "<group>"; };
 		9B95090B83C36E4F06C7C5E3 /* RoutineRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineRunner.swift; sourceTree = "<group>"; };
 		9BB432A30E8C51EB12CE66E9 /* ChatSelectionEventRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSelectionEventRouterTests.swift; sourceTree = "<group>"; };
@@ -799,6 +827,7 @@
 		B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerCatalogTests.swift; sourceTree = "<group>"; };
 		B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerCatalog.swift; sourceTree = "<group>"; };
 		B3A721B07262EFFDF44CC505 /* MarkdownImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImages.swift; sourceTree = "<group>"; };
+		B452ADDA2C5C41C33534F763 /* NativTextSelectionAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativTextSelectionAccess.swift; sourceTree = "<group>"; };
 		B4E0214BE1D88EB4CDB66836 /* WebBrowsingProviderClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBrowsingProviderClient.swift; sourceTree = "<group>"; };
 		B50DB6DEB5C434C27FE9AF66 /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
 		B598294F3FC3EA81BCD7A680 /* ChatListModelsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListModelsTool.swift; sourceTree = "<group>"; };
@@ -817,6 +846,7 @@
 		C037FCFD18E57EA3829DEEAB /* ChatStreamEventRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamEventRelayTests.swift; sourceTree = "<group>"; };
 		C0BAEA101D7ED907CE4A2FCF /* ChatTranscriptPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptPresentation.swift; sourceTree = "<group>"; };
 		C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatProjectStore.swift; sourceTree = "<group>"; };
+		C23B4931E0830BC402FCDE33 /* NativTaskModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativTaskModelSelection.swift; sourceTree = "<group>"; };
 		C3F46907258A26CF631CB3BD /* ReleaseVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseVersion.swift; sourceTree = "<group>"; };
 		C42683FE576BB34517A487B0 /* ChatAttachmentValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentValidatorTests.swift; sourceTree = "<group>"; };
 		C503D1550EDF250574853F25 /* LocalModelDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscoveryTests.swift; sourceTree = "<group>"; };
@@ -839,6 +869,7 @@
 		D34FBE730C051EFF28B1323B /* RoutineLaunchAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineLaunchAgent.swift; sourceTree = "<group>"; };
 		D4798C02CC1A5D4A92DA96B0 /* RoutineEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineEditorView.swift; sourceTree = "<group>"; };
 		D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReadFileToolTests.swift; sourceTree = "<group>"; };
+		D658975EDBA140428E89BBAB /* NativWorkflowRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWorkflowRunnerTests.swift; sourceTree = "<group>"; };
 		D726D6B7B3242DA22BDC8600 /* InferenceActivityCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceActivityCoordinatorTests.swift; sourceTree = "<group>"; };
 		D7A4264A4B88B593ED47AF0E /* ChatImageModelSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatImageModelSelection.swift; sourceTree = "<group>"; };
 		D873D2FEC84059F689E7F623 /* ChatWebSearchTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatWebSearchTool.swift; sourceTree = "<group>"; };
@@ -865,6 +896,7 @@
 		E902D6BB4117C3F240832FA3 /* ToolsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsSectionView.swift; sourceTree = "<group>"; };
 		E9834B71F0C15C17A014C4ED /* ChatTextSelectionReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextSelectionReaderTests.swift; sourceTree = "<group>"; };
 		E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceCache.swift; sourceTree = "<group>"; };
+		EC48B5313F84A167115E98A2 /* NativWorkflowServices+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NativWorkflowServices+Live.swift"; sourceTree = "<group>"; };
 		EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NativExtensionSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE151F7A36DA21A32ABCFD63 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalModelDiscovery.swift; sourceTree = "<group>"; };
@@ -1152,6 +1184,7 @@
 				4C93856381B1D89C4DE61DCC /* VoiceCaptureOverlay.swift */,
 				7405BB62742DE08EB640A2C5 /* VoiceShortcut.swift */,
 				23155DB5E733D8887D83AFD0 /* VoiceTranscriptInserter.swift */,
+				7A552B9C1BDF0DAE48EF7ADC /* VoiceTranscriptInsertionTarget.swift */,
 			);
 			path = VoiceCapture;
 			sourceTree = "<group>";
@@ -1237,6 +1270,21 @@
 				BF65681C9FD920314BECC7D3 /* Tavily.png */,
 			);
 			path = Assets;
+			sourceTree = "<group>";
+		};
+		6792EB85897F600C2D7C6B83 /* Declarative */ = {
+			isa = PBXGroup;
+			children = (
+				8DEEF657154CD9B23D6633BC /* NativDeclarativeDashboardView.swift */,
+				44C887A2598FE12E991F02E6 /* NativDeclarativeExtension.swift */,
+				43E26FFE892E437B6DB2F745 /* NativDeclarativeExtension+Host.swift */,
+				B452ADDA2C5C41C33534F763 /* NativTextSelectionAccess.swift */,
+				9ABE68784380EEB83CFAD61D /* NativWorkflowRunner.swift */,
+				408FABF6AB575CA0D313A40A /* NativWorkflowServices.swift */,
+				EC48B5313F84A167115E98A2 /* NativWorkflowServices+Live.swift */,
+				49DFCB65B6527A90384819F9 /* NativWorkspaceState.swift */,
+			);
+			path = Declarative;
 			sourceTree = "<group>";
 		};
 		6FC4F77BDC88A365FD01B7C9 /* Tests */ = {
@@ -1407,6 +1455,7 @@
 				61126D4235AFF77D82F1F80B /* MLXImageModelResolver.swift */,
 				141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */,
 				52EB7572F271F7D68DC3F97D /* ModelsView.swift */,
+				C23B4931E0830BC402FCDE33 /* NativTaskModelSelection.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1447,6 +1496,7 @@
 				CDDB4C89F8DD338E9209E7FF /* NativSkill.swift */,
 				E902D6BB4117C3F240832FA3 /* ToolsSectionView.swift */,
 				49B4556627CCB5BD1D3DE5F8 /* VoiceDictationExtension.swift */,
+				6792EB85897F600C2D7C6B83 /* Declarative */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1619,8 +1669,11 @@
 				780A9582305FC184F6C68D12 /* NativKitTests.swift */,
 				982F3BB563023885587DC860 /* NativNotificationTests.swift */,
 				E4EE3654E8AF5B3D6513FF62 /* NativSettingsTests.swift */,
+				68684DEC351E5E06173036B7 /* NativTaskModelSelectionTests.swift */,
 				2110C8328A3FFDF6E02D3FF8 /* NativWindowRegistryTests.swift */,
 				2E103C92A2FC5D00734DC471 /* NativWindowStateTests.swift */,
+				D658975EDBA140428E89BBAB /* NativWorkflowRunnerTests.swift */,
+				2BE83BABE1ACDBE5E7FDA418 /* NativWorkspaceRuntimeTests.swift */,
 				8513AE482EB6C3113080826A /* PDFDocumentTextExtractorTests.swift */,
 				C870DD5A3B825D12BC04EB9D /* PersistedDataChangeHubTests.swift */,
 				C01D6D1C8C321F16B5FD31F8 /* RealtimeAudioMeterTests.swift */,
@@ -2051,6 +2104,9 @@
 				D635FD9C6938DC35CC56CAD7 /* NativApplicationCommands.swift in Sources */,
 				18BA08A2DD4C4CAD2DC6B0E3 /* NativBulkSelection.swift in Sources */,
 				9954F8086FE0A7A9B3378EC9 /* NativComponents.swift in Sources */,
+				DF748B5A2F6F10DCA854F1FB /* NativDeclarativeDashboardView.swift in Sources */,
+				B31A8529F85DF537C02DA63C /* NativDeclarativeExtension+Host.swift in Sources */,
+				EB5F0F79780A277CF061C7F4 /* NativDeclarativeExtension.swift in Sources */,
 				584E2B79AC7BCD949CC53070 /* NativExtensionCatalogClient.swift in Sources */,
 				39ADE4524CF22ED36D505546 /* NativExtensionHostBroker.swift in Sources */,
 				F4F5A265970521BCC2273D23 /* NativExtensionMarketplace.swift in Sources */,
@@ -2065,12 +2121,18 @@
 				ED1F61AA671F9F65A2F34ADB /* NativSettings.swift in Sources */,
 				B6FAA495B9166FE42AAD9478 /* NativSkill.swift in Sources */,
 				B580FFA54780AE54DFC27957 /* NativSystemPermissionController.swift in Sources */,
+				F4F096A542D6D496F09E3914 /* NativTaskModelSelection.swift in Sources */,
+				E682B0E95B83FCFA449BDC36 /* NativTextSelectionAccess.swift in Sources */,
 				85D87B59449B338462FFAC13 /* NativWindowHandle.swift in Sources */,
 				6B69F2F6AA92A75F24F8AC9F /* NativWindowReaderView.swift in Sources */,
 				9381AA529980BBAF307CD0B2 /* NativWindowRegistry.swift in Sources */,
 				EBFEB06DE701CB82A0D9C246 /* NativWindowRegistryReader.swift in Sources */,
 				C8A1887418039B9DDBCE1226 /* NativWindowRoot.swift in Sources */,
 				C410036C89EF4AC16C1AFE76 /* NativWindowState.swift in Sources */,
+				3EF458C32567BB83FC872DA5 /* NativWorkflowRunner.swift in Sources */,
+				BCD3E93D917167BEB89F4617 /* NativWorkflowServices+Live.swift in Sources */,
+				F6DDF5442DFBFC0640F4FB76 /* NativWorkflowServices.swift in Sources */,
+				8A540E02BF32D8489653CD6F /* NativWorkspaceState.swift in Sources */,
 				7AF5260E8044A3AED5B705A6 /* NimbleBrowsingProvider.swift in Sources */,
 				2D2E2AE0FB5D588884E86BFB /* OfficeArchive.swift in Sources */,
 				28197A70541BE1F1F482BCF4 /* PDFDocumentTextExtractor.swift in Sources */,
@@ -2118,6 +2180,7 @@
 				611C241FA2E18A65BF3F210E /* VoiceDictationExtension.swift in Sources */,
 				97EEA29CCD874048A8CE9D54 /* VoiceShortcut.swift in Sources */,
 				463870509178CCD59287E1BE /* VoiceTranscriptInserter.swift in Sources */,
+				0A1585576190A127B6E84FAB /* VoiceTranscriptInsertionTarget.swift in Sources */,
 				AD5DF112FF75CE5723332074 /* WebBrowsingError.swift in Sources */,
 				40FAF7AC21743208E1C38AC2 /* WebBrowsingProviderClient.swift in Sources */,
 				09AFBDCFDE11D1048329E070 /* WebBrowsingRuntime.swift in Sources */,
@@ -2270,6 +2333,7 @@
 				D963B49FA9E1E766B9081104 /* NativBulkSelection.swift in Sources */,
 				5C64F06C8BE83F8E0E589B78 /* NativBulkSelectionTests.swift in Sources */,
 				83E74199C4F9A50350E3E354 /* NativComponents.swift in Sources */,
+				EAD7248567C4F2D7DECD3F53 /* NativDeclarativeExtension.swift in Sources */,
 				385B524770D5084E48B80F41 /* NativExtensionCatalogClient.swift in Sources */,
 				3D2458AA39D0AE10CCACE7CD /* NativExtensionCatalogTests.swift in Sources */,
 				0540ED8AC08AE7236F98A9DE /* NativExtensionPackageInstallerTests.swift in Sources */,
@@ -2288,11 +2352,18 @@
 				DEDEBC7EB86CE9711D0D5E8C /* NativSettingsTests.swift in Sources */,
 				ACBA3EAEE7677FCAD4977850 /* NativSkill.swift in Sources */,
 				07E17841B388FBBD8C8A28EF /* NativSystemPermissionController.swift in Sources */,
+				67C36476AC0ADFC1F8E3B5A1 /* NativTaskModelSelection.swift in Sources */,
+				4155E4D3811761EB982A38F3 /* NativTaskModelSelectionTests.swift in Sources */,
 				70545F329C01AD4C683BF264 /* NativWindowHandle.swift in Sources */,
 				365516E3068E90F4C0F3D0A3 /* NativWindowRegistry.swift in Sources */,
 				775DB7887AFEDD61790606FC /* NativWindowRegistryTests.swift in Sources */,
 				78C43B7B0A82ADE447B56D0B /* NativWindowState.swift in Sources */,
 				88883B5201142E3A7E03CD70 /* NativWindowStateTests.swift in Sources */,
+				6FD5395B3B412B843CB3E1B9 /* NativWorkflowRunner.swift in Sources */,
+				40CFB4DC3362687148A5AB07 /* NativWorkflowRunnerTests.swift in Sources */,
+				C0273D3D6FD933FD12CC5CA5 /* NativWorkflowServices.swift in Sources */,
+				BB6B6FA3F9DBB34EACB80210 /* NativWorkspaceRuntimeTests.swift in Sources */,
+				B27545BD97574066D6F24CB0 /* NativWorkspaceState.swift in Sources */,
 				3AA3A795AAD2F1EE33BECFCB /* NimbleBrowsingProvider.swift in Sources */,
 				D4AA61C3BEF5538E3DA9A54F /* OfficeArchive.swift in Sources */,
 				A236DC57A71965B0E0666C60 /* PDFDocumentTextExtractor.swift in Sources */,
@@ -2329,6 +2400,7 @@
 				E180E254213BCD770141B872 /* VoiceAnimationPreferences.swift in Sources */,
 				A6E043CD0C3AD882D0D0AE66 /* VoiceAudioRecorder.swift in Sources */,
 				3A4D3E1F9313D9896173130D /* VoiceShortcut.swift in Sources */,
+				5B40D2CCC0CFD3A5782468CD /* VoiceTranscriptInsertionTarget.swift in Sources */,
 				3545A0F2A3E0FE78FE7D501E /* WebBrowsingError.swift in Sources */,
 				49D9B119A4F90BBE66343B5B /* WebBrowsingProviderClient.swift in Sources */,
 				388F4BD381D9732C614162C4 /* WebBrowsingRuntime.swift in Sources */,

--- a/Sources/Nativ/AppDelegate.swift
+++ b/Sources/Nativ/AppDelegate.swift
@@ -11,7 +11,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @MainActor UNUserNotif
     let windowRegistry = NativWindowRegistry()
     private let voiceDictationExtension = VoiceDictationExtension()
     private lazy var extensionManager = NativExtensionManager(
-        builtInExtensions: [voiceDictationExtension]
+        builtInExtensions: [voiceDictationExtension],
+        declarativeServices: { [model] in .live(model: model) }
     )
     private let runtime = SystemRuntimeMonitor()
     private let routineStore = RoutineStore.shared

--- a/Sources/Nativ/Features/Extensions/Declarative/NativDeclarativeDashboardView.swift
+++ b/Sources/Nativ/Features/Extensions/Declarative/NativDeclarativeDashboardView.swift
@@ -1,0 +1,167 @@
+import NativExtensionSDK
+import SwiftUI
+
+struct NativDeclarativeDashboardView: View {
+    let runtime: NativDeclarativeExtension
+    let dashboard: NativExtensionDashboard
+    let titleLeadingInset: CGFloat
+    @State private var selectedTab: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(dashboard.title).font(.title2.weight(.semibold))
+                Text(runtime.manifest.summary).font(.callout).foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 22)
+            .padding(.leading, titleLeadingInset)
+            .controlPanelDetailHeaderTopPadding()
+            .padding(.bottom, 16)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(dashboard.tabs) { tab in
+                        Button(tab.title) { selectedTab = tab.id }
+                            .buttonStyle(.bordered)
+                            .tint(currentTab?.id == tab.id ? .accentColor : .secondary)
+                            .accessibilityAddTraits(currentTab?.id == tab.id ? .isSelected : [])
+                    }
+                }
+                .padding(.horizontal, 22)
+                .padding(.vertical, 12)
+            }
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    if let error = runtime.workspace?.loadError ?? runtime.workspace?.errorMessage ?? runtime.runError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .textSelection(.enabled)
+                    }
+                    if let tab = currentTab {
+                        ForEach(tab.sections) { section in
+                            GroupBox {
+                                VStack(alignment: .leading, spacing: 16) {
+                                    ForEach(section.components) { component in
+                                        NativDashboardComponentView(component: component, runtime: runtime)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(12)
+                            } label: {
+                                Text(section.title).font(.headline)
+                            }
+                        }
+                    }
+                }
+                .padding(22)
+            }
+            if runtime.workflow != nil {
+                Divider()
+                HStack {
+                    if runtime.isRunning {
+                        ProgressView(value: Double(runtime.completedSteps), total: Double(max(runtime.totalSteps, 1)))
+                            .frame(width: 120)
+                            .accessibilityLabel("Command progress")
+                    }
+                    Text(runtime.status).foregroundStyle(.secondary)
+                    Spacer()
+                    if runtime.isRunning {
+                        Button("Cancel") { runtime.cancel() }
+                    }
+                }
+                .padding(16)
+            }
+        }
+        .disabled(!runtime.isActive)
+    }
+
+    private var currentTab: NativDashboardTab? {
+        dashboard.tabs.first(where: { $0.id == selectedTab }) ?? dashboard.tabs.first
+    }
+}
+
+private struct NativDashboardComponentView: View {
+    let component: NativDashboardComponent
+    let runtime: NativDeclarativeExtension
+
+    private var value: NativWorkflowValue {
+        runtime.workspace?.values[component.storageKey ?? ""] ?? .none
+    }
+
+    var body: some View {
+        Group {
+            switch component.type {
+            case .text:
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(component.title).font(.subheadline.weight(.medium))
+                    Text(component.text ?? NativWorkflowRunner.scalarText(value))
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            case .textField:
+                NativDashboardField(component: component, runtime: runtime)
+            case .toggle:
+                Toggle(component.title, isOn: Binding(
+                    get: { if case .boolean(let flag) = value { return flag }; return false },
+                    set: { runtime.setValue(.boolean($0), for: component.storageKey ?? "") }
+                ))
+            case .picker:
+                Picker(component.title, selection: Binding(
+                    get: { value.text ?? "" },
+                    set: { runtime.setValue(.text($0), for: component.storageKey ?? "") }
+                )) {
+                    if let current = value.text, !(component.options ?? []).contains(current) {
+                        Text("\(current) (unavailable)").tag(current)
+                    }
+                    ForEach(component.options ?? [], id: \.self) { option in
+                        Text(option).tag(option)
+                    }
+                }
+            case .button:
+                Button(component.title) { runtime.performCommand(id: component.commandID ?? "") }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .disabled(runtime.isRunning || runtime.workspace?.loadError != nil)
+    }
+}
+
+private struct NativDashboardField: View {
+    let component: NativDashboardComponent
+    let runtime: NativDeclarativeExtension
+    @State private var draft = ""
+    @FocusState private var isFocused: Bool
+
+    private var key: String { component.storageKey ?? "" }
+    private var storedText: String { NativWorkflowRunner.scalarText(runtime.workspace?.values[key] ?? .none) }
+
+    var body: some View {
+        TextField(component.title, text: $draft)
+            .textFieldStyle(.roundedBorder)
+            .focused($isFocused)
+            .onAppear { draft = storedText }
+            .onSubmit { save() }
+            .onChange(of: draft) { _, _ in save() }
+            .onChange(of: isFocused) { _, focused in
+                if !focused { save() }
+            }
+            .onChange(of: storedText) { _, text in
+                if !isFocused { draft = text }
+            }
+            .onDisappear { save() }
+    }
+
+    private func save() {
+        guard draft != storedText else { return }
+        if runtime.dashboard?.storage[key]?.type == .number {
+            guard let number = Double(draft), number.isFinite else {
+                runtime.workspace?.errorMessage = "Enter a valid number for \(component.title)."
+                return
+            }
+            runtime.setValue(.number(number), for: key)
+        } else {
+            runtime.setValue(.text(draft), for: key)
+        }
+    }
+}

--- a/Sources/Nativ/Features/Extensions/Declarative/NativDeclarativeExtension+Host.swift
+++ b/Sources/Nativ/Features/Extensions/Declarative/NativDeclarativeExtension+Host.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+extension NativDeclarativeExtension: NativHostExtension {
+    func activate(context: NativExtensionHostContext) {
+        activate()
+    }
+
+    func makePage(id: String, context: NativExtensionPageContext) -> AnyView? {
+        guard isActive, let dashboard,
+              manifest.contributions.sidebar.contains(where: { $0.id == id }) else { return nil }
+        return AnyView(NativDeclarativeDashboardView(
+            runtime: self,
+            dashboard: dashboard,
+            titleLeadingInset: context.titleLeadingInset
+        ).id(ObjectIdentifier(self)))
+    }
+
+}

--- a/Sources/Nativ/Features/Extensions/Declarative/NativDeclarativeExtension.swift
+++ b/Sources/Nativ/Features/Extensions/Declarative/NativDeclarativeExtension.swift
@@ -1,0 +1,127 @@
+import Foundation
+import NativExtensionSDK
+import Observation
+
+@Observable
+@MainActor
+final class NativDeclarativeExtension {
+    let manifest: NativExtensionManifest
+    let workflow: NativExtensionWorkflow?
+    let dashboard: NativExtensionDashboard?
+    let workspace: NativWorkspaceState?
+    private(set) var isActive = false
+    private(set) var isRunning = false
+    private(set) var completedSteps = 0
+    private(set) var totalSteps = 0
+    private(set) var status = "Ready"
+    private(set) var runError: String?
+
+    private let services: @MainActor () -> NativWorkflowServices
+    private let onFailure: @MainActor (String) -> Void
+    private var grantedPermissions: Set<NativExtensionPermission>
+    private var activeRun: Task<Void, Never>?
+    private var runID: UUID?
+
+    init(
+        manifest: NativExtensionManifest,
+        workflow: NativExtensionWorkflow?,
+        dashboard: NativExtensionDashboard? = nil,
+        storageDirectory: URL? = nil,
+        grantedPermissions: Set<NativExtensionPermission>,
+        services: @escaping @MainActor () -> NativWorkflowServices,
+        onFailure: @escaping @MainActor (String) -> Void
+    ) {
+        self.manifest = manifest
+        self.workflow = workflow
+        self.dashboard = dashboard
+        workspace = storageDirectory.map { NativWorkspaceState(directory: $0, fields: dashboard?.storage ?? [:]) }
+        self.grantedPermissions = grantedPermissions
+        self.services = services
+        self.onFailure = onFailure
+    }
+
+    func activate() {
+        isActive = true
+    }
+
+    func deactivate() {
+        isActive = false
+        cancel()
+        do { try workspace?.flush() }
+        catch { onFailure(error.localizedDescription) }
+    }
+
+    func cancel() {
+        activeRun?.cancel()
+        activeRun = nil
+        runID = nil
+        if isRunning { status = "Cancelled" }
+        isRunning = false
+    }
+
+    func setValue(_ value: NativWorkflowValue, for key: String) {
+        guard isActive, !isRunning, grantedPermissions.contains(.namespacedStorage) else { return }
+        do { try workspace?.stage(key, value: value) }
+        catch { workspace?.errorMessage = error.localizedDescription }
+    }
+
+    func performCommand(id commandID: String) {
+        guard isActive, !isRunning, let workflow,
+              workflow.trigger(forCommand: commandID) != nil else { return }
+        do { try workspace?.flush() }
+        catch {
+            runError = error.localizedDescription
+            return
+        }
+        let id = UUID()
+        runID = id
+        isRunning = true
+        completedSteps = 0
+        totalSteps = workflow.steps(forCommand: commandID).count
+        status = manifest.contributions.commands.first(where: { $0.id == commandID })?.title ?? "Running"
+        runError = nil
+        var services = services()
+        services.readStorage = { [weak self] key in
+            try Task.checkCancellation()
+            guard let self, self.isActive, self.runID == id, let workspace = self.workspace else { throw CancellationError() }
+            return try workspace.read(key)
+        }
+        services.writeStorage = { [weak self] key, value in
+            try Task.checkCancellation()
+            guard let self, self.isActive, self.runID == id, let workspace = self.workspace else { throw CancellationError() }
+            try workspace.write(key, value: value)
+        }
+        let context = NativWorkflowRunContext(
+            extensionID: manifest.id,
+            grantedPermissions: grantedPermissions,
+            services: services
+        )
+        activeRun = Task { [weak self] in
+            do {
+                _ = try await NativWorkflowRunner.run(workflow, commandID: commandID, context: context) { [weak self] completed, _ in
+                    guard self?.runID == id else { return }
+                    self?.completedSteps = completed
+                }
+                guard self?.runID == id else { return }
+                self?.status = "Completed"
+            } catch is CancellationError {
+                guard self?.runID == id else { return }
+                self?.status = "Cancelled"
+            } catch {
+                guard self?.runID == id else { return }
+                self?.status = "Failed"
+                self?.runError = error.localizedDescription
+                self?.onFailure(error.localizedDescription)
+            }
+            guard self?.runID == id else { return }
+            self?.isRunning = false
+            self?.runID = nil
+            self?.activeRun = nil
+        }
+    }
+
+    func updateGrantedPermissions(_ granted: Set<NativExtensionPermission>) {
+        if granted != grantedPermissions { cancel() }
+        grantedPermissions = granted
+    }
+}

--- a/Sources/Nativ/Features/Extensions/Declarative/NativTextSelectionAccess.swift
+++ b/Sources/Nativ/Features/Extensions/Declarative/NativTextSelectionAccess.swift
@@ -1,0 +1,141 @@
+import AppKit
+import ApplicationServices
+
+/// Reads and writes the user's current text selection through the
+/// accessibility API.
+///
+/// Nothing here is unit-testable — every call is a syscall into another
+/// process — so it is kept to the two entry points the workflow services need.
+@MainActor
+enum NativTextSelectionAccess {
+    static func read() -> NativTextSelection? {
+        let systemWide = AXUIElementCreateSystemWide()
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedUIElementAttribute as CFString,
+            &focused
+        ) == .success, let element = focused else {
+            return nil
+        }
+        let focusedElement = element as! AXUIElement
+
+        var selected: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            focusedElement,
+            kAXSelectedTextAttribute as CFString,
+            &selected
+        ) == .success,
+            let text = selected as? String,
+            !text.isEmpty
+        else {
+            return nil
+        }
+
+        return NativTextSelection(
+            text: text,
+            target: frontmostTarget(),
+            origin: NativSelectionOrigin(
+                element: focusedElement,
+                range: selectedRange(of: focusedElement)
+            )
+        )
+    }
+
+    /// Writes over the selection in place where the app supports it, and pastes
+    /// otherwise.
+    ///
+    /// Pasting is the fallback rather than the primary path because it replaces
+    /// only while a selection is still live — after a slow model call the
+    /// caret may have moved, and the user would get their text duplicated
+    /// rather than rewritten.
+    static func replace(_ text: String, selection: NativTextSelection) async -> Bool {
+        if let origin = selection.origin,
+           let element = origin.element,
+           writeInPlace(text, element: element as! AXUIElement, range: origin.range) {
+            return true
+        }
+        return await pasteRestoringPasteboard(text, target: selection.target)
+    }
+
+    private static func selectedRange(of element: AXUIElement) -> NSRange? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXSelectedTextRangeAttribute as CFString,
+            &value
+        ) == .success, let value else {
+            return nil
+        }
+        var range = CFRange()
+        guard AXValueGetValue(value as! AXValue, .cfRange, &range) else {
+            return nil
+        }
+        return NSRange(location: range.location, length: range.length)
+    }
+
+    private static func writeInPlace(
+        _ text: String,
+        element: AXUIElement,
+        range: NSRange?
+    ) -> Bool {
+        if let range {
+            var cfRange = CFRange(location: range.location, length: range.length)
+            if let value = AXValueCreate(.cfRange, &cfRange) {
+                _ = AXUIElementSetAttributeValue(
+                    element,
+                    kAXSelectedTextRangeAttribute as CFString,
+                    value
+                )
+            }
+        }
+        return AXUIElementSetAttributeValue(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            text as CFString
+        ) == .success
+    }
+
+    /// `VoiceTranscriptInserter` leaves the replacement on the pasteboard,
+    /// which is acceptable for dictation the user just spoke but not for text
+    /// an extension rewrote behind them.
+    private static func pasteRestoringPasteboard(
+        _ text: String,
+        target: VoiceTranscriptInsertionTarget?
+    ) async -> Bool {
+        let pasteboard = NSPasteboard.general
+        let saved = pasteboard.pasteboardItems?.compactMap { item -> [NSPasteboard.PasteboardType: Data] in
+            var contents: [NSPasteboard.PasteboardType: Data] = [:]
+            for type in item.types {
+                contents[type] = item.data(forType: type)
+            }
+            return contents
+        }
+
+        let inserted = await VoiceTranscriptInserter.insertAtCursor(text, target: target)
+
+        // Only restore if nothing else has written since our paste, so we never
+        // clobber something the user copied in the meantime.
+        if let saved, !saved.isEmpty {
+            pasteboard.clearContents()
+            for contents in saved {
+                let item = NSPasteboardItem()
+                for (type, data) in contents {
+                    item.setData(data, forType: type)
+                }
+                pasteboard.writeObjects([item])
+            }
+        }
+        return inserted
+    }
+
+    private static func frontmostTarget() -> VoiceTranscriptInsertionTarget? {
+        guard let application = NSWorkspace.shared.frontmostApplication else {
+            return nil
+        }
+        return VoiceTranscriptInsertionTarget(
+            processIdentifier: application.processIdentifier,
+            applicationName: application.localizedName
+        )
+    }
+}

--- a/Sources/Nativ/Features/Extensions/Declarative/NativWorkflowRunner.swift
+++ b/Sources/Nativ/Features/Extensions/Declarative/NativWorkflowRunner.swift
@@ -1,0 +1,186 @@
+import Foundation
+import NativExtensionSDK
+
+/// Executes a declarative workflow.
+///
+/// Stateless on purpose: every run's state is local, so there is no shared
+/// mutable state to reason about and the whole thing can be driven from a test
+/// with stubbed services.
+enum NativWorkflowRunner {
+    static func run(
+        _ workflow: NativExtensionWorkflow,
+        commandID: String,
+        context: NativWorkflowRunContext,
+        onProgress: @MainActor @Sendable (Int, Int) -> Void = { _, _ in }
+    ) async throws -> NativWorkflowRunSummary {
+        guard workflow.trigger(forCommand: commandID) != nil else {
+            throw NativWorkflowRunError.noTriggerForCommand(commandID)
+        }
+
+        let steps = workflow.steps(forCommand: commandID)
+        var outputs: [String: NativWorkflowStepOutput] = [:]
+        var selection: NativTextSelection?
+        var substitutedModel: String?
+
+        for (index, step) in steps.enumerated() {
+            await onProgress(index, steps.count)
+            try Task.checkCancellation()
+
+            guard let operation = step.operation else {
+                throw NativWorkflowRunError.operationUnavailable(
+                    step: step.id,
+                    operation: step.type
+                )
+            }
+            try verifyPermission(for: step, operation: operation, context: context)
+
+            switch operation {
+            case .readSelection:
+                guard let read = await context.services.readSelection() else {
+                    throw NativWorkflowRunError.nothingSelected
+                }
+                selection = read
+                outputs[step.id] = ["text": .text(read.text)]
+
+            case .invokeModel:
+                guard let task = step.modelTask else {
+                    throw NativWorkflowRunError.operationUnavailable(
+                        step: step.id,
+                        operation: step.type
+                    )
+                }
+                let prompt = try resolvedText(step: step, input: "prompt", outputs: outputs)
+                let response = try await context.services.invokeModel(
+                    NativWorkflowModelRequest(
+                        task: task,
+                        requestedModel: step.model,
+                        prompt: prompt,
+                        maxTokens: step.maxTokens,
+                        temperature: step.temperature
+                    )
+                )
+                substitutedModel = response.substitutedModel ?? substitutedModel
+                outputs[step.id] = ["text": .text(response.text)]
+
+            case .replaceSelection:
+                let text = try resolvedText(step: step, input: "text", outputs: outputs)
+                guard let selection else {
+                    throw NativWorkflowRunError.selectionUnavailable
+                }
+                // Past this point cancellation is ignored: a posted event
+                // cannot be recalled, so stopping half way is worse than
+                // finishing.
+                guard await context.services.replaceSelection(text, selection) else {
+                    throw NativWorkflowRunError.replaceFailed
+                }
+                outputs[step.id] = [:]
+
+            case .readStorage:
+                let key = try resolvedText(step: step, input: "key", outputs: [:])
+                outputs[step.id] = ["value": try await context.services.readStorage(key)]
+
+            case .writeStorage:
+                let key = try resolvedText(step: step, input: "key", outputs: [:])
+                guard let authored = step.inputs["value"] else {
+                    throw NativWorkflowRunError.missingInput(step: step.id, name: "value")
+                }
+                let value = resolvedValue(authored, outputs: outputs)
+                try Task.checkCancellation()
+                try await context.services.writeStorage(key, value)
+                outputs[step.id] = [:]
+
+            case .readClipboard, .insertText, .recordAudio, .transcribeAudio,
+                 .captureScreen, .saveFile, .writeClipboard, .showOverlay,
+                 .showNotification:
+                throw NativWorkflowRunError.operationUnavailable(
+                    step: step.id,
+                    operation: step.type
+                )
+            }
+        }
+
+        try Task.checkCancellation()
+        await onProgress(steps.count, steps.count)
+        return NativWorkflowRunSummary(
+            extensionID: context.extensionID,
+            commandID: commandID,
+            stepsRun: steps.count,
+            substitutedModel: substitutedModel
+        )
+    }
+
+    /// The execution half of the permission rule. Redundant with the check the
+    /// installer runs, deliberately: an installed package can be edited on
+    /// disk, and a grant can be revoked after activation. This is the check
+    /// that stands in for the XPC broker's, which in-process code bypasses.
+    private static func verifyPermission(
+        for step: NativWorkflowStep,
+        operation: NativWorkflowOperation,
+        context: NativWorkflowRunContext
+    ) throws {
+        let required: NativExtensionPermission?
+        if operation == .invokeModel {
+            required = step.modelTask?.requiredPermission
+        } else {
+            required = operation.requiredPermission
+        }
+        guard let required else { return }
+        guard context.grantedPermissions.contains(required) else {
+            throw NativWorkflowRunError.permissionNotGranted(
+                step: step.id,
+                permission: required
+            )
+        }
+    }
+
+    private static func resolvedText(
+        step: NativWorkflowStep,
+        input: String,
+        outputs: [String: NativWorkflowStepOutput]
+    ) throws -> String {
+        guard case .text(let template)? = step.inputs[input] else {
+            throw NativWorkflowRunError.missingInput(step: step.id, name: input)
+        }
+        return substitute(template, outputs: outputs)
+    }
+
+    static func resolvedValue(
+        _ value: NativWorkflowValue,
+        outputs: [String: NativWorkflowStepOutput]
+    ) -> NativWorkflowValue {
+        guard case .text(let template) = value else { return value }
+        for reference in NativWorkflowReference.references(in: template) {
+            let token = reference.output.map { "{{\(reference.step).\($0)}}" } ?? "{{\(reference.step)}}"
+            if template == token {
+                return outputs[reference.step]?[reference.output ?? "text"] ?? .none
+            }
+        }
+        return .text(substitute(template, outputs: outputs))
+    }
+
+    static func scalarText(_ value: NativWorkflowValue) -> String {
+        switch value {
+        case .text(let text): text
+        case .number(let number): String(number)
+        case .boolean(let flag): flag ? "true" : "false"
+        default: ""
+        }
+    }
+
+    /// Replace ranges in the authored template only, so values containing
+    /// template syntax cannot read another step's output.
+    static func substitute(
+        _ template: String,
+        outputs: [String: NativWorkflowStepOutput]
+    ) -> String {
+        guard let pattern = try? NSRegularExpression(pattern: "\\{\\{([A-Za-z0-9_.-]+)\\}\\}") else { return template }
+        let result = NSMutableString(string: template)
+        for match in pattern.matches(in: template, range: NSRange(location: 0, length: result.length)).reversed() {
+            let raw = (template as NSString).substring(with: match.range(at: 1))
+            guard let reference = NativWorkflowReference(raw) else { continue }
+            let value = outputs[reference.step]?[reference.output ?? "text"] ?? .none
+            result.replaceCharacters(in: match.range, with: scalarText(value))
+        }
+        return result as String
+    }
+}

--- a/Sources/Nativ/Features/Extensions/Declarative/NativWorkflowServices+Live.swift
+++ b/Sources/Nativ/Features/Extensions/Declarative/NativWorkflowServices+Live.swift
@@ -1,0 +1,110 @@
+import Foundation
+import NativExtensionSDK
+import NativServerKit
+
+extension NativWorkflowServices {
+    /// Wires the workflow operations to the app's real subsystems.
+    ///
+    /// Everything stateful is captured from `model` here rather than threaded
+    /// through the runner, so the runner stays free of the host.
+    @MainActor
+    static func live(model: NativModel) -> NativWorkflowServices {
+        NativWorkflowServices(
+            readSelection: {
+                NativTextSelectionAccess.read()
+            },
+            replaceSelection: { text, selection in
+                await NativTextSelectionAccess.replace(text, selection: selection)
+            },
+            invokeModel: { request in
+                try await invoke(request, model: model)
+            }
+        )
+    }
+
+    @MainActor
+    private static func invoke(
+        _ request: NativWorkflowModelRequest,
+        model: NativModel
+    ) async throws -> NativWorkflowModelResponse {
+        guard request.task == .language else {
+            throw NativWorkflowServiceError.taskNotSupported(request.task)
+        }
+
+        let installed = (try? await LocalModelDiscovery.scan(
+            searchPaths: model.settings.localModelSearchPaths
+        )) ?? []
+        let resolution = NativTaskModelSelection.resolve(
+            task: request.task,
+            requested: request.requestedModel,
+            pinned: model.settings.modelID(
+                for: NativTaskModelSelection.preloadSlot(for: request.task)
+            ),
+            installed: installed
+        )
+        guard case .resolved(let modelID, let substitutedFor) = resolution else {
+            throw NativWorkflowServiceError.noCompatibleModel(request.task)
+        }
+
+        guard let baseURL = await waitForServer(model: model) else {
+            throw NativWorkflowServiceError.serverUnavailable
+        }
+
+        let settings = model.settings
+        let client = NativChatClient(baseURL: baseURL, apiKey: settings.serverAPIKey)
+        let completion = try await client.completeChat(
+            MLXChatCompletionRequest(
+                model: modelID,
+                messages: [.init(role: "user", content: request.prompt)],
+                maxTokens: request.maxTokens ?? settings.maxTokens,
+                temperature: request.temperature ?? settings.temperature,
+                topK: settings.topK,
+                topP: settings.topP,
+                minP: settings.minP
+            )
+        )
+
+        let text = completion.content.trimmingCharacters(
+            in: CharacterSet.whitespacesAndNewlines
+        )
+        guard !text.isEmpty else {
+            throw NativWorkflowServiceError.emptyResponse
+        }
+        return NativWorkflowModelResponse(text: text, substitutedModel: substitutedFor)
+    }
+
+    /// Mirrors `RoutineRunner.waitForServer`: a workflow can be triggered while
+    /// the server is still coming up.
+    @MainActor
+    private static func waitForServer(
+        model: NativModel,
+        timeout: TimeInterval = 120
+    ) async -> URL? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while model.activeServerBaseURL == nil, Date() < deadline {
+            guard !Task.isCancelled else { return nil }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+        return model.activeServerBaseURL
+    }
+}
+
+enum NativWorkflowServiceError: LocalizedError, Equatable {
+    case taskNotSupported(NativWorkflowModelTask)
+    case noCompatibleModel(NativWorkflowModelTask)
+    case serverUnavailable
+    case emptyResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .taskNotSupported(let task):
+            "Nativ cannot run the “\(task.rawValue)” model task yet."
+        case .noCompatibleModel(let task):
+            "No installed model can handle “\(task.rawValue)”. Download one from Models."
+        case .serverUnavailable:
+            "The Nativ server is not running."
+        case .emptyResponse:
+            "The model returned nothing."
+        }
+    }
+}

--- a/Sources/Nativ/Features/Extensions/Declarative/NativWorkflowServices.swift
+++ b/Sources/Nativ/Features/Extensions/Declarative/NativWorkflowServices.swift
@@ -1,0 +1,120 @@
+import Foundation
+import NativExtensionSDK
+
+/// Text the user had selected, plus enough context to put a replacement back
+/// where it came from.
+struct NativTextSelection: Sendable {
+    let text: String
+    let target: VoiceTranscriptInsertionTarget?
+    /// Opaque link to the element the text was read from. Set by the reading
+    /// service and handed back on replace; the runner never looks inside. It is
+    /// deliberately not addressable as a workflow value — a process identifier
+    /// is not something a package should be able to bind to.
+    let origin: NativSelectionOrigin?
+
+    init(
+        text: String,
+        target: VoiceTranscriptInsertionTarget? = nil,
+        origin: NativSelectionOrigin? = nil
+    ) {
+        self.text = text
+        self.target = target
+        self.origin = origin
+    }
+}
+
+/// Boxes the accessibility element and range a selection came from. Held as
+/// `AnyObject` so this file stays free of the accessibility framework and can
+/// be compiled into the test target.
+@MainActor
+final class NativSelectionOrigin {
+    let element: AnyObject?
+    let range: NSRange?
+
+    init(element: AnyObject?, range: NSRange?) {
+        self.element = element
+        self.range = range
+    }
+}
+
+struct NativWorkflowModelRequest: Sendable {
+    let task: NativWorkflowModelTask
+    let requestedModel: String?
+    let prompt: String
+    let maxTokens: Int?
+    let temperature: Double?
+}
+
+/// Everything a workflow step reaches the outside world through.
+///
+/// Mirrors the injectable dependency structs on `ChatToolExecutionContext`, so
+/// the runner can be exercised with no server, no model, and no accessibility
+/// grant.
+struct NativWorkflowModelResponse: Sendable {
+    let text: String
+    /// Set when the resolver had to use a model other than the one the
+    /// workflow named, so the caller can say what it used instead.
+    var substitutedModel: String?
+
+    init(text: String, substitutedModel: String? = nil) {
+        self.text = text
+        self.substitutedModel = substitutedModel
+    }
+}
+
+struct NativWorkflowServices: Sendable {
+    var readSelection: @MainActor @Sendable () async -> NativTextSelection?
+    var replaceSelection: @MainActor @Sendable (String, NativTextSelection) async -> Bool
+    var invokeModel: @Sendable (NativWorkflowModelRequest) async throws -> NativWorkflowModelResponse
+    var readStorage: @MainActor @Sendable (String) throws -> NativWorkflowValue = { _ in
+        throw NativWorkflowRunError.operationUnavailable(step: "storage", operation: "storage.read")
+    }
+    var writeStorage: @MainActor @Sendable (String, NativWorkflowValue) throws -> Void = { _, _ in
+        throw NativWorkflowRunError.operationUnavailable(step: "storage", operation: "storage.write")
+    }
+}
+
+struct NativWorkflowRunContext: Sendable {
+    /// Non-optional: in process nothing scopes anything by construction, so
+    /// identity has to be impossible to forget.
+    let extensionID: String
+    let grantedPermissions: Set<NativExtensionPermission>
+    let services: NativWorkflowServices
+}
+
+struct NativWorkflowRunSummary: Equatable, Sendable {
+    let extensionID: String
+    let commandID: String
+    let stepsRun: Int
+    /// Set when a model other than the one the workflow named was used.
+    var substitutedModel: String?
+}
+
+enum NativWorkflowRunError: LocalizedError, Equatable {
+    case permissionNotGranted(step: String, permission: NativExtensionPermission)
+    case operationUnavailable(step: String, operation: String)
+    case missingInput(step: String, name: String)
+    case nothingSelected
+    case selectionUnavailable
+    case replaceFailed
+    case noTriggerForCommand(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .permissionNotGranted(_, let permission):
+            "This extension has not been granted “\(permission.displayName)”."
+        case .operationUnavailable(let step, let operation):
+            "Step “\(step)” uses “\(operation)”, which this version of Nativ cannot run."
+        case .missingInput(let step, let name):
+            "Step “\(step)” is missing its “\(name)” input."
+        case .nothingSelected:
+            "Select some text first."
+        case .selectionUnavailable:
+            "The selection is no longer available."
+        case .replaceFailed:
+            "Nativ could not replace the selected text."
+        case .noTriggerForCommand(let commandID):
+            "No workflow step runs “\(commandID)”."
+        }
+    }
+}

--- a/Sources/Nativ/Features/Extensions/Declarative/NativWorkspaceState.swift
+++ b/Sources/Nativ/Features/Extensions/Declarative/NativWorkspaceState.swift
@@ -1,0 +1,66 @@
+import Foundation
+import NativExtensionSDK
+import Observation
+
+@Observable
+@MainActor
+final class NativWorkspaceState {
+    private(set) var values: [String: NativWorkflowValue] = [:]
+    private(set) var loadError: String?
+    var errorMessage: String?
+    private let storage: NativExtensionWorkspaceStorage
+    private var pendingSave: Task<Void, Never>?
+    private var isDirty = false
+    private let fields: [String: NativWorkspaceField]
+
+    init(directory: URL, fields: [String: NativWorkspaceField]) {
+        self.fields = fields
+        storage = NativExtensionWorkspaceStorage(directory: directory, fields: fields)
+        do {
+            values = try storage.load()
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    func read(_ key: String) throws -> NativWorkflowValue {
+        guard loadError == nil, let value = values[key] else {
+            throw NativDashboardError.invalid(loadError ?? "Unknown storage key: \(key).")
+        }
+        return value
+    }
+
+    func stage(_ key: String, value: NativWorkflowValue) throws {
+        guard loadError == nil, let field = fields[key], field.type.accepts(value) else {
+            throw NativDashboardError.invalid(loadError ?? "Invalid value for storage key: \(key).")
+        }
+        guard values[key] != value else { return }
+        values[key] = value
+        isDirty = true
+        errorMessage = nil
+        pendingSave?.cancel()
+        pendingSave = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(300))
+                try self?.flush()
+            } catch is CancellationError {
+            } catch {
+                self?.errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func flush() throws {
+        pendingSave?.cancel()
+        pendingSave = nil
+        guard isDirty else { return }
+        try storage.save(values)
+        isDirty = false
+        errorMessage = nil
+    }
+
+    func write(_ key: String, value: NativWorkflowValue) throws {
+        try stage(key, value: value)
+        try flush()
+    }
+}

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -355,6 +355,10 @@ private struct ExtensionRow: View {
                 sectionDivider
                 NoticeRow(tone: .warning, title: errorMessage)
             }
+            if !runnableCommands.isEmpty {
+                sectionDivider
+                commands
+            }
             if !record.manifest.permissions.isEmpty {
                 sectionDivider
                 permissions
@@ -392,6 +396,32 @@ private struct ExtensionRow: View {
                 ? "Hide this included extension"
                 : "Delete this extension package"
         )
+    }
+
+    /// Declarative extensions have no page of their own yet, so their commands
+    /// need somewhere to be run from.
+    private var runnableCommands: [NativCommandContribution] {
+        guard record.manifest.runtime == .declarative, record.isEnabled else {
+            return []
+        }
+        return record.manifest.contributions.commands
+    }
+
+    private var commands: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text("Commands")
+                .font(.subheadline.weight(.semibold))
+            FlowLayout(spacing: 8) {
+                ForEach(runnableCommands) { command in
+                    Button {
+                        manager.performCommand(id: command.id)
+                    } label: {
+                        Label(command.title, systemImage: command.systemImage ?? "play")
+                    }
+                    .controlSize(.small)
+                }
+            }
+        }
     }
 
     private var permissions: some View {

--- a/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
+++ b/Sources/Nativ/Features/Extensions/NativExtensionPlatform.swift
@@ -114,6 +114,11 @@ final class NativExtensionManager: ObservableObject {
     private let installer: NativExtensionPackageInstaller
     private let builtIns: [String: any NativHostExtension]
     private var externalManifests: [String: NativExtensionInstalledPackage] = [:]
+    /// Declarative packages run in process but are not built in, so they
+    /// cannot live in `builtIns` — that dictionary is also the reserved
+    /// identifier set, and anything in it is refused on install.
+    private var declarativeRuntimes: [String: NativDeclarativeExtension] = [:]
+    private let declarativeServices: (@MainActor () -> NativWorkflowServices)?
     private var activeExtensionIDs = Set<String>()
     private var hostContext: NativExtensionHostContext?
     private var systemMonitor: AppExtensionPoint.Monitor?
@@ -135,8 +140,10 @@ final class NativExtensionManager: ObservableObject {
         fileManager: FileManager = .default,
         extensionsDirectory: URL? = nil,
         hostVersion: String? = nil,
-        permissionDefaults: UserDefaults = .standard
+        permissionDefaults: UserDefaults = .standard,
+        declarativeServices: (@MainActor () -> NativWorkflowServices)? = nil
     ) {
+        self.declarativeServices = declarativeServices
         self.stateStore = stateStore
         self.fileManager = fileManager
         self.extensionsDirectory = extensionsDirectory
@@ -157,6 +164,10 @@ final class NativExtensionManager: ObservableObject {
             ($0.manifest.id, $0)
         })
         reloadInstalledPackages()
+    }
+
+    private func hostExtension(for extensionID: String) -> (any NativHostExtension)? {
+        builtIns[extensionID] ?? declarativeRuntimes[extensionID]
     }
 
     var enabledSidebarContributions: [NativSidebarContribution] {
@@ -191,7 +202,7 @@ final class NativExtensionManager: ObservableObject {
 
     func shutdown() {
         for extensionID in activeExtensionIDs {
-            builtIns[extensionID]?.deactivate()
+            hostExtension(for: extensionID)?.deactivate()
         }
         activeExtensionIDs.removeAll()
         hostContext = nil
@@ -243,7 +254,7 @@ final class NativExtensionManager: ObservableObject {
         }
 
         if case .external(let packageURL) = record.origin {
-            builtIns[extensionID]?.deactivate()
+            hostExtension(for: extensionID)?.deactivate()
             stopSystemRuntime(extensionID: extensionID)
             activeExtensionIDs.remove(extensionID)
             do {
@@ -319,7 +330,7 @@ final class NativExtensionManager: ObservableObject {
               record.hasRuntime else {
             return nil
         }
-        return builtIns[record.id]?.makePage(id: pageID, context: context)
+        return hostExtension(for: record.id)?.makePage(id: pageID, context: context)
     }
 
     func performCommand(id commandID: String) {
@@ -330,7 +341,7 @@ final class NativExtensionManager: ObservableObject {
         }) else {
             return
         }
-        builtIns[record.id]?.performCommand(id: commandID)
+        hostExtension(for: record.id)?.performCommand(id: commandID)
     }
 
     func record(containingPage pageID: String) -> NativExtensionRecord? {
@@ -473,6 +484,14 @@ final class NativExtensionManager: ObservableObject {
         }
         grantedPermissionSnapshot = nextSnapshot
 
+        // Out-of-process runtimes are restarted below so they cannot hold a
+        // stale grant. In-process ones are just handed the new set.
+        for (identifier, runtime) in declarativeRuntimes {
+            runtime.updateGrantedPermissions(
+                granted(for: externalManifests[identifier]?.manifest ?? runtime.manifest)
+            )
+        }
+
         // An extension runtime receives its granted permissions at activation.
         // Restart active runtimes when a system grant changes so their broker
         // and activation context cannot retain stale permission state.
@@ -512,14 +531,12 @@ final class NativExtensionManager: ObservableObject {
         )
 
         for extensionID in activeExtensionIDs.subtracting(shouldBeActive) {
-            builtIns[extensionID]?.deactivate()
+            hostExtension(for: extensionID)?.deactivate()
             stopSystemRuntime(extensionID: extensionID)
             activeExtensionIDs.remove(extensionID)
         }
         for extensionID in shouldBeActive.subtracting(activeExtensionIDs) {
-            if let hostExtension = builtIns[extensionID] {
-                hostExtension.activate(context: hostContext)
-            }
+            hostExtension(for: extensionID)?.activate(context: hostContext)
             activeExtensionIDs.insert(extensionID)
             startSystemRuntimeIfAvailable(extensionID: extensionID)
         }
@@ -533,7 +550,60 @@ final class NativExtensionManager: ObservableObject {
         if packageIssues != result.issues {
             packageIssues = result.issues
         }
+        rebuildDeclarativeRuntimes()
         rebuildRecords()
+    }
+
+    /// Keeps a live runtime when its package is unchanged, so reloading after
+    /// an unrelated install does not tear down a workflow that is running.
+    private func rebuildDeclarativeRuntimes() {
+        guard let declarativeServices else {
+            for (identifier, runtime) in declarativeRuntimes {
+                runtime.deactivate()
+                activeExtensionIDs.remove(identifier)
+            }
+            declarativeRuntimes.removeAll()
+            return
+        }
+        var next: [String: NativDeclarativeExtension] = [:]
+        for (identifier, installed) in externalManifests {
+            guard installed.manifest.runtime == .declarative,
+                  installed.workflow != nil || installed.dashboard != nil else {
+                continue
+            }
+            if let existing = declarativeRuntimes[identifier],
+               existing.manifest == installed.manifest,
+               existing.workflow == installed.workflow,
+               existing.dashboard == installed.dashboard {
+                next[identifier] = existing
+                continue
+            }
+            declarativeRuntimes[identifier]?.deactivate()
+            activeExtensionIDs.remove(identifier)
+            next[identifier] = NativDeclarativeExtension(
+                manifest: installed.manifest,
+                workflow: installed.workflow,
+                dashboard: installed.dashboard,
+                storageDirectory: extensionsDirectory.appendingPathComponent("Data", isDirectory: true)
+                    .appendingPathComponent(identifier, isDirectory: true),
+                grantedPermissions: granted(for: installed.manifest),
+                services: declarativeServices,
+                onFailure: { [weak self] message in
+                    self?.setLastError(message)
+                }
+            )
+        }
+        for (identifier, runtime) in declarativeRuntimes where next[identifier] == nil {
+            runtime.deactivate()
+            activeExtensionIDs.remove(identifier)
+        }
+        declarativeRuntimes = next
+    }
+
+    private func granted(
+        for manifest: NativExtensionManifest
+    ) -> Set<NativExtensionPermission> {
+        Set(manifest.permissions.filter(isPermissionGranted))
     }
 
     private func rebuildRecords() {
@@ -551,6 +621,21 @@ final class NativExtensionManager: ObservableObject {
 
         nextRecords += externalManifests.values.map { installed in
             let manifest = installed.manifest
+            // A declarative package runs inside Nativ, so its runtime is the
+            // workflow the installer already validated rather than an
+            // extension the operating system had to register.
+            guard manifest.runtime != .declarative else {
+                return NativExtensionRecord(
+                    manifest: manifest,
+                    origin: .external(installed.packageURL),
+                    state: stateStore.state(for: manifest),
+                    hasRuntime: declarativeRuntimes[manifest.id] != nil,
+                    runtimeBundleIdentifier: nil,
+                    errorMessage: declarativeRuntimes[manifest.id] == nil
+                        ? NativExtensionPackageError.missingWorkflowDocument.localizedDescription
+                        : nil
+                )
+            }
             let systemIdentity = manifest.runtimeBundleIdentifier.flatMap {
                 systemIdentities[$0]
             }

--- a/Sources/Nativ/Features/Models/NativTaskModelSelection.swift
+++ b/Sources/Nativ/Features/Models/NativTaskModelSelection.swift
@@ -1,0 +1,81 @@
+import Foundation
+import NativExtensionSDK
+
+/// Chooses an installed model for a declarative workflow's `model.invoke` step.
+///
+/// Generalises `LocalModelDiscovery.speechToTextModelID(in:selectedModelID:)` to
+/// every task, and borrows the actionable-failure shape from
+/// `ChatImageModelSelection.resolve`.
+enum NativTaskModelSelection {
+    enum Resolution: Equatable {
+        /// `substitutedFor` names the model the workflow asked for when it was
+        /// unavailable, so the caller can say what it used instead.
+        case resolved(modelID: String, substitutedFor: String?)
+        case noCompatibleModel(task: NativWorkflowModelTask)
+    }
+
+    /// Which installed models can serve a task.
+    static func isEligible(_ model: LocalModel, for task: NativWorkflowModelTask) -> Bool {
+        switch task {
+        case .language:
+            // Not a raw `.text` check: that would admit drafters and rerankers.
+            return model.isEligibleForLanguageModelPicker
+        case .vision:
+            return model.capabilities.contains(.vision)
+                && !model.capabilities.contains(.imageGeneration)
+        case .imageGeneration:
+            return model.capabilities.contains(.imageGeneration)
+        case .imageEditing:
+            return model.capabilities.contains(.imageEditing)
+        case .speechToText:
+            return model.capabilities.contains(.speechToText)
+        case .textToSpeech:
+            return model.capabilities.contains(.textToSpeech)
+        case .embedding:
+            return model.capabilities.contains(.embeddings)
+        }
+    }
+
+    /// The settings slot a user pins for this task. Vision has no slot of its
+    /// own and shares the language pin, filtered by capability — so a pinned
+    /// text-only model correctly falls through rather than being handed an
+    /// image it cannot read.
+    static func preloadSlot(for task: NativWorkflowModelTask) -> ModelPreloadSlot {
+        switch task {
+        case .language, .vision: .language
+        case .imageGeneration, .imageEditing: .imageGeneration
+        case .speechToText: .speechToText
+        case .textToSpeech: .textToSpeech
+        case .embedding: .embeddings
+        }
+    }
+
+    /// Explicit request, then the user's pin, then the first compatible model.
+    ///
+    /// A named model that is not installed falls through rather than failing:
+    /// a language model is fungible in a way an image model is not, and an
+    /// extension should not break because the author's favourite is missing.
+    /// The substitution is reported so the caller can say so.
+    static func resolve(
+        task: NativWorkflowModelTask,
+        requested: String?,
+        pinned: String?,
+        installed: [LocalModel]
+    ) -> Resolution {
+        let eligible = installed
+            .filter { isEligible($0, for: task) }
+            .sorted { $0.repoID.localizedStandardCompare($1.repoID) == .orderedAscending }
+        guard !eligible.isEmpty else {
+            return .noCompatibleModel(task: task)
+        }
+
+        let wanted = requested.flatMap { $0 == "automatic" ? nil : $0 }
+        if let wanted, eligible.contains(where: { $0.repoID == wanted }) {
+            return .resolved(modelID: wanted, substitutedFor: nil)
+        }
+        if let pinned, eligible.contains(where: { $0.repoID == pinned }) {
+            return .resolved(modelID: pinned, substitutedFor: wanted)
+        }
+        return .resolved(modelID: eligible[0].repoID, substitutedFor: wanted)
+    }
+}

--- a/Sources/Nativ/Features/VoiceCapture/VoiceTranscriptInserter.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceTranscriptInserter.swift
@@ -1,16 +1,6 @@
 import AppKit
 import ApplicationServices
 
-struct VoiceTranscriptInsertionTarget: Equatable, Sendable {
-    let processIdentifier: pid_t
-    let applicationName: String?
-
-    init(processIdentifier: pid_t, applicationName: String? = nil) {
-        self.processIdentifier = processIdentifier
-        self.applicationName = applicationName
-    }
-}
-
 @MainActor
 enum VoiceTranscriptInserter {
     private static let pasteKeyCode = CGKeyCode(9)

--- a/Sources/Nativ/Features/VoiceCapture/VoiceTranscriptInsertionTarget.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceTranscriptInsertionTarget.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// The application that was frontmost when text was captured, so a later
+/// insertion can be aimed at it rather than at whatever is frontmost by then.
+struct VoiceTranscriptInsertionTarget: Equatable, Sendable {
+    let processIdentifier: pid_t
+    let applicationName: String?
+
+    init(processIdentifier: pid_t, applicationName: String? = nil) {
+        self.processIdentifier = processIdentifier
+        self.applicationName = applicationName
+    }
+}

--- a/Tests/NativTests/NativTaskModelSelectionTests.swift
+++ b/Tests/NativTests/NativTaskModelSelectionTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import NativExtensionSDK
+import XCTest
+
+final class NativTaskModelSelectionTests: XCTestCase {
+    private func model(
+        _ repoID: String,
+        _ capabilities: Set<LocalModelCapability>
+    ) -> LocalModel {
+        LocalModel(
+            repoID: repoID,
+            snapshotURL: nil,
+            modifiedAt: nil,
+            sizeBytes: nil,
+            parameterCount: nil,
+            quantizationBits: nil,
+            quantizationGroupSize: nil,
+            contextSize: nil,
+            provider: nil,
+            capabilities: capabilities,
+            drafterKind: nil,
+            hiddenSize: nil
+        )
+    }
+
+    private lazy var installed: [LocalModel] = [
+        model("org/zeta-chat", [.text]),
+        model("org/alpha-chat", [.text]),
+        model("org/see", [.vision]),
+        model("org/draft", [.text, .drafter]),
+        model("org/rank", [.reranking]),
+        model("org/paint", [.imageGeneration]),
+        model("org/hear", [.speechToText]),
+    ]
+
+    func testExplicitModelWins() {
+        XCTAssertEqual(
+            NativTaskModelSelection.resolve(
+                task: .language,
+                requested: "org/zeta-chat",
+                pinned: "org/alpha-chat",
+                installed: installed
+            ),
+            .resolved(modelID: "org/zeta-chat", substitutedFor: nil)
+        )
+    }
+
+    func testAutomaticDefersToThePin() {
+        XCTAssertEqual(
+            NativTaskModelSelection.resolve(
+                task: .language,
+                requested: "automatic",
+                pinned: "org/zeta-chat",
+                installed: installed
+            ),
+            .resolved(modelID: "org/zeta-chat", substitutedFor: nil)
+        )
+    }
+
+    /// A language model is fungible; an extension should not break because the
+    /// author's choice is not installed.
+    func testMissingRequestedModelFallsThroughAndReportsTheSubstitution() {
+        XCTAssertEqual(
+            NativTaskModelSelection.resolve(
+                task: .language,
+                requested: "org/not-installed",
+                pinned: "org/zeta-chat",
+                installed: installed
+            ),
+            .resolved(modelID: "org/zeta-chat", substitutedFor: "org/not-installed")
+        )
+    }
+
+    func testWithoutARequestOrPinTheChoiceIsDeterministic() {
+        XCTAssertEqual(
+            NativTaskModelSelection.resolve(
+                task: .language,
+                requested: nil,
+                pinned: nil,
+                installed: installed
+            ),
+            .resolved(modelID: "org/alpha-chat", substitutedFor: nil)
+        )
+    }
+
+    /// A pinned model that cannot serve the task is ignored, not handed work it
+    /// cannot do. Vision shares the language pin, which is why this matters.
+    func testPinIncompatibleWithTheTaskIsIgnored() {
+        XCTAssertEqual(
+            NativTaskModelSelection.resolve(
+                task: .vision,
+                requested: nil,
+                pinned: "org/alpha-chat",
+                installed: installed
+            ),
+            .resolved(modelID: "org/see", substitutedFor: nil)
+        )
+    }
+
+    func testNoCompatibleModelIsReportedPerTask() {
+        XCTAssertEqual(
+            NativTaskModelSelection.resolve(
+                task: .textToSpeech,
+                requested: nil,
+                pinned: nil,
+                installed: installed
+            ),
+            .noCompatibleModel(task: .textToSpeech)
+        )
+        XCTAssertEqual(
+            NativTaskModelSelection.resolve(
+                task: .embedding,
+                requested: nil,
+                pinned: nil,
+                installed: []
+            ),
+            .noCompatibleModel(task: .embedding)
+        )
+    }
+
+    func testDraftersAndRerankersAreNotLanguageModels() {
+        XCTAssertFalse(
+            NativTaskModelSelection.isEligible(model("org/draft", [.text, .drafter]), for: .language)
+        )
+        XCTAssertFalse(
+            NativTaskModelSelection.isEligible(model("org/rank", [.reranking]), for: .language)
+        )
+    }
+
+    func testAVisionModelCanAlsoServeLanguage() {
+        XCTAssertTrue(
+            NativTaskModelSelection.isEligible(model("org/see", [.vision]), for: .language)
+        )
+        XCTAssertFalse(
+            NativTaskModelSelection.isEligible(
+                model("org/paint", [.imageGeneration, .vision]),
+                for: .vision
+            )
+        )
+    }
+
+    func testEveryTaskMapsToASlot() {
+        for task in NativWorkflowModelTask.allCases {
+            XCTAssertNotNil(NativTaskModelSelection.preloadSlot(for: task))
+        }
+        XCTAssertEqual(NativTaskModelSelection.preloadSlot(for: .vision), .language)
+    }
+}

--- a/Tests/NativTests/NativWorkflowRunnerTests.swift
+++ b/Tests/NativTests/NativWorkflowRunnerTests.swift
@@ -1,0 +1,376 @@
+import Foundation
+import NativExtensionSDK
+import XCTest
+
+/// Records what each stubbed service was asked to do, so a test can assert a
+/// service was *not* reached as easily as it can assert a result.
+private final class ServiceLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _selectionReads = 0
+    private var _modelPrompts: [String] = []
+    private var _replaced: [String] = []
+
+    var selectionReads: Int { lock.withLock { _selectionReads } }
+    var modelPrompts: [String] { lock.withLock { _modelPrompts } }
+    var replaced: [String] { lock.withLock { _replaced } }
+
+    func recordSelectionRead() { lock.withLock { _selectionReads += 1 } }
+    func recordPrompt(_ value: String) { lock.withLock { _modelPrompts.append(value) } }
+    func recordReplacement(_ value: String) { lock.withLock { _replaced.append(value) } }
+}
+
+final class NativWorkflowRunnerTests: XCTestCase {
+    private let extensionID = "com.example.rewrite"
+    private var commandID: String { "\(extensionID).improve" }
+
+    private func services(
+        log: ServiceLog,
+        selection: String? = "rough draft",
+        modelResponse: String = "polished draft",
+        substituted: String? = nil,
+        replaceSucceeds: Bool = true
+    ) -> NativWorkflowServices {
+        NativWorkflowServices(
+            readSelection: {
+                log.recordSelectionRead()
+                return selection.map { NativTextSelection(text: $0) }
+            },
+            replaceSelection: { text, _ in
+                log.recordReplacement(text)
+                return replaceSucceeds
+            },
+            invokeModel: { request in
+                log.recordPrompt(request.prompt)
+                return NativWorkflowModelResponse(
+                    text: modelResponse,
+                    substitutedModel: substituted
+                )
+            }
+        )
+    }
+
+    private func context(
+        log: ServiceLog,
+        granted: Set<NativExtensionPermission> = [
+            .readSelection, .accessibilityInsertText, .modelsLanguage,
+        ],
+        selection: String? = "rough draft",
+        modelResponse: String = "polished draft",
+        substituted: String? = nil,
+        replaceSucceeds: Bool = true
+    ) -> NativWorkflowRunContext {
+        NativWorkflowRunContext(
+            extensionID: extensionID,
+            grantedPermissions: granted,
+            services: services(
+                log: log,
+                selection: selection,
+                modelResponse: modelResponse,
+                substituted: substituted,
+                replaceSucceeds: replaceSucceeds
+            )
+        )
+    }
+
+    private func rewriteWorkflow() -> NativExtensionWorkflow {
+        NativExtensionWorkflow(
+            triggers: [.init(id: "improve", type: .command, commandID: commandID)],
+            steps: [
+                .init(id: "selection", type: "text.readSelection"),
+                .init(
+                    id: "rewrite",
+                    type: "model.invoke",
+                    task: "language",
+                    model: "automatic",
+                    inputs: ["prompt": .text("Improve: {{selection.text}}")]
+                ),
+                .init(
+                    id: "apply",
+                    type: "text.replaceSelection",
+                    inputs: ["text": .text("{{rewrite.text}}")]
+                ),
+            ]
+        )
+    }
+
+    // MARK: - Acceptance
+
+    /// The whole point of the slice: a declarative extension runs end to end
+    /// with no server, no model, and no accessibility grant.
+    func testRewriteWorkflowRunsEndToEnd() async throws {
+        let log = ServiceLog()
+
+        let summary = try await NativWorkflowRunner.run(
+            rewriteWorkflow(),
+            commandID: commandID,
+            context: context(log: log)
+        )
+
+        XCTAssertEqual(summary.stepsRun, 3)
+        XCTAssertEqual(summary.extensionID, extensionID)
+        XCTAssertEqual(log.selectionReads, 1)
+        XCTAssertEqual(log.modelPrompts, ["Improve: rough draft"])
+        XCTAssertEqual(log.replaced, ["polished draft"])
+    }
+
+    func testSubstitutedModelIsReported() async throws {
+        let log = ServiceLog()
+
+        let summary = try await NativWorkflowRunner.run(
+            rewriteWorkflow(),
+            commandID: commandID,
+            context: context(log: log, substituted: "org/author-choice")
+        )
+
+        XCTAssertEqual(summary.substitutedModel, "org/author-choice")
+    }
+
+    // MARK: - Permission enforcement replaces the broker
+
+    /// A missing grant must stop the step *before* its service is reached, not
+    /// after. Asserting the stub was never called is the point of the test.
+    func testMissingPermissionThrowsBeforeTheServiceIsCalled() async {
+        let log = ServiceLog()
+
+        await XCTAssertThrowsErrorAsync(
+            try await NativWorkflowRunner.run(
+                rewriteWorkflow(),
+                commandID: commandID,
+                context: context(log: log, granted: [.accessibilityInsertText, .modelsLanguage])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? NativWorkflowRunError,
+                .permissionNotGranted(step: "selection", permission: .readSelection)
+            )
+        }
+        XCTAssertEqual(log.selectionReads, 0, "the service ran despite a missing grant")
+    }
+
+    func testRevokedModelPermissionStopsBeforeTheModelIsCalled() async {
+        let log = ServiceLog()
+
+        await XCTAssertThrowsErrorAsync(
+            try await NativWorkflowRunner.run(
+                rewriteWorkflow(),
+                commandID: commandID,
+                context: context(log: log, granted: [.readSelection, .accessibilityInsertText])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? NativWorkflowRunError,
+                .permissionNotGranted(step: "rewrite", permission: .modelsLanguage)
+            )
+        }
+        XCTAssertEqual(log.selectionReads, 1)
+        XCTAssertTrue(log.modelPrompts.isEmpty, "the model ran despite a missing grant")
+    }
+
+    // MARK: - Failure paths
+
+    func testNothingSelectedStopsTheRun() async {
+        let log = ServiceLog()
+
+        await XCTAssertThrowsErrorAsync(
+            try await NativWorkflowRunner.run(
+                rewriteWorkflow(),
+                commandID: commandID,
+                context: context(log: log, selection: nil)
+            )
+        ) { error in
+            XCTAssertEqual(error as? NativWorkflowRunError, .nothingSelected)
+        }
+        XCTAssertTrue(log.modelPrompts.isEmpty)
+    }
+
+    func testAFailedReplacementIsReported() async {
+        let log = ServiceLog()
+
+        await XCTAssertThrowsErrorAsync(
+            try await NativWorkflowRunner.run(
+                rewriteWorkflow(),
+                commandID: commandID,
+                context: context(log: log, replaceSucceeds: false)
+            )
+        ) { error in
+            XCTAssertEqual(error as? NativWorkflowRunError, .replaceFailed)
+        }
+    }
+
+    func testAnUnimplementedOperationIsRefusedAtRunTime() async {
+        let log = ServiceLog()
+        let workflow = NativExtensionWorkflow(
+            triggers: [.init(id: "t", type: .command, commandID: commandID)],
+            steps: [.init(id: "shot", type: "screen.capture")]
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await NativWorkflowRunner.run(
+                workflow,
+                commandID: commandID,
+                context: context(log: log, granted: [.screenCapture])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? NativWorkflowRunError,
+                .operationUnavailable(step: "shot", operation: "screen.capture")
+            )
+        }
+    }
+
+    func testACommandWithNoTriggerDoesNotRun() async {
+        let log = ServiceLog()
+
+        await XCTAssertThrowsErrorAsync(
+            try await NativWorkflowRunner.run(
+                rewriteWorkflow(),
+                commandID: "\(extensionID).other",
+                context: context(log: log)
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? NativWorkflowRunError,
+                .noTriggerForCommand("\(extensionID).other")
+            )
+        }
+        XCTAssertEqual(log.selectionReads, 0)
+    }
+
+    func testMissingInputIsNamed() async {
+        let log = ServiceLog()
+        let workflow = NativExtensionWorkflow(
+            triggers: [.init(id: "t", type: .command, commandID: commandID)],
+            steps: [
+                .init(id: "selection", type: "text.readSelection"),
+                .init(id: "rewrite", type: "model.invoke", task: "language"),
+            ]
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await NativWorkflowRunner.run(
+                workflow,
+                commandID: commandID,
+                context: context(log: log)
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? NativWorkflowRunError,
+                .missingInput(step: "rewrite", name: "prompt")
+            )
+        }
+    }
+
+    // MARK: - Cancellation
+
+    /// Disabling or removing an extension cancels its run. The check has to
+    /// land between steps, so a cancelled workflow must not reach the model
+    /// after the selection has already been read.
+    func testCancellationStopsBeforeTheNextStep() async {
+        let log = ServiceLog()
+        let gate = RunGate()
+        var stubbed = services(log: log)
+        stubbed.readSelection = {
+            log.recordSelectionRead()
+            await gate.signalEnteredAndWait()
+            return NativTextSelection(text: "rough draft")
+        }
+        let runContext = NativWorkflowRunContext(
+            extensionID: extensionID,
+            grantedPermissions: [.readSelection, .accessibilityInsertText, .modelsLanguage],
+            services: stubbed
+        )
+
+        let workflow = rewriteWorkflow()
+        let identifier = commandID
+        let task = Task {
+            try await NativWorkflowRunner.run(
+                workflow,
+                commandID: identifier,
+                context: runContext
+            )
+        }
+
+        await gate.waitUntilEntered()
+        task.cancel()
+        await gate.open()
+
+        let result = await task.result
+        switch result {
+        case .success:
+            XCTFail("The run completed despite being cancelled")
+        case .failure(let error):
+            XCTAssertTrue(error is CancellationError, "Unexpected error: \(error)")
+        }
+        XCTAssertEqual(log.selectionReads, 1)
+        XCTAssertTrue(log.modelPrompts.isEmpty, "the model ran after cancellation")
+        XCTAssertTrue(log.replaced.isEmpty)
+    }
+
+    // MARK: - Bindings
+
+    func testSubstitutionFillsEveryBinding() {
+        let outputs: [String: NativWorkflowStepOutput] = [
+            "a": ["text": .text("one")],
+            "b": ["other": .text("two")],
+        ]
+
+        XCTAssertEqual(
+            NativWorkflowRunner.substitute("{{a.text}} and {{b.other}}", outputs: outputs),
+            "one and two"
+        )
+        XCTAssertEqual(
+            NativWorkflowRunner.substitute("{{a}}", outputs: outputs),
+            "one",
+            "a bare step reference should read its text output"
+        )
+        XCTAssertEqual(
+            NativWorkflowRunner.substitute("{{missing.text}}", outputs: outputs),
+            "",
+            "an unresolvable binding must not leave its template in the prompt"
+        )
+    }
+}
+
+/// Lets a test pause inside a stubbed service, cancel the run, and then let
+/// the service finish — so the cancellation check is exercised deterministically
+/// rather than raced.
+private actor RunGate {
+    private var entered: CheckedContinuation<Void, Never>?
+    private var hasEntered = false
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signalEnteredAndWait() async {
+        hasEntered = true
+        entered?.resume()
+        entered = nil
+        guard !opened else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { entered = $0 }
+    }
+
+    func open() {
+        opened = true
+        let pending = waiters
+        waiters.removeAll()
+        for continuation in pending { continuation.resume() }
+    }
+}
+
+func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ handler: (any Error) -> Void
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected an error", file: file, line: line)
+    } catch {
+        handler(error)
+    }
+}

--- a/Tests/NativTests/NativWorkspaceRuntimeTests.swift
+++ b/Tests/NativTests/NativWorkspaceRuntimeTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import NativExtensionSDK
+import XCTest
+
+@MainActor
+final class NativWorkspaceRuntimeTests: XCTestCase {
+    private func fixture() throws -> (NativExtensionManifest, NativExtensionDashboard, NativExtensionWorkflow) {
+        let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent().appendingPathComponent("Examples/ExtensionWorkspace/com.example.workspace.nativextension")
+        let decoder = JSONDecoder()
+        return (
+            try decoder.decode(NativExtensionManifest.self, from: Data(contentsOf: root.appendingPathComponent("Manifest.json"))),
+            try decoder.decode(NativExtensionDashboard.self, from: Data(contentsOf: root.appendingPathComponent("Dashboard.json"))),
+            try decoder.decode(NativExtensionWorkflow.self, from: Data(contentsOf: root.appendingPathComponent("Workflow.json")))
+        )
+    }
+
+    private func waitUntilIdle(_ runtime: NativDeclarativeExtension) async {
+        for _ in 0..<10_000 {
+            if !runtime.isRunning { return }
+            await Task.yield()
+        }
+        XCTFail("Workspace command did not finish")
+    }
+
+    func testCommandsUseDistinctRoutesAndPersistWithoutASelection() async throws {
+        let (manifest, dashboard, workflow) = try fixture()
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let runtime = NativDeclarativeExtension(
+            manifest: manifest, workflow: workflow, dashboard: dashboard, storageDirectory: root,
+            grantedPermissions: [.namespacedStorage], services: {
+                NativWorkflowServices(readSelection: { XCTFail("Unexpected selection read"); return nil },
+                    replaceSelection: { _, _ in XCTFail("Unexpected insertion"); return false },
+                    invokeModel: { _ in XCTFail("Unexpected model request"); return .init(text: "") })
+            }, onFailure: { XCTFail($0) }
+        )
+        runtime.activate()
+        runtime.setValue(.text("Keep this note"), for: "draft")
+        runtime.performCommand(id: "com.example.workspace.save")
+        await waitUntilIdle(runtime)
+        XCTAssertEqual(runtime.workspace?.values["saved"], .text("Keep this note"))
+        XCTAssertEqual(runtime.completedSteps, 2)
+        runtime.performCommand(id: "com.example.workspace.clear")
+        await waitUntilIdle(runtime)
+        XCTAssertEqual(runtime.workspace?.values["saved"], .text(""))
+        XCTAssertEqual(runtime.workspace?.values["draft"], .text("Keep this note"))
+        XCTAssertEqual(runtime.completedSteps, 1)
+        runtime.deactivate()
+        let restored = NativWorkspaceState(directory: root, fields: dashboard.storage)
+        XCTAssertEqual(restored.values["draft"], .text("Keep this note"))
+        runtime.performCommand(id: "com.example.workspace.save")
+        XCTAssertFalse(runtime.isRunning)
+    }
+
+    func testCancellationPreventsLateModelResultFromWritingState() async throws {
+        let (manifest, dashboard, _) = try fixture()
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let gate = WorkspaceModelGate()
+        let workflow = NativExtensionWorkflow(triggers: [
+            .init(id: "save", type: .command, commandID: "com.example.workspace.save", steps: ["model", "save"]),
+            .init(id: "clear", type: .command, commandID: "com.example.workspace.clear", steps: ["new"]),
+        ], steps: [
+            .init(id: "model", type: "model.invoke", task: "language", inputs: ["prompt": .text("test")]),
+            .init(id: "save", type: "storage.write", inputs: ["key": .text("saved"), "value": .text("{{model.text}}")]),
+            .init(id: "new", type: "storage.write", inputs: ["key": .text("saved"), "value": .text("new run")]),
+        ])
+        let runtime = NativDeclarativeExtension(
+            manifest: manifest, workflow: workflow, dashboard: dashboard, storageDirectory: root,
+            grantedPermissions: [.namespacedStorage, .modelsLanguage], services: {
+                NativWorkflowServices(readSelection: { nil }, replaceSelection: { _, _ in false },
+                    invokeModel: { _ in await gate.response() })
+            }, onFailure: { XCTFail($0) }
+        )
+        runtime.activate()
+        runtime.performCommand(id: "com.example.workspace.save")
+        for _ in 0..<10_000 {
+            if await gate.isWaiting { break }
+            await Task.yield()
+        }
+        let waiting = await gate.isWaiting
+        XCTAssertTrue(waiting)
+        runtime.deactivate()
+        runtime.activate()
+        runtime.performCommand(id: "com.example.workspace.clear")
+        await waitUntilIdle(runtime)
+        await gate.finish()
+        for _ in 0..<100 { await Task.yield() }
+        XCTAssertEqual(runtime.workspace?.values["saved"], .text("new run"))
+        XCTAssertEqual(runtime.status, "Completed")
+        XCTAssertFalse(runtime.isRunning)
+    }
+
+    func testPermissionRevocationCancelsRunAndControlsCannotWriteWhileDisabled() throws {
+        let (manifest, dashboard, workflow) = try fixture()
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let runtime = NativDeclarativeExtension(
+            manifest: manifest, workflow: workflow, dashboard: dashboard, storageDirectory: root,
+            grantedPermissions: [.namespacedStorage], services: {
+                NativWorkflowServices(readSelection: { nil }, replaceSelection: { _, _ in false }, invokeModel: { _ in .init(text: "") })
+            }, onFailure: { XCTFail($0) }
+        )
+        runtime.setValue(.text("disabled"), for: "draft")
+        XCTAssertEqual(runtime.workspace?.values["draft"], .text(""))
+        runtime.activate()
+        runtime.performCommand(id: "com.example.workspace.save")
+        runtime.updateGrantedPermissions([])
+        XCTAssertFalse(runtime.isRunning)
+        XCTAssertEqual(runtime.status, "Cancelled")
+        runtime.setValue(.text("revoked"), for: "draft")
+        XCTAssertEqual(runtime.workspace?.values["draft"], .text(""))
+    }
+
+    func testBindingValuesAreNeverReinterpretedAsTemplates() {
+        let output: [String: NativWorkflowStepOutput] = [
+            "input": ["text": .text("{{secret.text}}")],
+            "secret": ["text": .text("must not leak")],
+            "tempo": ["value": .number(120)],
+        ]
+        XCTAssertEqual(NativWorkflowRunner.substitute("{{input.text}} and {{secret.text}}", outputs: output), "{{secret.text}} and must not leak")
+        XCTAssertEqual(NativWorkflowRunner.resolvedValue(.text("{{tempo.value}}"), outputs: output), .number(120))
+    }
+}
+
+private actor WorkspaceModelGate {
+    private var continuation: CheckedContinuation<NativWorkflowModelResponse, Never>?
+    var isWaiting: Bool { continuation != nil }
+    func response() async -> NativWorkflowModelResponse {
+        await withCheckedContinuation { continuation = $0 }
+    }
+    func finish() {
+        continuation?.resume(returning: .init(text: "late result"))
+        continuation = nil
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -222,6 +222,12 @@ targets:
       - path: Sources/Nativ/Features/VoiceCapture/AudioAnalyticsStore.swift
       - path: Sources/Nativ/Utilities/NativSystemPermissionController.swift
       - path: Sources/Nativ/Features/Extensions/NativExtensionStateStore.swift
+      - path: Sources/Nativ/Features/Models/NativTaskModelSelection.swift
+      - path: Sources/Nativ/Features/VoiceCapture/VoiceTranscriptInsertionTarget.swift
+      - path: Sources/Nativ/Features/Extensions/Declarative/NativWorkflowServices.swift
+      - path: Sources/Nativ/Features/Extensions/Declarative/NativWorkflowRunner.swift
+      - path: Sources/Nativ/Features/Extensions/Declarative/NativDeclarativeExtension.swift
+      - path: Sources/Nativ/Features/Extensions/Declarative/NativWorkspaceState.swift
       - path: Sources/Nativ/Features/Extensions/NativExtensionCatalogClient.swift
       - path: Sources/Nativ/Features/MCP/MCPServerCatalog.swift
       - path: Sources/Nativ/Features/MCP/GitHubOAuth.swift


### PR DESCRIPTION
Stacked on #506; adds native extension pages with persistent state, command routing, progress, and cancellation, verified with 99 focused tests and a local Debug build, with interactive workspace QA still pending.
