### PR TITLE
Safer voice activation key combo monitoring

### DIFF
--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -115,7 +115,7 @@ final class AudioCaptureLibrary: ObservableObject {
     private let meetingJoinMonitor = MeetingJoinMonitor()
     private let meetingSuggestion = MeetingTranscriptionSuggestionController()
     private let analytics: AudioAnalyticsStore
-    private var elapsedTimer: Timer?
+    private var elapsedTask: Task<Void, Never>?
     private var captureStartedAt: Date?
     private var shouldSummarizeCurrentCapture = false
     private var activeBackend: ActiveAudioCaptureBackend?
@@ -270,7 +270,7 @@ final class AudioCaptureLibrary: ObservableObject {
             phase = .recording
             recordingOverlay.update(level: 0, elapsed: 0)
             recordingOverlay.didStartRecording()
-            startElapsedTimer()
+            startElapsedUpdates()
         } catch {
             if Self.isScreenCapturePermissionError(error) {
                 // ScreenCaptureKit presents the native permission dialog itself.
@@ -305,7 +305,7 @@ final class AudioCaptureLibrary: ObservableObject {
 
         phase = .processing
         recordingOverlay.waitForTranscription()
-        stopElapsedTimer()
+        stopElapsedUpdates()
         let duration = max(
             elapsed,
             captureStartedAt.map { Date().timeIntervalSince($0) } ?? 0
@@ -582,7 +582,7 @@ final class AudioCaptureLibrary: ObservableObject {
         meetingSuggestion.dismiss()
         activeTask?.cancel()
         activeTask = nil
-        stopElapsedTimer()
+        stopElapsedUpdates()
         if let unfinishedVoiceNote = voiceRecorder.stop() {
             try? FileManager.default.removeItem(at: unfinishedVoiceNote)
         }
@@ -826,7 +826,7 @@ final class AudioCaptureLibrary: ObservableObject {
         }
 
         phase = .preparing
-        stopElapsedTimer()
+        stopElapsedUpdates()
         switch activeBackend {
         case .microphone:
             if let recordingURL = voiceRecorder.stop() {
@@ -839,7 +839,7 @@ final class AudioCaptureLibrary: ObservableObject {
     }
 
     private func resetCaptureState(hideOverlay: Bool = true) {
-        stopElapsedTimer()
+        stopElapsedUpdates()
         if hideOverlay {
             recordingOverlay.hide()
         }
@@ -855,13 +855,18 @@ final class AudioCaptureLibrary: ObservableObject {
         activeTask = nil
     }
 
-    private func startElapsedTimer() {
-        stopElapsedTimer()
-        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
-            MainActor.assumeIsolated {
-                guard let self, let captureStartedAt = self.captureStartedAt else {
+    private func startElapsedUpdates() {
+        stopElapsedUpdates()
+        elapsedTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .milliseconds(250))
+                } catch {
                     return
                 }
+                guard !Task.isCancelled, let self,
+                    let captureStartedAt = self.captureStartedAt
+                else { return }
                 self.elapsed = Date().timeIntervalSince(captureStartedAt)
                 self.updateRecordingOverlay(
                     level: self.meterState.level,
@@ -869,13 +874,11 @@ final class AudioCaptureLibrary: ObservableObject {
                 )
             }
         }
-        RunLoop.main.add(timer, forMode: .common)
-        elapsedTimer = timer
     }
 
-    private func stopElapsedTimer() {
-        elapsedTimer?.invalidate()
-        elapsedTimer = nil
+    private func stopElapsedUpdates() {
+        elapsedTask?.cancel()
+        elapsedTask = nil
     }
 
     private func updateRecordingOverlay(level: Float, elapsed: TimeInterval) {

--- a/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/FnControlShortcutMonitor.swift
@@ -155,7 +155,7 @@ final class FnControlShortcutMonitor {
 
     private var localMonitor: Any?
     private var globalMonitor: Any?
-    private var modifierPollTimer: Timer?
+    private var modifierPollTask: Task<Void, Never>?
     private var preferenceObserver: NSObjectProtocol?
     private var recordIsHeld = false
     private var retryModifierIsHeld = false
@@ -166,12 +166,21 @@ final class FnControlShortcutMonitor {
     private var hotKeys: [UInt32: EventHotKeyRef] = [:]
     private var hotKeyEventHandler: EventHandlerRef?
     private let preferences: VoiceShortcutPreferences
+    private let readModifiers: () -> VoiceShortcutModifiers
     private let hotKeySignature = OSType(0x4E_41_54_56)
     private let recordHotKeyID: UInt32 = 1
     private let retryHotKeyID: UInt32 = 2
 
-    init(preferences: VoiceShortcutPreferences? = nil) {
+    init(
+        preferences: VoiceShortcutPreferences? = nil,
+        readModifiers: @escaping () -> VoiceShortcutModifiers = {
+            VoiceShortcutModifiers(
+                cgEventFlags: CGEventSource.flagsState(.combinedSessionState)
+            )
+        }
+    ) {
         self.preferences = preferences ?? .shared
+        self.readModifiers = readModifiers
     }
 
     func start() {
@@ -216,8 +225,8 @@ final class FnControlShortcutMonitor {
         }
         localMonitor = nil
         globalMonitor = nil
-        modifierPollTimer?.invalidate()
-        modifierPollTimer = nil
+        modifierPollTask?.cancel()
+        modifierPollTask = nil
         if let preferenceObserver {
             NotificationCenter.default.removeObserver(preferenceObserver)
         }
@@ -250,24 +259,26 @@ final class FnControlShortcutMonitor {
     }
 
     private func startModifierPolling() {
-        modifierPollTimer?.invalidate()
-        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) {
-            [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.consumeCurrentModifierFlags()
+        modifierPollTask?.cancel()
+        // The task inherits this monitor's isolation. Sleeping suspends it
+        // without occupying the main actor.
+        modifierPollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(1.0 / 60.0))
+                } catch {
+                    return
+                }
+                // stop() may run after sleep completes but before we resume.
+                guard !Task.isCancelled, let self else { return }
+                self.consumeCurrentModifierFlags()
             }
         }
-        RunLoop.main.add(timer, forMode: .common)
-        modifierPollTimer = timer
         consumeCurrentModifierFlags()
     }
 
     private func consumeCurrentModifierFlags() {
-        consume(
-            VoiceShortcutModifiers(
-                cgEventFlags: CGEventSource.flagsState(.combinedSessionState)
-            )
-        )
+        consume(readModifiers())
     }
 
     private func consume(_ event: NSEvent) {

--- a/Tests/NativTests/AudioTests.swift
+++ b/Tests/NativTests/AudioTests.swift
@@ -463,6 +463,84 @@ final class AudioAnalyticsStoreTests: XCTestCase {
     }
 }
 
+@MainActor
+final class FnControlShortcutMonitorTests: XCTestCase {
+    func testPollingDeliversPressAndReleaseThenStops() async throws {
+        let preferences = makePreferences()
+        var modifiers: VoiceShortcutModifiers = [.function, .control]
+        var samples = 0
+        var changes: [Bool] = []
+        let released = expectation(description: "Polling observes modifier release")
+        let monitor = FnControlShortcutMonitor(preferences: preferences) {
+            samples += 1
+            return modifiers
+        }
+        monitor.onChange = { held in
+            XCTAssertTrue(Thread.isMainThread)
+            changes.append(held)
+            if !held { released.fulfill() }
+        }
+        monitor.start()
+        defer { monitor.stop() }
+
+        // The first sample is synchronous, before the polling task starts.
+        XCTAssertEqual(changes, [true])
+        modifiers = []
+        await fulfillment(of: [released], timeout: 2)
+        XCTAssertEqual(changes, [true, false])
+
+        monitor.stop()
+        let samplesAtStop = samples
+        modifiers = [.function, .control]
+        try await Task.sleep(for: .milliseconds(75))
+        XCTAssertEqual(samples, samplesAtStop)
+        XCTAssertEqual(changes, [true, false])
+    }
+
+    func testImmediateStopAndRestartDoNotLeaveOldPollersRunning() async throws {
+        let preferences = makePreferences()
+        var samples = 0
+        var retryEnabled = false
+        let polled = expectation(description: "Restarted monitor polls")
+        let monitor = FnControlShortcutMonitor(preferences: preferences) {
+            samples += 1
+            return retryEnabled && samples > 21 ? [.option] : []
+        }
+
+        for _ in 0 ..< 20 {
+            monitor.start()
+            monitor.stop()
+        }
+        XCTAssertEqual(samples, 20)
+        try await Task.sleep(for: .milliseconds(75))
+        XCTAssertEqual(samples, 20)
+
+        monitor.onRetry = { polled.fulfill() }
+        retryEnabled = true
+        monitor.start()
+        defer { monitor.stop() }
+        await fulfillment(of: [polled], timeout: 2)
+        monitor.stop()
+        let samplesAtStop = samples
+        try await Task.sleep(for: .milliseconds(75))
+        XCTAssertEqual(samples, samplesAtStop)
+    }
+
+    private func makePreferences() -> VoiceShortcutPreferences {
+        let suiteName = "FnControlShortcutMonitorTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        let preferences = VoiceShortcutPreferences(defaults: defaults)
+        preferences.isHandsFreeEnabled = false
+        preferences.retryShortcut = VoiceShortcut(
+            keyCode: nil,
+            keyDisplay: nil,
+            modifiers: [.option]
+        )
+        return preferences
+    }
+}
+
 final class FnControlShortcutStateTests: XCTestCase {
     func testActivatesOnlyWhenFnAndControlAreBothHeld() {
         var state = FnControlShortcutState()


### PR DESCRIPTION
Use an async task for monitoring instead of a timer and avoid use of `assumeIsolated()` which is unsafe in this context. Resolves https://github.com/Blaizzy/nativ/issues/511