### PR TITLE
Move notification settings into Permissions section

### DIFF
--- a/Sources/Nativ/Features/Settings/NativPermissionsCard.swift
+++ b/Sources/Nativ/Features/Settings/NativPermissionsCard.swift
@@ -1,7 +1,16 @@
 import SwiftUI
 
-struct NativPermissionsCard: View {
+struct NativPermissionsCard<AdditionalContent: View>: View {
     @ObservedObject var store: NativPermissionStore
+    private let additionalContent: AdditionalContent
+
+    init(
+        store: NativPermissionStore,
+        @ViewBuilder additionalContent: () -> AdditionalContent = { EmptyView() }
+    ) {
+        self.store = store
+        self.additionalContent = additionalContent()
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -20,6 +29,8 @@ struct NativPermissionsCard: View {
                     store.resolve(permission)
                 }
             }
+
+            additionalContent
         }
         .background(Color(nsColor: .controlBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/Sources/Nativ/Features/Settings/SettingsView.swift
+++ b/Sources/Nativ/Features/Settings/SettingsView.swift
@@ -174,17 +174,6 @@ struct SettingsView: View {
                     .padding(.horizontal, 18)
                     .padding(.vertical, 12)
                 }
-
-                Divider()
-                    .padding(.leading, 52)
-
-                settingsRow(
-                    title: "Notifications",
-                    description: notificationDescription,
-                    systemImage: "bell.badge"
-                ) {
-                    notificationSettingsControl
-                }
             }
             .background(Color(nsColor: .controlBackgroundColor))
             .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -200,7 +189,18 @@ struct SettingsView: View {
             Text("Permissions")
                 .font(.headline)
 
-            NativPermissionsCard(store: permissions)
+            NativPermissionsCard(store: permissions) {
+                Divider()
+                    .padding(.leading, 52)
+
+                settingsRow(
+                    title: "Notifications",
+                    description: notificationDescription,
+                    systemImage: "bell.badge"
+                ) {
+                    notificationSettingsControl
+                }
+            }
         }
         .onAppear {
             permissions.refresh()


### PR DESCRIPTION
This pr changes the location of the notifications permissions view from the general to the permissions section
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/2a0532aa-9185-4a90-a1f5-232f36d92397" />
