### PR TITLE
Fix microphone format selection for preview and recording

### DIFF
--- a/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
@@ -41,7 +41,8 @@ final class AudioInputLevelMonitor: ObservableObject {
                 try inputNode.auAudioUnit.setDeviceID(deviceID)
             }
 
-            let format = inputNode.outputFormat(forBus: 0)
+            // Device selection can leave the node's output format on the previous device's rate.
+            let format = inputNode.inputFormat(forBus: 0)
             guard format.sampleRate > 0, format.channelCount > 0 else {
                 throw VoiceAudioRecorderError.couldNotStart
             }

--- a/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
@@ -186,7 +186,8 @@ final class VoiceAudioRecorder {
             try inputNode.auAudioUnit.setDeviceID(deviceID)
         }
 
-        let inputFormat = inputNode.outputFormat(forBus: 0)
+        // Device selection can leave the node's output format on the previous device's rate.
+        let inputFormat = inputNode.inputFormat(forBus: 0)
         guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
             throw VoiceAudioRecorderError.couldNotStart
         }


### PR DESCRIPTION
Fix audio input format mismatch closes #511 

This fixes a possible cause of the crash in #511. After switching microphones, Nativ could still use the previous device’s sample rate. I reproduced a 24 kHz audio tap being used with a 48 kHz microphone, which caused an exception and then the same runtime crash shown in the issue.

Both preview and recording now use the selected microphone’s input format.
