### PR TITLE
Rename existing typography system to LegacyTypography

### DIFF
--- a/Sources/Nativ/Features/Artifacts/ArtifactPreview.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactPreview.swift
@@ -57,11 +57,11 @@ struct ArtifactPreview: View {
             }
             VStack(alignment: .leading, spacing: 2) {
                 Text(artifact.filename)
-                    .nativTextStyle(.compactCardTitle)
+                    .legacyTextStyle(.compactCardTitle)
                     .foregroundStyle(.white)
                     .lineLimit(1)
                 Text("\(artifact.typeLabel) · \(artifact.source.label)")
-                    .nativTextStyle(.metadata)
+                    .legacyTextStyle(.metadata)
                     .foregroundStyle(.white.opacity(0.6))
             }
             Spacer(minLength: 0)
@@ -107,7 +107,7 @@ struct ArtifactPreview: View {
         HStack {
             if let prompt = artifact.prompt, !prompt.isEmpty {
                 Text(prompt)
-                    .nativTextStyle(.body)
+                    .legacyTextStyle(.body)
                     .foregroundStyle(.white.opacity(0.7))
                     .lineLimit(2)
                     .textSelection(.enabled)
@@ -115,7 +115,7 @@ struct ArtifactPreview: View {
             Spacer(minLength: 0)
             if let index {
                 Text("\(index + 1) of \(artifacts.count)")
-                    .nativTextStyle(.metadataNumeric)
+                    .legacyTextStyle(.metadataNumeric)
                     .foregroundStyle(.white.opacity(0.5))
             }
         }
@@ -128,7 +128,7 @@ struct ArtifactPreview: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 28))
             Text("Preview unavailable")
-                .nativTextStyle(.body)
+                .legacyTextStyle(.body)
         }
         .foregroundStyle(.white.opacity(0.6))
     }

--- a/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
+++ b/Sources/Nativ/Features/Artifacts/ArtifactsView.swift
@@ -197,9 +197,9 @@ struct ArtifactsView: View {
                     .foregroundStyle(.secondary)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Turn On Smart Search")
-                        .nativTextStyle(.sectionTitle)
+                        .legacyTextStyle(.sectionTitle)
                     Text("Install a \(config.sizeLabel) on-device model to search artifacts by their contents. You can also do this later in Settings.")
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 12)
@@ -232,7 +232,7 @@ struct ArtifactsView: View {
         .popover(isPresented: $showsSemanticPopover, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 10) {
                 Label("Smart Search", systemImage: "sparkle.magnifyingglass")
-                    .nativTextStyle(.sectionTitle)
+                    .legacyTextStyle(.sectionTitle)
                 if config.isModelInstalled {
                     Toggle("Enabled", isOn: $smartSearchEnabled)
                         .toggleStyle(.switch)
@@ -240,10 +240,10 @@ struct ArtifactsView: View {
                     Text(smartSearchEnabled
                         ? "Searching by image, video and document contents."
                         : "Turned off. The model stays installed.")
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                     Text("Runs on-device — results are fastest when your Mac isn’t busy generating.")
-                        .nativTextStyle(.metadata)
+                        .legacyTextStyle(.metadata)
                         .foregroundStyle(.tertiary)
                     Divider()
                     Button("Remove Model", role: .destructive) {
@@ -255,11 +255,11 @@ struct ArtifactsView: View {
                     HStack(spacing: 6) {
                         ProgressView().controlSize(.small)
                         Text("Downloading model… \(Int((config.downloadProgress * 100).rounded()))%")
-                            .nativTextStyle(.supporting)
+                            .legacyTextStyle(.supporting)
                     }
                 } else {
                     Text("Install a \(config.sizeLabel) on-device model to search artifacts by their contents.")
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                     Button("Install") {
                         config.onEnable()
@@ -271,7 +271,7 @@ struct ArtifactsView: View {
                     .disabled(!config.canInstall)
                     if let reason = config.insufficientReason {
                         Text(reason)
-                            .nativTextStyle(.metadata)
+                            .legacyTextStyle(.metadata)
                             .foregroundStyle(.orange)
                     }
                 }
@@ -857,7 +857,7 @@ struct ArtifactsView: View {
             if activeFilterCount > 0 {
                 HStack {
                     Text("\(activeFilterCount) \(activeFilterCount == 1 ? "filter" : "filters") applied")
-                        .nativTextStyle(.metadata)
+                        .legacyTextStyle(.metadata)
                         .foregroundStyle(.secondary)
 
                     Spacer()
@@ -870,7 +870,7 @@ struct ArtifactsView: View {
                         groupByChat = false
                     }
                     .buttonStyle(.plain)
-                    .nativTextStyle(.badge)
+                    .legacyTextStyle(.badge)
                     .foregroundStyle(Color.accentColor)
                 }
             }
@@ -941,9 +941,9 @@ struct ArtifactsView: View {
     private func sectionHeader(_ title: String, count: Int) -> some View {
         HStack(spacing: 6) {
             Text(title)
-                .nativTextStyle(.sectionTitle)
+                .legacyTextStyle(.sectionTitle)
             Text("\(count)")
-                .nativTextStyle(.metadataNumeric)
+                .legacyTextStyle(.metadataNumeric)
                 .foregroundStyle(.secondary)
             Spacer(minLength: 0)
         }
@@ -1032,7 +1032,7 @@ struct ArtifactsView: View {
                         .font(.system(size: 10))
                 }
                 Text(title)
-                    .nativTextStyle(.supportingEmphasized)
+                    .legacyTextStyle(.supportingEmphasized)
                     .lineLimit(1)
                     .fixedSize()
             }
@@ -1053,9 +1053,9 @@ struct ArtifactsView: View {
                 .font(.system(size: 42))
                 .foregroundStyle(.secondary.opacity(0.5))
             Text(title)
-                .nativTextStyle(.cardTitle)
+                .legacyTextStyle(.cardTitle)
             Text(message)
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
         }
@@ -1218,7 +1218,7 @@ struct ArtifactTile: View {
             .overlay(alignment: .bottom) {
                 if isHovering, !isSelecting {
                     Text(store.displayName(for: artifact))
-                        .nativTextStyle(.supportingEmphasized)
+                        .legacyTextStyle(.supportingEmphasized)
                         .foregroundStyle(.white)
                         .lineLimit(1)
                         .shadow(radius: 2)
@@ -1303,22 +1303,22 @@ struct ArtifactRow: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(artifact.filename)
-                    .nativTextStyle(.rowTitle)
+                    .legacyTextStyle(.rowTitle)
                     .lineLimit(1)
                 Text("\(artifact.typeLabel) · \(artifact.source.label)")
-                    .nativTextStyle(.metadata)
+                    .legacyTextStyle(.metadata)
                     .foregroundStyle(.secondary)
             }
 
             Spacer(minLength: 0)
 
             Text(Int64(artifact.byteSize).formatted(.byteCount(style: .file)))
-                .nativTextStyle(.metadataNumeric)
+                .legacyTextStyle(.metadataNumeric)
                 .foregroundStyle(.secondary)
                 .frame(width: 70, alignment: .trailing)
 
             Text(artifact.createdAt.formatted(date: .abbreviated, time: .omitted))
-                .nativTextStyle(.metadata)
+                .legacyTextStyle(.metadata)
                 .foregroundStyle(.secondary)
                 .frame(width: 90, alignment: .trailing)
         }
@@ -1403,7 +1403,7 @@ private struct ArtifactThumbnail: View {
                 VStack(spacing: 8) {
                     FileTypeIcon(fileExtension: artifact.fileExtension, size: min(size.width, size.height) * 0.42)
                     Text(FileTypeStyle.resolve(fileExtension: artifact.fileExtension).label)
-                        .nativTextStyle(.badgeStrong)
+                        .legacyTextStyle(.badgeStrong)
                         .foregroundStyle(.secondary)
                 }
             } else {
@@ -1413,7 +1413,7 @@ private struct ArtifactThumbnail: View {
                         .foregroundStyle(.secondary)
                     if !artifact.fileExtension.isEmpty {
                         Text(artifact.fileExtension)
-                            .nativTextStyle(.badgeStrong)
+                            .legacyTextStyle(.badgeStrong)
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -1433,7 +1433,7 @@ struct ArtifactInspector: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text("Details")
-                    .nativTextStyle(.cardTitle)
+                    .legacyTextStyle(.cardTitle)
                 Spacer()
                 Button(action: onClose) {
                     Image(systemName: "xmark")
@@ -1461,10 +1461,10 @@ struct ArtifactInspector: View {
                         if let prompt = artifact.prompt, !prompt.isEmpty {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text("Prompt")
-                                    .nativTextStyle(.supportingEmphasized)
+                                    .legacyTextStyle(.supportingEmphasized)
                                     .foregroundStyle(.secondary)
                                 Text(prompt)
-                                    .nativTextStyle(.body)
+                                    .legacyTextStyle(.body)
                                     .textSelection(.enabled)
                             }
                         }
@@ -1487,11 +1487,11 @@ struct ArtifactInspector: View {
     private func detailRow(_ label: String, _ value: String) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(label)
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
                 .frame(width: 68, alignment: .leading)
             Text(value)
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .lineLimit(2)
                 .textSelection(.enabled)
@@ -1553,10 +1553,10 @@ struct ChatDeck: View {
             .frame(height: 190)
 
             Text(group.title)
-                .nativTextStyle(.sectionTitle)
+                .legacyTextStyle(.sectionTitle)
                 .lineLimit(1)
             Text("\(group.items.count) \(group.items.count == 1 ? "item" : "items")")
-                .nativTextStyle(.metadata)
+                .legacyTextStyle(.metadata)
                 .foregroundStyle(.secondary)
         }
     }
@@ -1581,7 +1581,7 @@ struct ChatDeck: View {
             Image(systemName: "square.on.square")
             Text("\(group.items.count)")
         }
-        .nativTextStyle(.statusBadge)
+        .legacyTextStyle(.statusBadge)
         .foregroundStyle(.white)
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -1612,7 +1612,7 @@ struct ArtifactAlbum: View {
                     }
                     Spacer()
                     Text(title)
-                        .nativTextStyle(.cardTitle)
+                        .legacyTextStyle(.cardTitle)
                         .lineLimit(1)
                     Spacer()
                     if let first = artifacts.first {

--- a/Sources/Nativ/Features/Browsing/WebSearchSettingsView.swift
+++ b/Sources/Nativ/Features/Browsing/WebSearchSettingsView.swift
@@ -334,7 +334,7 @@ struct WebBrowsingSettingsView: View {
     private var providerPicker: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Providers")
-                .nativTextStyle(.sectionTitle)
+                .legacyTextStyle(.sectionTitle)
 
             ForEach(viewModel.availableProviders) { provider in
                 providerRow(provider)
@@ -436,7 +436,7 @@ struct WebBrowsingSettingsView: View {
     private var providerSetup: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(viewModel.selectedProvider.metadata.displayName)
-                .nativTextStyle(.sectionTitle)
+                .legacyTextStyle(.sectionTitle)
 
             routingActions
 
@@ -478,12 +478,12 @@ struct WebBrowsingSettingsView: View {
             if viewModel.selectedCapability == .read,
                let status = viewModel.pageReaderStatus {
                 Label(status, systemImage: "exclamationmark.triangle.fill")
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.orange)
             }
 
             Text(configurationPrivacyNote)
-                .nativTextStyle(.metadata)
+                .legacyTextStyle(.metadata)
                 .foregroundStyle(.tertiary)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -506,7 +506,7 @@ struct WebBrowsingSettingsView: View {
             case .search:
                 if viewModel.searchProvider == viewModel.selectedProvider {
                     Label("Search", systemImage: "checkmark")
-                        .nativTextStyle(.actionLabel)
+                        .legacyTextStyle(.actionLabel)
                         .foregroundStyle(.secondary)
                 } else {
                     Button("Use for Search") {
@@ -518,7 +518,7 @@ struct WebBrowsingSettingsView: View {
             case .read:
                 if viewModel.resolvedPageReaderProvider == viewModel.selectedProvider {
                     Label("Page reading", systemImage: "checkmark")
-                        .nativTextStyle(.actionLabel)
+                        .legacyTextStyle(.actionLabel)
                         .foregroundStyle(.secondary)
                 } else {
                     Button("Use for Page Reading") {
@@ -594,11 +594,11 @@ struct WebBrowsingSettingsView: View {
             switch status {
             case .connected(let message):
                 Label(message, systemImage: "checkmark.circle.fill")
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.green)
             case .failure(let message):
                 Label(message, systemImage: "exclamationmark.triangle.fill")
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.red)
             }
         } else {
@@ -607,11 +607,11 @@ struct WebBrowsingSettingsView: View {
                 EmptyView()
             case .connected:
                 Label("Connected", systemImage: "checkmark.circle.fill")
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.green)
             case .issue(let issue):
                 Label(issue.message, systemImage: "exclamationmark.triangle.fill")
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.orange)
             }
         }

--- a/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
+++ b/Sources/Nativ/Features/Chat/ChatCapabilitiesSheet.swift
@@ -133,13 +133,13 @@ struct ChatCapabilitiesSheet: View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
                 Text("Directory")
-                    .nativTextStyle(.sheetTitle)
+                    .legacyTextStyle(.sheetTitle)
                 Spacer()
                 NativHoverCloseButton { dismiss() }
             }
 
             Text("These settings apply to every chat.")
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
 
             TextField("Search directory", text: $query)
@@ -152,7 +152,7 @@ struct ChatCapabilitiesSheet: View {
                             query.isEmpty
                                 ? "No capabilities are available." : "No matching capabilities."
                         )
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 44)
@@ -176,7 +176,7 @@ struct ChatCapabilitiesSheet: View {
         if !sectionItems.isEmpty {
             VStack(alignment: .leading, spacing: 6) {
                 Text(kind.title.uppercased())
-                    .nativTextStyle(.badge)
+                    .legacyTextStyle(.badge)
                     .foregroundStyle(.secondary)
 
                 VStack(spacing: 0) {
@@ -216,12 +216,12 @@ struct ChatCapabilitiesSheet: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.title)
-                    .nativTextStyle(.rowTitleEmphasized)
+                    .legacyTextStyle(.rowTitleEmphasized)
                     .foregroundStyle(item.isAvailable ? Color.primary : Color.secondary)
 
                 if item.isAvailable {
                     Text(item.detail)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                 } else if let setupSection = item.setupSection {
                     GlobalCapabilitySetupDetail(detail: item.detail) {
@@ -310,13 +310,13 @@ struct ChatKitsPickerSheet: View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
                 Text("Kits")
-                    .nativTextStyle(.sheetTitle)
+                    .legacyTextStyle(.sheetTitle)
                 Spacer()
                 NativHoverCloseButton { dismiss() }
             }
 
             Text("Enable a ready-made set of capabilities for every chat.")
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
 
             ScrollView {
@@ -378,17 +378,17 @@ struct ChatKitsPickerSheet: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(kit.name)
-                    .nativTextStyle(.rowTitle)
+                    .legacyTextStyle(.rowTitle)
                     .foregroundStyle(.primary)
                 Text(kit.summary)
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                 Label(
                     actionTitle,
                     systemImage: state == .enabled ? "checkmark.circle.fill" : "plus.circle"
                 )
-                .nativTextStyle(.actionLabel)
+                .legacyTextStyle(.actionLabel)
                 .foregroundStyle(state == .enabled ? Color.green : Color.accentColor)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -413,7 +413,7 @@ private struct GlobalCapabilitySetupDetail: View {
                     .underline()
             }
         }
-        .nativTextStyle(.metadata)
+        .legacyTextStyle(.metadata)
         .multilineTextAlignment(.leading)
         .buttonStyle(.plain)
         .environment(

--- a/Sources/Nativ/Features/Chat/ChatComposer.swift
+++ b/Sources/Nativ/Features/Chat/ChatComposer.swift
@@ -1824,7 +1824,7 @@ private struct ComposerModelPickerLabel: View {
                 .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(.secondary)
         }
-        .nativTextStyle(.supportingEmphasized)
+        .legacyTextStyle(.supportingEmphasized)
         .foregroundStyle(Color.primary)
         .padding(.leading, 10)
         .padding(.trailing, 8)
@@ -2153,7 +2153,7 @@ struct ChatComposerActionPanel: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(title)
-                .nativTextStyle(.supportingEmphasized)
+                .legacyTextStyle(.supportingEmphasized)
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 8)
 
@@ -2184,11 +2184,11 @@ private struct ChatComposerActionRow: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
-                        .nativTextStyle(.rowTitle)
+                        .legacyTextStyle(.rowTitle)
                         .foregroundStyle(.primary)
 
                     Text(detail)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -84,7 +84,7 @@ struct ChatView: View {
                 Image(systemName: "plus")
                     .font(.system(size: 34, weight: .semibold))
                 Text("Drop files here")
-                    .nativTextStyle(.emptyStateTitle)
+                    .legacyTextStyle(.emptyStateTitle)
             }
             .foregroundStyle(.secondary)
             .padding(44)
@@ -121,11 +121,11 @@ private struct ChatProjectContextBanner: View {
                 .foregroundStyle(rootIsAvailable ? Color.accentColor : Color.orange)
 
             Text(project.name)
-                .nativTextStyle(.rowTitleEmphasized)
+                .legacyTextStyle(.rowTitleEmphasized)
                 .lineLimit(1)
 
             Text(project.rootPath)
-                .nativTextStyle(.metadata)
+                .legacyTextStyle(.metadata)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -134,7 +134,7 @@ private struct ChatProjectContextBanner: View {
 
             if !rootIsAvailable || !toolsEnabled {
                 Text(rootIsAvailable ? "Tools Off" : "Unavailable")
-                    .nativTextStyle(.badgeMuted)
+                    .legacyTextStyle(.badgeMuted)
                     .foregroundStyle(rootIsAvailable ? Color.secondary : Color.orange)
             }
         }

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarDragAndDrop.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarDragAndDrop.swift
@@ -197,7 +197,7 @@ extension ControlPanelView {
             Image(systemName: "bubble.left")
                 .font(.system(size: 11))
             Text(recent.title)
-                .nativTextStyle(.rowTitle)
+                .legacyTextStyle(.rowTitle)
                 .lineLimit(1)
         }
         .padding(.horizontal, 10)

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarRows.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarRows.swift
@@ -294,7 +294,7 @@ struct ControlPanelProjectHeaderView: View {
                         folderIcon
 
                         Text(project.name)
-                            .nativTextStyle(.sidebarItem)
+                            .legacyTextStyle(.sidebarItem)
                             .lineLimit(1)
 
                         Spacer(minLength: 4)
@@ -316,7 +316,7 @@ struct ControlPanelProjectHeaderView: View {
                 Button(action: onNewChat) {
                     Label("New Chat in \(project.name)", systemImage: "square.and.pencil")
                         .labelStyle(.iconOnly)
-                        .nativTextStyle(.rowTitle)
+                        .legacyTextStyle(.rowTitle)
                         .frame(width: 24, height: 24)
                         .contentShape(.rect)
                 }
@@ -366,7 +366,7 @@ struct ControlPanelProjectHeaderView: View {
 
     private var folderIcon: some View {
         Image(systemName: project.isCollapsed ? "folder" : "folder.fill")
-            .nativTextStyle(.metadata)
+            .legacyTextStyle(.metadata)
             .foregroundStyle(isAvailable ? Color.secondary : Color.orange)
             .contentTransition(.opacity)
     }
@@ -437,13 +437,13 @@ struct ControlPanelFolderHeaderView: View {
                     }
             } else {
                 Text(folder.name)
-                    .nativTextStyle(.rowTitle)
+                    .legacyTextStyle(.rowTitle)
                     .lineLimit(1)
 
                 Spacer(minLength: 4)
 
                 Text("\(count)")
-                    .nativTextStyle(.metadata)
+                    .legacyTextStyle(.metadata)
                     .foregroundStyle(.secondary.opacity(0.7))
             }
         }
@@ -513,7 +513,7 @@ struct SidebarRowSelectionStyle: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .nativTextStyle(.sidebarItem)
+            .legacyTextStyle(.sidebarItem)
             .padding(.horizontal, 7)
             .padding(.vertical, isNavigation ? 8 : 6)
             .background(

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarSections.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarSections.swift
@@ -32,7 +32,7 @@ extension ControlPanelView {
     var emptyProjectsHint: some View {
         Button(action: createProject) {
             Label("Choose a folder to create a project", systemImage: "folder.badge.plus")
-                .nativTextStyle(.body)
+                .legacyTextStyle(.body)
                 .foregroundStyle(.secondary.opacity(0.7))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 17)
@@ -189,7 +189,7 @@ extension ControlPanelView {
 
     var emptyFoldersHint: some View {
         Label("No folders yet — create one above", systemImage: "folder")
-            .nativTextStyle(.body)
+            .legacyTextStyle(.body)
             .foregroundStyle(.secondary.opacity(0.6))
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 17)
@@ -303,7 +303,7 @@ extension ControlPanelView {
             } label: {
                 HStack(spacing: 4) {
                     Text(title)
-                        .nativTextStyle(.sidebarSectionTitle)
+                        .legacyTextStyle(.sidebarSectionTitle)
                         .foregroundStyle(.secondary.opacity(0.7))
 
                     Image(systemName: "chevron.right")

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarToolbar.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarToolbar.swift
@@ -10,7 +10,7 @@ extension ControlPanelView {
         VStack(spacing: 6) {
             HStack {
                 Text(bulkSelectionTitle)
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 0)
                 Button("Done") {
@@ -18,7 +18,7 @@ extension ControlPanelView {
                         exitSelectMode()
                     }
                 }
-                .nativTextStyle(.supportingEmphasized)
+                .legacyTextStyle(.supportingEmphasized)
             }
             HStack(spacing: 6) {
                 Button {

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
@@ -25,7 +25,7 @@ extension ControlPanelView {
                     )
 
                 Text("Nativ")
-                    .nativTextStyle(.brandTitle)
+                    .legacyTextStyle(.brandTitle)
                     .foregroundStyle(.primary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Nativ/Features/Dashboard/StatsView.swift
+++ b/Sources/Nativ/Features/Dashboard/StatsView.swift
@@ -822,7 +822,7 @@ private struct UserActivityPanel: View {
                         Text(percentLabel(for: period))
                             .font(.caption.weight(.semibold).monospacedDigit())
                         Text(period.title)
-                            .nativTextStyle(.chartLabel)
+                            .legacyTextStyle(.chartLabel)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }

--- a/Sources/Nativ/Features/Developer/DevHubView.swift
+++ b/Sources/Nativ/Features/Developer/DevHubView.swift
@@ -42,7 +42,7 @@ struct DevHubView: View {
                         Image(systemName: item.systemImage)
                             .frame(width: 18)
                         Text(item.rawValue)
-                            .nativTextStyle(.sidebarItem)
+                            .legacyTextStyle(.sidebarItem)
                         Spacer(minLength: 0)
                     }
                     .padding(.horizontal, 10)

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -1648,12 +1648,12 @@ private struct ServerEndpointRow: View {
         Button(action: copyAction) {
             HStack(spacing: 8) {
                 Text(endpoint.method.displayTitle)
-                    .nativTextStyle(.codeEmphasized)
+                    .legacyTextStyle(.codeEmphasized)
                     .foregroundStyle(endpoint.method.tint)
                     .frame(width: 42, alignment: .leading)
 
                 Text(endpoint.path)
-                    .nativTextStyle(.code)
+                    .legacyTextStyle(.code)
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
+++ b/Sources/Nativ/Features/Extensions/ExtensionsHubView.swift
@@ -58,7 +58,7 @@ struct ExtensionsHubView: View {
                         Image(systemName: item.systemImage)
                             .frame(width: 18)
                         Text(item.rawValue)
-                            .nativTextStyle(.sidebarItem)
+                            .legacyTextStyle(.sidebarItem)
                         Spacer(minLength: 0)
                     }
                     .padding(.horizontal, 10)
@@ -126,9 +126,9 @@ struct HubSectionScaffold<Content: View, Action: View>: View {
                 HStack(alignment: .firstTextBaseline) {
                     VStack(alignment: .leading, spacing: 3) {
                         Text(title)
-                            .nativTextStyle(.pageTitle)
+                            .legacyTextStyle(.pageTitle)
                         Text(subtitle)
-                            .nativTextStyle(.supporting)
+                            .legacyTextStyle(.supporting)
                             .foregroundStyle(.secondary)
                     }
                     Spacer(minLength: 12)
@@ -156,7 +156,7 @@ struct HubEmptyHint: View {
                 .font(.system(size: 26))
                 .foregroundStyle(.tertiary)
             Text(text)
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 320)
@@ -208,15 +208,15 @@ private struct ExtensionRow: View {
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 8) {
                         Text(record.manifest.displayName)
-                            .nativTextStyle(.compactCardTitle)
+                            .legacyTextStyle(.compactCardTitle)
                         if record.isIncluded { includedBadge }
                     }
                     Text(record.manifest.summary)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                     Text("Version \(record.manifest.version)")
-                        .nativTextStyle(.metadata)
+                        .legacyTextStyle(.metadata)
                         .foregroundStyle(.tertiary)
                         .padding(.top, 1)
                 }
@@ -491,16 +491,16 @@ private struct SkillRow: View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(skill.name.isEmpty ? "Untitled skill" : skill.name)
-                    .nativTextStyle(.rowTitle)
+                    .legacyTextStyle(.rowTitle)
                 Text(skill.instructions)
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
             Spacer(minLength: 12)
             if isBuiltIn {
                 Text("Built-in")
-                    .nativTextStyle(.badgeMuted)
+                    .legacyTextStyle(.badgeMuted)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 3)
@@ -539,16 +539,16 @@ private struct SkillEditor: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             Text(skill.name.isEmpty ? "New Skill" : "Edit Skill")
-                .nativTextStyle(.sheetTitle)
+                .legacyTextStyle(.sheetTitle)
             VStack(alignment: .leading, spacing: 6) {
-                Text("Name").nativTextStyle(.supportingEmphasized).foregroundStyle(.secondary)
+                Text("Name").legacyTextStyle(.supportingEmphasized).foregroundStyle(.secondary)
                 TextField("e.g. Concise replies", text: $skill.name)
                     .textFieldStyle(.roundedBorder)
             }
             VStack(alignment: .leading, spacing: 6) {
-                Text("Instructions").nativTextStyle(.supportingEmphasized).foregroundStyle(.secondary)
+                Text("Instructions").legacyTextStyle(.supportingEmphasized).foregroundStyle(.secondary)
                 TextEditor(text: $skill.instructions)
-                    .nativTextStyle(.code)
+                    .legacyTextStyle(.code)
                     .frame(minHeight: 160)
                     .overlay(
                         RoundedRectangle(cornerRadius: 6)

--- a/Sources/Nativ/Features/Extensions/KitsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/KitsSectionView.swift
@@ -206,16 +206,16 @@ private struct KitCard: View {
             }
             VStack(alignment: .leading, spacing: 3) {
                 Text(kit.name)
-                    .nativTextStyle(.cardTitle)
+                    .legacyTextStyle(.cardTitle)
                 if !kit.summary.isEmpty {
                     Text(kit.summary)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
             Text(capabilitiesText)
-                .nativTextStyle(.metadata)
+                .legacyTextStyle(.metadata)
                 .foregroundStyle(.tertiary)
                 .fixedSize(horizontal: false, vertical: true)
             ViewThatFits(in: .horizontal) {
@@ -223,7 +223,7 @@ private struct KitCard: View {
                     .fixedSize(horizontal: true, vertical: false)
                 VStack(alignment: .leading, spacing: 8) { actions }
             }
-            .nativTextStyle(.supporting)
+            .legacyTextStyle(.supporting)
             .controlSize(.regular)
         }
         .padding(14)
@@ -336,12 +336,12 @@ private struct KitDetailView: View {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
                     Text(kit.name)
-                        .nativTextStyle(.detailTitle)
+                        .legacyTextStyle(.detailTitle)
                     KitStateIcon(state: snapshot.state)
                 }
                 if !kit.summary.isEmpty {
                     Text(kit.summary)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -742,10 +742,10 @@ private struct KitGroup<Content: View>: View {
         VStack(alignment: .leading, spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .nativTextStyle(.sectionTitle)
+                    .legacyTextStyle(.sectionTitle)
                 if let caption {
                     Text(caption)
-                        .nativTextStyle(.metadata)
+                        .legacyTextStyle(.metadata)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -771,10 +771,10 @@ private struct KitPartRow: View {
                 .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(descriptor.title)
-                        .nativTextStyle(.rowTitle)
+                        .legacyTextStyle(.rowTitle)
                     if let subtitle = descriptor.subtitle {
                         Text(subtitle)
-                            .nativTextStyle(.metadata)
+                            .legacyTextStyle(.metadata)
                             .foregroundStyle(descriptor.isAvailable ? Color.secondary : Color.orange)
                             .fixedSize(horizontal: false, vertical: true)
                     }

--- a/Sources/Nativ/Features/Extensions/MCPSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/MCPSectionView.swift
@@ -40,7 +40,7 @@ struct MCPSectionView: View {
                     serverGroup(title: "Custom") {
                         if customServers.isEmpty {
                             Text("No custom servers have been added.")
-                                .nativTextStyle(.supporting)
+                                .legacyTextStyle(.supporting)
                                 .foregroundStyle(.secondary)
                                 .padding(.vertical, 11)
                         } else {
@@ -95,7 +95,7 @@ struct MCPSectionView: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
-                .nativTextStyle(.subsectionTitle)
+                .legacyTextStyle(.subsectionTitle)
                 .foregroundStyle(.secondary)
                 .padding(.bottom, 6)
             content()
@@ -176,9 +176,9 @@ private struct MCPServerRow: View {
                 NativStatusDot(tone: statusTone, pulsing: isConnecting)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(server.name.isEmpty ? "Untitled server" : server.name)
-                        .nativTextStyle(.rowTitle)
+                        .legacyTextStyle(.rowTitle)
                     Text(statusText)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 12)
@@ -225,7 +225,7 @@ private struct MCPServerRow: View {
                 ) {
                     HStack(spacing: 6) {
                         Text(code)
-                            .nativTextStyle(.codeEmphasized)
+                            .legacyTextStyle(.codeEmphasized)
                             .textSelection(.enabled)
                             .padding(.horizontal, 10)
                             .frame(height: 26)
@@ -361,10 +361,10 @@ private struct GitHubSetupCallout<Accessory: View>: View {
 
             VStack(alignment: .leading, spacing: 6) {
                 Text(title)
-                    .nativTextStyle(.sectionTitle)
+                    .legacyTextStyle(.sectionTitle)
 
                 Text(message)
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
@@ -486,7 +486,7 @@ private struct MCPServerEditor: View {
         VStack(alignment: .leading, spacing: 14) {
             HStack {
                 Text(server.name.isEmpty ? "New MCP Server" : "Edit MCP Server")
-                    .nativTextStyle(.sheetTitle)
+                    .legacyTextStyle(.sheetTitle)
                 Spacer()
                 Toggle("Edit as JSON", isOn: $editingJSON)
                     .toggleStyle(.switch)
@@ -498,7 +498,7 @@ private struct MCPServerEditor: View {
 
             if editingJSON {
                 TextEditor(text: $jsonText)
-                    .nativTextStyle(.code)
+                    .legacyTextStyle(.code)
                     .frame(minHeight: 220)
                     .overlay(
                         RoundedRectangle(cornerRadius: 6)
@@ -509,7 +509,7 @@ private struct MCPServerEditor: View {
                     }
                 if let jsonError {
                     Text(jsonError)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.red)
                 }
             } else {
@@ -522,21 +522,21 @@ private struct MCPServerEditor: View {
                         "/Applications/Humla.app/Contents/MacOS/humla-mcp",
                         text: $launchCommandText
                     )
-                        .nativTextStyle(.code)
+                        .legacyTextStyle(.code)
                         .textFieldStyle(.roundedBorder)
                     Text("Paste the executable and any arguments on one line. Nativ launches it directly over stdio without invoking a shell.")
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                     if let launchCommandError {
                         Text(launchCommandError)
-                            .nativTextStyle(.supporting)
+                            .legacyTextStyle(.supporting)
                             .foregroundStyle(.red)
                     }
                 }
                 field("Environment (KEY=VALUE per line)") {
                     TextEditor(text: environmentText)
-                        .nativTextStyle(.code)
+                        .legacyTextStyle(.code)
                         .frame(height: 60)
                         .overlay(
                             RoundedRectangle(cornerRadius: 6)
@@ -567,7 +567,7 @@ private struct MCPServerEditor: View {
     @ViewBuilder
     private func field<Content: View>(_ label: String, @ViewBuilder _ content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(label).nativTextStyle(.supportingEmphasized).foregroundStyle(.secondary)
+            Text(label).legacyTextStyle(.supportingEmphasized).foregroundStyle(.secondary)
             content()
         }
     }

--- a/Sources/Nativ/Features/Extensions/ToolsSectionView.swift
+++ b/Sources/Nativ/Features/Extensions/ToolsSectionView.swift
@@ -142,7 +142,7 @@ struct ToolsSectionView: View {
     private func toolGroup(title: String, tools: [ToolItem]) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title.uppercased())
-                .nativTextStyle(.badge)
+                .legacyTextStyle(.badge)
                 .foregroundStyle(.secondary)
                 .padding(.bottom, 6)
             ForEach(Array(tools.enumerated()), id: \.element.id) { index, tool in
@@ -341,11 +341,11 @@ private struct ToolRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(tool.title)
-                        .nativTextStyle(.technicalLabel)
+                        .legacyTextStyle(.technicalLabel)
                 }
                 if !tool.detail.isEmpty {
                     Text(tool.detail)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
                 }
@@ -398,13 +398,13 @@ private struct BrowsingToolConfigurationView: View {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(toolName)
-                        .nativTextStyle(.technicalDisplayTitle)
+                        .legacyTextStyle(.technicalDisplayTitle)
                     Text(
                         capability == .search
                             ? "Choose the provider used for web search."
                             : "Choose the provider used to read source pages."
                     )
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                 }
                 Spacer(minLength: 16)
@@ -443,10 +443,10 @@ private struct ToolInspectorView: View {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(tool.title)
-                        .nativTextStyle(.technicalTitle)
+                        .legacyTextStyle(.technicalTitle)
                     if !tool.detail.isEmpty {
                         Text(tool.detail)
-                            .nativTextStyle(.supporting)
+                            .legacyTextStyle(.supporting)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
@@ -462,7 +462,7 @@ private struct ToolInspectorView: View {
             section("Input schema") {
                 ScrollView {
                     Text(schemaText)
-                        .nativTextStyle(.code)
+                        .legacyTextStyle(.code)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(8)
@@ -474,7 +474,7 @@ private struct ToolInspectorView: View {
             if tool.isRunnable {
                 section("Try it — arguments (JSON)") {
                     TextEditor(text: $argumentsJSON)
-                        .nativTextStyle(.code)
+                        .legacyTextStyle(.code)
                         .frame(height: 70)
                         .overlay(
                             RoundedRectangle(cornerRadius: 6)
@@ -491,13 +491,13 @@ private struct ToolInspectorView: View {
                     Spacer()
                 }
                 if let errorText {
-                    Text(errorText).nativTextStyle(.supporting).foregroundStyle(.red)
+                    Text(errorText).legacyTextStyle(.supporting).foregroundStyle(.red)
                 }
                 if let result {
                     section("Result") {
                         ScrollView {
                             Text(result)
-                                .nativTextStyle(.code)
+                                .legacyTextStyle(.code)
                                 .textSelection(.enabled)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(8)
@@ -512,7 +512,7 @@ private struct ToolInspectorView: View {
                     tool.executionHint
                         ?? "Built-in tools run inside a chat when a tool-capable model calls them."
                 )
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
             }
         }
@@ -525,7 +525,7 @@ private struct ToolInspectorView: View {
         -> some View
     {
         VStack(alignment: .leading, spacing: 6) {
-            Text(label).nativTextStyle(.supportingEmphasized).foregroundStyle(.secondary)
+            Text(label).legacyTextStyle(.supportingEmphasized).foregroundStyle(.secondary)
             content()
         }
     }
@@ -610,13 +610,13 @@ private struct CustomToolEditorSheet: View {
         VStack(alignment: .leading, spacing: 18) {
             VStack(alignment: .leading, spacing: 4) {
                 Text(tool == nil ? "Add Tool" : "Edit Tool")
-                    .nativTextStyle(.sheetTitle)
+                    .legacyTextStyle(.sheetTitle)
                 Text(
                     kind == .endpoint
                         ? "Send model-provided JSON to an HTTP endpoint."
                         : "Run a local script with model-provided JSON."
                 )
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
             }
 
@@ -624,12 +624,12 @@ private struct CustomToolEditorSheet: View {
 
             if let validationError {
                 Text(validationError)
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.red)
             }
             if let testResult {
                 Text(testResult)
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(validationError == nil ? .green : .red)
                     .lineLimit(2)
             }
@@ -639,7 +639,7 @@ private struct CustomToolEditorSheet: View {
                 Spacer()
                 if kind == .script, isScriptVerified {
                     Label("Verified", systemImage: "checkmark.circle.fill")
-                        .nativTextStyle(.actionLabel)
+                        .legacyTextStyle(.actionLabel)
                         .foregroundStyle(.green)
                 }
                 Button(testing ? "Testing…" : testButtonTitle, action: test)
@@ -683,7 +683,7 @@ private struct CustomToolEditorSheet: View {
 
                     field("Parameters") {
                         TextEditor(text: $parametersJSON)
-                            .nativTextStyle(.code)
+                            .legacyTextStyle(.code)
                             .frame(height: 120)
                             .padding(6)
                             .overlay(
@@ -693,12 +693,12 @@ private struct CustomToolEditorSheet: View {
                     }
                     field("Test arguments") {
                         TextField(#"{"query":"test"}"#, text: $testArgumentsJSON)
-                            .nativTextStyle(.code)
+                            .legacyTextStyle(.code)
                     }
                 }
                 .padding(.top, 6)
             }
-            .nativTextStyle(.supportingEmphasized)
+            .legacyTextStyle(.supportingEmphasized)
         }
     }
 
@@ -709,7 +709,7 @@ private struct CustomToolEditorSheet: View {
                 .textContentType(.URL)
         }
         Text("Uses POST with a JSON request body.")
-            .nativTextStyle(.supporting)
+            .legacyTextStyle(.supporting)
             .foregroundStyle(.secondary)
     }
 
@@ -726,11 +726,11 @@ private struct CustomToolEditorSheet: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             Text(scriptLanguage.availabilityNote)
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
             field("Script") {
                 TextEditor(text: $script)
-                    .nativTextStyle(.code)
+                    .legacyTextStyle(.code)
                     .frame(height: 180)
                     .padding(6)
                     .overlay(
@@ -739,7 +739,7 @@ private struct CustomToolEditorSheet: View {
                     )
             }
             Text("Arguments arrive as JSON on stdin. Return the tool result on stdout.")
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
         }
     }
@@ -771,7 +771,7 @@ private struct CustomToolEditorSheet: View {
                 }
             }
             Text("The header value is saved only in Keychain.")
-                .nativTextStyle(.supporting)
+                .legacyTextStyle(.supporting)
                 .foregroundStyle(.secondary)
         }
     }
@@ -842,7 +842,7 @@ private struct CustomToolEditorSheet: View {
     {
         VStack(alignment: .leading, spacing: 5) {
             Text(title)
-                .nativTextStyle(.supportingEmphasized)
+                .legacyTextStyle(.supportingEmphasized)
             content()
         }
     }

--- a/Sources/Nativ/Features/Routines/RoutineEditorView.swift
+++ b/Sources/Nativ/Features/Routines/RoutineEditorView.swift
@@ -190,7 +190,7 @@ struct RoutineEditor: View {
                         .foregroundStyle(.secondary)
                     VStack(alignment: .leading, spacing: 2) {
                         Text("No capabilities selected")
-                            .nativTextStyle(.rowTitle)
+                            .legacyTextStyle(.rowTitle)
                     }
                 }
             } else {
@@ -204,15 +204,15 @@ struct RoutineEditor: View {
                                 .frame(width: 22)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(option.title)
-                                    .nativTextStyle(.supportingEmphasized)
+                                    .legacyTextStyle(.supportingEmphasized)
                                 Text(option.summaryLine)
-                                    .nativTextStyle(.metadata)
+                                    .legacyTextStyle(.metadata)
                                     .foregroundStyle(.secondary)
                                     .lineLimit(1)
                             }
                             Spacer(minLength: 8)
                             Text(option.section.singularTitle)
-                                .nativTextStyle(.badge)
+                                .legacyTextStyle(.badge)
                                 .foregroundStyle(.secondary)
                                 .padding(.horizontal, 6)
                                 .padding(.vertical, 3)
@@ -598,9 +598,9 @@ private struct ScheduledCapabilityPicker: View {
         HStack(alignment: .top, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Capabilities")
-                    .nativTextStyle(.sheetTitle)
+                    .legacyTextStyle(.sheetTitle)
                 Text("Choose the capabilities this scheduled task can use.")
-                    .nativTextStyle(.supporting)
+                    .legacyTextStyle(.supporting)
                     .foregroundStyle(.secondary)
             }
             Spacer()
@@ -629,11 +629,11 @@ private struct ScheduledCapabilityPicker: View {
                         let count = count(for: item)
                         if count > 0 {
                             Text("\(count)")
-                                .nativTextStyle(.badgeMuted)
+                                .legacyTextStyle(.badgeMuted)
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    .nativTextStyle(.supportingEmphasized)
+                    .legacyTextStyle(.supportingEmphasized)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 8)
                     .foregroundStyle(section == item ? Color.accentColor : Color.primary)
@@ -726,16 +726,16 @@ private struct ScheduledCapabilityPicker: View {
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 7) {
                         Text(option.title)
-                            .nativTextStyle(.rowTitle)
+                            .legacyTextStyle(.rowTitle)
                         Text(option.section.singularTitle)
-                            .nativTextStyle(.badge)
+                            .legacyTextStyle(.badge)
                             .foregroundStyle(.secondary)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
                             .background(Color.secondary.opacity(0.1), in: Capsule())
                     }
                     Text(option.summaryLine)
-                        .nativTextStyle(.supporting)
+                        .legacyTextStyle(.supporting)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
                 }
@@ -768,7 +768,7 @@ private struct ScheduledCapabilityPicker: View {
                     ? "No capabilities selected"
                     : "\(draftSelection.count) capabilities selected"
             )
-                .nativTextStyle(.metadata)
+                .legacyTextStyle(.metadata)
                 .foregroundStyle(.secondary)
             Spacer()
             Button("Done") {

--- a/Sources/Nativ/Features/Routines/ScheduledTaskViews.swift
+++ b/Sources/Nativ/Features/Routines/ScheduledTaskViews.swift
@@ -45,7 +45,7 @@ struct ScheduledTaskCard: View {
                     VStack(alignment: .leading, spacing: 9) {
                         HStack(spacing: 8) {
                             Text(task.name.isEmpty ? "Untitled scheduled task" : task.name)
-                                .nativTextStyle(.cardTitle)
+                                .legacyTextStyle(.cardTitle)
                                 .lineLimit(1)
                             if isRunning {
                                 Text("Running")

--- a/Sources/Nativ/Features/Settings/SettingsView.swift
+++ b/Sources/Nativ/Features/Settings/SettingsView.swift
@@ -218,7 +218,7 @@ struct SettingsView: View {
     private var projectSettings: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Projects")
-                .nativTextStyle(.sectionTitle)
+                .legacyTextStyle(.sectionTitle)
 
             VStack(spacing: 0) {
                 settingsRow(

--- a/Sources/Nativ/Features/Shared/NativBulkSelection.swift
+++ b/Sources/Nativ/Features/Shared/NativBulkSelection.swift
@@ -77,7 +77,7 @@ struct NativBulkSelectionCheckbox: View {
 
             if isSelected {
                 Image(systemName: "checkmark")
-                    .nativTextStyle(.badgeStrong)
+                    .legacyTextStyle(.badgeStrong)
                     .foregroundStyle(.white)
             }
         }
@@ -172,7 +172,7 @@ struct NativBulkSelectionToolbar<Actions: View>: View {
     var body: some View {
         HStack(spacing: 10) {
             Text("\(selectedCount) selected")
-                .nativTextStyle(.actionLabel)
+                .legacyTextStyle(.actionLabel)
                 .foregroundStyle(.secondary)
 
             Button(allSelected ? "Deselect All" : "Select All", action: onToggleAll)

--- a/Sources/Nativ/Features/Shared/NativComponents.swift
+++ b/Sources/Nativ/Features/Shared/NativComponents.swift
@@ -240,7 +240,7 @@ extension Color {
 // rather than a stack of boxes. Prefer these over re-rolling a pill/badge/dot.
 
 /// The application-wide typography roles used by Nativ interface chrome.
-enum NativTypography {
+enum LegacyTypography {
     enum Style {
         case displayTitle
         case pageTitle
@@ -340,8 +340,8 @@ enum NativTypography {
     }
 }
 
-private struct NativTypographyModifier: ViewModifier {
-    let style: NativTypography.Style
+private struct LegacyTypographyModifier: ViewModifier {
+    let style: LegacyTypography.Style
 
     func body(content: Content) -> some View {
         content.font(style.font)
@@ -397,8 +397,8 @@ private struct NativPanelSurfaceModifier: ViewModifier {
 
 extension View {
     /// Applies one of Nativ's application-wide typography roles.
-    func nativTextStyle(_ style: NativTypography.Style) -> some View {
-        modifier(NativTypographyModifier(style: style))
+    func legacyTextStyle(_ style: LegacyTypography.Style) -> some View {
+        modifier(LegacyTypographyModifier(style: style))
     }
 
     /// Applies Nativ's standard semantic panel surface.
@@ -415,7 +415,7 @@ extension View {
     }
 }
 
-private struct NativTypographyPreview: View {
+private struct LegacyTypographyPreview: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
@@ -473,7 +473,7 @@ private struct NativTypographyPreview: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Text(title)
-                .nativTextStyle(.sectionTitle)
+                .legacyTextStyle(.sectionTitle)
             content()
         }
     }
@@ -481,22 +481,22 @@ private struct NativTypographyPreview: View {
     private func previewRow(
         _ name: String,
         sample: String,
-        style: NativTypography.Style
+        style: LegacyTypography.Style
     ) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 16) {
             Text(name)
-                .nativTextStyle(.metadata)
+                .legacyTextStyle(.metadata)
                 .foregroundStyle(.secondary)
                 .frame(width: 150, alignment: .leading)
             Text(sample)
-                .nativTextStyle(style)
+                .legacyTextStyle(style)
             Spacer(minLength: 0)
         }
     }
 }
 
 #Preview("Typography") {
-    NativTypographyPreview()
+    LegacyTypographyPreview()
         .frame(width: 520, height: 760)
 }
 
@@ -563,7 +563,7 @@ struct NativStatusBadge: View {
             }
             Text(text)
         }
-        .nativTextStyle(.statusBadge)
+        .legacyTextStyle(.statusBadge)
         .foregroundStyle(tone.color)
         .padding(.horizontal, 8)
         .padding(.vertical, 4)

--- a/Sources/Nativ/WelcomeView.swift
+++ b/Sources/Nativ/WelcomeView.swift
@@ -215,7 +215,7 @@ private struct WelcomeView: View {
 
             VStack(spacing: 6) {
                 Text("Welcome to Nativ")
-                    .nativTextStyle(.displayTitle)
+                    .legacyTextStyle(.displayTitle)
                 Text(stepSubtitle)
                     .font(.body)
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
Renaming the typography system to avoid conflicts in the redesigned version of nativ. This pr only renames the system without changing any of its properties.