### PR TITLE
Improve audio engine error handling

### DIFF
--- a/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioCaptureLibrary.swift
@@ -166,6 +166,9 @@ final class AudioCaptureLibrary: ObservableObject {
             }
             self.publishMeter(level: level, elapsed: elapsed)
         }
+        voiceRecorder.onRecordingFailure = { [weak self] error, savedURL in
+            self?.microphoneRecordingInterrupted(error, savedURL: savedURL)
+        }
         meetingRecorder.onMicrophoneLevelUpdate = { [weak self] level in
             guard let self else {
                 return
@@ -306,7 +309,7 @@ final class AudioCaptureLibrary: ObservableObject {
         phase = .processing
         recordingOverlay.waitForTranscription()
         stopElapsedUpdates()
-        let duration = max(
+        var duration = max(
             elapsed,
             captureStartedAt.map { Date().timeIntervalSince($0) } ?? 0
         )
@@ -315,10 +318,16 @@ final class AudioCaptureLibrary: ObservableObject {
             let recordingURL: URL
             switch activeBackend {
             case .microphone:
-                guard let url = voiceRecorder.stop() else {
+                let savedURL = voiceRecorder.stop()
+                if let error = voiceRecorder.lastRecordingError {
+                    microphoneRecordingInterrupted(error, savedURL: savedURL)
+                    return
+                }
+                guard let savedURL else {
                     throw AudioCaptureLibraryError.recordingUnavailable
                 }
-                recordingURL = url
+                recordingURL = savedURL
+                duration = voiceRecorder.lastRecordingDuration ?? duration
             case .systemAndMicrophone:
                 recordingURL = try await meetingRecorder.stop()
             }
@@ -788,6 +797,18 @@ final class AudioCaptureLibrary: ObservableObject {
             .appendingPathComponent(recordID)
             .appendingPathExtension("summary.txt")
         try? FileManager.default.removeItem(at: summaryURL)
+    }
+
+    private func microphoneRecordingInterrupted(_ error: Error, savedURL: URL?) {
+        if let savedURL, let kind = activeKind {
+            analytics.addCapture(
+                recordingURL: savedURL,
+                kind: kind,
+                title: Self.defaultTitle(for: kind, date: captureStartedAt ?? Date()),
+                durationSeconds: voiceRecorder.lastRecordingDuration ?? 0
+            )
+        }
+        fail(error)
     }
 
     private func fail(_ error: Error) {

--- a/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
+++ b/Sources/Nativ/Features/VoiceCapture/AudioInputLevelMonitor.swift
@@ -16,7 +16,7 @@ final class AudioInputLevelMonitor: ObservableObject {
     @Published private(set) var isMonitoring = false
     @Published private(set) var errorMessage: String?
 
-    private var audioEngine: AVAudioEngine?
+    private let inputSession = AudioInputEngineSession()
     private var realtimeMeter: RealtimeAudioMeter?
     private var meterPublisherTask: Task<Void, Never>?
 
@@ -30,34 +30,14 @@ final class AudioInputLevelMonitor: ObservableObject {
         }
 
         do {
-            let engine = AVAudioEngine()
-            let inputNode = engine.inputNode
-            if let deviceUniqueID {
-                guard let deviceID = AudioInputDeviceResolver.coreAudioDeviceID(
-                    for: deviceUniqueID
-                ) else {
-                    throw VoiceAudioRecorderError.inputDeviceUnavailable
-                }
-                try inputNode.auAudioUnit.setDeviceID(deviceID)
-            }
-
-            // Device selection can leave the node's output format on the previous device's rate.
-            let format = inputNode.inputFormat(forBus: 0)
-            guard format.sampleRate > 0, format.channelCount > 0 else {
-                throw VoiceAudioRecorderError.couldNotStart
-            }
-
             let realtimeMeter = RealtimeAudioMeter(profile: .inputMonitor)
-            let tap = Self.makeTap(realtimeMeter: realtimeMeter)
-            inputNode.installTap(
-                onBus: 0,
-                bufferSize: 1_024,
-                format: format,
-                block: tap
-            )
-            engine.prepare()
-            try engine.start()
-            audioEngine = engine
+            try inputSession.start(
+                deviceUniqueID: deviceUniqueID,
+                tap: Self.makeTap(realtimeMeter: realtimeMeter)
+            ) { [weak self] error in
+                self?.errorMessage = error.localizedDescription
+                self?.stop(resetError: false)
+            }
             isMonitoring = true
             startMeterPublisher(realtimeMeter: realtimeMeter)
         } catch {
@@ -78,11 +58,7 @@ final class AudioInputLevelMonitor: ObservableObject {
     }
 
     private func stop(resetError: Bool) {
-        if let audioEngine {
-            audioEngine.inputNode.removeTap(onBus: 0)
-            audioEngine.stop()
-        }
-        audioEngine = nil
+        inputSession.stop()
         isMonitoring = false
         stopMeterPublisher()
         meterState.update(0)
@@ -142,7 +118,7 @@ final class AudioInputLevelMonitor: ObservableObject {
         for channel in 0..<channelCount {
             let samples = channelData[channel]
             for frame in 0..<frameCount {
-                let sample = samples[frame]
+                let sample = samples[frame * buffer.stride]
                 sum += sample * sample
             }
         }
@@ -153,4 +129,158 @@ final class AudioInputLevelMonitor: ObservableObject {
     private static func hasMicrophoneAccess() -> Bool {
         AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
     }
+}
+
+@MainActor
+protocol AudioInputEngineDriving: AnyObject {
+    var isRunning: Bool { get }
+    var onConfigurationChange: (() -> Void)? { get set }
+    func start(
+        deviceUniqueID: String?,
+        tap: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    ) throws
+    func stop()
+}
+
+@MainActor
+final class AudioInputEngineSession {
+    private let makeEngine: () -> any AudioInputEngineDriving
+    private let retryDelays: [Duration]
+    private var engine: (any AudioInputEngineDriving)?
+    private var recoveryTask: Task<Void, Never>?
+    private var generation = UUID()
+
+    init(
+        retryDelays: [Duration] = [.milliseconds(100), .milliseconds(250), .milliseconds(500)],
+        makeEngine: @escaping () -> any AudioInputEngineDriving = { SystemAudioInputEngine() }
+    ) {
+        self.retryDelays = retryDelays
+        self.makeEngine = makeEngine
+    }
+
+    func start(
+        deviceUniqueID: String?,
+        tap: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void,
+        onFailure: @escaping (Error) -> Void
+    ) throws {
+        stop()
+        try startEngine(deviceUniqueID: deviceUniqueID, tap: tap, onFailure: onFailure)
+    }
+
+    func stop() {
+        generation = UUID()
+        recoveryTask?.cancel()
+        recoveryTask = nil
+        engine?.onConfigurationChange = nil
+        engine?.stop()
+        engine = nil
+    }
+
+    isolated deinit {
+        recoveryTask?.cancel()
+        engine?.stop()
+    }
+
+    private func startEngine(
+        deviceUniqueID: String?,
+        tap: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void,
+        onFailure: @escaping (Error) -> Void
+    ) throws {
+        let nextEngine = makeEngine()
+        let expectedGeneration = generation
+        nextEngine.onConfigurationChange = { [weak self, weak nextEngine] in
+            guard let self, let nextEngine,
+                self.generation == expectedGeneration,
+                self.engine === nextEngine,
+                !nextEngine.isRunning,
+                self.recoveryTask == nil
+            else { return }
+            nextEngine.onConfigurationChange = nil
+            nextEngine.stop()
+            self.engine = nil
+            self.recoveryTask = Task { [weak self] in
+                var failure: Error = VoiceAudioRecorderError.couldNotStart
+                for delay in self?.retryDelays ?? [] {
+                    do { try await Task.sleep(for: delay) }
+                    catch { return }
+                    guard !Task.isCancelled, let self,
+                        self.generation == expectedGeneration
+                    else { return }
+                    do {
+                        try self.startEngine(
+                            deviceUniqueID: deviceUniqueID, tap: tap, onFailure: onFailure
+                        )
+                        self.recoveryTask = nil
+                        return
+                    } catch {
+                        failure = error
+                    }
+                }
+                guard let self, self.generation == expectedGeneration,
+                    !Task.isCancelled
+                else { return }
+                self.stop()
+                onFailure(failure)
+            }
+        }
+        engine = nextEngine
+        do {
+            try nextEngine.start(deviceUniqueID: deviceUniqueID, tap: tap)
+        } catch {
+            nextEngine.onConfigurationChange = nil
+            nextEngine.stop()
+            engine = nil
+            throw error
+        }
+    }
+}
+
+@MainActor
+private final class SystemAudioInputEngine: AudioInputEngineDriving {
+    var onConfigurationChange: (() -> Void)?
+    private let engine = AVAudioEngine()
+    private var observer: NSObjectProtocol?
+    private var hasTap = false
+
+    var isRunning: Bool { engine.isRunning }
+
+    func start(
+        deviceUniqueID: String?,
+        tap: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    ) throws {
+        let input = engine.inputNode
+        // An unavailable selected device falls back to the current system default.
+        if let deviceUniqueID,
+            let deviceID = AudioInputDeviceResolver.coreAudioDeviceID(for: deviceUniqueID)
+        {
+            try input.auAudioUnit.setDeviceID(deviceID)
+        }
+        let format = input.inputFormat(forBus: 0)
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            throw VoiceAudioRecorderError.couldNotStart
+        }
+        input.installTap(onBus: 0, bufferSize: 1_024, format: nil, block: tap)
+        hasTap = true
+        observer = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange, object: engine, queue: nil
+        ) { [weak self] _ in
+            // Engine teardown must happen outside AVFAudio's notification queue.
+            Task { @MainActor [weak self] in
+                guard let self, self.observer != nil else { return }
+                self.onConfigurationChange?()
+            }
+        }
+        engine.prepare()
+        try engine.start()
+    }
+
+    func stop() {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+        observer = nil
+        if hasTap { engine.inputNode.removeTap(onBus: 0) }
+        hasTap = false
+        engine.stop()
+    }
+
+    isolated deinit { stop() }
 }

--- a/Sources/Nativ/Features/VoiceCapture/SystemAudioMeetingRecorder.swift
+++ b/Sources/Nativ/Features/VoiceCapture/SystemAudioMeetingRecorder.swift
@@ -83,8 +83,6 @@ final class SystemAudioMeetingRecorder: NSObject {
         configuration.captureMicrophone = true
         configuration.microphoneCaptureDeviceID = microphoneDeviceID
         configuration.excludesCurrentProcessAudio = true
-        configuration.sampleRate = 48_000
-        configuration.channelCount = 2
 
         let stream = SCStream(
             filter: filter,
@@ -226,6 +224,7 @@ final class SystemAudioMeetingRecorder: NSObject {
         let audioMix = AVMutableAudioMix()
         audioMix.inputParameters = parameters
 
+        // The offline mix converts the captured tracks to a shared WAV format.
         let outputSettings: [String: Any] = [
             AVFormatIDKey: kAudioFormatLinearPCM,
             AVSampleRateKey: 48_000,
@@ -650,6 +649,7 @@ private final class MeetingAudioWriter: @unchecked Sendable {
         channels: Int,
         bitRate: Int
     ) -> [String: Any] {
+        // AVAssetWriter converts each capture stream to these AAC file settings.
         [
             AVFormatIDKey: kAudioFormatMPEG4AAC,
             AVSampleRateKey: 48_000,

--- a/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceAudioRecorder.swift
@@ -5,6 +5,7 @@ import Foundation
 enum VoiceAudioRecorderError: LocalizedError {
     case couldNotStart
     case inputDeviceUnavailable
+    case couldNotConvert
 
     var errorDescription: String? {
         switch self {
@@ -12,6 +13,8 @@ enum VoiceAudioRecorderError: LocalizedError {
             "Nativ could not start audio recording."
         case .inputDeviceUnavailable:
             "The selected microphone is no longer available. Choose another input device or use System Default."
+        case .couldNotConvert:
+            "Nativ could not convert audio from the microphone’s current format."
         }
     }
 }
@@ -131,14 +134,22 @@ protocol VoiceAudioBufferWriting: Sendable {
 @MainActor
 final class VoiceAudioRecorder {
     var onMeterUpdate: (@MainActor @Sendable (Float, TimeInterval) -> Void)?
+    var onRecordingFailure: (@MainActor @Sendable (Error, URL?) -> Void)?
 
     private(set) var isRecording = false
     private(set) var lastRecordingDuration: TimeInterval?
-    private var audioEngine: AVAudioEngine?
+    private(set) var lastRecordingError: Error?
+
+    private let inputSession: AudioInputEngineSession
+    private var recordingID: UUID?
     private var recordingWriter: VoiceAudioRecordingWriter?
     private var recordingURL: URL?
     private var realtimeMeter: RealtimeAudioMeter?
     private var meterPublisherTask: Task<Void, Never>?
+
+    init(inputSession: AudioInputEngineSession = AudioInputEngineSession()) {
+        self.inputSession = inputSession
+    }
 
     static var recordingsDirectory: URL {
         get throws {
@@ -175,51 +186,32 @@ final class VoiceAudioRecorder {
         )
         try? FileManager.default.removeItem(at: outputURL)
 
-        let audioEngine = AVAudioEngine()
-        let inputNode = audioEngine.inputNode
-        if let deviceUniqueID {
-            guard let deviceID = AudioInputDeviceResolver.coreAudioDeviceID(
-                for: deviceUniqueID
-            ) else {
-                throw VoiceAudioRecorderError.inputDeviceUnavailable
+        let id = UUID()
+        recordingID = id
+        lastRecordingError = nil
+        let writer = VoiceAudioRecordingWriter(outputURL: outputURL) { [weak self] error in
+            Task { @MainActor [weak self] in
+                guard let self, self.recordingID == id else { return }
+                self.recordingFailed(error)
             }
-            try inputNode.auAudioUnit.setDeviceID(deviceID)
         }
-
-        // Device selection can leave the node's output format on the previous device's rate.
-        let inputFormat = inputNode.inputFormat(forBus: 0)
-        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
-            throw VoiceAudioRecorderError.couldNotStart
-        }
-        let audioFile = try AVAudioFile(
-            forWriting: outputURL,
-            settings: inputFormat.settings,
-            commonFormat: .pcmFormatFloat32,
-            interleaved: false
-        )
-        let writer = VoiceAudioRecordingWriter(
-            audioFile: audioFile,
-            sampleRate: inputFormat.sampleRate
-        )
         let realtimeMeter = RealtimeAudioMeter(profile: .recording)
-        let tap = Self.makeTap(writer: writer, realtimeMeter: realtimeMeter)
-        inputNode.installTap(
-            onBus: 0,
-            bufferSize: 1_024,
-            format: inputFormat,
-            block: tap
-        )
-
         do {
-            audioEngine.prepare()
-            try audioEngine.start()
+            try inputSession.start(
+                deviceUniqueID: deviceUniqueID,
+                tap: Self.makeTap(writer: writer, realtimeMeter: realtimeMeter)
+            ) { [weak self] error in
+                guard let self, self.recordingID == id else { return }
+                self.recordingFailed(error)
+            }
         } catch {
-            inputNode.removeTap(onBus: 0)
+            recordingID = nil
+            inputSession.stop()
+            writer.finish()
             try? FileManager.default.removeItem(at: outputURL)
             throw error
         }
 
-        self.audioEngine = audioEngine
         recordingWriter = writer
         recordingURL = outputURL
         isRecording = true
@@ -230,15 +222,16 @@ final class VoiceAudioRecorder {
 
     @discardableResult
     func stop() -> URL? {
-        guard let audioEngine, let recordingWriter, let recordingURL else {
+        guard let recordingWriter, let recordingURL else {
             return nil
         }
 
-        audioEngine.inputNode.removeTap(onBus: 0)
-        audioEngine.stop()
+        recordingID = nil
+        inputSession.stop()
+        recordingWriter.finish()
+        lastRecordingError = recordingWriter.error
         let duration = recordingWriter.duration
         stopMeterPublisher()
-        self.audioEngine = nil
         self.recordingWriter = nil
         self.recordingURL = nil
         isRecording = false
@@ -258,6 +251,12 @@ final class VoiceAudioRecorder {
             try? FileManager.default.removeItem(at: recordingURL)
         }
         lastRecordingDuration = nil
+    }
+
+    private func recordingFailed(_ error: Error) {
+        let savedURL = stop()
+        lastRecordingError = error
+        onRecordingFailure?(error, savedURL)
     }
 
     private func startMeterPublisher(realtimeMeter: RealtimeAudioMeter) {
@@ -306,32 +305,58 @@ final class VoiceAudioRecorder {
 }
 
 final class VoiceAudioRecordingWriter: VoiceAudioBufferWriting, @unchecked Sendable {
-    private let audioFile: AVAudioFile
-    private let sampleRate: Double
+    private let outputURL: URL
+    private var audioFile: AVAudioFile?
     private let lock = NSLock()
     private var writtenFrames: AVAudioFramePosition = 0
+    private var isFinished = false
+    private let onFailure: @Sendable (Error) -> Void
+    private var failure: Error?
+    private var converter: AVAudioConverter?
+    private var conversionOutput: AVAudioPCMBuffer?
+    private var pendingConversionBuffer: AVAudioPCMBuffer?
 
-    init(audioFile: AVAudioFile, sampleRate: Double) {
-        self.audioFile = audioFile
-        self.sampleRate = sampleRate
+    init(outputURL: URL, onFailure: @escaping @Sendable (Error) -> Void = { _ in }) {
+        self.outputURL = outputURL
+        self.onFailure = onFailure
     }
 
     var duration: TimeInterval {
         lock.withLock {
-            guard sampleRate > 0 else {
+            guard let sampleRate = audioFile?.processingFormat.sampleRate,
+                sampleRate > 0
+            else {
                 return 0
             }
             return Double(writtenFrames) / sampleRate
         }
     }
 
+    var error: Error? {
+        lock.withLock { failure }
+    }
+
+    func finish() {
+        let newFailure = lock.withLock { () -> Error? in
+            guard !isFinished else { return nil }
+            let hadFailure = failure != nil
+            isFinished = true
+            if failure == nil {
+                do { try flushConverter() }
+                catch { reportFailure(error) }
+            }
+            audioFile?.close()
+            return hadFailure ? nil : failure
+        }
+        if let newFailure { onFailure(newFailure) }
+    }
+
     func append(_ buffer: AVAudioPCMBuffer) -> VoiceAudioBufferMeasurement {
-        lock.withLock {
-            do {
-                try audioFile.write(from: buffer)
-                writtenFrames += AVAudioFramePosition(buffer.frameLength)
-            } catch {
-                NSLog("Nativ could not write microphone audio: %@", error.localizedDescription)
+        let (measurement, newFailure) = lock.withLock {
+            let hadFailure = failure != nil
+            if !isFinished, failure == nil, buffer.frameLength > 0 {
+                do { try write(buffer) }
+                catch { reportFailure(error) }
             }
 
             var peak: Float = 0
@@ -341,15 +366,98 @@ final class VoiceAudioRecordingWriter: VoiceAudioBufferWriting, @unchecked Senda
                 for channel in 0..<channelCount {
                     let samples = channelData[channel]
                     for frame in 0..<frameCount {
-                        peak = max(peak, abs(samples[frame]))
+                        peak = max(peak, abs(samples[frame * buffer.stride]))
                     }
                 }
             }
+            let sampleRate = audioFile?.processingFormat.sampleRate ?? 0
             let elapsed = sampleRate > 0 ? Double(writtenFrames) / sampleRate : 0
-            return VoiceAudioBufferMeasurement(
-                level: min(1, peak * 3.5),
-                duration: elapsed
+            return (
+                VoiceAudioBufferMeasurement(level: min(1, peak * 3.5), duration: elapsed),
+                hadFailure ? nil : failure
             )
         }
+        if let newFailure { onFailure(newFailure) }
+        return measurement
     }
+
+    private func reportFailure(_ error: Error) {
+        guard failure == nil else { return }
+        failure = error
+        NSLog("Nativ could not write microphone audio: %@", error.localizedDescription)
+    }
+
+    private func write(_ buffer: AVAudioPCMBuffer) throws {
+        if audioFile == nil {
+            // The first delivered buffer establishes the recording's file format.
+            let format = buffer.format
+            audioFile = try AVAudioFile(
+                forWriting: outputURL,
+                settings: format.settings,
+                commonFormat: format.commonFormat,
+                interleaved: format.isInterleaved
+            )
+        }
+        guard let audioFile else { return }
+        if converter?.inputFormat != buffer.format {
+            try flushConverter()
+        }
+        if buffer.format == audioFile.processingFormat {
+            try audioFile.write(from: buffer)
+            writtenFrames += AVAudioFramePosition(buffer.frameLength)
+            return
+        }
+        if converter == nil {
+            guard let converter = AVAudioConverter(
+                from: buffer.format, to: audioFile.processingFormat
+            ), let output = AVAudioPCMBuffer(
+                pcmFormat: audioFile.processingFormat, frameCapacity: 4_096
+            ) else {
+                throw VoiceAudioRecorderError.couldNotConvert
+            }
+            converter.downmix = true
+            self.converter = converter
+            conversionOutput = output
+        }
+        try convertAndWrite(buffer)
+    }
+
+    private func flushConverter() throws {
+        guard converter != nil else { return }
+        defer {
+            converter = nil
+            conversionOutput = nil
+        }
+        try convertAndWrite(nil)
+    }
+
+    private func convertAndWrite(_ buffer: AVAudioPCMBuffer?) throws {
+        guard let converter, let output = conversionOutput, let audioFile else { return }
+        pendingConversionBuffer = buffer
+        defer { pendingConversionBuffer = nil }
+        let isEndOfStream = buffer == nil
+        while true {
+            output.frameLength = 0
+            var error: NSError?
+            // The converter calls its input block synchronously under the writer's lock.
+            let status = converter.convert(to: output, error: &error) { [self] _, status in
+                if let pending = pendingConversionBuffer {
+                    pendingConversionBuffer = nil
+                    status.pointee = .haveData
+                    return pending
+                }
+                status.pointee = isEndOfStream ? .endOfStream : .noDataNow
+                return nil
+            }
+            if status == .error {
+                throw error ?? VoiceAudioRecorderError.couldNotConvert as NSError
+            }
+            if output.frameLength > 0 {
+                try audioFile.write(from: output)
+                writtenFrames += AVAudioFramePosition(output.frameLength)
+            }
+            if status != .haveData { return }
+        }
+    }
+
 }

--- a/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
+++ b/Sources/Nativ/Features/VoiceCapture/VoiceCaptureCoordinator.swift
@@ -45,6 +45,9 @@ final class VoiceCaptureCoordinator {
         recorder.onMeterUpdate = { [weak self] level, elapsed in
             self?.overlay.update(level: level, elapsed: elapsed)
         }
+        recorder.onRecordingFailure = { [weak self] error, savedURL in
+            self?.recordingInterrupted(error, savedURL: savedURL)
+        }
     }
 
     func start() {
@@ -143,12 +146,27 @@ final class VoiceCaptureCoordinator {
         }
     }
 
+    private func recordingInterrupted(_ error: Error, savedURL: URL?) {
+        isShortcutHeld = false
+        isHandsFreeMode = false
+        insertionTarget = nil
+        activeOverlayTranscriptionID = nil
+        if let savedURL { scheduleAudioDeletion(savedURL) }
+        NSLog("Nativ voice recording interrupted: %@", error.localizedDescription)
+        overlay.showFailure()
+    }
+
     private func endCapture() {
         permissionTask?.cancel()
         permissionTask = nil
         let target = insertionTarget
         insertionTarget = nil
-        if let recordingURL = recorder.stop() {
+        let savedURL = recorder.stop()
+        if let error = recorder.lastRecordingError {
+            recordingInterrupted(error, savedURL: savedURL)
+            return
+        }
+        if let recordingURL = savedURL {
             NSLog("Nativ saved voice recording to %@", recordingURL.path)
             scheduleAudioDeletion(recordingURL)
             let overlayTranscriptionID = UUID()

--- a/Tests/NativTests/RealtimeAudioMeterTests.swift
+++ b/Tests/NativTests/RealtimeAudioMeterTests.swift
@@ -78,17 +78,7 @@ final class RealtimeAudioMeterTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let outputURL = directory.appendingPathComponent("recording.wav")
-        let format = Self.makeFormat()
-        let audioFile = try AVAudioFile(
-            forWriting: outputURL,
-            settings: format.settings,
-            commonFormat: .pcmFormatFloat32,
-            interleaved: false
-        )
-        let writer = VoiceAudioRecordingWriter(
-            audioFile: audioFile,
-            sampleRate: format.sampleRate
-        )
+        let writer = VoiceAudioRecordingWriter(outputURL: outputURL)
         let meter = RealtimeAudioMeter(profile: .recording)
         let tap = VoiceAudioRecorder.makeTap(
             writer: writer,
@@ -101,11 +91,148 @@ final class RealtimeAudioMeterTests: XCTestCase {
         XCTAssertEqual(writer.duration, 1_024.0 / 48_000.0, accuracy: 0.0001)
         let snapshot = try XCTUnwrap(meter.snapshot(after: 0))
         XCTAssertEqual(snapshot.elapsed, writer.duration, accuracy: 0.0001)
+        writer.finish()
         let fileSize = try XCTUnwrap(
             FileManager.default.attributesOfItem(atPath: outputURL.path)[.size]
                 as? NSNumber
         )
         XCTAssertGreaterThan(fileSize.intValue, 44)
+    }
+
+    func testRecordingFileUsesDeliveredSampleRateAndChannelLayout() throws {
+        let directory = try makeTemporaryDirectory()
+        for sampleRate in [16_000.0, 22_050, 44_100, 48_000, 96_000] {
+            for channels: AVAudioChannelCount in [1, 2] {
+                for interleaved in [false, true] {
+                    let format = try XCTUnwrap(AVAudioFormat(
+                        commonFormat: .pcmFormatFloat32,
+                        sampleRate: sampleRate,
+                        channels: channels,
+                        interleaved: interleaved
+                    ))
+                    let outputURL = directory.appendingPathComponent("\(UUID()).wav")
+                    let writer = VoiceAudioRecordingWriter(outputURL: outputURL)
+                    let buffer = Self.makeBuffer(amplitude: 0.25, format: format)
+
+                    let measurement = writer.append(buffer)
+                    writer.finish()
+
+                    XCTAssertEqual(measurement.duration, 1_024 / sampleRate, accuracy: 0.000001)
+                    let file = try AVAudioFile(forReading: outputURL)
+                    XCTAssertEqual(file.processingFormat.sampleRate, sampleRate)
+                    XCTAssertEqual(file.processingFormat.channelCount, channels)
+                    XCTAssertEqual(file.length, 1_024)
+                    let recorded = try XCTUnwrap(AVAudioPCMBuffer(
+                        pcmFormat: file.processingFormat,
+                        frameCapacity: 1_024
+                    ))
+                    try file.read(into: recorded)
+                    for channel in 0 ..< Int(channels) {
+                        XCTAssertEqual(recorded.floatChannelData![channel][1_023], 0.25)
+                    }
+                }
+            }
+        }
+    }
+
+    func testRecordingWriterSkipsEmptyBuffersAndFinishesBeforeLateBuffers() throws {
+        let directory = try makeTemporaryDirectory()
+        let outputURL = directory.appendingPathComponent("recording.wav")
+        let writer = VoiceAudioRecordingWriter(outputURL: outputURL)
+        let buffer = Self.makeBuffer(amplitude: 0.25)
+        buffer.frameLength = 0
+
+        XCTAssertEqual(writer.append(buffer).duration, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
+        buffer.frameLength = 1_024
+        _ = writer.append(buffer)
+        writer.finish()
+        let duration = writer.duration
+        XCTAssertEqual(writer.append(buffer).duration, duration)
+        XCTAssertEqual(try AVAudioFile(forReading: outputURL).length, 1_024)
+
+        let unusedURL = directory.appendingPathComponent("unused.wav")
+        let unusedWriter = VoiceAudioRecordingWriter(outputURL: unusedURL)
+        unusedWriter.finish()
+        XCTAssertEqual(unusedWriter.append(buffer).duration, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: unusedURL.path))
+    }
+
+    func testRecordingWriterConvertsFormatChangesIntoOneFile() throws {
+        let directory = try makeTemporaryDirectory()
+        let outputURL = directory.appendingPathComponent("recording.wav")
+        let writer = VoiceAudioRecordingWriter(outputURL: outputURL)
+        let buffer = Self.makeBuffer(
+            amplitude: 0.25,
+            format: try XCTUnwrap(AVAudioFormat(
+                standardFormatWithSampleRate: 48_000,
+                channels: 2
+            ))
+        )
+        let originalDuration = writer.append(buffer).duration
+
+        let differentFormats = [
+            AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 2),
+            AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1),
+            AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: 48_000,
+                channels: 2,
+                interleaved: true
+            ),
+        ]
+        for format in differentFormats {
+            let changedBuffer = Self.makeBuffer(
+                amplitude: 0.5,
+                format: try XCTUnwrap(format)
+            )
+            _ = writer.append(changedBuffer)
+        }
+        writer.finish()
+        let file = try AVAudioFile(forReading: outputURL)
+        let expectedDuration = originalDuration + 1_024 / 44_100.0 + 2 * 1_024 / 48_000.0
+        XCTAssertEqual(writer.duration, expectedDuration, accuracy: 0.001)
+        XCTAssertEqual(Double(file.length) / 48_000, expectedDuration, accuracy: 0.001)
+        XCTAssertEqual(file.processingFormat.sampleRate, 48_000)
+        XCTAssertEqual(file.processingFormat.channelCount, 2)
+    }
+
+    func testTapsMeasureAllFramesInInterleavedBuffers() throws {
+        let directory = try makeTemporaryDirectory()
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 44_100,
+            channels: 2,
+            interleaved: true
+        ))
+        let buffer = Self.makeBuffer(amplitude: 0, format: format)
+        buffer.floatChannelData![0][1_023 * buffer.stride] = 0.2
+
+        let inputMeter = RealtimeAudioMeter(profile: .inputMonitor)
+        AudioInputLevelMonitor.makeTap(realtimeMeter: inputMeter)(
+            buffer, AVAudioTime(hostTime: 0)
+        )
+        let expectedRMS = Float(0.2) / sqrt(Float(2 * 1_024))
+        let expectedInputLevel = pow(expectedRMS * 8, 0.65)
+        XCTAssertEqual(
+            try XCTUnwrap(inputMeter.snapshot(after: 0)).level,
+            expectedInputLevel * 0.35,
+            accuracy: 0.000001
+        )
+
+        let writer = VoiceAudioRecordingWriter(
+            outputURL: directory.appendingPathComponent("recording.wav")
+        )
+        XCTAssertEqual(writer.append(buffer).level, 0.7, accuracy: 0.000001)
+        writer.finish()
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try FileManager.default.removeItem(at: directory) }
+        return directory
     }
 
     private func invokeOffMain(
@@ -122,14 +249,19 @@ final class RealtimeAudioMeterTests: XCTestCase {
         }
     }
 
-    private static func makeBuffer(amplitude: Float) -> AVAudioPCMBuffer {
+    private static func makeBuffer(
+        amplitude: Float,
+        format: AVAudioFormat = makeFormat()
+    ) -> AVAudioPCMBuffer {
         let buffer = AVAudioPCMBuffer(
-            pcmFormat: makeFormat(),
+            pcmFormat: format,
             frameCapacity: 1_024
         )!
         buffer.frameLength = 1_024
-        for frame in 0 ..< Int(buffer.frameLength) {
-            buffer.floatChannelData![0][frame] = amplitude
+        for channel in 0 ..< Int(format.channelCount) {
+            for frame in 0 ..< Int(buffer.frameLength) {
+                buffer.floatChannelData![channel][frame * buffer.stride] = amplitude
+            }
         }
         return buffer
     }
@@ -241,5 +373,231 @@ private final class VoiceAudioWriterProbe: VoiceAudioBufferWriting, @unchecked S
             calledOnMainThread = Thread.isMainThread
         }
         return VoiceAudioBufferMeasurement(level: 0.75, duration: 0.25)
+    }
+}
+
+@MainActor
+final class AudioInputEngineSessionTests: XCTestCase {
+    func testConfigurationChangeRebuildsEngineAndIgnoresOldNotifications() async {
+        let first = AudioInputEngineProbe()
+        let second = AudioInputEngineProbe()
+        let restarted = expectation(description: "Engine restarted")
+        second.onStart = { restarted.fulfill() }
+        var creations = 0
+        let session = AudioInputEngineSession(retryDelays: [.zero]) {
+            creations += 1
+            return creations == 1 ? first : second
+        }
+        defer { session.stop() }
+        do {
+            try session.start(deviceUniqueID: "selected-input", tap: { _, _ in }) { error in
+                XCTFail("Unexpected recovery failure: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected start failure: \(error)")
+            return
+        }
+        let staleNotification = first.onConfigurationChange
+        first.changeConfiguration()
+        staleNotification?()
+        await fulfillment(of: [restarted], timeout: 2)
+        XCTAssertEqual(creations, 2)
+        XCTAssertEqual(first.stopCount, 1)
+        XCTAssertEqual(second.deviceUniqueID, "selected-input")
+        XCTAssertTrue(second.isRunning)
+        staleNotification?()
+        XCTAssertEqual(creations, 2)
+    }
+
+    func testStoppingCancelsPendingRecovery() async throws {
+        let first = AudioInputEngineProbe()
+        var creations = 0
+        let session = AudioInputEngineSession(retryDelays: [.milliseconds(20)]) {
+            creations += 1
+            return first
+        }
+        try session.start(deviceUniqueID: nil, tap: { _, _ in }) { error in
+            XCTFail("Stopped session reported a failure: \(error)")
+        }
+        first.changeConfiguration()
+        session.stop()
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(creations, 1)
+        XCTAssertFalse(first.isRunning)
+    }
+
+    func testRecoveryRetriesThenReportsOneFailure() async throws {
+        let first = AudioInputEngineProbe()
+        var attempts: [AudioInputEngineProbe] = []
+        let failed = expectation(description: "Recovery failure reported")
+        let session = AudioInputEngineSession(retryDelays: [.zero, .zero, .zero]) {
+            let engine = attempts.isEmpty ? first : AudioInputEngineProbe(failsToStart: true)
+            attempts.append(engine)
+            return engine
+        }
+        defer { session.stop() }
+        try session.start(deviceUniqueID: nil, tap: { _, _ in }) { _ in failed.fulfill() }
+        first.changeConfiguration()
+        await fulfillment(of: [failed], timeout: 2)
+        XCTAssertEqual(attempts.count, 4)
+        XCTAssertTrue(attempts.allSatisfy { !$0.isRunning && $0.stopCount == 1 })
+    }
+
+    func testRecordingContinuesAcrossDeviceFormatChange() async throws {
+        let directory = try temporaryDirectory()
+        let outputURL = directory.appendingPathComponent("recording.wav")
+        let first = AudioInputEngineProbe()
+        let second = AudioInputEngineProbe()
+        let restarted = expectation(description: "Recording input restarted")
+        second.onStart = { restarted.fulfill() }
+        var creations = 0
+        let session = AudioInputEngineSession(retryDelays: [.zero]) {
+            creations += 1
+            return creations == 1 ? first : second
+        }
+        let recorder = VoiceAudioRecorder(inputSession: session)
+        recorder.onRecordingFailure = { error, _ in XCTFail("Unexpected failure: \(error)") }
+        defer { recorder.stop() }
+        try recorder.start(outputURL: outputURL)
+        first.deliver(sampleRate: 48_000, channels: 1, frames: 4_800)
+        first.changeConfiguration()
+        await fulfillment(of: [restarted], timeout: 2)
+        second.deliver(sampleRate: 44_100, channels: 2, frames: 4_410)
+        XCTAssertTrue(recorder.isRecording)
+        XCTAssertEqual(recorder.stop(), outputURL)
+        XCTAssertEqual(recorder.lastRecordingDuration ?? 0, 0.2, accuracy: 0.001)
+        let file = try AVAudioFile(forReading: outputURL)
+        XCTAssertEqual(file.processingFormat.sampleRate, 48_000)
+        XCTAssertEqual(file.processingFormat.channelCount, 1)
+        XCTAssertEqual(Double(file.length) / 48_000, 0.2, accuracy: 0.001)
+    }
+
+    func testRecordingRecoveryFailurePreservesCapturedAudio() async throws {
+        let directory = try temporaryDirectory()
+        let outputURL = directory.appendingPathComponent("recording.wav")
+        let first = AudioInputEngineProbe()
+        var creations = 0
+        let session = AudioInputEngineSession(retryDelays: [.zero]) {
+            creations += 1
+            return creations == 1 ? first : AudioInputEngineProbe(failsToStart: true)
+        }
+        let recorder = VoiceAudioRecorder(inputSession: session)
+        let failed = expectation(description: "Recorder stopped with partial audio")
+        recorder.onRecordingFailure = { _, savedURL in
+            XCTAssertEqual(savedURL, outputURL)
+            failed.fulfill()
+        }
+        try recorder.start(outputURL: outputURL)
+        first.deliver(sampleRate: 48_000, channels: 1, frames: 4_800)
+        first.changeConfiguration()
+        await fulfillment(of: [failed], timeout: 2)
+        XCTAssertFalse(recorder.isRecording)
+        XCTAssertEqual(recorder.lastRecordingDuration ?? 0, 0.1, accuracy: 0.000001)
+        XCTAssertEqual(try AVAudioFile(forReading: outputURL).length, 4_800)
+    }
+
+    func testWriteFailureStopsRecordingAndNotifiesOnce() async throws {
+        let directory = try temporaryDirectory()
+        let first = AudioInputEngineProbe()
+        let session = AudioInputEngineSession { first }
+        let recorder = VoiceAudioRecorder(inputSession: session)
+        let failed = expectation(description: "Write failure delivered")
+        var failures = 0
+        recorder.onRecordingFailure = { _, savedURL in
+            failures += 1
+            XCTAssertNil(savedURL)
+            failed.fulfill()
+        }
+        try recorder.start(outputURL: directory.appendingPathComponent("missing/recording.wav"))
+        try FileManager.default.removeItem(at: directory.appendingPathComponent("missing"))
+        first.deliver(sampleRate: 48_000, channels: 1, frames: 1_024)
+        first.deliver(sampleRate: 48_000, channels: 1, frames: 1_024)
+        await fulfillment(of: [failed], timeout: 2)
+        XCTAssertFalse(recorder.isRecording)
+        XCTAssertNotNil(recorder.lastRecordingError)
+        XCTAssertEqual(failures, 1)
+    }
+
+    func testStoppingExposesWriteFailureAndOldFailureCannotStopNewRecording() async throws {
+        let directory = try temporaryDirectory()
+        let first = AudioInputEngineProbe()
+        let second = AudioInputEngineProbe()
+        var creations = 0
+        let session = AudioInputEngineSession {
+            creations += 1
+            return creations == 1 ? first : second
+        }
+        let recorder = VoiceAudioRecorder(inputSession: session)
+        recorder.onRecordingFailure = { error, _ in
+            XCTFail("A stopped recording delivered a stale failure: \(error)")
+        }
+        try recorder.start(outputURL: directory.appendingPathComponent("missing/recording.wav"))
+        try FileManager.default.removeItem(at: directory.appendingPathComponent("missing"))
+        first.deliver(sampleRate: 48_000, channels: 1, frames: 1_024)
+        XCTAssertNil(recorder.stop())
+        XCTAssertNotNil(recorder.lastRecordingError)
+
+        let newURL = directory.appendingPathComponent("new.wav")
+        try recorder.start(outputURL: newURL)
+        defer { recorder.stop() }
+        second.deliver(sampleRate: 48_000, channels: 1, frames: 1_024)
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertTrue(recorder.isRecording)
+        XCTAssertNil(recorder.lastRecordingError)
+        XCTAssertEqual(recorder.stop(), newURL)
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try FileManager.default.removeItem(at: directory) }
+        return directory
+    }
+}
+
+@MainActor
+private final class AudioInputEngineProbe: AudioInputEngineDriving {
+    var isRunning = false
+    var onConfigurationChange: (() -> Void)?
+    var onStart: (() -> Void)?
+    var stopCount = 0
+    var deviceUniqueID: String?
+    private let failsToStart: Bool
+    private var tap: (@Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void)?
+
+    init(failsToStart: Bool = false) { self.failsToStart = failsToStart }
+
+    func start(
+        deviceUniqueID: String?,
+        tap: @escaping @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
+    ) throws {
+        if failsToStart { throw VoiceAudioRecorderError.inputDeviceUnavailable }
+        self.deviceUniqueID = deviceUniqueID
+        self.tap = tap
+        isRunning = true
+        onStart?()
+    }
+
+    func stop() {
+        stopCount += 1
+        isRunning = false
+        tap = nil
+    }
+
+    func changeConfiguration() {
+        isRunning = false
+        onConfigurationChange?()
+    }
+
+    func deliver(sampleRate: Double, channels: AVAudioChannelCount, frames: AVAudioFrameCount) {
+        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: channels)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)!
+        buffer.frameLength = frames
+        for channel in 0 ..< Int(channels) {
+            for frame in 0 ..< Int(frames) {
+                buffer.floatChannelData![channel][frame] = 0.25
+            }
+        }
+        tap?(buffer, AVAudioTime(hostTime: 0))
     }
 }


### PR DESCRIPTION
1) Use automatic system resolution for taps and derive the format from buffers so format changes are less likely to throw runtime exceptions
2) Handle audio engine recovery on hardware format configuration changes
3) Make sure we don't lose partial recordings if the audio engine is interrupted

I manually tested dictation and creating recordings while changing the hardware input device and verified it didn't crash or lose data, and audio levels still show correctly.