### PR TITLE
Resolve exact model download sizes

### DIFF
--- a/Docs/features/models.md
+++ b/Docs/features/models.md
@@ -68,6 +68,13 @@ transfer, Nativ verifies the file list and checks the additional space needed af
 cached files and reservations for other downloads. If that verification fails, the download
 reports an error instead of proceeding with an unknown total.
 
+After resolving its exact uncached size, each downloader waits for the app to approve a disk
+reservation. A shared lock makes the fresh capacity check and reservation atomic across
+downloads on the same filesystem. Reservations remain held while paused and until the
+subprocess exits, including on cancellation or failure. Retries resolve and reserve again.
+The full reservation is retained during each attempt because displayed progress can be
+interpolated; this conservatively leaves less space available for additional downloads.
+
 ## Roles and preloading
 
 Separate models can be assigned per role and loaded concurrently, memory permitting:

--- a/Docs/features/models.md
+++ b/Docs/features/models.md
@@ -13,6 +13,12 @@ Installed models are found by scanning the Hugging Face cache plus any additiona
 - Capabilities are derived per model from its `config.json` (or `model_index.json` for
   diffusion pipelines) — see [`LocalModelDiscovery`](../../Sources/Nativ/Features/Models/LocalModelDiscovery.swift).
 
+Discover shows the total size of the files selected for download, including tokenizers and
+additional weight formats in the repository. Optional GGUF files are excluded. Sizes load in
+the background for visible rows; “Checking size…” changes to a verified total or “Size unavailable.”
+Size sorting uses these totals across the buffered search results. Memory-fit warnings remain
+separate estimates of runtime memory needs.
+
 ## External model storage
 
 The primary Hugging Face cache can live on a locally attached APFS external drive. Open
@@ -56,6 +62,11 @@ Compatible models download from Hugging Face
 warning when a model is unlikely to fit in available unified memory. Gated repositories require a
 Hugging Face token, set in the Developer page or via `HF_TOKEN`. Sharded downloads verify that
 every shard is present before a model counts as installed.
+
+Downloads from Discover use the repository revision displayed in the model list. Before any
+transfer, Nativ verifies the file list and checks the additional space needed after accounting for
+cached files and reservations for other downloads. If that verification fails, the download
+reports an error instead of proceeding with an unknown total.
 
 ## Roles and preloading
 

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		4262747AC6425403FC1F2210 /* ArtifactDeletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */; };
 		444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */; };
+		44E56C2D50FED9F7F03EAD48 /* HuggingFaceDownloadPreflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */; };
 		44F8A17BDE2610C6E90CE53F /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
 		455662EBEFC2C805F0223541 /* ControlPanelSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B9207F7063BEC112E5CAB /* ControlPanelSidebarView.swift */; };
 		4572BDBE09CB7D688B8838CA /* MCPServerCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352835BEC2B00D50C0F89D2 /* MCPServerCatalog.swift */; };
@@ -165,6 +166,7 @@
 		52927A9A78C07E5E649AFDF6 /* FilePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C9FECAED1FB3E2D43716FF /* FilePreview.swift */; };
 		52E78D326199C2BF37D16F66 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = 8DD1E187A7659D46CDC76CF9 /* MCP */; };
 		530018C1D89BF63546715147 /* GitHubOAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FC738EB813B7B63847838B /* GitHubOAuth.swift */; };
+		53632337EDE84A0F6C6995A4 /* HuggingFaceDownloadPreflightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA6589134B2561AE92F90E7 /* HuggingFaceDownloadPreflightTests.swift */; };
 		546A23A6921BCB4D3A1DD908 /* FileMutationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF1D2267F5230F7692BC886 /* FileMutationState.swift */; };
 		54A505B066D07337461E4F6C /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C408837A78A642A7AAB3ECDA /* MarkdownText.swift */; };
 		54B0738299776E5CEAEE6CC6 /* FileSyntaxValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846F6324EA769406B747062D /* FileSyntaxValidator.swift */; };
@@ -206,6 +208,7 @@
 		6CA6BFD98B270DBA87C36857 /* InferenceActivityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2C827258CAD4269D2428AD /* InferenceActivityCoordinator.swift */; };
 		6CFBB2F5B3720F1334BF3D47 /* UISFXMinimalStop.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8B12071ED75397C8639954B7 /* UISFXMinimalStop.mp3 */; };
 		6E7B34D02D005C83C71A412F /* NativServerKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5FC09C3EB40E94FB3D4AA4D6 /* NativServerKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6EE79BC99D6A44245D863E3F /* HubModelSizeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05586B0B909EAD6C76485D57 /* HubModelSizeResolverTests.swift */; };
 		6EFBB86CDB0CCCF393D7598E /* ChatDocumentExtractionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */; };
 		6F59E4CC485E211A7E6BC943 /* ScheduledTaskViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7213B7C6CEA995B14EBAC99 /* ScheduledTaskViews.swift */; };
 		70545F329C01AD4C683BF264 /* NativWindowHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1301809E464FD9315BF2A22 /* NativWindowHandle.swift */; };
@@ -427,6 +430,7 @@
 		F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */; };
 		F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
 		F32A65A75BCD6911505114F4 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
+		F55977B2BF1C55FDBC7AD537 /* HuggingFaceDownloadPreflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */; };
 		F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		F6BFEEE99336BB34E3194214 /* NativExtensionPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD28C5E1607C8E6025B7240 /* NativExtensionPlatform.swift */; };
@@ -529,6 +533,7 @@
 /* Begin PBXFileReference section */
 		028A6EB95776995CFF6F82A9 /* ControlPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelState.swift; sourceTree = "<group>"; };
 		03496D30CE58F138CA30EB0D /* ControlPanelDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelDetail.swift; sourceTree = "<group>"; };
+		05586B0B909EAD6C76485D57 /* HubModelSizeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubModelSizeResolverTests.swift; sourceTree = "<group>"; };
 		055942EFAB585BE493AC9AD7 /* ServerProcessEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessEnvironmentTests.swift; sourceTree = "<group>"; };
 		068ED8143814678E688A3A62 /* ChatServerStatsTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatServerStatsTool.swift; sourceTree = "<group>"; };
 		06D5CBFB467AADEE51EE098E /* DocumentTextExtractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTextExtractionTests.swift; sourceTree = "<group>"; };
@@ -715,6 +720,7 @@
 		A1389B0FCBFE26464CD80041 /* Brave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Brave.png; sourceTree = "<group>"; };
 		A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationServicesTests.swift; sourceTree = "<group>"; };
 		A35141B7390F1FF36B462CEA /* FileEditEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEditEngine.swift; sourceTree = "<group>"; };
+		A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceDownloadPreflight.swift; sourceTree = "<group>"; };
 		A55A33BE26A6AF77B69C0430 /* ArtifactSearchIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSearchIndex.swift; sourceTree = "<group>"; };
 		A5FC738EB813B7B63847838B /* GitHubOAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubOAuth.swift; sourceTree = "<group>"; };
 		A7D47DD0BF553DB26BA498D0 /* WindowCommandRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCommandRoutingTests.swift; sourceTree = "<group>"; };
@@ -723,6 +729,7 @@
 		A91D4332044DCC5DCE4B27F6 /* TextDocumentTextExtractors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDocumentTextExtractors.swift; sourceTree = "<group>"; };
 		AA054C2CE69D40692AB665CD /* ChatSearchFilesTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSearchFilesTool.swift; sourceTree = "<group>"; };
 		AA7F610FC8739BA80227DB26 /* NativKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKit.swift; sourceTree = "<group>"; };
+		AAA6589134B2561AE92F90E7 /* HuggingFaceDownloadPreflightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceDownloadPreflightTests.swift; sourceTree = "<group>"; };
 		AAC852B29463217932AE0212 /* NativModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativModel.swift; sourceTree = "<group>"; };
 		AB4EB9D6C2EB387FABD552B2 /* ControlPanelSidebarSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarSections.swift; sourceTree = "<group>"; };
 		AD3387C33E274E567979F013 /* ArtifactsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactsView.swift; sourceTree = "<group>"; };
@@ -1305,6 +1312,7 @@
 				F605E5C42FC442A37E4946BD /* ExternalModelCacheReference.swift */,
 				1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */,
 				E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */,
+				A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */,
 				7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */,
 				FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */,
 				EE984320AE8CCF8783DD30CE /* LocalModelDiscovery.swift */,
@@ -1489,8 +1497,10 @@
 				06D5CBFB467AADEE51EE098E /* DocumentTextExtractionTests.swift */,
 				1F39043C3E9B07A5EC3B7688 /* FormattingTests.swift */,
 				711EAE65183E78E000DD3253 /* GitHubOAuthTests.swift */,
+				05586B0B909EAD6C76485D57 /* HubModelSizeResolverTests.swift */,
 				A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */,
 				908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */,
+				AAA6589134B2561AE92F90E7 /* HuggingFaceDownloadPreflightTests.swift */,
 				2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */,
 				D726D6B7B3242DA22BDC8600 /* InferenceActivityCoordinatorTests.swift */,
 				A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */,
@@ -1899,6 +1909,7 @@
 				530018C1D89BF63546715147 /* GitHubOAuth.swift in Sources */,
 				F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */,
 				7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */,
+				44E56C2D50FED9F7F03EAD48 /* HuggingFaceDownloadPreflight.swift in Sources */,
 				B55A6BE5C7B03181E2CD03D6 /* HuggingFaceHub.swift in Sources */,
 				E36D43D088EF55D617BCDDBB /* HuggingFaceModelReadme.swift in Sources */,
 				575DCB7EC96DAB35B415434C /* ImageGenerationView.swift in Sources */,
@@ -2092,9 +2103,12 @@
 				E119D6964D35D4F49AD88EDF /* GitHubOAuth.swift in Sources */,
 				C22170FAE93CAF0FCEF39675 /* GitHubOAuthTests.swift in Sources */,
 				9E5AB6D42F995E0A78C4EA79 /* HubModelSizeResolver.swift in Sources */,
+				6EE79BC99D6A44245D863E3F /* HubModelSizeResolverTests.swift in Sources */,
 				A2DF29E907CC0CEF6EF86FBD /* HuggingFaceCache.swift in Sources */,
 				0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */,
 				E5DF6B83A09106489F564CED /* HuggingFaceCuratedModelLoaderTests.swift in Sources */,
+				F55977B2BF1C55FDBC7AD537 /* HuggingFaceDownloadPreflight.swift in Sources */,
+				53632337EDE84A0F6C6995A4 /* HuggingFaceDownloadPreflightTests.swift in Sources */,
 				D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */,
 				C92083D5C6AF4F5FE29A39E9 /* HuggingFaceModelReadme.swift in Sources */,
 				060FE6D6E84136D0F760A536 /* HuggingFaceModelReadmeTests.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		42293318F2E4FA62AD0CF762 /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
 		4262747AC6425403FC1F2210 /* ArtifactDeletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */; };
 		444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */; };
+		26ABD80DA0374B26A42CD6AB /* HuggingFaceDownloadCapacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8102248F226A47E787F2EAA2 /* HuggingFaceDownloadCapacity.swift */; };
 		44E56C2D50FED9F7F03EAD48 /* HuggingFaceDownloadPreflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */; };
 		44F8A17BDE2610C6E90CE53F /* CustomTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D53CFF2D565C0BFE3DE65E /* CustomTool.swift */; };
 		455662EBEFC2C805F0223541 /* ControlPanelSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B9207F7063BEC112E5CAB /* ControlPanelSidebarView.swift */; };
@@ -166,6 +167,7 @@
 		52927A9A78C07E5E649AFDF6 /* FilePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C9FECAED1FB3E2D43716FF /* FilePreview.swift */; };
 		52E78D326199C2BF37D16F66 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = 8DD1E187A7659D46CDC76CF9 /* MCP */; };
 		530018C1D89BF63546715147 /* GitHubOAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FC738EB813B7B63847838B /* GitHubOAuth.swift */; };
+		85CD212E6C9A4524B3AF8B86 /* HuggingFaceDownloadCapacityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBFC95E10EE414D8B3619A8 /* HuggingFaceDownloadCapacityTests.swift */; };
 		53632337EDE84A0F6C6995A4 /* HuggingFaceDownloadPreflightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA6589134B2561AE92F90E7 /* HuggingFaceDownloadPreflightTests.swift */; };
 		546A23A6921BCB4D3A1DD908 /* FileMutationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF1D2267F5230F7692BC886 /* FileMutationState.swift */; };
 		54A505B066D07337461E4F6C /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C408837A78A642A7AAB3ECDA /* MarkdownText.swift */; };
@@ -430,6 +432,7 @@
 		F2D992CF4F2CDFF9BEA13C3B /* ServerPortProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */; };
 		F3148D435BE180A3EB75EAC7 /* ModelPrimaryTaskResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A3E7402D8AE90971C374B /* ModelPrimaryTaskResolver.swift */; };
 		F32A65A75BCD6911505114F4 /* NativExtensionSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; };
+		FE6F394A7878430DB316BAD6 /* HuggingFaceDownloadCapacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8102248F226A47E787F2EAA2 /* HuggingFaceDownloadCapacity.swift */; };
 		F55977B2BF1C55FDBC7AD537 /* HuggingFaceDownloadPreflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */; };
 		F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */; };
 		F5EB384AAC13043938A0A7EB /* IntegrationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8DD9E277F67490B9744732 /* IntegrationTypes.swift */; };
@@ -720,6 +723,7 @@
 		A1389B0FCBFE26464CD80041 /* Brave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Brave.png; sourceTree = "<group>"; };
 		A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationServicesTests.swift; sourceTree = "<group>"; };
 		A35141B7390F1FF36B462CEA /* FileEditEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEditEngine.swift; sourceTree = "<group>"; };
+		8102248F226A47E787F2EAA2 /* HuggingFaceDownloadCapacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceDownloadCapacity.swift; sourceTree = "<group>"; };
 		A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceDownloadPreflight.swift; sourceTree = "<group>"; };
 		A55A33BE26A6AF77B69C0430 /* ArtifactSearchIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSearchIndex.swift; sourceTree = "<group>"; };
 		A5FC738EB813B7B63847838B /* GitHubOAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubOAuth.swift; sourceTree = "<group>"; };
@@ -729,6 +733,7 @@
 		A91D4332044DCC5DCE4B27F6 /* TextDocumentTextExtractors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDocumentTextExtractors.swift; sourceTree = "<group>"; };
 		AA054C2CE69D40692AB665CD /* ChatSearchFilesTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSearchFilesTool.swift; sourceTree = "<group>"; };
 		AA7F610FC8739BA80227DB26 /* NativKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKit.swift; sourceTree = "<group>"; };
+		CDBFC95E10EE414D8B3619A8 /* HuggingFaceDownloadCapacityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceDownloadCapacityTests.swift; sourceTree = "<group>"; };
 		AAA6589134B2561AE92F90E7 /* HuggingFaceDownloadPreflightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceDownloadPreflightTests.swift; sourceTree = "<group>"; };
 		AAC852B29463217932AE0212 /* NativModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativModel.swift; sourceTree = "<group>"; };
 		AB4EB9D6C2EB387FABD552B2 /* ControlPanelSidebarSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarSections.swift; sourceTree = "<group>"; };
@@ -1312,6 +1317,7 @@
 				F605E5C42FC442A37E4946BD /* ExternalModelCacheReference.swift */,
 				1B412A48D040D2DE044FF083 /* HubModelSizeResolver.swift */,
 				E9D1F1A2CDDD531089F289C9 /* HuggingFaceCache.swift */,
+				8102248F226A47E787F2EAA2 /* HuggingFaceDownloadCapacity.swift */,
 				A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */,
 				7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */,
 				FD670E29FC7EBFD886ED2DB8 /* HuggingFaceModelReadme.swift */,
@@ -1500,6 +1506,7 @@
 				05586B0B909EAD6C76485D57 /* HubModelSizeResolverTests.swift */,
 				A832F692EF1E810D78BD6B6C /* HuggingFaceCacheTests.swift */,
 				908D6ABDFE31E0FFFFF284EC /* HuggingFaceCuratedModelLoaderTests.swift */,
+				CDBFC95E10EE414D8B3619A8 /* HuggingFaceDownloadCapacityTests.swift */,
 				AAA6589134B2561AE92F90E7 /* HuggingFaceDownloadPreflightTests.swift */,
 				2D43B777F5D0E5B8E94DECA9 /* HuggingFaceModelReadmeTests.swift */,
 				D726D6B7B3242DA22BDC8600 /* InferenceActivityCoordinatorTests.swift */,
@@ -1909,6 +1916,7 @@
 				530018C1D89BF63546715147 /* GitHubOAuth.swift in Sources */,
 				F58ED8B576ABBE02882D43D1 /* HubModelSizeResolver.swift in Sources */,
 				7936A52CFFF5AB09FC9CDDCD /* HuggingFaceCache.swift in Sources */,
+				26ABD80DA0374B26A42CD6AB /* HuggingFaceDownloadCapacity.swift in Sources */,
 				44E56C2D50FED9F7F03EAD48 /* HuggingFaceDownloadPreflight.swift in Sources */,
 				B55A6BE5C7B03181E2CD03D6 /* HuggingFaceHub.swift in Sources */,
 				E36D43D088EF55D617BCDDBB /* HuggingFaceModelReadme.swift in Sources */,
@@ -2107,7 +2115,9 @@
 				A2DF29E907CC0CEF6EF86FBD /* HuggingFaceCache.swift in Sources */,
 				0AB78A4BB9F2D08433653C7C /* HuggingFaceCacheTests.swift in Sources */,
 				E5DF6B83A09106489F564CED /* HuggingFaceCuratedModelLoaderTests.swift in Sources */,
+				FE6F394A7878430DB316BAD6 /* HuggingFaceDownloadCapacity.swift in Sources */,
 				F55977B2BF1C55FDBC7AD537 /* HuggingFaceDownloadPreflight.swift in Sources */,
+				85CD212E6C9A4524B3AF8B86 /* HuggingFaceDownloadCapacityTests.swift in Sources */,
 				53632337EDE84A0F6C6995A4 /* HuggingFaceDownloadPreflightTests.swift in Sources */,
 				D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */,
 				C92083D5C6AF4F5FE29A39E9 /* HuggingFaceModelReadme.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
+++ b/Sources/Nativ/Features/Chat/Tools/ChatImageModelSelection.swift
@@ -172,7 +172,7 @@ enum ChatImageModelSelection {
             }
             .filter { !installedModelIDs.contains($0.0.id) }
             downloadableModels = await resolvedDownloadOptions(
-                Array(candidates.prefix(recommendedModelCount))
+                Array(candidates.prefix(recommendedModelCount)), token: huggingFaceToken
             )
         } catch {
             // Hub access is optional. When the device is offline, the picker
@@ -272,17 +272,14 @@ enum ChatImageModelSelection {
     }
 
     private static func resolvedDownloadOptions(
-        _ candidates: [(HuggingFaceModel, Set<LocalModelCapability>)]
+        _ candidates: [(HuggingFaceModel, Set<LocalModelCapability>)], token: String?
     ) async -> [ChatImageModelOption] {
         await withTaskGroup(of: (Int, ChatImageModelOption?).self) { group in
             for (index, candidate) in candidates.enumerated() {
                 group.addTask {
-                    let size: Int64?
-                    if let estimate = candidate.0.estimatedDownloadBytes {
-                        size = estimate
-                    } else {
-                        size = await HubModelSizeResolver.shared.resolveSize(for: candidate.0.id)
-                    }
+                    let size = await HubModelSizeResolver.shared.resolveSize(
+                        for: candidate.0.id, revision: candidate.0.revision, token: token
+                    )
                     guard let size else { return (index, nil) }
                     return (index, ChatImageModelOption(
                         downloadableModel: candidate.0,

--- a/Sources/Nativ/Features/Models/HubModelSizeResolver.swift
+++ b/Sources/Nativ/Features/Models/HubModelSizeResolver.swift
@@ -1,65 +1,172 @@
 import Foundation
 
+/// Resolves download bytes independently of tensor/memory estimates. Only callers
+/// still interested in a row keep its queued or in-flight request alive.
 @MainActor
 final class HubModelSizeResolver {
     static let shared = HubModelSizeResolver()
 
-    private var sizes: [String: Int64] = [:]
+    struct Request: Hashable, Sendable {
+        let repoID: String
+        let revision: String?
+        let token: String?
 
-    func resolveSize(for repoID: String) async -> Int64? {
-        if let size = sizes[repoID] {
-            return size
+        init(repoID: String, revision: String? = nil, token: String? = nil) {
+            self.repoID = repoID
+            self.revision = revision
+            self.token = HuggingFaceAuthentication.normalizedToken(token)
         }
-
-        do {
-            try await Task.sleep(nanoseconds: 250_000_000)
-        } catch {
-            return nil
-        }
-        guard !Task.isCancelled else { return nil }
-
-        if let size = sizes[repoID] {
-            return size
-        }
-
-        let bytes = await Self.fetchTotalBytes(repoID: repoID)
-        guard !Task.isCancelled else { return nil }
-        if let bytes {
-            sizes[repoID] = bytes
-        }
-        return bytes
     }
 
-    private nonisolated static func fetchTotalBytes(repoID: String) async -> Int64? {
-        guard let encoded = repoID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-              let url = URL(string: "https://huggingface.co/api/models/\(encoded)?blobs=true")
-        else {
-            return nil
-        }
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 20
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
-              (response as? HTTPURLResponse)?.statusCode == 200
-        else {
-            return nil
-        }
-        guard let payload = try? JSONDecoder().decode(SizePayload.self, from: data) else {
-            return nil
-        }
-        let total = payload.siblings?.reduce(Int64(0)) { partial, sibling in
-            guard !HuggingFaceDownloadFilePolicy.shouldIgnore(path: sibling.rfilename) else {
-                return partial
+    typealias Fetch = @Sendable (Request) async -> Data?
+
+    private struct CachedSize {
+        let bytes: Int64?
+        let expires: Date
+    }
+
+    private final class Job {
+        let request: Request
+        var waiters: [UUID: CheckedContinuation<Int64?, Never>] = [:]
+        var task: Task<Void, Never>?
+
+        init(request: Request) { self.request = request }
+    }
+
+    private let maximumConcurrentRequests: Int
+    private let debounce: Duration
+    private let fetch: Fetch
+    private var cache: [Request: CachedSize] = [:]
+    private var jobs: [Request: Job] = [:]
+    private var queue: [Job] = []
+    private var activeRequests = 0
+
+    init(maximumConcurrentRequests: Int = 4, debounce: Duration = .milliseconds(250),
+         fetch: @escaping Fetch = HubModelSizeResolver.fetchMetadata) {
+        precondition(maximumConcurrentRequests > 0)
+        self.maximumConcurrentRequests = maximumConcurrentRequests
+        self.debounce = debounce
+        self.fetch = fetch
+    }
+
+    func cachedSize(for request: Request) -> Int64? {
+        guard let cached = cache[request], cached.expires > .now else { return nil }
+        return cached.bytes
+    }
+
+    func resolveSize(for repoID: String, revision: String? = nil, token: String? = nil) async -> Int64? {
+        let request = Request(repoID: repoID, revision: revision, token: token)
+        guard !Task.isCancelled else { return nil }
+        if let cached = cache[request], cached.expires > .now { return cached.bytes }
+        do { try await Task.sleep(for: debounce) } catch { return nil }
+        guard !Task.isCancelled else { return nil }
+        if let cached = cache[request], cached.expires > .now { return cached.bytes }
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let job: Job
+                if let existing = jobs[request] {
+                    job = existing
+                } else {
+                    job = Job(request: request)
+                    jobs[request] = job
+                    queue.append(job)
+                }
+                job.waiters[waiterID] = continuation
+                startQueuedRequests()
             }
-            return partial + (sibling.lfs?.size ?? sibling.size ?? 0)
-        } ?? 0
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancel(waiterID, request: request)
+            }
+        }
+    }
+
+    private func cancel(_ waiterID: UUID, request: Request) {
+        guard let job = jobs[request] else { return }
+        job.waiters.removeValue(forKey: waiterID)?.resume(returning: nil)
+        guard job.waiters.isEmpty else { return }
+        jobs[request] = nil
+        queue.removeAll { $0 === job }
+        // The slot is released when URLSession acknowledges cancellation.
+        job.task?.cancel()
+    }
+
+    private func startQueuedRequests() {
+        while activeRequests < maximumConcurrentRequests, !queue.isEmpty {
+            let job = queue.removeFirst()
+            activeRequests += 1
+            let fetch = fetch
+            job.task = Task { [weak self] in
+                let bytes = await Self.fetchSize(job.request, fetch: fetch)
+                guard let self else { return }
+                self.activeRequests -= 1
+                if self.jobs[job.request] === job {
+                    self.jobs[job.request] = nil
+                    if !Task.isCancelled {
+                        // Bound memory; failures briefly back off rather than refetching
+                        // every time a lazy row appears. Unspecified revisions expire sooner.
+                        let lifetime: TimeInterval = bytes == nil ? 30 : (job.request.revision == nil ? 300 : 3_600)
+                        if self.cache.count >= 512,
+                           let oldest = self.cache.min(by: { $0.value.expires < $1.value.expires })?.key {
+                            self.cache[oldest] = nil
+                        }
+                        self.cache[job.request] = CachedSize(bytes: bytes, expires: .now.addingTimeInterval(lifetime))
+                    }
+                    for waiter in job.waiters.values { waiter.resume(returning: bytes) }
+                    job.waiters.removeAll()
+                }
+                self.startQueuedRequests()
+            }
+        }
+    }
+
+    @concurrent
+    private static func fetchSize(_ request: Request, fetch: Fetch) async -> Int64? {
+        guard let data = await fetch(request), !Task.isCancelled else { return nil }
+        return totalBytes(from: data)
+    }
+
+    nonisolated static func metadataRequest(for request: Request) -> URLRequest? {
+        var components = URLComponents(string: "https://huggingface.co")
+        components?.path = "/api/models/\(request.repoID)"
+        if let revision = request.revision { components?.path += "/revision/\(revision)" }
+        components?.queryItems = [URLQueryItem(name: "blobs", value: "true")]
+        guard let url = components?.url else { return nil }
+        var result = URLRequest(url: url)
+        result.timeoutInterval = 20
+        HuggingFaceAuthentication.authorize(&result, token: request.token)
+        return result
+    }
+
+    private nonisolated static func fetchMetadata(_ request: Request) async -> Data? {
+        guard let urlRequest = metadataRequest(for: request),
+              let (data, response) = try? await URLSession.shared.data(for: urlRequest),
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+        return data
+    }
+
+    nonisolated static func totalBytes(from data: Data) -> Int64? {
+        guard let payload = try? JSONDecoder().decode(SizePayload.self, from: data),
+              let siblings = payload.siblings, !siblings.isEmpty else { return nil }
+        var total: Int64 = 0
+        for sibling in siblings where !HuggingFaceDownloadFilePolicy.shouldIgnore(path: sibling.rfilename) {
+            // Missing sizes must never silently become zero and understate a download.
+            guard let size = sibling.lfs?.size ?? sibling.size, size >= 0 else { return nil }
+            let sum = total.addingReportingOverflow(size)
+            guard !sum.overflow else { return nil }
+            total = sum.partialValue
+        }
         return total > 0 ? total : nil
     }
 
     private struct SizePayload: Decodable {
         struct Sibling: Decodable {
-            struct LFS: Decodable {
-                let size: Int64?
-            }
+            struct LFS: Decodable { let size: Int64? }
             let rfilename: String
             let size: Int64?
             let lfs: LFS?

--- a/Sources/Nativ/Features/Models/HuggingFaceDownloadCapacity.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceDownloadCapacity.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Admission control shared by all downloader subprocesses in this app.
+/// Every read/check/reserve happens under one lock, after the Hub dry run.
+final class HuggingFaceDownloadCapacity: @unchecked Sendable {
+    static let shared = HuggingFaceDownloadCapacity()
+
+    struct Snapshot: Sendable {
+        let volume: UInt64
+        let freeBytes: Int64
+    }
+
+    enum Failure: LocalizedError {
+        case unavailable
+        case invalidReservation
+        case insufficientSpace(required: Int64, available: Int64)
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable:
+                return "Could not verify available disk space. Try again."
+            case .invalidReservation:
+                return "Could not verify the model's disk reservation. Try again."
+            case let .insufficientSpace(required, available):
+                let needed = ByteCountFormatter.string(fromByteCount: required, countStyle: .file)
+                let free = ByteCountFormatter.string(fromByteCount: available, countStyle: .file)
+                return "Model needs \(needed) of additional space, but only \(free) is available after reserving other downloads."
+            }
+        }
+    }
+
+    private struct Reservation {
+        let volume: UInt64
+        let bytes: Int64
+    }
+
+    private let lock = NSLock()
+    private let readCapacity: @Sendable (String) throws -> Snapshot
+    private var reservations: [UUID: Reservation] = [:]
+
+    init(readCapacity: @escaping @Sendable (String) throws -> Snapshot = readFileSystem) {
+        self.readCapacity = readCapacity
+    }
+
+    func reserve(_ id: UUID, bytes: Int64, atPath path: String) throws {
+        try lock.withLock {
+            guard bytes >= 0, reservations[id] == nil else {
+                throw Failure.invalidReservation
+            }
+            // Read fresh free space inside the critical section. In particular,
+            // do not use a snapshot taken before another request was admitted.
+            let snapshot = try readCapacity(path)
+            guard snapshot.freeBytes >= 0 else { throw Failure.unavailable }
+            let available = reservations.values.reduce(snapshot.freeBytes) { free, reservation in
+                reservation.volume == snapshot.volume ? max(free - reservation.bytes, 0) : free
+            }
+            guard bytes <= available else {
+                throw Failure.insufficientSpace(required: bytes, available: available)
+            }
+            reservations[id] = Reservation(volume: snapshot.volume, bytes: bytes)
+        }
+    }
+
+    func release(_ id: UUID) {
+        lock.withLock { _ = reservations.removeValue(forKey: id) }
+    }
+
+    private static func readFileSystem(atPath path: String) throws -> Snapshot {
+        let attributes = try FileManager.default.attributesOfFileSystem(forPath: path)
+        guard let volume = attributes[.systemNumber] as? NSNumber,
+              let free = attributes[.systemFreeSize] as? NSNumber else {
+            throw Failure.unavailable
+        }
+        return Snapshot(volume: volume.uint64Value, freeBytes: free.int64Value)
+    }
+}

--- a/Sources/Nativ/Features/Models/HuggingFaceDownloadPreflight.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceDownloadPreflight.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Shared with the subprocess tests so capacity checks run before any transfer.
 enum HuggingFaceDownloadPreflight {
     static let script = """
-    import shutil
+    import json
     print("__NATIV_STAGE__:preparing", flush=True)
     revision = sys.argv[4]
     files = snapshot_download(
@@ -23,12 +23,13 @@ enum HuggingFaceDownloadPreflight {
     cached_bytes = sum(item.file_size for item in files if not item.will_download)
     remaining_bytes = total_bytes - cached_bytes
     os.makedirs(sys.argv[2], exist_ok=True)
-    available_bytes = max(shutil.disk_usage(sys.argv[2]).free - int(sys.argv[5]), 0)
-    if remaining_bytes > available_bytes:
-        raise RuntimeError(
-            f"Model needs {remaining_bytes / 1e9:.2f} GB of additional space, "
-            f"but only {available_bytes / 1e9:.2f} GB is available after reserving other downloads."
-        )
+    print(f"__NATIV_RESERVE__:{remaining_bytes}", flush=True)
+    approval_line = sys.stdin.readline()
+    if not approval_line:
+        raise RuntimeError("Download stopped before disk space was reserved.")
+    approval = json.loads(approval_line)
+    if approval.get("approved") is not True:
+        raise RuntimeError(approval.get("error", "Disk space reservation was denied."))
     print(f"__NATIV_PROGRESS__:{cached_bytes}:{total_bytes}", flush=True)
     """
 }

--- a/Sources/Nativ/Features/Models/HuggingFaceDownloadPreflight.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceDownloadPreflight.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Shared with the subprocess tests so capacity checks run before any transfer.
+enum HuggingFaceDownloadPreflight {
+    static let script = """
+    import shutil
+    print("__NATIV_STAGE__:preparing", flush=True)
+    revision = sys.argv[4]
+    files = snapshot_download(
+        repo_id=sys.argv[1],
+        revision=revision,
+        cache_dir=sys.argv[2],
+        dry_run=True,
+        ignore_patterns=ignored_patterns,
+    )
+    if not files or any(item.file_size is None or item.file_size < 0 for item in files):
+        raise RuntimeError("Could not verify the model's download size. Try again.")
+    revisions = {item.commit_hash for item in files}
+    if len(revisions) != 1 or not next(iter(revisions)):
+        raise RuntimeError("Could not verify the model revision. Try again.")
+    revision = next(iter(revisions))
+    total_bytes = sum(item.file_size for item in files)
+    cached_bytes = sum(item.file_size for item in files if not item.will_download)
+    remaining_bytes = total_bytes - cached_bytes
+    os.makedirs(sys.argv[2], exist_ok=True)
+    available_bytes = max(shutil.disk_usage(sys.argv[2]).free - int(sys.argv[5]), 0)
+    if remaining_bytes > available_bytes:
+        raise RuntimeError(
+            f"Model needs {remaining_bytes / 1e9:.2f} GB of additional space, "
+            f"but only {available_bytes / 1e9:.2f} GB is available after reserving other downloads."
+        )
+    print(f"__NATIV_PROGRESS__:{cached_bytes}:{total_bytes}", flush=True)
+    """
+}

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -185,6 +185,7 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
     // and memory estimation during every SwiftUI body pass while scrolling.
     let provider: LocalModelProvider?
     let sizeBytes: Int64?
+    let revision: String?
     let capabilities: Set<LocalModelCapability>
     let memoryEstimate: LocalModelMemoryEstimate?
     let drafterKind: String?
@@ -201,6 +202,7 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         case isPrivate = "private"
         case gated
         case safetensors
+        case revision = "sha"
         case modelConfiguration = "config"
     }
 
@@ -231,6 +233,7 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
         }
 
         provider = LocalModelProviderResolver.resolve(repoID: id, modelType: nil, architectures: [])
+        revision = try container.decodeIfPresent(String.self, forKey: .revision)
         sizeBytes = safetensors?.sizeBytes
         drafterKind =
             MLXDrafterModelResolver.shared.metadata(
@@ -248,26 +251,6 @@ struct HuggingFaceModel: Decodable, Identifiable, Equatable, Sendable {
             sizeBytes: sizeBytes,
             capabilities: capabilities
         )
-    }
-
-    // The safetensors parameter summary only covers the diffusion transformer,
-    // so for image models it lands well under the real download. Scale it toward
-    // the components a modern image pipeline also ships (text encoder + VAE).
-    // The download manager validates available capacity again before enqueueing.
-    var estimatedDownloadBytes: Int64? {
-        guard let sizeBytes else {
-            return nil
-        }
-        let isImageModel = capabilities.contains(.imageGeneration)
-            || capabilities.contains(.imageEditing)
-        guard isImageModel else {
-            return sizeBytes
-        }
-        let scaled = Double(sizeBytes) * 2.5
-        guard scaled <= Double(Int64.max) else {
-            return sizeBytes
-        }
-        return Int64(scaled.rounded(.up))
     }
 
     private static func resolveMemoryEstimate(
@@ -698,7 +681,7 @@ private struct HuggingFaceHubClient: Sendable {
 
     private static let expandedFields = [
         "downloads", "likes", "trendingScore", "lastModified", "pipeline_tag",
-        "library_name", "tags", "private", "gated", "safetensors", "config",
+        "library_name", "tags", "private", "gated", "safetensors", "config", "sha",
     ]
 }
 
@@ -810,6 +793,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
     private var activeDirection: HuggingFaceSortDirection = .descending
     private var visibilityPredicate: (HuggingFaceModel) -> Bool = { _ in true }
     private var nextPageURLs: [URL] = []
+    private var resolvedDownloadSizes: [String: Int64] = [:]
     private let pageSize = 24
     private let maximumPageCount = 5
     private let maximumFillFetches = 8
@@ -831,6 +815,7 @@ final class HuggingFaceModelLibrary: ObservableObject {
         error = nil
         models = []
         buffer = []
+        resolvedDownloadSizes = [:]
         nextPageURLs = []
         pageNumber = 1
         activeSort = sort
@@ -859,6 +844,24 @@ final class HuggingFaceModelLibrary: ObservableObject {
                     self.nextPageURLs = []
                 }
                 try Task.checkCancellation()
+                if sort.sortsBySize {
+                    let candidates = self.buffer.filter(predicate)
+                    let sizes = await withTaskGroup(of: (String, Int64?).self) { group in
+                        for model in candidates {
+                            group.addTask {
+                                let bytes = await HubModelSizeResolver.shared.resolveSize(
+                                    for: model.id, revision: model.revision, token: token
+                                )
+                                return (model.id, bytes)
+                            }
+                        }
+                        var result: [String: Int64] = [:]
+                        for await (id, bytes) in group { result[id] = bytes }
+                        return result
+                    }
+                    try Task.checkCancellation()
+                    self.resolvedDownloadSizes = sizes
+                }
                 self.models = self.slice(forPage: 1)
                 self.error = nil
             } catch is CancellationError {
@@ -1015,8 +1018,8 @@ final class HuggingFaceModelLibrary: ObservableObject {
                     }
                 }
             case .size:
-                if lhs.sizeBytes != rhs.sizeBytes {
-                    switch (lhs.sizeBytes, rhs.sizeBytes) {
+                if resolvedDownloadSizes[lhs.id] != resolvedDownloadSizes[rhs.id] {
+                    switch (resolvedDownloadSizes[lhs.id], resolvedDownloadSizes[rhs.id]) {
                     case (let lhsSize?, let rhsSize?):
                         return isAscending ? lhsSize < rhsSize : lhsSize > rhsSize
                     case (nil, _):
@@ -1164,6 +1167,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
         let cachePath: String
         let volumeIdentifier: String?
         let token: String?
+        let revision: String?
         var onCompletion: (() -> Void)?
         var operation: HuggingFaceDownloadOperation?
         var task: Task<Void, Never>?
@@ -1174,12 +1178,14 @@ final class HuggingFaceDownloadManager: ObservableObject {
             cachePath: String,
             volumeIdentifier: String?,
             token: String?,
+            revision: String?,
             onCompletion: (() -> Void)?
         ) {
             self.modelID = modelID
             self.cachePath = cachePath
             self.volumeIdentifier = volumeIdentifier
             self.token = token
+            self.revision = revision
             self.onCompletion = onCompletion
         }
     }
@@ -1258,6 +1264,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     func download(
         repoID: String,
         sizeBytes: Int64?,
+        revision: String? = nil,
         cachePath: String,
         volumeIdentifier: String?,
         token: String?,
@@ -1269,12 +1276,10 @@ final class HuggingFaceDownloadManager: ObservableObject {
                 path: cachePath,
                 expectedVolumeIdentifier: volumeIdentifier
             )
-            if let blocker = capacityBlocker(sizeBytes: sizeBytes, cachePath: cachePath) {
-                throw HuggingFaceDownloadFailure.message(blocker)
-            }
             try enqueue(
                 repoID: repoID,
                 sizeBytes: sizeBytes,
+                revision: revision,
                 cachePath: cachePath,
                 volumeIdentifier: volumeIdentifier,
                 token: token,
@@ -1289,6 +1294,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     func downloadIfNeeded(
         repoID: String,
         sizeBytes: Int64?,
+        revision: String? = nil,
         cachePath: String,
         volumeIdentifier: String?,
         token: String?
@@ -1304,6 +1310,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
                 try enqueue(
                     repoID: repoID,
                     sizeBytes: sizeBytes,
+                    revision: revision,
                     cachePath: expandedCachePath,
                     volumeIdentifier: volumeIdentifier,
                     token: token,
@@ -1425,6 +1432,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
     private func enqueue(
         repoID: String,
         sizeBytes: Int64?,
+        revision: String? = nil,
         cachePath: String,
         volumeIdentifier: String?,
         token: String?,
@@ -1439,6 +1447,7 @@ final class HuggingFaceDownloadManager: ObservableObject {
             cachePath: cacheURL.path,
             volumeIdentifier: volumeIdentifier,
             token: token,
+            revision: revision,
             onCompletion: onCompletion
         )
         contexts[repoID] = context
@@ -1468,6 +1477,10 @@ final class HuggingFaceDownloadManager: ObservableObject {
             repoID: repoID,
             cachePath: context.cachePath,
             token: normalizedToken,
+            revision: context.revision,
+            reservedBytes: downloads.filter { $0.modelID != repoID }.reduce(Int64(0)) {
+                $0 + ($1.metrics.remainingBytes ?? 0)
+            },
             progress: { [weak self] progress in
                 Task { @MainActor [weak self] in
                     self?.updateProgress(repoID, progress)
@@ -1995,6 +2008,8 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         repoID: String,
         cachePath: String,
         token: String?,
+        revision: String?,
+        reservedBytes: Int64,
         progress: @escaping @Sendable (ModelDownloadProgress) -> Void,
         transferSpeed: @escaping @Sendable (Double?) -> Void,
         phase: @escaping @Sendable (HuggingFaceDownloadManager.DownloadPhase) -> Void
@@ -2023,21 +2038,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         threading.Thread(target=exit_if_parent_terminates, daemon=True).start()
 
         ignored_patterns = \(HuggingFaceDownloadFilePolicy.pythonListLiteral)
-        total_bytes = 0
-        cached_bytes = 0
-        print("__NATIV_STAGE__:preparing", flush=True)
-        try:
-            files = snapshot_download(
-                repo_id=sys.argv[1],
-                cache_dir=sys.argv[2],
-                dry_run=True,
-                ignore_patterns=ignored_patterns,
-            )
-            total_bytes = sum(item.file_size for item in files)
-            cached_bytes = sum(item.file_size for item in files if not item.will_download)
-        except Exception:
-            pass
-        print(f"__NATIV_PROGRESS__:{cached_bytes}:{total_bytes}", flush=True)
+        \(HuggingFaceDownloadPreflight.script)
 
         class NativProgress(tqdm):
             _lock = threading.Lock()
@@ -2104,6 +2105,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         print("__NATIV_STAGE__:downloading", flush=True)
         snapshot_download(
             repo_id=sys.argv[1],
+            revision=revision,
             cache_dir=sys.argv[2],
             ignore_patterns=ignored_patterns,
             tqdm_class=NativProgress,
@@ -2129,7 +2131,9 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
             script,
             repoID,
             cachePath,
-            String(ProcessInfo.processInfo.processIdentifier)
+            String(ProcessInfo.processInfo.processIdentifier),
+            revision ?? "main",
+            String(reservedBytes)
         ]
         self.environment = environment
         self.progress = progress

--- a/Sources/Nativ/Features/Models/HuggingFaceHub.swift
+++ b/Sources/Nativ/Features/Models/HuggingFaceHub.swift
@@ -1478,9 +1478,6 @@ final class HuggingFaceDownloadManager: ObservableObject {
             cachePath: context.cachePath,
             token: normalizedToken,
             revision: context.revision,
-            reservedBytes: downloads.filter { $0.modelID != repoID }.reduce(Int64(0)) {
-                $0 + ($1.metrics.remainingBytes ?? 0)
-            },
             progress: { [weak self] progress in
                 Task { @MainActor [weak self] in
                     self?.updateProgress(repoID, progress)
@@ -1920,12 +1917,16 @@ private final class HuggingFaceDownloadActivity: @unchecked Sendable {
 }
 
 enum HuggingFaceDownloadOutput: Equatable {
+    case reservation(Int64)
     case progress(ModelDownloadProgress)
     case transferredBytes(Int64)
     case phase(HuggingFaceDownloadManager.DownloadPhase)
 
     init?(line: String) {
-        if let payload = Self.payload(in: line, after: "__NATIV_PROGRESS__:"),
+        if let payload = Self.payload(in: line, after: "__NATIV_RESERVE__:"),
+           let bytes = Int64(payload) {
+            self = .reservation(bytes)
+        } else if let payload = Self.payload(in: line, after: "__NATIV_PROGRESS__:"),
            let separator = payload.firstIndex(of: ":"),
            let completedBytes = Int64(payload[..<separator]),
            let totalBytes = Int64(payload[payload.index(after: separator)...]),
@@ -1985,8 +1986,7 @@ private final class HuggingFaceCapturedOutput: @unchecked Sendable {
     }
 }
 
-private final class HuggingFaceDownloadOperation: @unchecked Sendable {
-    private static let stallTimeout: TimeInterval = 60
+final class HuggingFaceDownloadOperation: @unchecked Sendable {
     private static let finalizationStallTimeout: TimeInterval = 10 * 60
     private static let monitorInterval: TimeInterval = 0.5
     private static let maximumAttempts = 3
@@ -1995,6 +1995,9 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
     private let executableURL: URL
     private let arguments: [String]
     private let environment: [String: String]
+    private let cachePath: String
+    private let capacity: HuggingFaceDownloadCapacity
+    private let stallTimeout: TimeInterval
     private let progress: @Sendable (ModelDownloadProgress) -> Void
     private let transferSpeed: @Sendable (Double?) -> Void
     private let phase: @Sendable (HuggingFaceDownloadManager.DownloadPhase) -> Void
@@ -2004,12 +2007,11 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
     private var wasCancelled = false
     private var isPaused = false
 
-    init(
+    convenience init(
         repoID: String,
         cachePath: String,
         token: String?,
         revision: String?,
-        reservedBytes: Int64,
         progress: @escaping @Sendable (ModelDownloadProgress) -> Void,
         transferSpeed: @escaping @Sendable (Double?) -> Void,
         phase: @escaping @Sendable (HuggingFaceDownloadManager.DownloadPhase) -> Void
@@ -2125,17 +2127,37 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
             environment[HuggingFaceAuthentication.environmentVariableName] = token
         }
 
-        self.executableURL = pythonURL
-        self.arguments = [
+        let arguments = [
             "-c",
             script,
             repoID,
             cachePath,
             String(ProcessInfo.processInfo.processIdentifier),
-            revision ?? "main",
-            String(reservedBytes)
+            revision ?? "main"
         ]
+        self.init(executableURL: pythonURL, arguments: arguments, environment: environment,
+                  cachePath: cachePath, capacity: .shared,
+                  progress: progress, transferSpeed: transferSpeed, phase: phase)
+    }
+
+    /// Also allows subprocess tests to exercise admission and cleanup without Hub access.
+    init(
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        cachePath: String,
+        capacity: HuggingFaceDownloadCapacity,
+        stallTimeout: TimeInterval = 60,
+        progress: @escaping @Sendable (ModelDownloadProgress) -> Void = { _ in },
+        transferSpeed: @escaping @Sendable (Double?) -> Void = { _ in },
+        phase: @escaping @Sendable (HuggingFaceDownloadManager.DownloadPhase) -> Void = { _ in }
+    ) {
+        self.executableURL = executableURL
+        self.arguments = arguments
         self.environment = environment
+        self.cachePath = cachePath
+        self.capacity = capacity
+        self.stallTimeout = stallTimeout
         self.progress = progress
         self.transferSpeed = transferSpeed
         self.phase = phase
@@ -2161,6 +2183,12 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
     }
 
     private func runAttempt() throws {
+        let reservationID = UUID()
+        // Keep the full uncached-byte reservation until the subprocess and its
+        // output reader exit, including while paused or being cancelled. UI
+        // progress can be interpolated and is not proof that bytes are on disk.
+        // Retries release the old attempt and reserve again after a fresh dry run.
+        defer { capacity.release(reservationID) }
         activity.beginAttempt()
         let process = Process()
         process.executableURL = executableURL
@@ -2168,8 +2196,19 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         process.environment = environment
 
         let pipe = Pipe()
+        let approvalPipe = Pipe()
+        process.standardInput = approvalPipe
         process.standardOutput = pipe
         process.standardError = pipe
+        defer {
+            try? approvalPipe.fileHandleForWriting.close()
+            try? approvalPipe.fileHandleForReading.close()
+        }
+        // Cancellation may close the child's stdin before its approval is sent.
+        // Treat that as a failed write, never a signal that terminates the app.
+        guard fcntl(approvalPipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1) != -1 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
 
         let outputGroup = DispatchGroup()
         let output = HuggingFaceCapturedOutput(
@@ -2177,7 +2216,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
         )
         outputGroup.enter()
         DispatchQueue.global(qos: .utility).async {
-            [activity, phase, progress] in
+            [self, activity, phase, progress] in
             var lineBuffer = ""
             while true {
                 let data = pipe.fileHandleForReading.availableData
@@ -2192,6 +2231,23 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
                 for line in lines.dropLast() {
                     guard let output = HuggingFaceDownloadOutput(line: line) else { continue }
                     switch output {
+                    case .reservation(let bytes):
+                        let response: [String: Any]
+                        do {
+                            guard !isCancelled else { throw CancellationError() }
+                            try capacity.reserve(reservationID, bytes: bytes, atPath: cachePath)
+                            response = ["approved": true]
+                        } catch {
+                            response = ["error": error.localizedDescription]
+                        }
+                        do {
+                            var data = try JSONSerialization.data(withJSONObject: response)
+                            data.append(0x0a)
+                            try approvalPipe.fileHandleForWriting.write(contentsOf: data)
+                        } catch {
+                            // EOF also denies admission if the reply cannot be delivered.
+                        }
+                        try? approvalPipe.fileHandleForWriting.close()
                     case .progress(let reportedProgress):
                         if let updatedProgress = activity.recordProgress(reportedProgress) {
                             progress(updatedProgress)
@@ -2220,6 +2276,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
 
         do {
             try process.run()
+            try? approvalPipe.fileHandleForReading.close()
         } catch {
             try? pipe.fileHandleForWriting.close()
             clearProcess(process)
@@ -2245,7 +2302,7 @@ private final class HuggingFaceDownloadOperation: @unchecked Sendable {
                 transferSpeed(activity.bytesPerSecond)
                 let timeout = activity.isFinishing
                     ? Self.finalizationStallTimeout
-                    : Self.stallTimeout
+                    : stallTimeout
                 if activity.isStalled(timeout: timeout, isPaused: false) {
                     stalled = true
                     stopProcess(process)

--- a/Sources/Nativ/Features/Models/ModelsView.swift
+++ b/Sources/Nativ/Features/Models/ModelsView.swift
@@ -637,6 +637,7 @@ struct ModelsView: View {
 
         if !activeDownloadIDs.isEmpty {
             InstalledActiveDownloadRows(
+                token: modelState.effectiveHuggingFaceToken,
                 hubModels: hubLibrary.models,
                 onShowReadme: { repoID, provider in
                     showReadme(
@@ -882,6 +883,7 @@ struct ModelsView: View {
                     ForEach(models) { hubModel in
                         HubModelRowContainer(
                             model: hubModel,
+                            token: modelState.effectiveHuggingFaceToken,
                             isInstalled: installedIDs.contains(hubModel.id),
                             isReadmeSelected: readmeSelection?.repoID == hubModel.id,
                             onShowReadme: {
@@ -895,6 +897,7 @@ struct ModelsView: View {
                                 downloadManager.download(
                                     repoID: hubModel.id,
                                     sizeBytes: downloadSizeBytes,
+                                    revision: hubModel.revision,
                                     cachePath: modelState.settings.modelSearchPath,
                                     volumeIdentifier: modelState.settings
                                         .externalModelCache?.volumeIdentifier,
@@ -2121,6 +2124,7 @@ private struct InstalledModelRow: View, @MainActor Equatable {
 private struct InstalledActiveDownloadRows: View {
     @ObservedObject private var downloadManager = HuggingFaceDownloadManager.shared
 
+    let token: String?
     let hubModels: [HuggingFaceModel]
     let onShowReadme: (String, LocalModelProvider?) -> Void
 
@@ -2129,6 +2133,7 @@ private struct InstalledActiveDownloadRows: View {
             if let hubModel = hubModels.first(where: { $0.id == download.modelID }) {
                 HubModelRowContainer(
                     model: hubModel,
+                    token: token,
                     isInstalled: false,
                     isReadmeSelected: false,
                     onShowReadme: {
@@ -2461,6 +2466,7 @@ private struct HubModelMemoryFitWarning: Equatable {
 private struct HubModelRow: View, @MainActor Equatable {
     let model: HuggingFaceModel
     let downloadSizeBytes: Int64?
+    let isResolvingSize: Bool
     let isInstalled: Bool
     let isReadmeSelected: Bool
     let isDownloading: Bool
@@ -2477,6 +2483,7 @@ private struct HubModelRow: View, @MainActor Equatable {
         // while closures are recreated whenever the parent view is rebuilt.
         lhs.model == rhs.model
             && lhs.downloadSizeBytes == rhs.downloadSizeBytes
+            && lhs.isResolvingSize == rhs.isResolvingSize
             && lhs.isInstalled == rhs.isInstalled
             && lhs.isReadmeSelected == rhs.isReadmeSelected
             && lhs.isDownloading == rhs.isDownloading
@@ -2517,6 +2524,9 @@ private struct HubModelRow: View, @MainActor Equatable {
     }
 
     var body: some View {
+        let sizeLabel = downloadSizeBytes.map {
+            ByteCountFormatter.string(fromByteCount: $0, countStyle: .file)
+        } ?? (isResolvingSize ? "Checking size…" : "Size unavailable")
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 14) {
                 Button(action: onShowReadme) {
@@ -2550,13 +2560,7 @@ private struct HubModelRow: View, @MainActor Equatable {
                                     title: NativFormatting.compactCount(model.likes).display,
                                     systemImage: "heart"
                                 )
-                                if let sizeBytes = downloadSizeBytes {
-                                    ModelPill(
-                                        title: ByteCountFormatter.string(
-                                            fromByteCount: sizeBytes, countStyle: .file),
-                                        systemImage: "internaldrive"
-                                    )
-                                }
+                                ModelPill(title: sizeLabel, systemImage: "internaldrive")
                                 if let memoryFitWarning {
                                     HubModelMemoryWarningBadge(warning: memoryFitWarning)
                                 }
@@ -2589,6 +2593,7 @@ private struct HubModelRow: View, @MainActor Equatable {
                 .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
                 .help("Show README for \(model.id)")
                 .accessibilityLabel("Show details for \(model.id)")
+                .accessibilityValue(sizeLabel)
 
                 if isInstalled {
                     Label("Installed", systemImage: "checkmark.circle.fill")
@@ -2784,6 +2789,15 @@ private struct HubModelRowContainer: View, @MainActor Equatable {
     private let downloadManager = HuggingFaceDownloadManager.shared
     @State private var downloadSnapshot: HuggingFaceDownloadManager.RowSnapshot
 
+    @State private var resolvedSize: Int64?
+    @State private var resolvedRequest: HubModelSizeResolver.Request?
+    @State private var isResolvingSize = true
+
+    private var sizeRequest: HubModelSizeResolver.Request {
+        .init(repoID: model.id, revision: model.revision, token: token)
+    }
+
+    let token: String?
     let model: HuggingFaceModel
     let isInstalled: Bool
     let isReadmeSelected: Bool
@@ -2794,6 +2808,7 @@ private struct HubModelRowContainer: View, @MainActor Equatable {
 
     init(
         model: HuggingFaceModel,
+        token: String?,
         isInstalled: Bool,
         isReadmeSelected: Bool,
         onShowReadme: @escaping () -> Void,
@@ -2802,12 +2817,18 @@ private struct HubModelRowContainer: View, @MainActor Equatable {
         onRemoveDownload: @escaping () -> Void
     ) {
         self.model = model
+        self.token = token
         self.isInstalled = isInstalled
         self.isReadmeSelected = isReadmeSelected
         self.onShowReadme = onShowReadme
         self.onDownload = onDownload
         self.onPauseResume = onPauseResume
         self.onRemoveDownload = onRemoveDownload
+        let request = HubModelSizeResolver.Request(repoID: model.id, revision: model.revision, token: token)
+        let cached = HubModelSizeResolver.shared.cachedSize(for: request)
+        _resolvedSize = State(initialValue: cached)
+        _resolvedRequest = State(initialValue: cached == nil ? nil : request)
+        _isResolvingSize = State(initialValue: cached == nil)
         _downloadSnapshot = State(
             initialValue: HuggingFaceDownloadManager.shared.rowSnapshot(for: model.id)
         )
@@ -2815,15 +2836,17 @@ private struct HubModelRowContainer: View, @MainActor Equatable {
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.model == rhs.model
+            && lhs.token == rhs.token
             && lhs.isInstalled == rhs.isInstalled
             && lhs.isReadmeSelected == rhs.isReadmeSelected
     }
 
     var body: some View {
-        let downloadSizeBytes = model.estimatedDownloadBytes
+        let downloadSizeBytes = resolvedRequest == sizeRequest ? resolvedSize : nil
         HubModelRow(
             model: model,
             downloadSizeBytes: downloadSizeBytes,
+            isResolvingSize: resolvedRequest != sizeRequest || isResolvingSize,
             isInstalled: isInstalled,
             isReadmeSelected: isReadmeSelected,
             isDownloading: downloadSnapshot.isDownloading,
@@ -2838,6 +2861,26 @@ private struct HubModelRowContainer: View, @MainActor Equatable {
             onRemoveDownload: onRemoveDownload
         )
         .equatable()
+        .task(id: sizeRequest) {
+            let request = sizeRequest
+            if let cached = HubModelSizeResolver.shared.cachedSize(for: request) {
+                if resolvedRequest != request || resolvedSize != cached || isResolvingSize {
+                    resolvedRequest = request
+                    resolvedSize = cached
+                    isResolvingSize = false
+                }
+                return
+            }
+            isResolvingSize = true
+            resolvedSize = nil
+            resolvedRequest = request
+            let bytes = await HubModelSizeResolver.shared.resolveSize(
+                for: request.repoID, revision: request.revision, token: request.token
+            )
+            guard !Task.isCancelled else { return }
+            resolvedSize = bytes
+            isResolvingSize = false
+        }
         .onReceive(downloadManager.rowUpdates) { updatedModelID in
             guard updatedModelID == nil || updatedModelID == model.id else { return }
             let snapshot = downloadManager.rowSnapshot(for: model.id)

--- a/Tests/NativTests/HubModelSizeResolverTests.swift
+++ b/Tests/NativTests/HubModelSizeResolverTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import XCTest
+
+@MainActor
+final class HubModelSizeResolverTests: XCTestCase {
+    func testCountsAllSelectedFormatsAndUsesLFSBytes() throws {
+        let data = Data(#"{"siblings":[{"rfilename":"model.safetensors","size":12,"lfs":{"size":100}},{"rfilename":"pytorch_model.bin","size":100},{"rfilename":"onnx/model.onnx","size":100},{"rfilename":"tokenizer.json","size":5},{"rfilename":"optional.GgUf"}]}"#.utf8)
+        XCTAssertEqual(HubModelSizeResolver.totalBytes(from: data), 305)
+    }
+
+    func testIncompleteInvalidOrOverflowingMetadataNeverBecomesAnExactSize() {
+        for json in [
+            #"{"siblings":[{"rfilename":"model.safetensors","size":100},{"rfilename":"tokenizer.json"}]}"#,
+            #"{"siblings":[{"rfilename":"model.safetensors","size":-1}]}"#,
+            #"{"siblings":[{"rfilename":"a","size":9223372036854775807},{"rfilename":"b","size":1}]}"#,
+            #"{"siblings":[]}"#, #"{}"#, "not-json",
+        ] {
+            XCTAssertNil(HubModelSizeResolver.totalBytes(from: Data(json.utf8)))
+        }
+    }
+
+    func testRequestUsesRevisionAndAuthentication() throws {
+        let request = try XCTUnwrap(HubModelSizeResolver.metadataRequest(for: .init(
+            repoID: "org/model", revision: "abcdef", token: " test-token \n"
+        )))
+        XCTAssertEqual(request.url?.path, "/api/models/org/model/revision/abcdef")
+        XCTAssertEqual(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.query, "blobs=true")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+    }
+
+    func testBoundsConcurrentLookups() async {
+        let probe = SizeFetchProbe()
+        let resolver = HubModelSizeResolver(maximumConcurrentRequests: 3, debounce: .zero) { await probe.fetch($0) }
+        let results = await withTaskGroup(of: Int64?.self) { group in
+            for index in 0..<12 {
+                group.addTask { await resolver.resolveSize(for: "org/\(index)") }
+            }
+            var result: [Int64?] = []
+            for await size in group { result.append(size) }
+            return result
+        }
+        XCTAssertEqual(results.compactMap { $0 }, Array(repeating: Int64(105), count: 12))
+        let maximum = await probe.maximumConcurrency
+        XCTAssertEqual(maximum, 3)
+    }
+
+    func testSharesRequestsAndCachesByRevisionAndCredential() async {
+        let probe = SizeFetchProbe()
+        let resolver = HubModelSizeResolver(debounce: .zero) { await probe.fetch($0) }
+        async let first = resolver.resolveSize(for: "org/model", revision: "a")
+        async let second = resolver.resolveSize(for: "org/model", revision: "a")
+        let sizes = await [first, second]
+        XCTAssertEqual(sizes, [105, 105])
+        _ = await resolver.resolveSize(for: "org/model", revision: "a")
+        let cachedCount = await probe.calls
+        XCTAssertEqual(cachedCount, 1)
+        _ = await resolver.resolveSize(for: "org/model", revision: "b")
+        _ = await resolver.resolveSize(for: "org/model", revision: "b", token: "other-user")
+        let count = await probe.calls
+        XCTAssertEqual(count, 3)
+    }
+
+    func testCancellingOneSubscriberDoesNotCancelSharedRequest() async throws {
+        let probe = SizeFetchProbe()
+        let resolver = HubModelSizeResolver(debounce: .zero) { await probe.fetch($0) }
+        let first = Task { await resolver.resolveSize(for: "org/model") }
+        let second = Task { await resolver.resolveSize(for: "org/model") }
+        try await Task.sleep(for: .milliseconds(10))
+        first.cancel()
+        let firstSize = await first.value
+        let secondSize = await second.value
+        XCTAssertNil(firstSize)
+        XCTAssertEqual(secondSize, 105)
+        let calls = await probe.calls
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testCancelledQueuedRowsDoNotFetchOrOccupySlots() async throws {
+        let probe = SizeFetchProbe()
+        let resolver = HubModelSizeResolver(maximumConcurrentRequests: 1, debounce: .zero) { await probe.fetch($0) }
+        let first = Task { await resolver.resolveSize(for: "org/first") }
+        try await Task.sleep(for: .milliseconds(5))
+        let queued = Task { await resolver.resolveSize(for: "org/queued") }
+        try await Task.sleep(for: .milliseconds(5))
+        queued.cancel()
+        let cancelled = await queued.value
+        XCTAssertNil(cancelled)
+        _ = await first.value
+        let next = await resolver.resolveSize(for: "org/next")
+        XCTAssertEqual(next, 105)
+        let calls = await probe.calls
+        XCTAssertEqual(calls, 2)
+    }
+
+    func testFailedLookupsBackOffWithoutReportingPartialBytes() async {
+        let probe = SizeFetchProbe(fails: true)
+        let resolver = HubModelSizeResolver(debounce: .zero) { await probe.fetch($0) }
+        let first = await resolver.resolveSize(for: "org/model")
+        let second = await resolver.resolveSize(for: "org/model")
+        XCTAssertNil(first)
+        XCTAssertNil(second)
+        let calls = await probe.calls
+        XCTAssertEqual(calls, 1)
+    }
+}
+
+private actor SizeFetchProbe {
+    let fails: Bool
+    private(set) var calls = 0
+    private(set) var maximumConcurrency = 0
+    private var active = 0
+
+    init(fails: Bool = false) { self.fails = fails }
+
+    func fetch(_ request: HubModelSizeResolver.Request) async -> Data? {
+        calls += 1
+        active += 1
+        maximumConcurrency = max(maximumConcurrency, active)
+        defer { active -= 1 }
+        do { try await Task.sleep(for: .milliseconds(40)) } catch { return nil }
+        return fails ? nil : Data(#"{"siblings":[{"rfilename":"model.safetensors","size":100},{"rfilename":"tokenizer.json","size":5}]}"#.utf8)
+    }
+}

--- a/Tests/NativTests/HuggingFaceDownloadCapacityTests.swift
+++ b/Tests/NativTests/HuggingFaceDownloadCapacityTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import XCTest
+
+@MainActor
+final class HuggingFaceDownloadCapacityTests: XCTestCase {
+    func testConcurrentReservationsCannotOvercommitOneDisk() async {
+        let capacity = HuggingFaceDownloadCapacity { _ in .init(volume: 1, freeBytes: 10) }
+        let admitted = await withTaskGroup(of: UUID?.self) { group in
+            for _ in 0..<20 {
+                group.addTask {
+                    let id = UUID()
+                    do {
+                        try capacity.reserve(id, bytes: 8, atPath: "/cache")
+                        return id
+                    } catch { return nil }
+                }
+            }
+            var ids: [UUID] = []
+            for await id in group { if let id { ids.append(id) } }
+            return ids
+        }
+        XCTAssertEqual(admitted.count, 1)
+        admitted.forEach { capacity.release($0) }
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 10, atPath: "/cache"))
+    }
+
+    func testGroupsDifferentPathsOnTheSameVolumeAndSeparatesOtherDisks() throws {
+        let capacity = HuggingFaceDownloadCapacity { path in
+            .init(volume: path == "/external" ? 2 : 1, freeBytes: 10)
+        }
+        let first = UUID()
+        try capacity.reserve(first, bytes: 8, atPath: "/cache/a")
+        XCTAssertThrowsError(try capacity.reserve(UUID(), bytes: 8, atPath: "/cache/b"))
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 8, atPath: "/external"))
+        capacity.release(first)
+        capacity.release(first) // Cleanup is idempotent.
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 10, atPath: "/cache/b"))
+    }
+
+    func testInvalidAndDuplicateRequestsCannotReplaceAnExistingReservation() throws {
+        let capacity = HuggingFaceDownloadCapacity { _ in .init(volume: 1, freeBytes: .max) }
+        let first = UUID()
+        try capacity.reserve(first, bytes: .max, atPath: "/cache")
+        XCTAssertThrowsError(try capacity.reserve(first, bytes: 0, atPath: "/cache"))
+        XCTAssertThrowsError(try capacity.reserve(UUID(), bytes: 1, atPath: "/cache"))
+        XCTAssertThrowsError(try capacity.reserve(UUID(), bytes: -1, atPath: "/cache"))
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 0, atPath: "/cache"))
+    }
+
+    func testRealFileSystemLookupAndUnavailablePath() throws {
+        let capacity = HuggingFaceDownloadCapacity()
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 0, atPath: NSTemporaryDirectory()))
+        XCTAssertThrowsError(try capacity.reserve(UUID(), bytes: 1, atPath: "/nonexistent-\(UUID())"))
+    }
+
+    func testConcurrentSubprocessesResolveBeforeAdmissionAndOnlyOneStarts() async throws {
+        let directory = try temporaryDirectory()
+        let capacity = HuggingFaceDownloadCapacity { _ in .init(volume: 1, freeBytes: 10) }
+        let started = expectation(description: "one transfer admitted")
+        let rejected = expectation(description: "other transfer rejected")
+        let operations = (0..<2).map { index in
+            operation(capacity: capacity, directory: directory, bytes: 8,
+                      beforeResolution: """
+                      open(os.path.join(sys.argv[2], 'ready-\(index)'), 'w').close()
+                      while not all(os.path.exists(os.path.join(sys.argv[2], 'ready-' + str(i))) for i in range(2)):
+                          time.sleep(0.01)
+                      """,
+                      afterApproval: """
+                      while not os.path.exists(os.path.join(sys.argv[2], 'finish')):
+                          time.sleep(0.01)
+                      """, phase: { if $0 == .downloading { started.fulfill() } })
+        }
+        defer {
+            operations.forEach { $0.cancel() }
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let tasks = operations.map { operation in
+            Task.detached {
+                do { try operation.run(); return true }
+                catch { rejected.fulfill(); return false }
+            }
+        }
+        await fulfillment(of: [started, rejected], timeout: 10)
+        try Data().write(to: directory.appendingPathComponent("finish"))
+        var successes = 0
+        for task in tasks { if await task.value { successes += 1 } }
+        XCTAssertEqual(successes, 1)
+        // Successful and rejected attempts have both released their reservations.
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 10, atPath: directory.path))
+    }
+
+    func testPausedAttemptKeepsReservationUntilCancellationExits() async throws {
+        let directory = try temporaryDirectory()
+        let capacity = HuggingFaceDownloadCapacity { _ in .init(volume: 1, freeBytes: 10) }
+        let started = expectation(description: "transfer admitted")
+        let download = operation(capacity: capacity, directory: directory, bytes: 8,
+                                 afterApproval: "while True: time.sleep(0.01)",
+                                 phase: { if $0 == .downloading { started.fulfill() } })
+        defer { download.cancel(); try? FileManager.default.removeItem(at: directory) }
+        let task = Task.detached { try download.run() }
+        await fulfillment(of: [started], timeout: 5)
+        download.pause()
+        XCTAssertThrowsError(try capacity.reserve(UUID(), bytes: 8, atPath: directory.path))
+        download.resume()
+        XCTAssertThrowsError(try capacity.reserve(UUID(), bytes: 8, atPath: directory.path))
+        download.pause()
+        download.cancel()
+        do { try await task.value; XCTFail("Expected cancellation") }
+        catch { XCTAssertTrue(error is CancellationError) }
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 10, atPath: directory.path))
+    }
+
+    func testCancellationDuringSizeResolutionDoesNotLeakReservation() async throws {
+        let directory = try temporaryDirectory()
+        let capacity = HuggingFaceDownloadCapacity { _ in .init(volume: 1, freeBytes: 10) }
+        let preparing = expectation(description: "resolving size")
+        let download = operation(capacity: capacity, directory: directory, bytes: 8,
+                                 beforeResolution: "time.sleep(30)",
+                                 phase: { if $0 == .preparing { preparing.fulfill() } })
+        defer { download.cancel(); try? FileManager.default.removeItem(at: directory) }
+        let task = Task.detached { try download.run() }
+        await fulfillment(of: [preparing], timeout: 5)
+        download.cancel()
+        do { try await task.value; XCTFail("Expected cancellation") }
+        catch { XCTAssertTrue(error is CancellationError) }
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 10, atPath: directory.path))
+    }
+
+    func testFailureAfterAdmissionReleasesCapacity() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let capacity = HuggingFaceDownloadCapacity { _ in .init(volume: 1, freeBytes: 10) }
+        let download = operation(capacity: capacity, directory: directory, bytes: 8,
+                                 afterApproval: "raise RuntimeError('simulated transfer failure')")
+        do { try await Task.detached { try download.run() }.value; XCTFail("Expected failure") }
+        catch { XCTAssertTrue(error.localizedDescription.contains("simulated transfer failure")) }
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 10, atPath: directory.path))
+    }
+
+    func testCancellationWhileCapacityCheckIsRunningReleasesLateReservation() async throws {
+        let directory = try temporaryDirectory()
+        let checking = expectation(description: "capacity check is in flight")
+        let resumeCheck = DispatchSemaphore(value: 0)
+        let capacity = HuggingFaceDownloadCapacity { path in
+            if path == directory.path {
+                checking.fulfill()
+                _ = resumeCheck.wait(timeout: .now() + 5)
+            }
+            return .init(volume: 1, freeBytes: 10)
+        }
+        let download = operation(capacity: capacity, directory: directory, bytes: 8)
+        defer {
+            resumeCheck.signal()
+            download.cancel()
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let task = Task.detached { try download.run() }
+        await fulfillment(of: [checking], timeout: 5)
+        download.cancel()
+        await download.waitForExit(timeout: .seconds(2))
+        resumeCheck.signal()
+        do { try await task.value; XCTFail("Expected cancellation") }
+        catch { XCTAssertTrue(error is CancellationError) }
+        // An approval delivered after the child exits must not crash or leak capacity.
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 10, atPath: "/after-cancellation"))
+    }
+
+    func testAdmissionReadsCurrentFreeSpaceAfterAnEarlierAttemptFinishes() throws {
+        let capacity = HuggingFaceDownloadCapacity { path in
+            .init(volume: 1, freeBytes: path == "/before-transfer" ? 10 : 2)
+        }
+        let first = UUID()
+        try capacity.reserve(first, bytes: 8, atPath: "/before-transfer")
+        capacity.release(first)
+        XCTAssertThrowsError(try capacity.reserve(UUID(), bytes: 3, atPath: "/after-transfer"))
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 2, atPath: "/after-transfer"))
+    }
+
+    func testRetryResolvesAndReservesAgainAfterPreviousAttemptExits() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let capacity = HuggingFaceDownloadCapacity { _ in .init(volume: 1, freeBytes: 10) }
+        let retried = expectation(description: "stalled transfer retries")
+        let download = operation(capacity: capacity, directory: directory, bytes: 8,
+                                 beforeResolution: """
+                                 if os.path.exists(os.path.join(sys.argv[2], 'attempted')):
+                                     size = 10
+                                 """,
+                                 afterApproval: """
+                                 if not os.path.exists(os.path.join(sys.argv[2], 'attempted')):
+                                     open(os.path.join(sys.argv[2], 'attempted'), 'w').close()
+                                     while True: time.sleep(0.01)
+                                 """, stallTimeout: 0.2,
+                                 phase: { if $0 == .retrying { retried.fulfill() } })
+        defer { download.cancel() }
+        let task = Task.detached { try download.run() }
+        await fulfillment(of: [retried], timeout: 10)
+        try await task.value
+        XCTAssertNoThrow(try capacity.reserve(UUID(), bytes: 10, atPath: directory.path))
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func operation(
+        capacity: HuggingFaceDownloadCapacity, directory: URL, bytes: Int,
+        beforeResolution: String = "pass", afterApproval: String = "pass",
+        stallTimeout: TimeInterval = 60,
+        phase: @escaping @Sendable (HuggingFaceDownloadManager.DownloadPhase) -> Void = { _ in }
+    ) -> HuggingFaceDownloadOperation {
+        let script = """
+        import os, sys, time
+        from types import SimpleNamespace
+        ignored_patterns = ["*.[gG][gG][uU][fF]"]
+        def snapshot_download(**kwargs):
+            assert kwargs['dry_run'] is True
+            size = \(bytes)
+        \(beforeResolution.split(separator: "\n", omittingEmptySubsequences: false).map { "    " + $0 }.joined(separator: "\n"))
+            return [SimpleNamespace(file_size=size, will_download=True, commit_hash='resolved-commit')]
+        \(HuggingFaceDownloadPreflight.script)
+        print('__NATIV_STAGE__:downloading', flush=True)
+        \(afterApproval)
+        """
+        return HuggingFaceDownloadOperation(
+            executableURL: URL(fileURLWithPath: "/usr/bin/python3"),
+            arguments: ["-c", script, "org/model", directory.path, "0", "requested-commit"],
+            environment: ProcessInfo.processInfo.environment,
+            cachePath: directory.path, capacity: capacity, stallTimeout: stallTimeout, phase: phase
+        )
+    }
+}

--- a/Tests/NativTests/HuggingFaceDownloadPreflightTests.swift
+++ b/Tests/NativTests/HuggingFaceDownloadPreflightTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import XCTest
+
+final class HuggingFaceDownloadPreflightTests: XCTestCase {
+    func testPinsDryRunRevisionAndOnlyRequiresUncachedBytes() throws {
+        let result = try run(files: "[(90, False, 'commit-a'), (10, True, 'commit-a')]", free: 20)
+        XCTAssertEqual(result.status, 0, result.output)
+        XCTAssertTrue(result.output.contains("__NATIV_PROGRESS__:90:100"))
+        XCTAssertTrue(result.output.contains("resolved=commit-a"))
+    }
+
+    func testInsufficientSpaceIncludesOtherDownloadReservations() throws {
+        let result = try run(files: "[(100, True, 'commit-a')]", free: 150, reserved: 60)
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("additional space"))
+        XCTAssertFalse(result.output.contains("__NATIV_PROGRESS__"))
+    }
+
+    func testUnknownFileSizeAndMixedRevisionsFailBeforeTransfer() throws {
+        for files in ["[(None, True, 'commit-a')]", "[(1, True, 'a'), (1, True, 'b')]", "[]"] {
+            let result = try run(files: files, free: 1_000)
+            XCTAssertNotEqual(result.status, 0)
+            XCTAssertFalse(result.output.contains("__NATIV_PROGRESS__"))
+        }
+    }
+
+    private func run(files: String, free: Int, reserved: Int = 0) throws -> (status: Int32, output: String) {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let script = """
+        import os, sys, shutil
+        from types import SimpleNamespace
+        ignored_patterns = ["*.[gG][gG][uU][fF]"]
+        def snapshot_download(**kwargs):
+            assert kwargs['dry_run'] is True
+            assert kwargs['revision'] == 'requested-commit'
+            assert kwargs['ignore_patterns'] == ignored_patterns
+            return [SimpleNamespace(file_size=s, will_download=d, commit_hash=c) for s,d,c in \(files)]
+        shutil.disk_usage = lambda path: SimpleNamespace(free=\(free))
+        \(HuggingFaceDownloadPreflight.script)
+        print('resolved=' + revision)
+        """
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = ["-c", script, "org/model", directory.path, "0", "requested-commit", String(reserved)]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+}

--- a/Tests/NativTests/HuggingFaceDownloadPreflightTests.swift
+++ b/Tests/NativTests/HuggingFaceDownloadPreflightTests.swift
@@ -3,32 +3,37 @@ import XCTest
 
 final class HuggingFaceDownloadPreflightTests: XCTestCase {
     func testPinsDryRunRevisionAndOnlyRequiresUncachedBytes() throws {
-        let result = try run(files: "[(90, False, 'commit-a'), (10, True, 'commit-a')]", free: 20)
+        let result = try run(files: "[(90, False, 'commit-a'), (10, True, 'commit-a')]")
         XCTAssertEqual(result.status, 0, result.output)
+        XCTAssertTrue(result.output.contains("__NATIV_RESERVE__:10"))
         XCTAssertTrue(result.output.contains("__NATIV_PROGRESS__:90:100"))
         XCTAssertTrue(result.output.contains("resolved=commit-a"))
     }
 
-    func testInsufficientSpaceIncludesOtherDownloadReservations() throws {
-        let result = try run(files: "[(100, True, 'commit-a')]", free: 150, reserved: 60)
-        XCTAssertNotEqual(result.status, 0)
-        XCTAssertTrue(result.output.contains("additional space"))
-        XCTAssertFalse(result.output.contains("__NATIV_PROGRESS__"))
+    func testRefusesTransferWithoutExplicitCapacityApproval() throws {
+        for approval in ["", "{}\n", "not-json\n", "{\"error\":\"Insufficient disk space\"}\n"] {
+            let result = try run(files: "[(100, True, 'commit-a')]", approval: approval)
+            XCTAssertNotEqual(result.status, 0)
+            XCTAssertTrue(result.output.contains("__NATIV_RESERVE__:100"))
+            XCTAssertFalse(result.output.contains("__NATIV_PROGRESS__"))
+            XCTAssertFalse(result.output.contains("resolved="))
+        }
     }
 
     func testUnknownFileSizeAndMixedRevisionsFailBeforeTransfer() throws {
-        for files in ["[(None, True, 'commit-a')]", "[(1, True, 'a'), (1, True, 'b')]", "[]"] {
-            let result = try run(files: files, free: 1_000)
+        for files in ["[(None, True, 'commit-a')]", "[(-1, True, 'commit-a')]", "[(1, True, 'a'), (1, True, 'b')]", "[]"] {
+            let result = try run(files: files)
             XCTAssertNotEqual(result.status, 0)
+            XCTAssertFalse(result.output.contains("__NATIV_RESERVE__"))
             XCTAssertFalse(result.output.contains("__NATIV_PROGRESS__"))
         }
     }
 
-    private func run(files: String, free: Int, reserved: Int = 0) throws -> (status: Int32, output: String) {
+    private func run(files: String, approval: String = "{\"approved\":true}\n") throws -> (status: Int32, output: String) {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: directory) }
         let script = """
-        import os, sys, shutil
+        import os, sys
         from types import SimpleNamespace
         ignored_patterns = ["*.[gG][gG][uU][fF]"]
         def snapshot_download(**kwargs):
@@ -36,17 +41,20 @@ final class HuggingFaceDownloadPreflightTests: XCTestCase {
             assert kwargs['revision'] == 'requested-commit'
             assert kwargs['ignore_patterns'] == ignored_patterns
             return [SimpleNamespace(file_size=s, will_download=d, commit_hash=c) for s,d,c in \(files)]
-        shutil.disk_usage = lambda path: SimpleNamespace(free=\(free))
         \(HuggingFaceDownloadPreflight.script)
         print('resolved=' + revision)
         """
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
-        process.arguments = ["-c", script, "org/model", directory.path, "0", "requested-commit", String(reserved)]
+        process.arguments = ["-c", script, "org/model", directory.path, "0", "requested-commit"]
         let pipe = Pipe()
+        let input = Pipe()
+        process.standardInput = input
         process.standardOutput = pipe
         process.standardError = pipe
         try process.run()
+        try input.fileHandleForWriting.write(contentsOf: Data(approval.utf8))
+        try input.fileHandleForWriting.close()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
         return (process.terminationStatus, String(decoding: data, as: UTF8.self))

--- a/project.yml
+++ b/project.yml
@@ -201,6 +201,7 @@ targets:
       - path: Sources/Nativ/Features/Models/ExternalModelCacheReference.swift
       - path: Sources/Nativ/Features/Models/HubModelSizeResolver.swift
       - path: Sources/Nativ/Features/Models/HuggingFaceDownloadPreflight.swift
+      - path: Sources/Nativ/Features/Models/HuggingFaceDownloadCapacity.swift
       - path: Sources/Nativ/Features/Models/LocalModelDiscovery.swift
       - path: Sources/Nativ/Features/Models/LocalModelProvider.swift
       - path: Sources/Nativ/Features/Models/MLXImageModelResolver.swift

--- a/project.yml
+++ b/project.yml
@@ -200,6 +200,7 @@ targets:
       - path: Sources/Nativ/Features/Models/HuggingFaceCache.swift
       - path: Sources/Nativ/Features/Models/ExternalModelCacheReference.swift
       - path: Sources/Nativ/Features/Models/HubModelSizeResolver.swift
+      - path: Sources/Nativ/Features/Models/HuggingFaceDownloadPreflight.swift
       - path: Sources/Nativ/Features/Models/LocalModelDiscovery.swift
       - path: Sources/Nativ/Features/Models/LocalModelProvider.swift
       - path: Sources/Nativ/Features/Models/MLXImageModelResolver.swift


### PR DESCRIPTION
Discovery previously estimated download sizes from tensor metadata, with a fixed multiplier for image models. This omitted supporting files and alternative weight formats selected by the downloader. For example, `sentence-transformers/all-MiniLM-L6-v2` appeared as approximately 90.9 MB despite its selected files totaling 976.9 MB.

This change calculates sizes from the exact selected-file metadata, excluding GGUF files according to the existing download policy **(Prince will GGUF back later).** 

**Changes**

- Display verified download totals and use them for size sorting.
- Resolve sizes asynchronously with a 250 ms debounce, up to four concurrent requests, shared requests, cancellation, and caching.
- Show “Checking size…” or “Size unavailable” instead of an inaccurate estimate.
- Pin downloads started from Discover to the displayed repository revision.
- Verify the download file list and remaining disk space before transferring files, accounting for cached files and other download reservations.
- Keep runtime memory estimates separate from download sizes.

**Model verification**

All 10 models below displayed the expected totals in the updated discovery UI. Previous estimates were calculated from the original implementation; corrected totals were verified against recorded repository file metadata.

| Model | Previous estimate | Verified total |
| --- | ---: | ---: |
| `mlx-community/whisper-tiny-asr-fp16` | 74.4 MB | 78.8 MB |
| `sentence-transformers/all-MiniLM-L6-v2` | 90.9 MB | 976.9 MB |
| `sentence-transformers/all-MiniLM-L12-v2` | 133.4 MB | 1.30 GB |
| `BAAI/bge-small-en-v1.5` | 133.4 MB | 401.1 MB |
| `openai/whisper-tiny` | 151.0 MB | 608.9 MB |
| `intfloat/e5-small-v2` | 133.4 MB | 803.2 MB |
| `BAAI/bge-base-en-v1.5` | 437.9 MB | 1.31 GB |
| `sentence-transformers/all-mpnet-base-v2` | 437.9 MB | 3.82 GB |
| `stabilityai/sdxl-turbo` | 25.67 GB | 55.52 GB |
| `stabilityai/stable-diffusion-xl-base-1.0` | 25.67 GB | 76.91 GB |

These are full selected-file totals before subtracting cached files, including alternative weight formats selected by the current downloader. 

**Performance benchmarks**

Both builds completed the same 45-operation workload on the same Mac, running under Xcode in Debug with a 1920 × 1080 window. Search timings are medians of five trials; entry and pagination timings use three trials.

| Operation | Before | After |
| --- | ---: | ---: |
| Open Discover | 240 ms | 264 ms |
| Search: empty query | 632 ms | 790 ms |
| Search: `mlx-community` | 520 ms | 598 ms |
| Search: `sentence-transformers` | 510 ms | 542 ms |
| Search: `BAAI/bge` | 535 ms | 651 ms |
| Search: `stabilityai/sdxl-turbo` | 560 ms | 696 ms |
| Page 1 → 2 | 551 ms | 557 ms |
| Page 2 → 3 | 327 ms | 343 ms |
| Page 3 → 2 | 298 ms | 318 ms |
| Page 2 → 1 | 304 ms | 324 ms |
| Mean scrolling CPU | 13.47% | 16.38% |
| Final idle CPU | 2.41% | 2.37% |
| Peak sampled memory footprint | 561.7 MB | 528.8 MB |

These timings measure when search results appear, not when every size lookup completes. Results come from warm sessions against the live Hub.