### PR TITLE
Add an auto-run option for terminal commands

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -214,6 +214,7 @@ struct ChatComposer: View {
     @State private var showsKits = false
     @State private var showsCapabilities = false
     @State private var showsAddPanel = false
+    @State private var showsApprovalModePanel = false
     @State private var isWebSearchAvailable = false
     @State private var isWebReadAvailable = false
     @State private var webSearchProviderLabel: String?
@@ -327,6 +328,8 @@ struct ChatComposer: View {
                         onSelect: onSelectWorkspaceMode
                     )
 
+                    approvalModeButton
+
                     Spacer(minLength: 12)
 
                     if let contextWindowUsage {
@@ -378,6 +381,11 @@ struct ChatComposer: View {
             .background {
                 NativArrowlessPopoverPresenter(isPresented: $showsAddPanel) {
                     addPanel
+                }
+            }
+            .background {
+                NativArrowlessPopoverPresenter(isPresented: $showsApprovalModePanel) {
+                    approvalModePanel
                 }
             }
         }
@@ -464,6 +472,76 @@ struct ChatComposer: View {
             await Task.yield()
             action()
         }
+    }
+
+    private var approvalModeButton: some View {
+        Button {
+            showsApprovalModePanel.toggle()
+        } label: {
+            HStack(spacing: 5) {
+                Image(
+                    systemName: model.settings.terminalAutoApprovalEnabled
+                        ? "bolt.badge.checkmark" : "hand.raised"
+                )
+                .font(.system(size: 11, weight: .semibold))
+
+                Text(model.settings.terminalAutoApprovalEnabled ? "Auto" : "Manual")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .foregroundStyle(Color.secondary)
+            .padding(.horizontal, 10)
+            .frame(height: 26)
+            .background(
+                Color.primary.opacity(0.045),
+                in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .help("Choose how terminal commands are approved")
+        .accessibilityLabel(
+            "Terminal approval mode: \(model.settings.terminalAutoApprovalEnabled ? "Auto" : "Manual")"
+        )
+    }
+
+    private var approvalModePanel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("How should terminal commands be approved?")
+                .nativTextStyle(.supportingEmphasized)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 1) {
+                ChatComposerActionRow(
+                    title: "Manual",
+                    detail: "Always ask before running",
+                    systemName: "hand.raised",
+                    isSelected: !model.settings.terminalAutoApprovalEnabled,
+                    action: { setTerminalAutoApproval(false) }
+                )
+
+                ChatComposerActionRow(
+                    title: "Auto",
+                    detail: "Skip prompts for safe commands",
+                    systemName: "bolt.badge.checkmark",
+                    isSelected: model.settings.terminalAutoApprovalEnabled,
+                    action: { setTerminalAutoApproval(true) }
+                )
+            }
+        }
+        .padding(10)
+        .frame(width: 260)
+    }
+
+    private func setTerminalAutoApproval(_ isEnabled: Bool) {
+        var settings = model.settings
+        settings.terminalAutoApprovalEnabled = isEnabled
+        model.settings = settings.normalized()
+        showsApprovalModePanel = false
     }
 
     private func globalToolIsEnabled(_ toolName: String, isAvailable: Bool) -> Bool {

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -1640,8 +1640,9 @@ final class ChatViewModel: ObservableObject {
                     } ?? false)
                     && toolCall.function?.name == ChatTerminalToolRegistry.toolName
                 if isNativeTerminal {
+                    let terminalRequest: ChatTerminalToolRequest
                     do {
-                        try ChatTerminalToolExecutor().preflight(
+                        terminalRequest = try ChatTerminalToolExecutor().preflight(
                             call: toolCall,
                             defaultWorkingDirectory: queuedRequest.toolScope
                                 .terminalWorkingDirectory
@@ -1657,37 +1658,17 @@ final class ChatViewModel: ObservableObject {
                         continue
                     }
 
-                    updateToolMessage(
-                        toolMessageID,
-                        in: queuedRequest.sessionID,
-                        status: .awaitingConsent,
-                        content: "",
-                        attachments: []
-                    )
-                    let approved = await awaitToolConsent(for: toolMessageID)
-                    switch ChatToolConsentRouter.outcome(
-                        approved: approved,
-                        isCancelled: Task.isCancelled
-                    ) {
-                    case .cancelled:
-                        cancelToolMessages(
-                            currentID: toolMessageID,
-                            currentCall: toolCall,
-                            remainingCalls: Array(toolCalls.dropFirst(index + 1)),
-                            after: insertionAnchor,
-                            in: queuedRequest.sessionID
-                        )
-                        throw CancellationError()
-                    case .declined:
-                        updateToolMessage(
-                            toolMessageID,
-                            in: queuedRequest.sessionID,
-                            status: .declined,
-                            content: ChatTerminalToolExecutor().declinedPayload(),
-                            attachments: []
-                        )
-                        continue
-                    case .approved:
+                    // Auto-approval only ever skips the prompt for commands the
+                    // safety policy found nothing to warn about; anything on the
+                    // warn list (sudo, recursive rm, destructive git ops, etc.)
+                    // still requires an explicit click, and hard-blocked commands
+                    // already failed in preflight above regardless of this setting.
+                    let canAutoApprove =
+                        queuedRequest.settings.terminalAutoApprovalEnabled
+                        && TerminalCommandSafetyPolicy.assess(command: terminalRequest.command)
+                            .warnings.isEmpty
+
+                    if canAutoApprove {
                         terminalApprovalGranted = true
                         updateToolMessage(
                             toolMessageID,
@@ -1696,6 +1677,47 @@ final class ChatViewModel: ObservableObject {
                             content: "",
                             attachments: []
                         )
+                    } else {
+                        updateToolMessage(
+                            toolMessageID,
+                            in: queuedRequest.sessionID,
+                            status: .awaitingConsent,
+                            content: "",
+                            attachments: []
+                        )
+                        let approved = await awaitToolConsent(for: toolMessageID)
+                        switch ChatToolConsentRouter.outcome(
+                            approved: approved,
+                            isCancelled: Task.isCancelled
+                        ) {
+                        case .cancelled:
+                            cancelToolMessages(
+                                currentID: toolMessageID,
+                                currentCall: toolCall,
+                                remainingCalls: Array(toolCalls.dropFirst(index + 1)),
+                                after: insertionAnchor,
+                                in: queuedRequest.sessionID
+                            )
+                            throw CancellationError()
+                        case .declined:
+                            updateToolMessage(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .declined,
+                                content: ChatTerminalToolExecutor().declinedPayload(),
+                                attachments: []
+                            )
+                            continue
+                        case .approved:
+                            terminalApprovalGranted = true
+                            updateToolMessage(
+                                toolMessageID,
+                                in: queuedRequest.sessionID,
+                                status: .running,
+                                content: "",
+                                attachments: []
+                            )
+                        }
                     }
                 }
 

--- a/Sources/Nativ/Features/Settings/SettingsView.swift
+++ b/Sources/Nativ/Features/Settings/SettingsView.swift
@@ -230,19 +230,6 @@ struct SettingsView: View {
                     Toggle("", isOn: projectToolsEnabledBinding)
                         .labelsHidden()
                 }
-
-                Divider()
-                    .padding(.leading, 52)
-
-                settingsRow(
-                    title: "Auto-Run Terminal Commands",
-                    description:
-                        "Skip the confirmation prompt for terminal commands with no safety warnings. Commands the safety check flags, and destructive commands it blocks outright, still require a manual approval.",
-                    systemImage: "bolt.badge.checkmark"
-                ) {
-                    Toggle("", isOn: terminalAutoApprovalEnabledBinding)
-                        .labelsHidden()
-                }
             }
             .background(Color(nsColor: .controlBackgroundColor))
             .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -259,17 +246,6 @@ struct SettingsView: View {
             set: { isEnabled in
                 var settings = model.settings
                 settings.projectToolsEnabled = isEnabled
-                model.settings = settings.normalized()
-            }
-        )
-    }
-
-    private var terminalAutoApprovalEnabledBinding: Binding<Bool> {
-        Binding(
-            get: { model.settings.terminalAutoApprovalEnabled },
-            set: { isEnabled in
-                var settings = model.settings
-                settings.terminalAutoApprovalEnabled = isEnabled
                 model.settings = settings.normalized()
             }
         )

--- a/Sources/Nativ/Features/Settings/SettingsView.swift
+++ b/Sources/Nativ/Features/Settings/SettingsView.swift
@@ -230,6 +230,19 @@ struct SettingsView: View {
                     Toggle("", isOn: projectToolsEnabledBinding)
                         .labelsHidden()
                 }
+
+                Divider()
+                    .padding(.leading, 52)
+
+                settingsRow(
+                    title: "Auto-Run Terminal Commands",
+                    description:
+                        "Skip the confirmation prompt for terminal commands with no safety warnings. Commands the safety check flags, and destructive commands it blocks outright, still require a manual approval.",
+                    systemImage: "bolt.badge.checkmark"
+                ) {
+                    Toggle("", isOn: terminalAutoApprovalEnabledBinding)
+                        .labelsHidden()
+                }
             }
             .background(Color(nsColor: .controlBackgroundColor))
             .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -246,6 +259,17 @@ struct SettingsView: View {
             set: { isEnabled in
                 var settings = model.settings
                 settings.projectToolsEnabled = isEnabled
+                model.settings = settings.normalized()
+            }
+        )
+    }
+
+    private var terminalAutoApprovalEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { model.settings.terminalAutoApprovalEnabled },
+            set: { isEnabled in
+                var settings = model.settings
+                settings.terminalAutoApprovalEnabled = isEnabled
                 model.settings = settings.normalized()
             }
         )

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -427,6 +427,7 @@ struct NativSettings: Codable, Equatable {
     var fileReadRootPath: String?
     var fileWriteRootPath: String?
     var projectToolsEnabled: Bool
+    var terminalAutoApprovalEnabled: Bool
     var skills: [NativSkill]
     var imageGenerationModelID: String?
     var textToSpeechModelID: String?
@@ -484,6 +485,7 @@ struct NativSettings: Codable, Equatable {
         fileReadRootPath: String? = nil,
         fileWriteRootPath: String? = nil,
         projectToolsEnabled: Bool = true,
+        terminalAutoApprovalEnabled: Bool = false,
         skills: [NativSkill] = [],
         imageGenerationModelID: String? = nil,
         textToSpeechModelID: String? = nil,
@@ -540,6 +542,7 @@ struct NativSettings: Codable, Equatable {
         self.fileReadRootPath = fileReadRootPath
         self.fileWriteRootPath = fileWriteRootPath
         self.projectToolsEnabled = projectToolsEnabled
+        self.terminalAutoApprovalEnabled = terminalAutoApprovalEnabled
         self.skills = skills
         self.imageGenerationModelID = imageGenerationModelID
         self.textToSpeechModelID = textToSpeechModelID
@@ -598,6 +601,7 @@ struct NativSettings: Codable, Equatable {
         case fileReadRootPath
         case fileWriteRootPath
         case projectToolsEnabled
+        case terminalAutoApprovalEnabled
         case skills
         case imageGenerationModelID
         case textToSpeechModelID
@@ -684,6 +688,9 @@ struct NativSettings: Codable, Equatable {
         projectToolsEnabled =
             try container.decodeIfPresent(Bool.self, forKey: .projectToolsEnabled)
             ?? defaults.projectToolsEnabled
+        terminalAutoApprovalEnabled =
+            try container.decodeIfPresent(Bool.self, forKey: .terminalAutoApprovalEnabled)
+            ?? defaults.terminalAutoApprovalEnabled
         skills =
             try container.decodeIfPresent([NativSkill].self, forKey: .skills) ?? defaults.skills
         imageGenerationModelID =
@@ -815,6 +822,7 @@ struct NativSettings: Codable, Equatable {
         try container.encodeIfPresent(fileReadRootPath, forKey: .fileReadRootPath)
         try container.encodeIfPresent(fileWriteRootPath, forKey: .fileWriteRootPath)
         try container.encode(projectToolsEnabled, forKey: .projectToolsEnabled)
+        try container.encode(terminalAutoApprovalEnabled, forKey: .terminalAutoApprovalEnabled)
         try container.encode(skills, forKey: .skills)
         try container.encodeIfPresent(imageGenerationModelID, forKey: .imageGenerationModelID)
         try container.encodeIfPresent(textToSpeechModelID, forKey: .textToSpeechModelID)

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -701,6 +701,19 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertEqual(decoded.disabledToolNames, ["terminal"])
     }
 
+    func testTerminalAutoApprovalDefaultsToDisabledAndRoundTrips() throws {
+        XCTAssertFalse(NativSettings().terminalAutoApprovalEnabled)
+
+        var settings = NativSettings()
+        settings.terminalAutoApprovalEnabled = true
+        let decoded = try JSONDecoder().decode(
+            NativSettings.self,
+            from: JSONEncoder().encode(settings)
+        )
+
+        XCTAssertTrue(decoded.terminalAutoApprovalEnabled)
+    }
+
     func testRememberProfileCapturesCurrentModelSettings() throws {
         var settings = NativSettings()
         settings.thinkingEnabled = true


### PR DESCRIPTION
Terminal commands always require a manual approval today, with no way to skip it. This adds an "Auto-Run Terminal Commands" setting (off by default) that only skips the prompt when the safety check finds nothing to warn about — commands it flags, and the ones it blocks outright, still need an explicit approval either way. Mirrors how Claude Code, Codex CLI, and Cursor scope their own auto-run modes: auto never means unconditional.

Draft while I finish testing.