### PR TITLE
Fix chat deletion for migrated chats

### DIFF
--- a/Sources/Nativ/Features/Chat/ChatSessionStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSessionStore.swift
@@ -696,6 +696,7 @@ struct ChatImageAttachment: Identifiable, Equatable, Codable, Sendable {
 }
 
 struct ChatSessionStore {
+    private static let migrationLock = NSLock()
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "Nativ",
         category: "ChatPersistence"
@@ -862,28 +863,48 @@ struct ChatSessionStore {
     }
 
     private func migrateLegacyStoreIfNeeded() {
+        Self.migrationLock.lock()
+        defer { Self.migrationLock.unlock() }
+
+        let completionURL = chatDirectory.appendingPathComponent(".legacy-cache-migration-complete")
         guard let legacyChatDirectory,
               legacyChatDirectory.standardizedFileURL != chatDirectory.standardizedFileURL,
               fileManager.fileExists(atPath: legacyChatDirectory.path)
         else { return }
         do {
-            try fileManager.createDirectory(at: chatDirectory, withIntermediateDirectories: true)
-            for name in ["folders.json", "current.json"] {
-                let source = legacyChatDirectory.appendingPathComponent(name)
-                let destination = chatDirectory.appendingPathComponent(name)
-                if fileManager.fileExists(atPath: source.path), !fileManager.fileExists(atPath: destination.path) {
-                    try fileManager.copyItem(at: source, to: destination)
-                }
-            }
             let legacySessions = legacyChatDirectory.appendingPathComponent("Sessions", isDirectory: true)
+            var files = ["folders.json", "current.json"].map {
+                (source: legacyChatDirectory.appendingPathComponent($0), destination: chatDirectory.appendingPathComponent($0))
+            }.filter { fileManager.fileExists(atPath: $0.source.path) }
             if fileManager.fileExists(atPath: legacySessions.path) {
+                files += try fileManager.contentsOfDirectory(at: legacySessions, includingPropertiesForKeys: nil)
+                    .filter { $0.pathExtension == "json" }
+                    .map { (source: $0, destination: sessionsDirectory.appendingPathComponent($0.lastPathComponent)) }
+            }
+            if !fileManager.fileExists(atPath: completionURL.path) {
                 try fileManager.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
-                for source in try fileManager.contentsOfDirectory(at: legacySessions, includingPropertiesForKeys: nil)
-                    where source.pathExtension == "json" {
-                    let destination = sessionsDirectory.appendingPathComponent(source.lastPathComponent)
+                for (source, destination) in files {
                     if !fileManager.fileExists(atPath: destination.path) {
                         try fileManager.copyItem(at: source, to: destination)
                     }
+                    // Existing destination files are authoritative, but must be readable before discarding the fallback.
+                    let data = try Data(contentsOf: destination)
+                    switch source.lastPathComponent {
+                    case "folders.json": _ = try makeDecoder().decode([ChatFolder].self, from: data)
+                    case "current.json": _ = try makeDecoder().decode([ChatTranscriptMessage].self, from: data)
+                    default: _ = try makeDecoder().decode(ChatSession.self, from: data)
+                    }
+                }
+                // Commit before cleanup: a crash or failed removal must never cause deleted chats to be reimported.
+                try Data().write(to: completionURL, options: .atomic)
+            }
+            for (source, _) in files {
+                try fileManager.removeItem(at: source)
+            }
+            // Leave unrelated cache files alone, removing directories only when they are empty.
+            for directory in [legacySessions, legacyChatDirectory] where fileManager.fileExists(atPath: directory.path) {
+                if try fileManager.contentsOfDirectory(atPath: directory.path).isEmpty {
+                    try fileManager.removeItem(at: directory)
                 }
             }
         } catch {
@@ -916,8 +937,9 @@ struct ChatSessionStore {
                 updatedAt: updatedAt,
                 messages: messages
             )
-            saveSession(session)
-            try? fileManager.removeItem(at: legacyTranscriptURL)
+            if saveSession(session) {
+                try? fileManager.removeItem(at: legacyTranscriptURL)
+            }
         } catch {
             return
         }

--- a/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
+++ b/Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
@@ -1068,6 +1068,7 @@ struct ImageGenerationSessionSummary: Identifiable, Equatable {
 }
 
 struct ImageGenerationSessionStore {
+    private static let migrationLock = NSLock()
     private let fileManager: FileManager
     private let imageDirectory: URL
     private let legacyImageDirectory: URL?
@@ -1194,19 +1195,38 @@ struct ImageGenerationSessionStore {
     }
 
     private func migrateLegacyStoreIfNeeded() {
+        Self.migrationLock.lock()
+        defer { Self.migrationLock.unlock() }
+
+        let completionURL = imageDirectory.appendingPathComponent(".legacy-cache-migration-complete")
         guard let legacyImageDirectory,
               legacyImageDirectory.standardizedFileURL != imageDirectory.standardizedFileURL,
               fileManager.fileExists(atPath: legacyImageDirectory.path)
         else { return }
         do {
             let legacySessions = legacyImageDirectory.appendingPathComponent("Sessions", isDirectory: true)
-            guard fileManager.fileExists(atPath: legacySessions.path) else { return }
-            try fileManager.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
-            for source in try fileManager.contentsOfDirectory(at: legacySessions, includingPropertiesForKeys: nil)
-                where source.pathExtension == "json" {
-                let destination = sessionsDirectory.appendingPathComponent(source.lastPathComponent)
-                if !fileManager.fileExists(atPath: destination.path) {
-                    try fileManager.copyItem(at: source, to: destination)
+            let files = fileManager.fileExists(atPath: legacySessions.path)
+                ? try fileManager.contentsOfDirectory(at: legacySessions, includingPropertiesForKeys: nil)
+                    .filter { $0.pathExtension == "json" }
+                : []
+            if !fileManager.fileExists(atPath: completionURL.path) {
+                try fileManager.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
+                for source in files {
+                    let destination = sessionsDirectory.appendingPathComponent(source.lastPathComponent)
+                    if !fileManager.fileExists(atPath: destination.path) {
+                        try fileManager.copyItem(at: source, to: destination)
+                    }
+                    _ = try decoder().decode(ImageGenerationSession.self, from: Data(contentsOf: destination))
+                }
+                // Commit before removing originals so interrupted cleanup cannot reimport deleted sessions.
+                try Data().write(to: completionURL, options: .atomic)
+            }
+            for source in files {
+                try fileManager.removeItem(at: source)
+            }
+            for directory in [legacySessions, legacyImageDirectory] where fileManager.fileExists(atPath: directory.path) {
+                if try fileManager.contentsOfDirectory(atPath: directory.path).isEmpty {
+                    try fileManager.removeItem(at: directory)
                 }
             }
         } catch {

--- a/Tests/NativTests/ChatViewModelTests.swift
+++ b/Tests/NativTests/ChatViewModelTests.swift
@@ -112,7 +112,7 @@ final class MediaAssetPersistenceTests: XCTestCase {
         XCTAssertEqual(fixture.mediaStore.data(for: migratedAsset), payload)
     }
 
-    func testLegacyCacheMigrationIsIdempotentAndPreservesOriginal() throws {
+    func testLegacyCacheMigrationIsIdempotentAndRemovesOriginal() throws {
         let fixture = try makeFixture()
         let sessions = fixture.legacyChat.appendingPathComponent("Sessions", isDirectory: true)
         try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
@@ -140,13 +140,200 @@ final class MediaAssetPersistenceTests: XCTestCase {
 
         XCTAssertEqual(fixture.chatStore.loadSessions().map(\.id), [session.id])
         XCTAssertEqual(fixture.chatStore.loadSessions().map(\.id), [session.id])
-        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.legacyChat.path))
         let migratedJSON = try String(contentsOf: fixture.chatStore.sessionURL(for: session.id), encoding: .utf8)
         XCTAssertFalse(migratedJSON.contains("base64Data"))
         let migratedAsset = try XCTUnwrap(
             fixture.chatStore.loadSession(id: session.id)?.messages[0].imageAttachments[0].asset
         )
         XCTAssertEqual(fixture.mediaStore.data(for: migratedAsset), payload)
+    }
+
+    func testDeletedMigratedChatStaysDeletedAfterSaveAndRelaunch() throws {
+        let fixture = try makeFixture()
+        let legacySessions = fixture.legacyChat.appendingPathComponent("Sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacySessions, withIntermediateDirectories: true)
+        let now = Date()
+        let session = ChatSession(
+            id: UUID(), title: "Legacy", createdAt: now, updatedAt: now,
+            messages: [ChatTranscriptMessage(role: .user, content: "legacy")]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let legacyURL = legacySessions.appendingPathComponent("\(session.id.uuidString).json")
+        try encoder.encode(session).write(to: legacyURL)
+        XCTAssertEqual(fixture.chatStore.loadSessions().map(\.id), [session.id])
+
+        fixture.chatStore.deleteSession(id: session.id)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.chatStore.sessionURL(for: session.id).path))
+        let replacement = ChatSession(
+            id: UUID(), title: "New chat", createdAt: now, updatedAt: now, messages: []
+        )
+        XCTAssertTrue(fixture.chatStore.saveSession(replacement))
+
+        let relaunchedStore = ChatSessionStore(
+            chatDirectory: fixture.root.appendingPathComponent("Chat", isDirectory: true),
+            legacyChatDirectory: fixture.legacyChat,
+            mediaStore: fixture.mediaStore
+        )
+        XCTAssertNil(relaunchedStore.loadSession(id: session.id))
+        XCTAssertEqual(relaunchedStore.loadSessions().map(\.id), [replacement.id])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
+    func testDeletedLegacyTranscriptStaysDeletedAfterRelaunch() throws {
+        let fixture = try makeFixture()
+        try FileManager.default.createDirectory(at: fixture.legacyChat, withIntermediateDirectories: true)
+        let legacyURL = fixture.legacyChat.appendingPathComponent("current.json")
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode([ChatTranscriptMessage(role: .user, content: "old transcript")])
+            .write(to: legacyURL)
+        let session = try XCTUnwrap(fixture.chatStore.loadSessions().first)
+
+        fixture.chatStore.deleteSession(id: session.id)
+        let relaunchedStore = ChatSessionStore(
+            chatDirectory: fixture.root.appendingPathComponent("Chat", isDirectory: true),
+            legacyChatDirectory: fixture.legacyChat,
+            mediaStore: fixture.mediaStore
+        )
+        XCTAssertTrue(relaunchedStore.loadSessions().isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
+    func testFailedLegacyChatMigrationRetriesBeforeMarkingComplete() throws {
+        let fixture = try makeFixture()
+        let legacySessions = fixture.legacyChat.appendingPathComponent("Sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacySessions, withIntermediateDirectories: true)
+        let now = Date()
+        let session = ChatSession(
+            id: UUID(), title: "Legacy", createdAt: now, updatedAt: now,
+            messages: [ChatTranscriptMessage(role: .user, content: "legacy")]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(session).write(to: legacySessions.appendingPathComponent("\(session.id.uuidString).json"))
+
+        let destination = fixture.chatStore.sessionURL(for: session.id).deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        // A regular file prevents the session directory from being created on the first attempt.
+        try Data().write(to: destination)
+        XCTAssertTrue(fixture.chatStore.loadSessions().isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacySessions.appendingPathComponent("\(session.id.uuidString).json").path))
+        try FileManager.default.removeItem(at: destination)
+
+        let relaunchedStore = ChatSessionStore(
+            chatDirectory: fixture.root.appendingPathComponent("Chat", isDirectory: true),
+            legacyChatDirectory: fixture.legacyChat,
+            mediaStore: fixture.mediaStore
+        )
+        XCTAssertEqual(relaunchedStore.loadSessions().map(\.id), [session.id])
+        relaunchedStore.deleteSession(id: session.id)
+        XCTAssertTrue(relaunchedStore.loadSessions().isEmpty)
+    }
+
+    func testDeletedMigratedImageSessionStaysDeletedAfterRelaunch() throws {
+        let fixture = try makeFixture()
+        let legacyDirectory = fixture.root.appendingPathComponent("LegacyImages", isDirectory: true)
+        let legacySessions = legacyDirectory.appendingPathComponent("Sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacySessions, withIntermediateDirectories: true)
+        let now = Date()
+        let session = ImageGenerationSession(
+            id: UUID(), title: "Legacy image", createdAt: now, updatedAt: now,
+            modelKind: .imageGeneration, modelID: "test/model", draftSettings: ImageRequestSettings(),
+            activeReference: nil, turns: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let legacyURL = legacySessions.appendingPathComponent("\(session.id.uuidString).json")
+        try encoder.encode(session).write(to: legacyURL)
+        let store = ImageGenerationSessionStore(
+            imageDirectory: fixture.root.appendingPathComponent("Images", isDirectory: true),
+            legacyImageDirectory: legacyDirectory,
+            mediaStore: fixture.mediaStore
+        )
+        XCTAssertEqual(store.loadSessions().map(\.id), [session.id])
+        store.deleteSession(id: session.id)
+
+        let relaunchedStore = ImageGenerationSessionStore(
+            imageDirectory: fixture.root.appendingPathComponent("Images", isDirectory: true),
+            legacyImageDirectory: legacyDirectory,
+            mediaStore: fixture.mediaStore
+        )
+        XCTAssertNil(relaunchedStore.loadSession(id: session.id))
+        XCTAssertTrue(relaunchedStore.loadSessions().isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
+    func testCompletedMigrationCleansRemainingOriginalsWithoutRestoringDeletedSessions() throws {
+        let fixture = try makeFixture()
+        // Simulate a migration completed by an older build, with originals still present and destinations deleted.
+        for (legacyName, destinationName) in [("LegacyChat", "Chat"), ("LegacyImages", "Images")] {
+            let legacySessions = fixture.root.appendingPathComponent(legacyName).appendingPathComponent("Sessions")
+            let destination = fixture.root.appendingPathComponent(destinationName)
+            try FileManager.default.createDirectory(at: legacySessions, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: legacySessions.appendingPathComponent("deleted.json"))
+            try Data().write(to: destination.appendingPathComponent(".legacy-cache-migration-complete"))
+        }
+
+        XCTAssertTrue(fixture.chatStore.loadSessions().isEmpty)
+        let imageStore = ImageGenerationSessionStore(
+            imageDirectory: fixture.root.appendingPathComponent("Images"),
+            legacyImageDirectory: fixture.root.appendingPathComponent("LegacyImages"),
+            mediaStore: fixture.mediaStore
+        )
+        XCTAssertTrue(imageStore.loadSessions().isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.legacyChat.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.root.appendingPathComponent("LegacyImages").path))
+    }
+
+    func testLegacyCleanupPreservesCurrentVersionAndUnrelatedFiles() throws {
+        let fixture = try makeFixture()
+        let now = Date()
+        var session = ChatSession(
+            id: UUID(), title: "Current", createdAt: now, updatedAt: now,
+            messages: [ChatTranscriptMessage(role: .user, content: "current content")]
+        )
+        XCTAssertTrue(fixture.chatStore.saveSession(session))
+        let legacySessions = fixture.legacyChat.appendingPathComponent("Sessions")
+        try FileManager.default.createDirectory(at: legacySessions, withIntermediateDirectories: true)
+        session.messages = [ChatTranscriptMessage(role: .user, content: "outdated content")]
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let legacyURL = legacySessions.appendingPathComponent("\(session.id.uuidString).json")
+        try encoder.encode(session).write(to: legacyURL)
+        let unrelatedURL = fixture.legacyChat.appendingPathComponent("unrelated.txt")
+        try Data("keep".utf8).write(to: unrelatedURL)
+
+        XCTAssertEqual(fixture.chatStore.loadSessions().first?.messages.first?.content, "current content")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertEqual(try String(contentsOf: unrelatedURL, encoding: .utf8), "keep")
+    }
+
+    func testLegacyOriginalIsRetainedIfDestinationCannotBeDecoded() throws {
+        let fixture = try makeFixture()
+        let legacySessions = fixture.legacyChat.appendingPathComponent("Sessions")
+        try FileManager.default.createDirectory(at: legacySessions, withIntermediateDirectories: true)
+        let now = Date()
+        let session = ChatSession(
+            id: UUID(), title: "Legacy", createdAt: now, updatedAt: now,
+            messages: [ChatTranscriptMessage(role: .user, content: "recoverable content")]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let legacyURL = legacySessions.appendingPathComponent("\(session.id.uuidString).json")
+        try encoder.encode(session).write(to: legacyURL)
+        let destination = fixture.chatStore.sessionURL(for: session.id)
+        try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("invalid JSON".utf8).write(to: destination)
+
+        XCTAssertTrue(fixture.chatStore.loadSessions().isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyURL.path))
+        try FileManager.default.removeItem(at: destination)
+        XCTAssertEqual(fixture.chatStore.loadSessions().map(\.id), [session.id])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
     }
 
     func testSharedAssetIsDeletedOnlyAfterLastOwnerIsRemoved() throws {


### PR DESCRIPTION
Fix an issue where chats could be deleted from the new location and then re-migrated at launch and come back. Now we fully migrate once and have a consistent view on where they live so deletion always works.