### PR TITLE
Add optional cached model discovery to the API

### DIFF
--- a/Docs/features/developer.md
+++ b/Docs/features/developer.md
@@ -28,6 +28,14 @@ Available routes:
 
 External tools consume these endpoints — see [Integrations](integrations.md).
 
+The **Show cached models through API** toggle on the right of the Server Endpoints header,
+after the host and port controls, is off by default.
+When off, `/v1/models` lists loaded models. When on, it also lists eligible downloaded models
+from Nativ's configured Hugging Face cache, including models that are not loaded. The setting
+is saved automatically; use **Restart to Apply** for a running server, or start the server later.
+Listing models does not load them. Inference requests can already load or switch models using
+the request's `model` field. Additional model folders are not included in the cache scan.
+
 ## Hugging Face token
 
 A Hugging Face token enables downloading gated models. Set it in the Developer page or via

--- a/PythonDistribution/Requirements/mlx-vlm-server-macos-arm64.txt
+++ b/PythonDistribution/Requirements/mlx-vlm-server-macos-arm64.txt
@@ -29,7 +29,8 @@ mdurl==0.1.2
 miniaudio==1.71
 mlx-audio>=0.5.0
 mlx-metal>=0.32.0
-mlx-vlm>=0.6.10
+# Model discovery must support explicit served / hf-cache modes.
+mlx-vlm>=0.7.0
 mlx>=0.32.0
 multidict==6.7.1
 numpy==2.4.4

--- a/Sources/Nativ/Features/Developer/DeveloperView.swift
+++ b/Sources/Nativ/Features/Developer/DeveloperView.swift
@@ -259,8 +259,11 @@ struct DeveloperView: View {
                     serverHostField
 
                     serverPortField
+
+                    Spacer(minLength: 0)
+
+                    modelDiscoveryControl
                 }
-                .frame(width: 850, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 9) {
                     endpointPanelTitle
@@ -273,7 +276,9 @@ struct DeveloperView: View {
 
                         serverPortField
 
-                        Spacer()
+                        Spacer(minLength: 0)
+
+                        modelDiscoveryControl
                     }
                 }
 
@@ -284,9 +289,22 @@ struct DeveloperView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     HStack(spacing: 10) {
-                        serverHostField
-                        serverPortField
+                        ViewThatFits(in: .horizontal) {
+                            HStack(spacing: 10) {
+                                serverHostField
+                                serverPortField
+                            }
+                            .fixedSize()
+
+                            VStack(alignment: .leading, spacing: 9) {
+                                serverHostField
+                                serverPortField
+                            }
+                        }
+
                         Spacer(minLength: 0)
+
+                        modelDiscoveryControl
                     }
                 }
             }
@@ -334,6 +352,16 @@ struct DeveloperView: View {
         }
     }
 
+    private var modelDiscoveryControl: some View {
+        Toggle("Show cached models through API", isOn: $model.settings.cachedModelDiscoveryEnabled)
+            .font(.caption.weight(.medium))
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .fixedSize()
+            .help("Include unloaded models from your Hugging Face cache in the API model list. Applies on the next server start.")
+            .accessibilityHint("Include unloaded models from your Hugging Face cache. Applies on the next server start.")
+    }
+
     @ViewBuilder
     private var serverRestartIndicator: some View {
         if let countdown = model.serverRestartCountdown {
@@ -351,6 +379,12 @@ struct DeveloperView: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 10)
             .accessibilityElement(children: .combine)
+        } else if model.settingsRequireRestart {
+            Button("Restart to Apply", systemImage: "arrow.clockwise", action: model.restartServer)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 10)
         }
     }
 

--- a/Sources/Nativ/NativSettings.swift
+++ b/Sources/Nativ/NativSettings.swift
@@ -436,6 +436,7 @@ struct NativSettings: Codable, Equatable {
     var huggingFaceToken: String?
     var serverHost: String
     var serverPort: Int
+    var cachedModelDiscoveryEnabled: Bool
     var maxTokens: Int
     var maxKVSize: Int
     var systemPrompt: String
@@ -493,6 +494,7 @@ struct NativSettings: Codable, Equatable {
         huggingFaceToken: String? = nil,
         serverHost: String = Self.defaultServerHost,
         serverPort: Int = 8080,
+        cachedModelDiscoveryEnabled: Bool = false,
         maxTokens: Int = 2048,
         maxKVSize: Int = 0,
         systemPrompt: String = "",
@@ -549,6 +551,7 @@ struct NativSettings: Codable, Equatable {
         self.huggingFaceToken = huggingFaceToken
         self.serverHost = serverHost
         self.serverPort = serverPort
+        self.cachedModelDiscoveryEnabled = cachedModelDiscoveryEnabled
         self.maxTokens = maxTokens
         self.maxKVSize = maxKVSize
         self.systemPrompt = systemPrompt
@@ -607,6 +610,7 @@ struct NativSettings: Codable, Equatable {
         case huggingFaceToken
         case serverHost
         case serverPort
+        case cachedModelDiscoveryEnabled
         case selectedModelID
         case maxTokens
         case maxKVSize
@@ -708,6 +712,9 @@ struct NativSettings: Codable, Equatable {
             try container.decodeIfPresent(String.self, forKey: .serverHost) ?? defaults.serverHost
         serverPort =
             try container.decodeIfPresent(Int.self, forKey: .serverPort) ?? defaults.serverPort
+        cachedModelDiscoveryEnabled =
+            try container.decodeIfPresent(Bool.self, forKey: .cachedModelDiscoveryEnabled)
+            ?? defaults.cachedModelDiscoveryEnabled
         maxTokens =
             try container.decodeIfPresent(Int.self, forKey: .maxTokens) ?? defaults.maxTokens
         maxKVSize =
@@ -822,6 +829,7 @@ struct NativSettings: Codable, Equatable {
         try container.encodeIfPresent(embeddingModelID, forKey: .embeddingModelID)
         try container.encode(serverHost, forKey: .serverHost)
         try container.encode(serverPort, forKey: .serverPort)
+        try container.encode(cachedModelDiscoveryEnabled, forKey: .cachedModelDiscoveryEnabled)
         try container.encode(maxTokens, forKey: .maxTokens)
         try container.encode(maxKVSize, forKey: .maxKVSize)
         try container.encode(systemPrompt, forKey: .systemPrompt)
@@ -1127,6 +1135,7 @@ struct NativSettings: Codable, Equatable {
             && lhs.huggingFaceToken == rhs.huggingFaceToken
             && lhs.serverHost == rhs.serverHost
             && lhs.serverPort == rhs.serverPort
+            && lhs.cachedModelDiscoveryEnabled == rhs.cachedModelDiscoveryEnabled
             && lhs.maxTokens == rhs.maxTokens
             && lhs.maxKVSize == rhs.maxKVSize
             && lhs.kvQuantizationEnabled == rhs.kvQuantizationEnabled
@@ -1155,7 +1164,8 @@ struct NativSettings: Codable, Equatable {
     var launchEnvironment: [String: String] {
         let settings = normalized()
         var environment = [
-            "HF_HUB_CACHE": settings.expandedModelSearchPath
+            "HF_HUB_CACHE": settings.expandedModelSearchPath,
+            "MLX_VLM_MODEL_DISCOVERY": settings.cachedModelDiscoveryEnabled ? "hf-cache" : "served"
         ]
 
         environment["APC_ENABLED"] = settings.prefixCachingEnabled ? "1" : "0"

--- a/Tests/NativTests/NativSettingsTests.swift
+++ b/Tests/NativTests/NativSettingsTests.swift
@@ -220,6 +220,57 @@ final class NativSettingsTests: XCTestCase {
         XCTAssertFalse(original.hasSameLaunchConfiguration(as: changed))
     }
 
+    func testCachedModelDiscoveryDefaultsToServedForNewAndLegacySettings() throws {
+        let legacyData = try PropertyListSerialization.data(
+            fromPropertyList: ["serverPort": 8080],
+            format: .xml,
+            options: 0
+        )
+        let legacy = try PropertyListDecoder().decode(NativSettings.self, from: legacyData)
+
+        for settings in [NativSettings(), legacy] {
+            XCTAssertFalse(settings.cachedModelDiscoveryEnabled)
+            XCTAssertEqual(settings.launchEnvironment["MLX_VLM_MODEL_DISCOVERY"], "served")
+        }
+    }
+
+    func testCachedModelDiscoveryRoundTripsAndUsesConfiguredCache() throws {
+        for enabled in [false, true] {
+            let settings = NativSettings(
+                modelSearchPath: "~/custom-hf-cache",
+                cachedModelDiscoveryEnabled: enabled
+            )
+            let decoded = try PropertyListDecoder().decode(
+                NativSettings.self,
+                from: PropertyListEncoder().encode(settings)
+            )
+
+            XCTAssertEqual(decoded.cachedModelDiscoveryEnabled, enabled)
+            XCTAssertEqual(
+                decoded.launchEnvironment["MLX_VLM_MODEL_DISCOVERY"],
+                enabled ? "hf-cache" : "served"
+            )
+            XCTAssertEqual(
+                decoded.launchEnvironment["HF_HUB_CACHE"],
+                NSString(string: "~/custom-hf-cache").expandingTildeInPath
+            )
+            XCTAssertFalse(decoded.launchArguments.contains("--model"))
+        }
+    }
+
+    func testCachedModelDiscoveryRequiresRestartInBothDirectionsAndCanBeReverted() {
+        for enabled in [false, true] {
+            let original = NativSettings(cachedModelDiscoveryEnabled: enabled)
+            var changed = original
+            changed.cachedModelDiscoveryEnabled.toggle()
+
+            XCTAssertFalse(original.hasSameLaunchConfiguration(as: changed))
+
+            changed.cachedModelDiscoveryEnabled = enabled
+            XCTAssertTrue(original.hasSameLaunchConfiguration(as: changed))
+        }
+    }
+
     func testServerAPITokenIsNormalizedMaskedAndPassedToServer() {
         let settings = NativSettings(serverAPIKey: "  nativ_1234567890abcdef\n")
         let normalized = settings.normalized()


### PR DESCRIPTION
Closes #530.

Adds a “Show cached models through API” toggle to the Developer page, after the host and port controls. External clients can discover downloaded models through `/v1/models` before loading them, then use the existing request-driven model loading and switching.

The setting defaults to off, persists across launches, and applies after restarting the server. It explicitly selects mlx-vlm’s `served` or `hf-cache` mode. 

Note: Raises the minimum mlx-vlm version to 0.7.0.

Discovery uses the configured Hugging Face cache and upstream eligibility checks. 

Validation:
- All 58 settings tests passed.
- Bundled-server HTTP tests verified discovery on/off, authentication, unloading, streaming, and an empty cache.
- Real chat requests loaded Qwen 0.5B, switched to Qwen 3B, and switched back successfully.