### PR TITLE
Search through chats

### DIFF
--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		2E732395142F22D4CDCA2227 /* IntegrationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A221B9B5CCE60A43CC46AC /* IntegrationServices.swift */; };
 		2F0882CE4C27E77454B20EF7 /* HuggingFaceDownloadCapacityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7FAAC665AB7A2867987CDF /* HuggingFaceDownloadCapacityTests.swift */; };
 		308D702D90DECE44C62375CD /* SwaTexRender in Frameworks */ = {isa = PBXBuildFile; productRef = 7C44F2BDEB36AE1669F3B4C5 /* SwaTexRender */; };
+		311407E18801C3393389E496 /* ChatSearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CF08DC293C1B48C6DDEB01 /* ChatSearchStore.swift */; };
 		31C08C22828567AEB0F8BC0E /* NativKitLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE65855FB48CA89F7A0DDA8 /* NativKitLibrary.swift */; };
 		31D67AFE2E2CD864C37D6CFA /* NativExtensionSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC94DCF581824C3B1FCADAB8 /* NativExtensionSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		326C969CB7D0F41F38467DFE /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
@@ -209,6 +210,7 @@
 		686A83AD1E07A381F56F6D05 /* ChatDocumentContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A176708720937F2AEF36812 /* ChatDocumentContextBuilder.swift */; };
 		690202C6E092ABA0A086955F /* NativKitRuntimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F14184E993AE756775A648F /* NativKitRuntimeResolver.swift */; };
 		692EA024371CB249BE53DB86 /* NativAnalyticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C30476FCFDB8FC736643EEB /* NativAnalyticsStore.swift */; };
+		6AA5EBC231A62CCBD0F605E3 /* ChatSearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CF08DC293C1B48C6DDEB01 /* ChatSearchStore.swift */; };
 		6B5A139573E38850CE9C1E3F /* AudioInputDevicePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */; };
 		6B69F2F6AA92A75F24F8AC9F /* NativWindowReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895F3583A69041C321FE9195 /* NativWindowReaderView.swift */; };
 		6B75126FADAA6F8B2016DBDF /* ChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE817B51A37BDB25AD26A11 /* ChatViewModelTests.swift */; };
@@ -477,8 +479,6 @@
 		FEB97639F6A1334E409830CF /* ChatWebSearchToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA5142DB692E378ADE8DFA0 /* ChatWebSearchToolTests.swift */; };
 		FF3A7CB3645D73897EE7535A /* ScheduledTaskChatLinkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBC23C0369758C056A8182D /* ScheduledTaskChatLinkerTests.swift */; };
 		FF9252FDCB6E44F672B53452 /* ChatAttachmentValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9483127E124DE562AFFFAC94 /* ChatAttachmentValidator.swift */; };
-		D0894483234C4F31834BE4DB = {isa = PBXBuildFile; fileRef = 17EB4A67699945E7ADF19820; };
-		01A419F22E7747F1BC2B91D7 = {isa = PBXBuildFile; fileRef = 17EB4A67699945E7ADF19820; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -769,6 +769,7 @@
 		A118DF27AE0EF852DC458BB7 /* AudioInputVolumeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputVolumeController.swift; sourceTree = "<group>"; };
 		A1389B0FCBFE26464CD80041 /* Brave.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Brave.png; sourceTree = "<group>"; };
 		A1D1AD1FEA6B27EDEC9D49D1 /* IntegrationServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationServicesTests.swift; sourceTree = "<group>"; };
+		A2CF08DC293C1B48C6DDEB01 /* ChatSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSearchStore.swift; sourceTree = "<group>"; };
 		A35141B7390F1FF36B462CEA /* FileEditEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEditEngine.swift; sourceTree = "<group>"; };
 		A4D6131B6961BE835918A998 /* HuggingFaceDownloadPreflight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggingFaceDownloadPreflight.swift; sourceTree = "<group>"; };
 		A55A33BE26A6AF77B69C0430 /* ArtifactSearchIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSearchIndex.swift; sourceTree = "<group>"; };
@@ -879,7 +880,6 @@
 		FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDeletionTests.swift; sourceTree = "<group>"; };
 		FE82B4EBA796206F12005498 /* OfficeArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeArchive.swift; sourceTree = "<group>"; };
 		FF6D2D7280064648E0EFC847 /* BraveBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveBrowsingProvider.swift; sourceTree = "<group>"; };
-		17EB4A67699945E7ADF19820 = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSearchStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1507,11 +1507,11 @@
 				7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */,
 				F9988535384E783847070506 /* ChatImportAlert.swift */,
 				37E69CFB16DC6B3E115ABA77 /* ChatLibrarySearch.swift */,
-				17EB4A67699945E7ADF19820,
 				C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */,
 				F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */,
 				8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */,
 				9EB5FE1937AB157ACAEC5354 /* ChatSearch.swift */,
+				A2CF08DC293C1B48C6DDEB01 /* ChatSearchStore.swift */,
 				530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */,
 				6424934AA457AEE6B59C1227 /* ChatStreamEventRelay.swift */,
 				4BBF7A59DCE85B6CEBFFD743 /* ChatTextSearch.swift */,
@@ -1781,11 +1781,11 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				ED4CB78AB93E015D0BE21F7B /* NativExtensionSDK */,
 				1622B274F4DF5A85C2FDB081 /* NativServerKit */,
-				51AD42FA29E71F2450386688 /* NativTests */,
+				465C23BB3ADA415A5004AAD9 /* Nativ */,
 				7082E254E8272A5E8D13E6F0 /* VoiceDictationExtensionRuntime */,
+				51AD42FA29E71F2450386688 /* NativTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1930,7 +1930,6 @@
 				B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */,
 				D96122BA0806CCE96CC145E0 /* ChatImportAlert.swift in Sources */,
 				92CAC313D093FBC25B4B1261 /* ChatLibrarySearch.swift in Sources */,
-				D0894483234C4F31834BE4DB,
 				04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */,
 				96A319074CB28B885E031213 /* ChatMarkdownRenderer.swift in Sources */,
 				59F063A85DE0A1DFA681282F /* ChatMathPreprocessor.swift in Sources */,
@@ -1940,6 +1939,7 @@
 				C904E51D66BFED1808E18FE5 /* ChatScreenCapture.swift in Sources */,
 				93995C5064EE1E0C38ACA008 /* ChatSearch.swift in Sources */,
 				35ED06368BDFA94106E39053 /* ChatSearchFilesTool.swift in Sources */,
+				6AA5EBC231A62CCBD0F605E3 /* ChatSearchStore.swift in Sources */,
 				96AE764D2F938395E9B76C9E /* ChatServerStatsTool.swift in Sources */,
 				D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */,
 				B8D44F30A79786E04C9B69DE /* ChatStreamEventRelay.swift in Sources */,
@@ -2142,7 +2142,6 @@
 				76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */,
 				D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */,
 				A821F372837FDD950F55193A /* ChatLibrarySearch.swift in Sources */,
-				01A419F22E7747F1BC2B91D7,
 				9251752AF85A79EEDF3D2E54 /* ChatLibrarySearchTests.swift in Sources */,
 				39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */,
 				D835C99B486C3FE352A27039 /* ChatMarkdownRenderer.swift in Sources */,
@@ -2157,6 +2156,7 @@
 				FBD608F58527BA13C4F8CC5A /* ChatSearch.swift in Sources */,
 				70620E92994E9828794445D8 /* ChatSearchFilesTool.swift in Sources */,
 				7775550C303776DF9AE6030E /* ChatSearchFilesToolTests.swift in Sources */,
+				311407E18801C3393389E496 /* ChatSearchStore.swift in Sources */,
 				02276EF90584AF165373487D /* ChatSearchTests.swift in Sources */,
 				9619E33DBABD478108A4D36D /* ChatSelectionEventRouterTests.swift in Sources */,
 				32E3DD03D61C201E783539AF /* ChatServerStatsTool.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -282,6 +282,8 @@
 		90A91F19C53567C017E37E28 /* RoutineRunCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50843C4D4ABCEC290EE626AF /* RoutineRunCoordinator.swift */; };
 		90EE7AA87400E84D947CBBF3 /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
 		91D44CF9A9E6E472C7498789 /* MarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151A0F6AD81E505ADF4C8BE2 /* MarkdownTests.swift */; };
+		9251752AF85A79EEDF3D2E54 /* ChatLibrarySearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FECA3794E8FFD7F7495DC1F /* ChatLibrarySearchTests.swift */; };
+		92CAC313D093FBC25B4B1261 /* ChatLibrarySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E69CFB16DC6B3E115ABA77 /* ChatLibrarySearch.swift */; };
 		9381AA529980BBAF307CD0B2 /* NativWindowRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788823D67AF46B07A6D65E78 /* NativWindowRegistry.swift */; };
 		93995C5064EE1E0C38ACA008 /* ChatSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB5FE1937AB157ACAEC5354 /* ChatSearch.swift */; };
 		94504A0DB46777F5DA8CDBD6 /* Parallel.png in Resources */ = {isa = PBXBuildFile; fileRef = 530CA8743FEBF843F79321A7 /* Parallel.png */; };
@@ -319,6 +321,7 @@
 		A5E3473F7FA26A19AB9FF7B2 /* SystemAudioMeetingRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7AE3F3DB48E640950CCDB4 /* SystemAudioMeetingRecorder.swift */; };
 		A6E043CD0C3AD882D0D0AE66 /* VoiceAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0952EC469768D8775A2D188 /* VoiceAudioRecorder.swift */; };
 		A7C190FC6FF6AC56F880614A /* SearXNGBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7552A0926132AC026ED6F530 /* SearXNGBrowsingProvider.swift */; };
+		A821F372837FDD950F55193A /* ChatLibrarySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E69CFB16DC6B3E115ABA77 /* ChatLibrarySearch.swift */; };
 		A9A3CE3DEBA182260722FEA8 /* ChatWebSearchTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = D873D2FEC84059F689E7F623 /* ChatWebSearchTool.swift */; };
 		A9B82EFAD4FD8C57E045721B /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB9D1D0FC24AC771442B628 /* Artifact.swift */; };
 		AA4FD64FCA38FCA61BC4A490 /* SafeLocalFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7A0A31B4307E2520BCD4F2 /* SafeLocalFileReader.swift */; };
@@ -588,6 +591,7 @@
 		1D4B44C59153CB242FE92D3A /* ImageGenerationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGenerationView.swift; sourceTree = "<group>"; };
 		1F39043C3E9B07A5EC3B7688 /* FormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattingTests.swift; sourceTree = "<group>"; };
 		1F7D407CD0B6A6F5440AE923 /* NativWindowRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWindowRoot.swift; sourceTree = "<group>"; };
+		1FECA3794E8FFD7F7495DC1F /* ChatLibrarySearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLibrarySearchTests.swift; sourceTree = "<group>"; };
 		20EE1CE9AAE5A3B9A2D4669C /* NativComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativComponents.swift; sourceTree = "<group>"; };
 		2110C8328A3FFDF6E02D3FF8 /* NativWindowRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWindowRegistryTests.swift; sourceTree = "<group>"; };
 		219898F64D1B7C28FA4A1B38 /* AppleSpeechTranscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSpeechTranscriber.swift; sourceTree = "<group>"; };
@@ -617,6 +621,7 @@
 		330FEA0F4955A2486E0C3A22 /* ServerPortProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerPortProbe.swift; sourceTree = "<group>"; };
 		35C1220F03EC60874920E0CE /* RoutineScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineScheduler.swift; sourceTree = "<group>"; };
 		37408935D4EAA2CA89CC0A4C /* VoiceDictationExtensionRuntime.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = VoiceDictationExtensionRuntime.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		37E69CFB16DC6B3E115ABA77 /* ChatLibrarySearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLibrarySearch.swift; sourceTree = "<group>"; };
 		38E6FD97A66F91B3B667B3FE /* NativChatClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativChatClient.swift; sourceTree = "<group>"; };
 		39B3E82A6F0DC701B7780AE6 /* ChatWorkspacePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatWorkspacePicker.swift; sourceTree = "<group>"; };
 		3A546937463F81A0E6913BB3 /* ShellEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -1498,6 +1503,7 @@
 				5375C079FD79C48C0CB41C82 /* ChatDocumentExtractionCache.swift */,
 				7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */,
 				F9988535384E783847070506 /* ChatImportAlert.swift */,
+				37E69CFB16DC6B3E115ABA77 /* ChatLibrarySearch.swift */,
 				C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */,
 				F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */,
 				8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */,
@@ -1540,6 +1546,7 @@
 				B059AF48F10F1B0502DC5E6F /* ChatConversationBranchTests.swift */,
 				F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */,
 				BC9BAAC27515691F6C7950B4 /* ChatFileWriteToolTests.swift */,
+				1FECA3794E8FFD7F7495DC1F /* ChatLibrarySearchTests.swift */,
 				23682FBD5DC3FC2517ABF397 /* ChatProjectStoreTests.swift */,
 				D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */,
 				DED337312E3F6206B56477D2 /* ChatRenderingTests.swift */,
@@ -1918,6 +1925,7 @@
 				2BF78B0A20ED752102326A38 /* ChatImageModelSelection.swift in Sources */,
 				B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */,
 				D96122BA0806CCE96CC145E0 /* ChatImportAlert.swift in Sources */,
+				92CAC313D093FBC25B4B1261 /* ChatLibrarySearch.swift in Sources */,
 				04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */,
 				96A319074CB28B885E031213 /* ChatMarkdownRenderer.swift in Sources */,
 				59F063A85DE0A1DFA681282F /* ChatMathPreprocessor.swift in Sources */,
@@ -2128,6 +2136,8 @@
 				B53F0BCBE1C538AB55D8D62F /* ChatFontScale.swift in Sources */,
 				76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */,
 				D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */,
+				A821F372837FDD950F55193A /* ChatLibrarySearch.swift in Sources */,
+				9251752AF85A79EEDF3D2E54 /* ChatLibrarySearchTests.swift in Sources */,
 				39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */,
 				D835C99B486C3FE352A27039 /* ChatMarkdownRenderer.swift in Sources */,
 				2D00D7A5F23F9250577351F7 /* ChatMathPreprocessor.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -477,6 +477,8 @@
 		FEB97639F6A1334E409830CF /* ChatWebSearchToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA5142DB692E378ADE8DFA0 /* ChatWebSearchToolTests.swift */; };
 		FF3A7CB3645D73897EE7535A /* ScheduledTaskChatLinkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBC23C0369758C056A8182D /* ScheduledTaskChatLinkerTests.swift */; };
 		FF9252FDCB6E44F672B53452 /* ChatAttachmentValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9483127E124DE562AFFFAC94 /* ChatAttachmentValidator.swift */; };
+		D0894483234C4F31834BE4DB = {isa = PBXBuildFile; fileRef = 17EB4A67699945E7ADF19820; };
+		01A419F22E7747F1BC2B91D7 = {isa = PBXBuildFile; fileRef = 17EB4A67699945E7ADF19820; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -877,6 +879,7 @@
 		FE4FFC04214D6E98258786D8 /* ArtifactDeletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDeletionTests.swift; sourceTree = "<group>"; };
 		FE82B4EBA796206F12005498 /* OfficeArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeArchive.swift; sourceTree = "<group>"; };
 		FF6D2D7280064648E0EFC847 /* BraveBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BraveBrowsingProvider.swift; sourceTree = "<group>"; };
+		17EB4A67699945E7ADF19820 = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSearchStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1504,6 +1507,7 @@
 				7A9C24932DBACE75BA4E0CCB /* ChatFontScale.swift */,
 				F9988535384E783847070506 /* ChatImportAlert.swift */,
 				37E69CFB16DC6B3E115ABA77 /* ChatLibrarySearch.swift */,
+				17EB4A67699945E7ADF19820,
 				C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */,
 				F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */,
 				8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */,
@@ -1926,6 +1930,7 @@
 				B426C6D2B2C1B7C7D2F831E2 /* ChatImageTool.swift in Sources */,
 				D96122BA0806CCE96CC145E0 /* ChatImportAlert.swift in Sources */,
 				92CAC313D093FBC25B4B1261 /* ChatLibrarySearch.swift in Sources */,
+				D0894483234C4F31834BE4DB,
 				04E587A0A3714FD30ECFDE91 /* ChatListModelsTool.swift in Sources */,
 				96A319074CB28B885E031213 /* ChatMarkdownRenderer.swift in Sources */,
 				59F063A85DE0A1DFA681282F /* ChatMathPreprocessor.swift in Sources */,
@@ -2137,6 +2142,7 @@
 				76EF60E40F6CC404F4CF8F91 /* ChatImageModelSelection.swift in Sources */,
 				D51D08482F5C0E76ACFEFDB1 /* ChatImageTool.swift in Sources */,
 				A821F372837FDD950F55193A /* ChatLibrarySearch.swift in Sources */,
+				01A419F22E7747F1BC2B91D7,
 				9251752AF85A79EEDF3D2E54 /* ChatLibrarySearchTests.swift in Sources */,
 				39F8BACAF5377A5DA14581BA /* ChatListModelsTool.swift in Sources */,
 				D835C99B486C3FE352A27039 /* ChatMarkdownRenderer.swift in Sources */,

--- a/Nativ.xcodeproj/project.pbxproj
+++ b/Nativ.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		000EAB97CDF74A172ED79748 /* ChatWebReadTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8158351DC9E135F30DA83A01 /* ChatWebReadTool.swift */; };
 		009747F9B06053A59F9040A7 /* FileSyntaxValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846F6324EA769406B747062D /* FileSyntaxValidator.swift */; };
 		01A65582AEB5E196FDEFDBE8 /* AudioInputDevicePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23B2DDDCBC745B54A08174D /* AudioInputDevicePreferences.swift */; };
+		02276EF90584AF165373487D /* ChatSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779B1A6490A5D640B4206C00 /* ChatSearchTests.swift */; };
 		02571B1CDC31A5D168247CCD /* RoutineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D5C36EAF284CDDE30E19CB /* RoutineStore.swift */; };
 		025B3FFF2FB85B2511BCA927 /* NativModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC852B29463217932AE0212 /* NativModel.swift */; };
 		0394DEE40DF5A06244F72794 /* MCPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F373627C4A522AF78E2A17 /* MCPClientTests.swift */; };
@@ -57,6 +58,7 @@
 		1A6F5207528E44EA9FF8F831 /* NativChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E6FD97A66F91B3B667B3FE /* NativChatClient.swift */; };
 		1A82A76742BFEEBE881659BD /* TavilyBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90AC464C5C04FB14A3C789 /* TavilyBrowsingProvider.swift */; };
 		1AF312AA0292E34A471F5D16 /* ChatToolConfirmationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8272E05C13BEB152E8C7C3D4 /* ChatToolConfirmationButton.swift */; };
+		1BC04270E5886ABB757CF78B /* ChatTextSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A912DB7266F6655AA7BB8E /* ChatTextSearchTests.swift */; };
 		1C6295D830FE941FDCE3ECCC /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
 		1CD847CE1BC2696D9306656D /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */; };
 		1DCBC70AA972310D3FBC22CC /* ChatSwitchModelTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BBBE5DAD60FA5D2450B2CD /* ChatSwitchModelTool.swift */; };
@@ -281,6 +283,7 @@
 		90EE7AA87400E84D947CBBF3 /* NativSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594711E024396C78703CE05A /* NativSettings.swift */; };
 		91D44CF9A9E6E472C7498789 /* MarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151A0F6AD81E505ADF4C8BE2 /* MarkdownTests.swift */; };
 		9381AA529980BBAF307CD0B2 /* NativWindowRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788823D67AF46B07A6D65E78 /* NativWindowRegistry.swift */; };
+		93995C5064EE1E0C38ACA008 /* ChatSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB5FE1937AB157ACAEC5354 /* ChatSearch.swift */; };
 		94504A0DB46777F5DA8CDBD6 /* Parallel.png in Resources */ = {isa = PBXBuildFile; fileRef = 530CA8743FEBF843F79321A7 /* Parallel.png */; };
 		950EBC77308DA759E4D2906C /* HuggingFaceDownloadCapacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A876C6D832E392C40F6154E /* HuggingFaceDownloadCapacity.swift */; };
 		95711758521BCF469B48481E /* PerplexityBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F316824C4C3D36A94717A62 /* PerplexityBrowsingProvider.swift */; };
@@ -391,6 +394,7 @@
 		CB0D232F71771BF7F3EE2B53 /* FirecrawlBrowsingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195075F70CCB0E7DE02934DF /* FirecrawlBrowsingProvider.swift */; };
 		CB2186CE3DF58C79C1D8ACD1 /* MarkdownFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696F983B4F1F1DEABA37ABBB /* MarkdownFixtures.swift */; };
 		CEE42CCB57866B76CE85E588 /* MCPServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7A7ACB288953FD476C47E8 /* MCPServerConfig.swift */; };
+		CFE41B9A0EF8EAA3CDA4B83F /* ChatTextSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBF7A59DCE85B6CEBFFD743 /* ChatTextSearch.swift */; };
 		D2D5168B1A4243EB55EB1D68 /* RealtimeAudioMeterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01D6D1C8C321F16B5FD31F8 /* RealtimeAudioMeterTests.swift */; };
 		D47008C83EF6C9B110342EA2 /* ChatStreamEventRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C037FCFD18E57EA3829DEEAB /* ChatStreamEventRelayTests.swift */; };
 		D4AA61C3BEF5538E3DA9A54F /* OfficeArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE82B4EBA796206F12005498 /* OfficeArchive.swift */; };
@@ -404,6 +408,7 @@
 		D849D6A8E4B6C43284891EA9 /* NativKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7F610FC8739BA80227DB26 /* NativKit.swift */; };
 		D8838254D03112C2EABE37AC /* ModelPrimaryTaskResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDBC269531FA6C6DA9F5DDC /* ModelPrimaryTaskResolverTests.swift */; };
 		D883C59602EE2B16CC7988EE /* HuggingFaceHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F7FC582B0E18D226E87A1FE /* HuggingFaceHub.swift */; };
+		D9220ACA5997C9AE8FCE2CD5 /* ChatTextSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBF7A59DCE85B6CEBFFD743 /* ChatTextSearch.swift */; };
 		D96122BA0806CCE96CC145E0 /* ChatImportAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9988535384E783847070506 /* ChatImportAlert.swift */; };
 		D963B49FA9E1E766B9081104 /* NativBulkSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7069F17AAC82BF3F1FD1C95E /* NativBulkSelection.swift */; };
 		D9CA77A603AF02C2C70BC9FF /* MCPServerCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1DC9B27547E82B74589D6B5 /* MCPServerCatalogTests.swift */; };
@@ -460,6 +465,7 @@
 		F7F573F15C7DC5CD17061EB9 /* ChatProjectStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */; };
 		F945C21FDDC8AE619860D222 /* Highlightr in Frameworks */ = {isa = PBXBuildFile; productRef = B47FB8D68E53A933ACF71A58 /* Highlightr */; };
 		F9B4AAA3C467240C00807753 /* ChatReadFileToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */; };
+		FBD608F58527BA13C4F8CC5A /* ChatSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB5FE1937AB157ACAEC5354 /* ChatSearch.swift */; };
 		FBF7379DD55C920F6D5C4197 /* ControlPanelDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90494E1AE30EF515482DDBE7 /* ControlPanelDependencies.swift */; };
 		FC65EA7675E8441D11372F9C /* ChatDocumentContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56569EDB0E77FAF6269F577 /* ChatDocumentContextBuilderTests.swift */; };
 		FD18166B4B3FAEB77E0D8C69 /* CodexCLIProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF52CED5DE873DD6BF02B /* CodexCLIProfile.swift */; };
@@ -633,6 +639,7 @@
 		46B469F1D62E2DB0DE8CFAF1 /* NativPermissionsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativPermissionsCard.swift; sourceTree = "<group>"; };
 		46BCF5F68C499E27A789A91F /* ArtifactSemanticSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactSemanticSearch.swift; sourceTree = "<group>"; };
 		49B4556627CCB5BD1D3DE5F8 /* VoiceDictationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDictationExtension.swift; sourceTree = "<group>"; };
+		4BBF7A59DCE85B6CEBFFD743 /* ChatTextSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextSearch.swift; sourceTree = "<group>"; };
 		4BEAD8583687ABA95FF4986E /* LogTextStorageMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTextStorageMutationTests.swift; sourceTree = "<group>"; };
 		4C93856381B1D89C4DE61DCC /* VoiceCaptureOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCaptureOverlay.swift; sourceTree = "<group>"; };
 		4DCD9D4118F0B3580590998F /* ScheduledTaskChatLinker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTaskChatLinker.swift; sourceTree = "<group>"; };
@@ -687,6 +694,7 @@
 		7552A0926132AC026ED6F530 /* SearXNGBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearXNGBrowsingProvider.swift; sourceTree = "<group>"; };
 		769A36AA0753AB7F4CB1E371 /* ExaBrowsingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExaBrowsingProvider.swift; sourceTree = "<group>"; };
 		76F460CC6B734041A8C60AAE /* ControlPanelSidebarModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarModels.swift; sourceTree = "<group>"; };
+		779B1A6490A5D640B4206C00 /* ChatSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSearchTests.swift; sourceTree = "<group>"; };
 		780A9582305FC184F6C68D12 /* NativKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativKitTests.swift; sourceTree = "<group>"; };
 		788823D67AF46B07A6D65E78 /* NativWindowRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWindowRegistry.swift; sourceTree = "<group>"; };
 		7A111F0BE402A5EDEAB117C7 /* ChatTranscriptScrollingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptScrollingTests.swift; sourceTree = "<group>"; };
@@ -721,6 +729,7 @@
 		87D1C65C1EB54C135A37646A /* ChatAnnotationActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAnnotationActionsTests.swift; sourceTree = "<group>"; };
 		87EF3E0B4A9EEC293EFD5F8A /* ChatImageTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatImageTool.swift; sourceTree = "<group>"; };
 		885B9207F7063BEC112E5CAB /* ControlPanelSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlPanelSidebarView.swift; sourceTree = "<group>"; };
+		88A912DB7266F6655AA7BB8E /* ChatTextSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextSearchTests.swift; sourceTree = "<group>"; };
 		895F3583A69041C321FE9195 /* NativWindowReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWindowReaderView.swift; sourceTree = "<group>"; };
 		89EF5054AA7F54AC65ED2F25 /* NativWindowRegistryReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativWindowRegistryReader.swift; sourceTree = "<group>"; };
 		8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreenCapture.swift; sourceTree = "<group>"; };
@@ -745,6 +754,7 @@
 		9B95090B83C36E4F06C7C5E3 /* RoutineRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineRunner.swift; sourceTree = "<group>"; };
 		9BB432A30E8C51EB12CE66E9 /* ChatSelectionEventRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSelectionEventRouterTests.swift; sourceTree = "<group>"; };
 		9C57E985705899CDD8DB5996 /* MCPCatalog.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MCPCatalog.json; sourceTree = "<group>"; };
+		9EB5FE1937AB157ACAEC5354 /* ChatSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSearch.swift; sourceTree = "<group>"; };
 		9F15F7E180170C5FA55BD38F /* WebReadContentSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebReadContentSelector.swift; sourceTree = "<group>"; };
 		9FB275767AC2B912FA2FEDEE /* UISFXMinimalPlay.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = UISFXMinimalPlay.mp3; sourceTree = "<group>"; };
 		9FDFD79A8E1B8AA56AB21FE3 /* NativImageClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativImageClient.swift; sourceTree = "<group>"; };
@@ -1491,8 +1501,10 @@
 				C11A25CB7C798C39A206FACC /* ChatProjectStore.swift */,
 				F3B8F25491BDEED4717A5D23 /* ChatPromptRevision.swift */,
 				8A11D3AF5467488478CAC264 /* ChatScreenCapture.swift */,
+				9EB5FE1937AB157ACAEC5354 /* ChatSearch.swift */,
 				530D284E65297E3CA8050AE1 /* ChatSessionStore.swift */,
 				6424934AA457AEE6B59C1227 /* ChatStreamEventRelay.swift */,
+				4BBF7A59DCE85B6CEBFFD743 /* ChatTextSearch.swift */,
 				8272E05C13BEB152E8C7C3D4 /* ChatToolConfirmationButton.swift */,
 				31D10F9AFCCD57FA0625CA24 /* ChatToolRegistry.swift */,
 				C0BAEA101D7ED907CE4A2FCF /* ChatTranscriptPresentation.swift */,
@@ -1532,9 +1544,11 @@
 				D56181DA223153BACC750E96 /* ChatReadFileToolTests.swift */,
 				DED337312E3F6206B56477D2 /* ChatRenderingTests.swift */,
 				2A1E6ED5DB03C63851E6AAE2 /* ChatSearchFilesToolTests.swift */,
+				779B1A6490A5D640B4206C00 /* ChatSearchTests.swift */,
 				9BB432A30E8C51EB12CE66E9 /* ChatSelectionEventRouterTests.swift */,
 				C037FCFD18E57EA3829DEEAB /* ChatStreamEventRelayTests.swift */,
 				97D987724FB28974BA95CF29 /* ChatTerminalToolTests.swift */,
+				88A912DB7266F6655AA7BB8E /* ChatTextSearchTests.swift */,
 				E9834B71F0C15C17A014C4ED /* ChatTextSelectionReaderTests.swift */,
 				C9A57792805B0438492CB6AB /* ChatToolRegistryTests.swift */,
 				257CE2FD6DEE59CA174E9E17 /* ChatTranscriptPresentationTests.swift */,
@@ -1911,6 +1925,7 @@
 				902CD676AA3002459DF7ACAE /* ChatPromptRevision.swift in Sources */,
 				B6E24E55015CB5A98973B993 /* ChatReadFileTool.swift in Sources */,
 				C904E51D66BFED1808E18FE5 /* ChatScreenCapture.swift in Sources */,
+				93995C5064EE1E0C38ACA008 /* ChatSearch.swift in Sources */,
 				35ED06368BDFA94106E39053 /* ChatSearchFilesTool.swift in Sources */,
 				96AE764D2F938395E9B76C9E /* ChatServerStatsTool.swift in Sources */,
 				D63A4CDF0E69DFAF43C5B12F /* ChatSessionStore.swift in Sources */,
@@ -1918,6 +1933,7 @@
 				1DCBC70AA972310D3FBC22CC /* ChatSwitchModelTool.swift in Sources */,
 				3D7F718E2E136C35CD3509B4 /* ChatSystemStatsTool.swift in Sources */,
 				35250151AA1AA5EF7B4257DE /* ChatTerminalTool.swift in Sources */,
+				CFE41B9A0EF8EAA3CDA4B83F /* ChatTextSearch.swift in Sources */,
 				1AF312AA0292E34A471F5D16 /* ChatToolConfirmationButton.swift in Sources */,
 				444833C6AEF5C794590B8A45 /* ChatToolRegistry.swift in Sources */,
 				9B1534713951740BC50F537D /* ChatTranscriptPresentation.swift in Sources */,
@@ -2122,8 +2138,10 @@
 				F9B4AAA3C467240C00807753 /* ChatReadFileToolTests.swift in Sources */,
 				2024C3DBE60A54C0DA7EF5A9 /* ChatRenderingTests.swift in Sources */,
 				A0D30C905A2788C3BD2149BF /* ChatScreenCapture.swift in Sources */,
+				FBD608F58527BA13C4F8CC5A /* ChatSearch.swift in Sources */,
 				70620E92994E9828794445D8 /* ChatSearchFilesTool.swift in Sources */,
 				7775550C303776DF9AE6030E /* ChatSearchFilesToolTests.swift in Sources */,
+				02276EF90584AF165373487D /* ChatSearchTests.swift in Sources */,
 				9619E33DBABD478108A4D36D /* ChatSelectionEventRouterTests.swift in Sources */,
 				32E3DD03D61C201E783539AF /* ChatServerStatsTool.swift in Sources */,
 				1CD847CE1BC2696D9306656D /* ChatSessionStore.swift in Sources */,
@@ -2133,6 +2151,8 @@
 				37733336E268AC8DFE5AEC6C /* ChatSystemStatsTool.swift in Sources */,
 				A2BAB58B6858D60E142947C6 /* ChatTerminalTool.swift in Sources */,
 				E4F038909BA9A122B26A1466 /* ChatTerminalToolTests.swift in Sources */,
+				D9220ACA5997C9AE8FCE2CD5 /* ChatTextSearch.swift in Sources */,
+				1BC04270E5886ABB757CF78B /* ChatTextSearchTests.swift in Sources */,
 				805BD3CD5DAF52052E2747C5 /* ChatTextSelectionReaderTests.swift in Sources */,
 				62CAD81D603FF4AC296279CB /* ChatToolRegistry.swift in Sources */,
 				BEA11D430947F6C01177EDE8 /* ChatToolRegistryTests.swift in Sources */,

--- a/Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
@@ -406,7 +406,6 @@ struct ChatLibrarySearchPopup: View {
                     .onKeyPress(.upArrow) { search.move(-1); return .handled }
                     .onExitCommand { search.dismiss() }
                     .accessibilityLabel("Search all chats")
-                if search.isSearching { ProgressView().controlSize(.small).frame(width: 16) }
                 Button("Close search", systemImage: "xmark") { search.dismiss() }
                     .labelStyle(.iconOnly)
                     .buttonStyle(.plain)
@@ -415,7 +414,9 @@ struct ChatLibrarySearchPopup: View {
             }
             .padding(20)
             Divider()
-            if search.results.isEmpty {
+            if search.isSearching && search.results.isEmpty {
+                ChatLibrarySearchLoadingRows()
+            } else if search.results.isEmpty {
                 VStack(spacing: 10) {
                     Image(systemName: "text.bubble").font(.largeTitle).foregroundStyle(.tertiary)
                     Text(emptyTitle).font(.headline)
@@ -451,7 +452,8 @@ struct ChatLibrarySearchPopup: View {
             }
             Divider()
             HStack {
-                Text(search.hasMore ? "Showing the first 200 matching messages" : "\(search.results.count) matching messages")
+                Text(search.isSearching ? "Searching…" : search.hasMore
+                     ? "Showing the first 200 matching messages" : "\(search.results.count) matching messages")
                 Spacer()
                 Text("↑↓ Navigate   ↵ Open   Esc Close")
             }
@@ -470,8 +472,6 @@ struct ChatLibrarySearchPopup: View {
 
     private var emptyTitle: String {
         if let error = search.error { return error }
-        if chat.isLoadingSessions { return "Loading chats…" }
-        if search.isSearching { return "Searching…" }
         return search.query.isEmpty ? "Search all chats" : "No matching messages"
     }
 
@@ -492,5 +492,54 @@ struct ChatLibrarySearchPopup: View {
     private func openSelected() {
         guard search.results.indices.contains(search.selectedIndex) else { return }
         onSelect(search.results[search.selectedIndex])
+    }
+}
+
+private struct ChatLibrarySearchLoadingRows: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        rows
+            .foregroundStyle(Color.primary.opacity(0.07))
+            .overlay {
+                if !reduceMotion {
+                    GeometryReader { geometry in
+                        LinearGradient(colors: [.clear, Color.primary.opacity(0.09), .clear],
+                                       startPoint: .leading, endPoint: .trailing)
+                            .frame(width: geometry.size.width * 0.45)
+                            .phaseAnimator([false, true]) { band, phase in
+                                band.offset(x: phase ? geometry.size.width : -geometry.size.width * 0.45)
+                            } animation: { phase in
+                                .linear(duration: phase ? 1.4 : 0)
+                            }
+                    }
+                    .mask { rows.foregroundStyle(.black) }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .clipped()
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Searching chats")
+    }
+
+    private var rows: some View {
+        VStack(spacing: 2) {
+            ForEach(0..<4) { index in
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        RoundedRectangle(cornerRadius: 4).frame(width: 16, height: 16)
+                        RoundedRectangle(cornerRadius: 4).frame(width: CGFloat(160 + index * 24), height: 12)
+                        Spacer()
+                        RoundedRectangle(cornerRadius: 4).frame(width: 56, height: 10)
+                    }
+                    RoundedRectangle(cornerRadius: 4).frame(height: 12)
+                    RoundedRectangle(cornerRadius: 4).frame(height: 12)
+                        .padding(.trailing, CGFloat(80 + index % 3 * 40))
+                    RoundedRectangle(cornerRadius: 4).frame(width: 48, height: 10)
+                }
+                .padding(12)
+            }
+        }
+        .padding(8)
     }
 }

--- a/Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Combine
 import Observation
 import SwiftUI
 
@@ -61,11 +60,19 @@ struct ChatLibrarySearchResult: Identifiable, Equatable, Sendable {
 
 @MainActor @Observable
 final class ChatSearchLibrary {
+    private enum Update {
+        case snapshot(() -> ChatLibrarySearchSession?)
+        case removal
+    }
+
     let worker: ChatLibrarySearchWorker
-    private var startup: Task<Void, Error>?
     private(set) var revision = 0
-    private(set) var resetRevision = 0
-    private(set) var sessions: [UUID: Int] = [:]
+    private(set) var error: String?
+    @ObservationIgnored private var startup: Task<Void, Error>?
+    @ObservationIgnored private var updateTask: Task<Void, Error>?
+    @ObservationIgnored private var pending: [UUID: Update] = [:]
+    @ObservationIgnored private var knownSessions: Set<UUID> = []
+    @ObservationIgnored private var sources: [UUID: () -> ChatViewModel?] = [:]
 
     init(storageURL: URL? = nil) {
         worker = ChatLibrarySearchWorker(storageURL: storageURL)
@@ -73,25 +80,90 @@ final class ChatSearchLibrary {
 
     func start(_ sessions: [ChatSession]) {
         guard startup == nil else { return }
+        knownSessions.formUnion(sessions.map(\.id))
         let worker = worker
         startup = Task(priority: .utility) { [weak self] in
-            try await worker.bootstrap(sessions)
-            self?.revision &+= 1
+            do {
+                try await worker.bootstrap(sessions)
+                self?.revision &+= 1
+            } catch {
+                self?.error = "Search is unavailable. Try again."
+                self?.revision &+= 1
+                throw error
+            }
         }
+        schedule()
     }
 
-    func ready() async throws { try await startup?.value }
-
-    func invalidate(_ sessionID: UUID?) {
-        guard let sessionID else { return }
-        revision &+= 1
-        sessions[sessionID] = revision
+    func ready() async throws {
+        try await startup?.value
+        schedule()
+        try await updateTask?.value
     }
 
-    func reset() {
-        revision &+= 1
-        resetRevision = revision
-        sessions = [:]
+    func invalidate(_ sessionID: UUID?, from chat: ChatViewModel) {
+        guard let sessionID, !chat.isLoadingSessions, acceptsUpdates(for: sessionID, from: chat) else { return }
+        sources[sessionID] = { [weak chat] in chat }
+        enqueue(sessionID) { [weak chat] in chat?.searchSnapshot(in: sessionID) }
+    }
+
+    func enqueue(_ sessionID: UUID, snapshot: @escaping () -> ChatLibrarySearchSession?) {
+        knownSessions.insert(sessionID)
+        pending[sessionID] = .snapshot(snapshot)
+        schedule()
+    }
+
+    func remove(_ sessionID: UUID) {
+        knownSessions.remove(sessionID)
+        sources[sessionID] = nil
+        pending[sessionID] = .removal
+        schedule()
+    }
+
+    func reconcile(_ sessions: [ChatSessionSummary], from chat: ChatViewModel) {
+        let ids = Set(sessions.map(\.id))
+        for id in knownSessions.subtracting(ids) where acceptsUpdates(for: id, from: chat) { remove(id) }
+        for id in ids { invalidate(id, from: chat) }
+    }
+
+    private func acceptsUpdates(for sessionID: UUID, from chat: ChatViewModel) -> Bool {
+        guard chat.canModifySession(sessionID) else { return false }
+        if let source = sources[sessionID]?(), source !== chat, source.isSessionBusy(sessionID) { return false }
+        return true
+    }
+
+    private func schedule() {
+        guard startup != nil, updateTask == nil, !pending.isEmpty else { return }
+        updateTask = Task(priority: .utility) { [weak self] in
+            try await Task.sleep(for: .milliseconds(250))
+            guard let self else { return }
+            try await self.startup?.value
+            let updates = self.pending
+            self.pending = [:]
+            var snapshots: [ChatLibrarySearchSession] = []
+            var removed: Set<UUID> = []
+            var reload: Set<UUID> = []
+            for (id, update) in updates {
+                switch update {
+                case .snapshot(let read):
+                    if let snapshot = read() { snapshots.append(snapshot) }
+                    else { reload.insert(id) }
+                case .removal: removed.insert(id)
+                }
+            }
+            do {
+                try await self.worker.update(snapshots, removed: removed, reload: reload)
+                self.error = nil
+                self.revision &+= 1
+                self.updateTask = nil
+                self.schedule()
+            } catch {
+                for (id, update) in updates where self.pending[id] == nil { self.pending[id] = update }
+                self.error = "Search is unavailable. Try again."
+                self.updateTask = nil
+                throw error
+            }
+        }
     }
 }
 
@@ -127,10 +199,25 @@ actor ChatLibrarySearchWorker {
         try synchronize(snapshots, summaries: sessions.map(\.summary))
     }
 
-    func synchronize(_ inputs: [ChatSearchInput], sessionID: UUID) throws {
+    func update(_ sessions: [ChatLibrarySearchSession], removed: Set<UUID> = [], reload: Set<UUID> = []) throws {
         try restore()
-        try index.synchronize(inputs, sessionID: sessionID)
-        try save()
+        var sessions = sessions
+        var removed = removed
+        if !reload.isEmpty {
+            let source = ChatSessionStore()
+            for id in reload {
+                if let session = source.loadSession(id: id) {
+                    sessions.append(ChatLibrarySearchSession(summary: session.summary,
+                        items: ChatTranscriptPresentation.items(from: session.messages)))
+                } else { removed.insert(id) }
+            }
+        }
+        for id in removed { index.removeSession(id) }
+        for session in sessions { try index.synchronize(session.inputs, sessionID: session.id) }
+        let changed = sessions.map { ChatSearchStore.Session($0.summary) }.filter { summaries[$0.id] != $0 }
+        try save(sessions: changed, removed: removed)
+        for id in removed { summaries[id] = nil }
+        for session in changed { summaries[session.id] = session }
     }
 
     func checkpoint() throws { try store?.checkpoint() }
@@ -140,11 +227,11 @@ actor ChatLibrarySearchWorker {
         index.didSave()
     }
 
-    func search(_ query: String, sessionID: UUID, limit: Int = 10_000) throws -> ChatSearchWorker.Result {
+    func search(_ query: String, sessionID: UUID, messageID: UUID? = nil, limit: Int = 10_000) throws -> ChatSearchWorker.Result {
         try restore()
         guard limit > 0 else { return ChatSearchWorker.Result(occurrences: [], hasMore: false) }
         let limit = min(limit, 10_000)
-        let results = try index.search(query, limit: limit + 1, sessionID: sessionID) { _, left, _, right in
+        let results = try index.search(query, limit: limit + 1, sessionID: sessionID, messageID: messageID) { _, left, _, right in
             left.position < right.position
         }
         try save()
@@ -211,9 +298,6 @@ final class ChatLibrarySearchState {
     @ObservationIgnored private var task: Task<Void, Never>?
     @ObservationIgnored private var generation = 0
     @ObservationIgnored private var revision = 0
-    @ObservationIgnored private var indexedSessions: [UUID: Int] = [:]
-    @ObservationIgnored private var indexedReset = -1
-    @ObservationIgnored private var needsSynchronization = true
 
     func present() { isPresented = true }
 
@@ -225,9 +309,6 @@ final class ChatLibrarySearchState {
         selectedIndex = 0
         hasMore = false
         error = nil
-        indexedSessions = [:]
-        indexedReset = -1
-        needsSynchronization = true
     }
 
     func move(_ offset: Int) {
@@ -248,8 +329,8 @@ final class ChatLibrarySearchState {
 
     func refresh(from chat: ChatViewModel, queryChanged: Bool = false) {
         guard isPresented else { return }
+        guard !chat.isLoadingSessions else { isSearching = true; return }
         revision &+= 1
-        if !queryChanged { needsSynchronization = true }
         if queryChanged {
             stop()
             results = []
@@ -275,21 +356,6 @@ final class ChatLibrarySearchState {
                 try await chat.searchLibrary.ready()
                 let worker = chat.searchLibrary.worker
                 let selected = self.results.indices.contains(self.selectedIndex) ? self.results[self.selectedIndex].id : nil
-                if self.needsSynchronization {
-                    let reset = chat.searchLibrary.resetRevision
-                    let versions = chat.searchLibrary.sessions
-                    let summaries = chat.sessions
-                    let changed = summaries.filter {
-                        reset != self.indexedReset || self.indexedSessions[$0.id] != (versions[$0.id] ?? 0)
-                    }.map {
-                        ChatLibrarySearchSession(summary: $0, items: chat.searchableTranscriptItems(in: $0.id))
-                    }
-                    try await worker.synchronize(changed, summaries: summaries)
-                    try Task.checkCancellation()
-                    self.indexedReset = reset
-                    self.indexedSessions = Dictionary(uniqueKeysWithValues: summaries.map { ($0.id, versions[$0.id] ?? 0) })
-                    self.needsSynchronization = self.revision != revision
-                }
                 let result = try await worker.search(self.query)
                 try Task.checkCancellation()
                 guard self.generation == generation else { return }
@@ -398,7 +464,6 @@ struct ChatLibrarySearchPopup: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .task { isFocused = true; search.refresh(from: chat) }
         .onChange(of: search.query) { _, _ in search.refresh(from: chat, queryChanged: true) }
-        .onReceive(chat.$sessions.dropFirst()) { _ in search.refresh(from: chat) }
         .onChange(of: chat.searchLibrary.revision) { _, _ in search.refresh(from: chat) }
         .onDisappear { search.dismiss() }
     }

--- a/Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
@@ -4,16 +4,13 @@ import Observation
 import SwiftUI
 
 struct ChatLibrarySearchSession: Sendable {
-    let id: UUID
-    let title: String
-    let updatedAt: Date
+    let summary: ChatSessionSummary
+    var id: UUID { summary.id }
     let inputs: [ChatSearchInput]
 
     init(summary: ChatSessionSummary, items: [ChatTranscriptItem]) {
-        id = summary.id
-        title = summary.title
-        updatedAt = summary.updatedAt
-        inputs = Array(ChatSearchInput.snapshots(from: items).reversed())
+        self.summary = summary
+        inputs = ChatSearchInput.snapshots(from: items)
     }
 }
 
@@ -62,41 +59,136 @@ struct ChatLibrarySearchResult: Identifiable, Equatable, Sendable {
     }
 }
 
+@MainActor @Observable
+final class ChatSearchLibrary {
+    let worker: ChatLibrarySearchWorker
+    private var startup: Task<Void, Error>?
+    private(set) var revision = 0
+    private(set) var resetRevision = 0
+    private(set) var sessions: [UUID: Int] = [:]
+
+    init(storageURL: URL? = nil) {
+        worker = ChatLibrarySearchWorker(storageURL: storageURL)
+    }
+
+    func start(_ sessions: [ChatSession]) {
+        guard startup == nil else { return }
+        let worker = worker
+        startup = Task(priority: .utility) { [weak self] in
+            try await worker.bootstrap(sessions)
+            self?.revision &+= 1
+        }
+    }
+
+    func ready() async throws { try await startup?.value }
+
+    func invalidate(_ sessionID: UUID?) {
+        guard let sessionID else { return }
+        revision &+= 1
+        sessions[sessionID] = revision
+    }
+
+    func reset() {
+        revision &+= 1
+        resetRevision = revision
+        sessions = [:]
+    }
+}
+
 actor ChatLibrarySearchWorker {
     struct Result: Sendable {
         let messages: [ChatLibrarySearchResult]
         let hasMore: Bool
     }
 
-    // Forks can share message IDs. Keep their prepared text in separate namespaces.
-    private var workers: [UUID: ChatSearchWorker] = [:]
+    private var index = ChatSearchIndex()
+    private var summaries: [UUID: ChatSearchStore.Session] = [:]
+    private let storageURL: URL?
+    private var store: ChatSearchStore?
+    private var restored = false
 
-    func search(_ query: String, sessions: [ChatLibrarySearchSession], limit: Int = 200) async throws -> Result {
+    init(storageURL: URL? = nil) { self.storageURL = storageURL }
+
+    func restore() throws {
+        guard !restored else { return }
+        if let storageURL {
+            let store = try ChatSearchStore(url: storageURL)
+            summaries = try store.restore(into: &index)
+            self.store = store
+        }
+        restored = true
+    }
+
+    func bootstrap(_ sessions: [ChatSession]) throws {
+        try restore()
+        let snapshots = sessions.map {
+            ChatLibrarySearchSession(summary: $0.summary, items: ChatTranscriptPresentation.items(from: $0.messages))
+        }
+        try synchronize(snapshots, summaries: sessions.map(\.summary))
+    }
+
+    func synchronize(_ inputs: [ChatSearchInput], sessionID: UUID) throws {
+        try restore()
+        try index.synchronize(inputs, sessionID: sessionID)
+        try save()
+    }
+
+    func checkpoint() throws { try store?.checkpoint() }
+
+    private func save(sessions: [ChatSearchStore.Session] = [], removed: Set<UUID> = []) throws {
+        try store?.save(index, sessions: sessions, removedSessions: removed)
+        index.didSave()
+    }
+
+    func search(_ query: String, sessionID: UUID, limit: Int = 10_000) throws -> ChatSearchWorker.Result {
+        try restore()
+        guard limit > 0 else { return ChatSearchWorker.Result(occurrences: [], hasMore: false) }
+        let limit = min(limit, 10_000)
+        let results = try index.search(query, limit: limit + 1, sessionID: sessionID) { _, left, _, right in
+            left.position < right.position
+        }
+        try save()
+        return ChatSearchWorker.Result(occurrences: results.prefix(limit).map { $0.1 }, hasMore: results.count > limit)
+    }
+
+    func synchronize(_ sessions: [ChatLibrarySearchSession], summaries: [ChatSessionSummary]) throws {
         try Task.checkCancellation()
+        try restore()
+        let updated = Dictionary(uniqueKeysWithValues: summaries.map { ($0.id, ChatSearchStore.Session($0)) })
+        let removed = Set(self.summaries.keys).subtracting(updated.keys)
+        let changed = updated.values.filter { self.summaries[$0.id] != $0 }
+        for id in removed { index.removeSession(id) }
+        for session in sessions { try index.synchronize(session.inputs, sessionID: session.id) }
+        try save(sessions: changed, removed: removed)
+        self.summaries = updated
+    }
+
+    func search(_ query: String, limit: Int = 200) throws -> Result {
+        try restore()
         guard limit > 0 else { return Result(messages: [], hasMore: false) }
         let limit = min(limit, 200)
-        let ids = Set(sessions.map(\.id))
-        workers = workers.filter { ids.contains($0.key) }
-        var messages: [ChatLibrarySearchResult] = []
-        let ordered = sessions.sorted {
-            $0.updatedAt == $1.updatedAt ? $0.id.uuidString < $1.id.uuidString : $0.updatedAt > $1.updatedAt
+        let summaries = summaries
+        let matches = try index.search(query, limit: limit + 1, firstMatchOnly: true) { left, lhs, right, rhs in
+            if left.sessionID == right.sessionID { return lhs.position > rhs.position }
+            let leftDate = left.sessionID.flatMap { summaries[$0]?.updatedAt } ?? .distantPast
+            let rightDate = right.sessionID.flatMap { summaries[$0]?.updatedAt } ?? .distantPast
+            return leftDate == rightDate
+                ? (left.sessionID?.uuidString ?? "") < (right.sessionID?.uuidString ?? "")
+                : leftDate > rightDate
         }
-        for session in ordered {
-            try Task.checkCancellation()
-            let worker = workers[session.id] ?? ChatSearchWorker()
-            workers[session.id] = worker
-            let result = try await worker.search(query, inputs: session.inputs, limit: limit + 1 - messages.count,
-                                                 firstMatchOnly: true)
-            guard !result.occurrences.isEmpty else { continue }
-            let inputs = Dictionary(uniqueKeysWithValues: session.inputs.map { ($0.messageID, $0) })
-            for occurrence in result.occurrences {
-                messages.append(ChatLibrarySearchResult(sessionID: session.id, title: session.title,
-                    updatedAt: session.updatedAt, isAssistant: inputs[occurrence.messageID]?.markdown == true,
-                    occurrence: occurrence))
-                if messages.count > limit { return Result(messages: Array(messages.prefix(limit)), hasMore: true) }
-            }
+        let messages = matches.prefix(limit).compactMap { key, occurrence -> ChatLibrarySearchResult? in
+            guard let id = key.sessionID, let summary = summaries[id] else { return nil }
+            return ChatLibrarySearchResult(sessionID: id, title: summary.title, updatedAt: summary.updatedAt,
+                                           isAssistant: index.entries[key]?.input.markdown == true,
+                                           occurrence: occurrence)
         }
-        return Result(messages: messages, hasMore: false)
+        try save()
+        return Result(messages: messages, hasMore: matches.count > limit)
+    }
+
+    func search(_ query: String, sessions: [ChatLibrarySearchSession], limit: Int = 200) throws -> Result {
+        try synchronize(sessions, summaries: sessions.map(\.summary))
+        return try search(query, limit: limit)
     }
 }
 
@@ -116,10 +208,12 @@ final class ChatLibrarySearchState {
     private(set) var hasMore = false
     private(set) var destination: Destination?
     var error: String?
-    @ObservationIgnored private var worker = ChatLibrarySearchWorker()
     @ObservationIgnored private var task: Task<Void, Never>?
     @ObservationIgnored private var generation = 0
     @ObservationIgnored private var revision = 0
+    @ObservationIgnored private var indexedSessions: [UUID: Int] = [:]
+    @ObservationIgnored private var indexedReset = -1
+    @ObservationIgnored private var needsSynchronization = true
 
     func present() { isPresented = true }
 
@@ -131,7 +225,9 @@ final class ChatLibrarySearchState {
         selectedIndex = 0
         hasMore = false
         error = nil
-        worker = ChatLibrarySearchWorker()
+        indexedSessions = [:]
+        indexedReset = -1
+        needsSynchronization = true
     }
 
     func move(_ offset: Int) {
@@ -153,6 +249,7 @@ final class ChatLibrarySearchState {
     func refresh(from chat: ChatViewModel, queryChanged: Bool = false) {
         guard isPresented else { return }
         revision &+= 1
+        if !queryChanged { needsSynchronization = true }
         if queryChanged {
             stop()
             results = []
@@ -175,11 +272,25 @@ final class ChatLibrarySearchState {
                 try await Task.sleep(for: .milliseconds(150))
                 guard let self, let chat, self.generation == generation else { return }
                 let revision = self.revision
+                try await chat.searchLibrary.ready()
+                let worker = chat.searchLibrary.worker
                 let selected = self.results.indices.contains(self.selectedIndex) ? self.results[self.selectedIndex].id : nil
-                let sessions = chat.sessions.map {
-                    ChatLibrarySearchSession(summary: $0, items: chat.searchableTranscriptItems(in: $0.id))
+                if self.needsSynchronization {
+                    let reset = chat.searchLibrary.resetRevision
+                    let versions = chat.searchLibrary.sessions
+                    let summaries = chat.sessions
+                    let changed = summaries.filter {
+                        reset != self.indexedReset || self.indexedSessions[$0.id] != (versions[$0.id] ?? 0)
+                    }.map {
+                        ChatLibrarySearchSession(summary: $0, items: chat.searchableTranscriptItems(in: $0.id))
+                    }
+                    try await worker.synchronize(changed, summaries: summaries)
+                    try Task.checkCancellation()
+                    self.indexedReset = reset
+                    self.indexedSessions = Dictionary(uniqueKeysWithValues: summaries.map { ($0.id, versions[$0.id] ?? 0) })
+                    self.needsSynchronization = self.revision != revision
                 }
-                let result = try await self.worker.search(self.query, sessions: sessions)
+                let result = try await worker.search(self.query)
                 try Task.checkCancellation()
                 guard self.generation == generation else { return }
                 self.results = result.messages
@@ -288,7 +399,7 @@ struct ChatLibrarySearchPopup: View {
         .task { isFocused = true; search.refresh(from: chat) }
         .onChange(of: search.query) { _, _ in search.refresh(from: chat, queryChanged: true) }
         .onReceive(chat.$sessions.dropFirst()) { _ in search.refresh(from: chat) }
-        .onReceive(chat.$messages.dropFirst()) { _ in search.refresh(from: chat) }
+        .onChange(of: chat.searchLibrary.revision) { _, _ in search.refresh(from: chat) }
         .onDisappear { search.dismiss() }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
@@ -1,0 +1,320 @@
+import AppKit
+import Combine
+import Observation
+import SwiftUI
+
+struct ChatLibrarySearchSession: Sendable {
+    let id: UUID
+    let title: String
+    let updatedAt: Date
+    let inputs: [ChatSearchInput]
+
+    init(summary: ChatSessionSummary, items: [ChatTranscriptItem]) {
+        id = summary.id
+        title = summary.title
+        updatedAt = summary.updatedAt
+        inputs = Array(ChatSearchInput.snapshots(from: items).reversed())
+    }
+}
+
+struct ChatLibrarySearchResult: Identifiable, Equatable, Sendable {
+    struct ID: Hashable, Sendable {
+        let sessionID: UUID
+        let messageID: UUID
+    }
+
+    let sessionID: UUID
+    let title: String
+    let updatedAt: Date
+    let isAssistant: Bool
+    let occurrence: ChatSearchOccurrence
+    var id: ID { ID(sessionID: sessionID, messageID: occurrence.messageID) }
+
+    func isCurrent(in items: [ChatTranscriptItem]) -> Bool {
+        guard let input = ChatSearchInput.snapshots(from: items).first(where: { $0.messageID == occurrence.messageID }),
+              input.rowID == occurrence.rowID else { return false }
+        let fragments = ChatSearchDocument.fragments(for: input)
+        return occurrence.fragments.allSatisfy { match in
+            fragments.contains { $0.id == match.id && $0.text == match.text }
+        }
+    }
+
+    var excerpt: AttributedString {
+        let source = occurrence.text
+        guard let match = Range(occurrence.range, in: source) else { return AttributedString(source.prefix(240)) }
+        let lower = source.index(match.lowerBound, offsetBy: -70, limitedBy: source.startIndex) ?? source.startIndex
+        let upper = source.index(lower, offsetBy: 240, limitedBy: source.endIndex) ?? source.endIndex
+        let crop = NSRange(lower..<upper, in: source)
+        let prefix = lower == source.startIndex ? "" : "…"
+        let text = prefix + String(source[lower..<upper]).replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ") + (upper == source.endIndex ? "" : "…")
+        var value = AttributedString(text)
+        let intersection = NSIntersectionRange(crop, occurrence.range)
+        let highlight = NSRange(location: intersection.location - crop.location + prefix.utf16.count,
+                                length: intersection.length)
+        if let range = Range(highlight, in: text),
+           let start = AttributedString.Index(range.lowerBound, within: value),
+           let end = AttributedString.Index(range.upperBound, within: value) {
+            value[start..<end].backgroundColor = Color.yellow.opacity(0.25)
+            value[start..<end].font = .body.bold()
+        }
+        return value
+    }
+}
+
+actor ChatLibrarySearchWorker {
+    struct Result: Sendable {
+        let messages: [ChatLibrarySearchResult]
+        let hasMore: Bool
+    }
+
+    // Forks can share message IDs. Keep their prepared text in separate namespaces.
+    private var workers: [UUID: ChatSearchWorker] = [:]
+
+    func search(_ query: String, sessions: [ChatLibrarySearchSession], limit: Int = 200) async throws -> Result {
+        try Task.checkCancellation()
+        guard limit > 0 else { return Result(messages: [], hasMore: false) }
+        let limit = min(limit, 200)
+        let ids = Set(sessions.map(\.id))
+        workers = workers.filter { ids.contains($0.key) }
+        var messages: [ChatLibrarySearchResult] = []
+        let ordered = sessions.sorted {
+            $0.updatedAt == $1.updatedAt ? $0.id.uuidString < $1.id.uuidString : $0.updatedAt > $1.updatedAt
+        }
+        for session in ordered {
+            try Task.checkCancellation()
+            let worker = workers[session.id] ?? ChatSearchWorker()
+            workers[session.id] = worker
+            let result = try await worker.search(query, inputs: session.inputs, limit: limit + 1 - messages.count,
+                                                 firstMatchOnly: true)
+            guard !result.occurrences.isEmpty else { continue }
+            let inputs = Dictionary(uniqueKeysWithValues: session.inputs.map { ($0.messageID, $0) })
+            for occurrence in result.occurrences {
+                messages.append(ChatLibrarySearchResult(sessionID: session.id, title: session.title,
+                    updatedAt: session.updatedAt, isAssistant: inputs[occurrence.messageID]?.markdown == true,
+                    occurrence: occurrence))
+                if messages.count > limit { return Result(messages: Array(messages.prefix(limit)), hasMore: true) }
+            }
+        }
+        return Result(messages: messages, hasMore: false)
+    }
+}
+
+@MainActor @Observable
+final class ChatLibrarySearchState {
+    struct Destination: Equatable {
+        let id = UUID()
+        let query: String
+        let result: ChatLibrarySearchResult
+    }
+
+    var isPresented = false
+    var query = ""
+    var selectedIndex = 0
+    private(set) var results: [ChatLibrarySearchResult] = []
+    private(set) var isSearching = false
+    private(set) var hasMore = false
+    private(set) var destination: Destination?
+    var error: String?
+    @ObservationIgnored private var worker = ChatLibrarySearchWorker()
+    @ObservationIgnored private var task: Task<Void, Never>?
+    @ObservationIgnored private var generation = 0
+    @ObservationIgnored private var revision = 0
+
+    func present() { isPresented = true }
+
+    func dismiss() {
+        stop()
+        isPresented = false
+        query = ""
+        results = []
+        selectedIndex = 0
+        hasMore = false
+        error = nil
+        worker = ChatLibrarySearchWorker()
+    }
+
+    func move(_ offset: Int) {
+        guard !results.isEmpty else { return }
+        selectedIndex = (selectedIndex + offset + results.count) % results.count
+    }
+
+    func select(_ result: ChatLibrarySearchResult) {
+        destination = Destination(query: query, result: result)
+        dismiss()
+    }
+
+    func takeDestination(for sessionID: UUID?) -> Destination? {
+        guard let destination, destination.result.sessionID == sessionID else { return nil }
+        self.destination = nil
+        return destination
+    }
+
+    func refresh(from chat: ChatViewModel, queryChanged: Bool = false) {
+        guard isPresented else { return }
+        revision &+= 1
+        if queryChanged {
+            stop()
+            results = []
+            selectedIndex = 0
+            hasMore = false
+        }
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            stop()
+            results = []
+            hasMore = false
+            error = nil
+            return
+        }
+        guard task == nil else { return }
+        isSearching = true
+        error = nil
+        let generation = generation
+        task = Task { [weak self, weak chat] in
+            do {
+                try await Task.sleep(for: .milliseconds(150))
+                guard let self, let chat, self.generation == generation else { return }
+                let revision = self.revision
+                let selected = self.results.indices.contains(self.selectedIndex) ? self.results[self.selectedIndex].id : nil
+                let sessions = chat.sessions.map {
+                    ChatLibrarySearchSession(summary: $0, items: chat.searchableTranscriptItems(in: $0.id))
+                }
+                let result = try await self.worker.search(self.query, sessions: sessions)
+                try Task.checkCancellation()
+                guard self.generation == generation else { return }
+                self.results = result.messages
+                self.hasMore = result.hasMore
+                self.selectedIndex = selected.flatMap { selected in self.results.firstIndex { $0.id == selected } } ?? 0
+                self.isSearching = false
+                self.task = nil
+                if self.revision != revision { self.refresh(from: chat) }
+            } catch is CancellationError {
+            } catch {
+                guard let self, self.generation == generation else { return }
+                self.error = "Search is unavailable. Try again."
+                self.isSearching = false
+                self.task = nil
+            }
+        }
+    }
+
+    private func stop() {
+        generation &+= 1
+        task?.cancel()
+        task = nil
+        isSearching = false
+    }
+}
+
+extension EnvironmentValues {
+    @Entry var chatLibrarySearch: ChatLibrarySearchState? = nil
+}
+
+struct ChatLibrarySearchPopup: View {
+    @Bindable var search: ChatLibrarySearchState
+    @ObservedObject var chat: ChatViewModel
+    let onSelect: (ChatLibrarySearchResult) -> Void
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                TextField("Search chats", text: $search.query)
+                    .textFieldStyle(.plain)
+                    .font(.title3)
+                    .focused($isFocused)
+                    .onSubmit(openSelected)
+                    .onKeyPress(.downArrow) { search.move(1); return .handled }
+                    .onKeyPress(.upArrow) { search.move(-1); return .handled }
+                    .onExitCommand { search.dismiss() }
+                    .accessibilityLabel("Search all chats")
+                if search.isSearching { ProgressView().controlSize(.small).frame(width: 16) }
+                Button("Close search", systemImage: "xmark") { search.dismiss() }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .help("Close search (Esc)")
+            }
+            .padding(20)
+            Divider()
+            if search.results.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: "text.bubble").font(.largeTitle).foregroundStyle(.tertiary)
+                    Text(emptyTitle).font(.headline)
+                    Text(search.query.isEmpty ? "Find messages from any conversation." : "Try another word or phrase.")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 2) {
+                            ForEach(Array(search.results.enumerated()), id: \.element.id) { index, result in
+                                Button { onSelect(result) } label: {
+                                    resultRow(result)
+                                        .padding(12)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .background(index == search.selectedIndex ? Color.primary.opacity(0.07) : .clear,
+                                                    in: .rect(cornerRadius: 8))
+                                        .contentShape(.rect)
+                                }
+                                .buttonStyle(.plain)
+                                .onHover { if $0 { search.selectedIndex = index } }
+                                .id(result.id)
+                                .accessibilityHint("Open this chat at the matching message")
+                            }
+                        }
+                        .padding(8)
+                    }
+                    .onChange(of: search.selectedIndex) { _, index in
+                        if search.results.indices.contains(index) { proxy.scrollTo(search.results[index].id) }
+                    }
+                }
+            }
+            Divider()
+            HStack {
+                Text(search.hasMore ? "Showing the first 200 matching messages" : "\(search.results.count) matching messages")
+                Spacer()
+                Text("↑↓ Navigate   ↵ Open   Esc Close")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 640, height: 480)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .task { isFocused = true; search.refresh(from: chat) }
+        .onChange(of: search.query) { _, _ in search.refresh(from: chat, queryChanged: true) }
+        .onReceive(chat.$sessions.dropFirst()) { _ in search.refresh(from: chat) }
+        .onReceive(chat.$messages.dropFirst()) { _ in search.refresh(from: chat) }
+        .onDisappear { search.dismiss() }
+    }
+
+    private var emptyTitle: String {
+        if let error = search.error { return error }
+        if chat.isLoadingSessions { return "Loading chats…" }
+        if search.isSearching { return "Searching…" }
+        return search.query.isEmpty ? "Search all chats" : "No matching messages"
+    }
+
+    private func resultRow(_ result: ChatLibrarySearchResult) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "bubble.left").foregroundStyle(.secondary)
+                Text(result.title).fontWeight(.medium).lineLimit(1)
+                Spacer(minLength: 8)
+                Text(result.updatedAt, style: .date).font(.caption).foregroundStyle(.secondary)
+            }
+            Text(result.excerpt).lineLimit(2).multilineTextAlignment(.leading)
+            Text(result.isAssistant ? "Assistant" : "You").font(.caption).foregroundStyle(.secondary)
+        }
+        .font(.body)
+    }
+
+    private func openSelected() {
+        guard search.results.indices.contains(search.selectedIndex) else { return }
+        onSelect(search.results[search.selectedIndex])
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatSearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatSearch.swift
@@ -124,7 +124,7 @@ actor ChatSearchWorker {
 
     private var entries: [UUID: Entry] = [:]
 
-    func search(_ query: String, inputs: [ChatSearchInput], limit: Int = 10_000) throws -> Result {
+    func search(_ query: String, inputs: [ChatSearchInput], limit: Int = 10_000, firstMatchOnly: Bool = false) throws -> Result {
         try Task.checkCancellation()
         guard limit > 0 else { return Result(occurrences: [], hasMore: false) }
         let limit = min(limit, 10_000)
@@ -160,7 +160,7 @@ actor ChatSearchWorker {
                 queries[languageKey] = preparedQuery
             }
             let matches = try ChatTextSearch.matches(in: entry.message, query: preparedQuery,
-                                                    limit: max(1, limit + 1 - results.count))
+                                                    limit: firstMatchOnly ? 1 : max(1, limit + 1 - results.count))
             var firstFragment = 0
             for match in matches {
                 while firstFragment < entry.fragments.count,
@@ -211,6 +211,7 @@ final class ChatSearchState {
     @ObservationIgnored private var sessionID: UUID?
     @ObservationIgnored private var generation = 0
     @ObservationIgnored private var revision = 0
+    @ObservationIgnored private var requestedMatch: (query: String, location: ChatSearchOccurrence.Location)?
 
     var selected: ChatSearchOccurrence? {
         occurrences.indices.contains(selectedIndex) ? occurrences[selectedIndex] : nil
@@ -231,6 +232,14 @@ final class ChatSearchState {
     func present() {
         isPresented = true
         focusID = UUID()
+    }
+
+    func reveal(_ occurrence: ChatSearchOccurrence, query: String, sessionID: UUID, items: [ChatTranscriptItem]) {
+        reset(sessionID: sessionID)
+        requestedMatch = (query, occurrence.location)
+        self.query = query
+        present()
+        update(items: items, queryChanged: true)
     }
 
     func dismiss() {
@@ -254,6 +263,7 @@ final class ChatSearchState {
         error = nil
         revealID = nil
         worker = ChatSearchWorker()
+        requestedMatch = nil
     }
 
     func update(items: [ChatTranscriptItem], queryChanged: Bool = false) {
@@ -309,15 +319,25 @@ final class ChatSearchState {
                 guard let self, self.generation == generation else { return }
                 let revision = self.revision
                 let previous = self.selected
-                let result = try await self.worker.search(self.query, inputs: self.inputs)
+                let requested = self.requestedMatch.flatMap { $0.query == self.query ? $0.location : nil }
+                let location = requested ?? previous?.location
+                var result = try await self.worker.search(self.query, inputs: self.inputs)
+                if result.hasMore, let location,
+                   !result.occurrences.contains(where: { $0.messageID == location.messageID }),
+                   let input = self.inputs.first(where: { $0.messageID == location.messageID }) {
+                    let focused = try await ChatSearchWorker().search(self.query, inputs: [input], limit: 1)
+                    result = ChatSearchWorker.Result(occurrences: result.occurrences + focused.occurrences, hasMore: true)
+                }
                 try Task.checkCancellation()
                 guard self.generation == generation else { return }
                 self.occurrences = result.occurrences
                 self.matchesByMessage = Dictionary(grouping: result.occurrences, by: \.messageID)
                 self.hasMore = result.hasMore
-                self.selectedIndex = previous.flatMap { previous in
-                    self.occurrences.firstIndex { $0.location == previous.location }
+                self.selectedIndex = location.flatMap { location in
+                    self.occurrences.firstIndex { $0.location == location }
+                        ?? self.occurrences.firstIndex { $0.messageID == location.messageID }
                 } ?? 0
+                self.requestedMatch = nil
                 if previous?.location != self.selected?.location {
                     self.revealID = nil
                     self.navigationID = UUID()

--- a/Sources/Nativ/Features/Chat/ChatSearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatSearch.swift
@@ -558,9 +558,13 @@ struct ChatSearchCommands: Commands {
 
     var body: some Commands {
         CommandGroup(after: .textEditing) {
-            Button("Find in Chat…") { search?.present() }
-                .keyboardShortcut("f", modifiers: .command)
-                .disabled(search == nil)
+            Button(search?.isPresented == true ? "Hide Find in Chat" : "Find in Chat…") {
+                guard let search else { return }
+                if search.isPresented { search.dismiss() }
+                else { search.present() }
+            }
+            .keyboardShortcut("f", modifiers: .command)
+            .disabled(search == nil)
         }
     }
 }

--- a/Sources/Nativ/Features/Chat/ChatSearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatSearch.swift
@@ -148,6 +148,7 @@ struct ChatSearchIndex {
     private var index = ChatTextSearch.Index<Int>()
     private var languages: [String: Int] = [:]
     private var documents: [Int: Key] = [:]
+    private var documentSessions: [UUID?: Set<Int>] = [:]
     private var nextDocumentID = 0
     private var singleWords: Set<Key> = []
     private var singleWordIndexes: [String: SingleWords] = [:]
@@ -193,6 +194,7 @@ struct ChatSearchIndex {
             return (fragment, range)
         }
         documents[documentID] = key
+        documentSessions[key.sessionID, default: []].insert(documentID)
         entries[key] = Entry(documentID: documentID, record: record, fragments: fragments, position: position)
         sessions[key.sessionID, default: []].insert(key)
         index.insert(record.message, id: documentID)
@@ -227,6 +229,7 @@ struct ChatSearchIndex {
     private mutating func remove(_ key: Key) {
         guard let entry = entries.removeValue(forKey: key) else { return }
         documents[entry.documentID] = nil
+        documentSessions[key.sessionID]?.remove(entry.documentID)
         index.remove(entry.message, id: entry.documentID)
         let language = entry.message.language?.rawValue ?? ""
         languages[language, default: 0] -= 1
@@ -241,23 +244,28 @@ struct ChatSearchIndex {
     }
 
     mutating func search(_ text: String, limit: Int, firstMatchOnly: Bool = false,
-                         sessionID: UUID? = nil,
+                         sessionID: UUID? = nil, messageID: UUID? = nil,
                          orderedBy: (Key, Entry, Key, Entry) -> Bool) throws -> [(Key, ChatSearchOccurrence)] {
         try Task.checkCancellation()
         guard limit > 0, !entries.isEmpty else { return [] }
         let automatic = try ChatTextSearch.Query(text)
         guard !automatic.text.isEmpty else { return [] }
+        let scope: Set<Int>?
+        if let sessionID, let messageID {
+            scope = entries[Key(sessionID: sessionID, messageID: messageID)].map { [$0.documentID] } ?? []
+        } else if let sessionID { scope = documentSessions[sessionID] ?? [] }
+        else { scope = nil }
         var queries: [String: ChatTextSearch.Query] = [:]
         var candidates: Set<Int> = []
         for language in languages.keys {
             let query = try ChatTextSearch.Query(text, languageCode: language)
             queries[language] = query
-            candidates.formUnion(try index.candidates(for: query))
+            candidates.formUnion(try index.candidates(for: query, within: scope))
         }
         if let language = automatic.language, !singleWords.isEmpty {
             let code = language.rawValue
             if singleWordIndexes[code] == nil { singleWordIndexes[code] = SingleWords(pending: singleWords) }
-            for key in singleWordIndexes[code]?.pending ?? [] {
+            for key in singleWordIndexes[code]?.pending ?? [] where sessionID == nil || key.sessionID == sessionID {
                 try Task.checkCancellation()
                 guard let entry = entries[key] else { continue }
                 if entry.message.language == language {
@@ -271,7 +279,7 @@ struct ChatSearchIndex {
                 singleWordIndexes[code]?.pending.remove(key)
                 changes.updated.insert(key)
             }
-            if let additional = try singleWordIndexes[code]?.index.candidates(for: automatic) {
+            if let additional = try singleWordIndexes[code]?.index.candidates(for: automatic, within: scope) {
                 candidates.formUnion(additional)
             }
         }
@@ -433,11 +441,12 @@ final class ChatSearchState {
             clear()
             return
         }
-        if contentRevision == nil || snapshotRevision != contentRevision {
+        if library == nil, contentRevision == nil || snapshotRevision != contentRevision {
             inputs = ChatSearchInput.snapshots(from: items())
             snapshotRevision = contentRevision
             revision &+= 1
         }
+        if library != nil { revision &+= 1 }
         if queryChanged {
             stop()
             occurrences = []
@@ -488,12 +497,8 @@ final class ChatSearchState {
                 let location = requested ?? previous?.location
                 let resultWorker = self.library?.worker
                 try await self.library?.ready()
-                if self.indexedRevision != revision {
-                    if let resultWorker, let sessionID = self.sessionID {
-                        try await resultWorker.synchronize(self.inputs, sessionID: sessionID)
-                    } else {
-                        try await self.worker.synchronize(self.inputs)
-                    }
+                if resultWorker == nil, self.indexedRevision != revision {
+                    try await self.worker.synchronize(self.inputs)
                     try Task.checkCancellation()
                     self.indexedRevision = revision
                 }
@@ -504,10 +509,17 @@ final class ChatSearchState {
                     result = try await self.worker.search(self.query)
                 }
                 if result.hasMore, let location,
-                   !result.occurrences.contains(where: { $0.messageID == location.messageID }),
-                   let input = self.inputs.first(where: { $0.messageID == location.messageID }) {
-                    let focused = try await ChatSearchWorker().search(self.query, inputs: [input], limit: 1)
-                    result = ChatSearchWorker.Result(occurrences: result.occurrences + focused.occurrences, hasMore: true)
+                   !result.occurrences.contains(where: { $0.messageID == location.messageID }) {
+                    let focused: ChatSearchWorker.Result?
+                    if let resultWorker, let sessionID = self.sessionID {
+                        focused = try await resultWorker.search(self.query, sessionID: sessionID,
+                                                                 messageID: location.messageID, limit: 1)
+                    } else if let input = self.inputs.first(where: { $0.messageID == location.messageID }) {
+                        focused = try await ChatSearchWorker().search(self.query, inputs: [input], limit: 1)
+                    } else { focused = nil }
+                    if let focused {
+                        result = ChatSearchWorker.Result(occurrences: result.occurrences + focused.occurrences, hasMore: true)
+                    }
                 }
                 try Task.checkCancellation()
                 guard self.generation == generation else { return }

--- a/Sources/Nativ/Features/Chat/ChatSearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatSearch.swift
@@ -1,0 +1,583 @@
+import AppKit
+import NaturalLanguage
+import Observation
+import QuartzCore
+import SwiftUI
+
+struct ChatSearchInput: Equatable, Sendable {
+    let messageID: UUID
+    let rowID: UUID
+    let text: String
+    let markdown: Bool
+
+    static func snapshots(from items: [ChatTranscriptItem]) -> [Self] {
+        items.compactMap { item in
+            let message: ChatTranscriptMessage
+            switch item {
+            case .message(let value): message = value
+            case .agentTurn(let turn):
+                guard let value = turn.finalAssistantMessage else { return nil }
+                message = value
+            }
+            guard message.role == .user || message.role == .assistant,
+                  !message.content.isEmpty else { return nil }
+            return Self(messageID: message.id, rowID: item.id, text: message.content,
+                        markdown: message.role == .assistant)
+        }
+    }
+}
+
+struct ChatSearchOccurrence: Equatable, Sendable {
+    struct Fragment: Equatable, Sendable {
+        let id: String
+        let text: String
+        let range: NSRange
+    }
+
+    struct Location: Equatable {
+        let messageID: UUID
+        let fragmentID: String
+        let range: NSRange
+    }
+
+    let messageID: UUID
+    let rowID: UUID
+    let fragment: Fragment
+    let continuations: [Fragment]
+    var fragmentID: String { fragment.id }
+    var text: String { fragment.text }
+    var range: NSRange { fragment.range }
+    var fragments: [Fragment] { [fragment] + continuations }
+    var location: Location { Location(messageID: messageID, fragmentID: fragmentID, range: range) }
+}
+
+enum ChatSearchDocument {
+    struct Fragment: Equatable, Sendable {
+        let id: String
+        let text: String
+    }
+
+    static func fragments(for input: ChatSearchInput) -> [Fragment] {
+        guard input.markdown else { return [Fragment(id: "plain/text", text: input.text)] }
+        return blocks(MarkdownParser.parse(MathPreprocessor.preprocess(input.text)), path: "root")
+    }
+
+    private static func blocks(_ nodes: [MarkdownNode], path: String) -> [Fragment] {
+        nodes.enumerated().flatMap { index, node -> [Fragment] in
+            let id = "\(path).\(index)"
+            switch node.kind {
+            case "list":
+                return node.children.enumerated().flatMap { offset, item in
+                    blocks(item.children, path: "\(id).\(offset)")
+                }
+            case "block_quote": return blocks(node.children, path: id)
+            case "table":
+                return node.children.enumerated().flatMap { row, value in
+                    value.children.enumerated().map { column, cell in
+                        Fragment(id: "\(id)/\(row).\(column)", text: inline(cell.children))
+                    }
+                }
+            case "thematic_break": return []
+            case "code_block":
+                let text = node.literal.hasSuffix("\n") ? String(node.literal.dropLast()) : node.literal
+                return [Fragment(id: id + "/text", text: text)]
+            case "paragraph", "heading", "html_block":
+                return [Fragment(id: id + "/text", text: node.children.isEmpty ? node.literal : inline(node.children))]
+            default:
+                return node.children.isEmpty
+                    ? [Fragment(id: id + "/text", text: node.literal)]
+                    : blocks(node.children, path: id)
+            }
+        }
+    }
+
+    private static func inline(_ nodes: [MarkdownNode]) -> String {
+        nodes.map { node in
+            switch node.kind {
+            case "softbreak": return " "
+            case "linebreak": return "\n"
+            case "image":
+                if URL(string: node.destination)?.scheme == "swiftmath" { return "\u{FFFC}" }
+                let label = inline(node.children)
+                return label.isEmpty ? node.destination : label
+            case "html_inline":
+                return node.literal.range(of: #"^<br\s*/?>$"#, options: [.regularExpression, .caseInsensitive]) != nil
+                    ? "\n" : node.literal
+            default: return node.children.isEmpty ? node.literal : inline(node.children)
+            }
+        }.joined()
+    }
+}
+
+actor ChatSearchWorker {
+    struct Result: Sendable {
+        let occurrences: [ChatSearchOccurrence]
+        let hasMore: Bool
+    }
+
+    private struct Entry {
+        let input: ChatSearchInput
+        let fragments: [(ChatSearchDocument.Fragment, NSRange)]
+        let message: ChatTextSearch.Message
+        let language: NLLanguage?
+    }
+
+    private var entries: [UUID: Entry] = [:]
+
+    func search(_ query: String, inputs: [ChatSearchInput], limit: Int = 10_000) throws -> Result {
+        try Task.checkCancellation()
+        guard limit > 0 else { return Result(occurrences: [], hasMore: false) }
+        let limit = min(limit, 10_000)
+        let ids = Set(inputs.map(\.messageID))
+        entries = entries.filter { ids.contains($0.key) }
+        var queries: [String: ChatTextSearch.Query] = [:]
+        var results: [ChatSearchOccurrence] = []
+        for input in inputs {
+            try Task.checkCancellation()
+            let entry: Entry
+            if let cached = entries[input.messageID], cached.input == input {
+                entry = cached
+            } else {
+                let fragments = ChatSearchDocument.fragments(for: input)
+                let text = fragments.map(\.text).joined(separator: "\n\n")
+                let language = NLLanguageRecognizer.dominantLanguage(for: text)
+                var offset = 0
+                let positioned = fragments.map { fragment in
+                    let range = NSRange(location: offset, length: fragment.text.utf16.count)
+                    offset = NSMaxRange(range) + 2
+                    return (fragment, range)
+                }
+                entry = Entry(input: input, fragments: positioned,
+                              message: try ChatTextSearch.Message(id: input.messageID, text: text, language: language),
+                              language: language)
+                entries[input.messageID] = entry
+            }
+            let languageKey = entry.language?.rawValue ?? ""
+            let preparedQuery: ChatTextSearch.Query
+            if let cached = queries[languageKey] { preparedQuery = cached }
+            else {
+                preparedQuery = try ChatTextSearch.Query(query, language: entry.language)
+                queries[languageKey] = preparedQuery
+            }
+            let matches = try ChatTextSearch.matches(in: entry.message, query: preparedQuery,
+                                                    limit: max(1, limit + 1 - results.count))
+            var firstFragment = 0
+            for match in matches {
+                while firstFragment < entry.fragments.count,
+                      NSMaxRange(entry.fragments[firstFragment].1) <= match.range.location { firstFragment += 1 }
+                var parts: [ChatSearchOccurrence.Fragment] = []
+                for (fragment, range) in entry.fragments.dropFirst(firstFragment) {
+                    if range.location >= NSMaxRange(match.range) { break }
+                    let intersection = NSIntersectionRange(range, match.range)
+                    if intersection.length > 0 {
+                        parts.append(.init(id: fragment.id, text: fragment.text,
+                                           range: NSRange(location: intersection.location - range.location,
+                                                          length: intersection.length)))
+                    }
+                }
+                guard let first = parts.first else { continue }
+                results.append(ChatSearchOccurrence(messageID: input.messageID, rowID: input.rowID,
+                                                    fragment: first, continuations: Array(parts.dropFirst())))
+                if results.count > limit {
+                    return Result(occurrences: Array(results.prefix(limit)), hasMore: true)
+                }
+            }
+        }
+        return Result(occurrences: results, hasMore: false)
+    }
+}
+
+struct ChatSearchNavigationRequest: Equatable {
+    let id: UUID
+    let rowID: UUID
+}
+
+@MainActor @Observable
+final class ChatSearchState {
+    var query = ""
+    private(set) var isPresented = false
+    private(set) var focusID = UUID()
+    private(set) var occurrences: [ChatSearchOccurrence] = []
+    private(set) var selectedIndex = 0
+    private(set) var isSearching = false
+    private(set) var hasMore = false
+    private(set) var error: String?
+    private(set) var navigationID = UUID()
+    private(set) var revealID: UUID?
+    private var matchesByMessage: [UUID: [ChatSearchOccurrence]] = [:]
+    @ObservationIgnored private var worker = ChatSearchWorker()
+    @ObservationIgnored private var task: Task<Void, Never>?
+    @ObservationIgnored private var inputs: [ChatSearchInput] = []
+    @ObservationIgnored private var sessionID: UUID?
+    @ObservationIgnored private var generation = 0
+    @ObservationIgnored private var revision = 0
+
+    var selected: ChatSearchOccurrence? {
+        occurrences.indices.contains(selectedIndex) ? occurrences[selectedIndex] : nil
+    }
+
+    var navigationRequest: ChatSearchNavigationRequest? {
+        guard let selected else { return nil }
+        return ChatSearchNavigationRequest(id: navigationID, rowID: selected.rowID)
+    }
+
+    var countLabel: String {
+        if error != nil { return "Unavailable" }
+        if isSearching && occurrences.isEmpty { return "Searching…" }
+        guard !occurrences.isEmpty else { return "No matches" }
+        return "\(selectedIndex + 1)/\(occurrences.count)\(hasMore ? "+" : "")"
+    }
+
+    func present() {
+        isPresented = true
+        focusID = UUID()
+    }
+
+    func dismiss() {
+        reset(sessionID: sessionID)
+    }
+
+    func reset(sessionID: UUID?) {
+        self.sessionID = sessionID
+        isPresented = false
+        clear()
+    }
+
+    private func clear() {
+        stop()
+        query = ""
+        inputs = []
+        occurrences = []
+        matchesByMessage = [:]
+        selectedIndex = 0
+        hasMore = false
+        error = nil
+        revealID = nil
+        worker = ChatSearchWorker()
+    }
+
+    func update(items: [ChatTranscriptItem], queryChanged: Bool = false) {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            clear()
+            return
+        }
+        inputs = ChatSearchInput.snapshots(from: items)
+        revision &+= 1
+        if queryChanged {
+            stop()
+            occurrences = []
+            matchesByMessage = [:]
+            selectedIndex = 0
+            revealID = nil
+        }
+        schedule()
+    }
+
+    func move(_ offset: Int) {
+        guard !occurrences.isEmpty else { return }
+        selectedIndex = (selectedIndex + offset + occurrences.count) % occurrences.count
+        revealID = nil
+        navigationID = UUID()
+    }
+
+    func finishNavigation(_ id: UUID) {
+        guard id == navigationID, selected != nil, revealID == nil else { return }
+        revealID = id
+    }
+
+    func highlight(for messageID: UUID) -> ChatSearchHighlight? {
+        guard let matches = matchesByMessage[messageID] else { return nil }
+        return ChatSearchHighlight(matches: matches, selected: selected?.messageID == messageID ? selected : nil,
+                                   revealID: revealID)
+    }
+
+    func stop() {
+        generation &+= 1
+        task?.cancel()
+        task = nil
+        isSearching = false
+    }
+
+    private func schedule() {
+        guard task == nil else { return }
+        isSearching = true
+        error = nil
+        let generation = generation
+        task = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(150))
+                guard let self, self.generation == generation else { return }
+                let revision = self.revision
+                let previous = self.selected
+                let result = try await self.worker.search(self.query, inputs: self.inputs)
+                try Task.checkCancellation()
+                guard self.generation == generation else { return }
+                self.occurrences = result.occurrences
+                self.matchesByMessage = Dictionary(grouping: result.occurrences, by: \.messageID)
+                self.hasMore = result.hasMore
+                self.selectedIndex = previous.flatMap { previous in
+                    self.occurrences.firstIndex { $0.location == previous.location }
+                } ?? 0
+                if previous?.location != self.selected?.location {
+                    self.revealID = nil
+                    self.navigationID = UUID()
+                }
+                self.task = nil
+                self.isSearching = false
+                // Streaming updates are throttled, not endlessly postponed by a trailing debounce.
+                if self.revision != revision { self.schedule() }
+            } catch is CancellationError {
+            } catch {
+                guard let self, self.generation == generation else { return }
+                self.error = "Search is unavailable. Try again."
+                self.task = nil
+                self.isSearching = false
+            }
+        }
+    }
+}
+
+extension FocusedValues {
+    @Entry var chatSearch: ChatSearchState?
+}
+
+struct ChatSearchCommands: Commands {
+    @FocusedValue(\.chatSearch) private var search
+
+    var body: some Commands {
+        CommandGroup(after: .textEditing) {
+            Button("Find in Chat…") { search?.present() }
+                .keyboardShortcut("f", modifiers: .command)
+                .disabled(search == nil)
+        }
+    }
+}
+
+struct ChatSearchBar: View {
+    @Bindable var search: ChatSearchState
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button("Find in chat", systemImage: "magnifyingglass") { search.present() }
+                .help("Find in chat (⌘F)")
+            TextField("Find in chat", text: $search.query)
+                .textFieldStyle(.plain)
+                .focused($isFocused)
+                .onSubmit { search.move(1) }
+                .onExitCommand { search.dismiss() }
+                .accessibilityLabel("Find in this chat")
+                .frame(minWidth: 100, idealWidth: 220)
+            if !search.query.isEmpty {
+                Text(search.countLabel)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Search results: \(search.countLabel)")
+                Button("Previous match", systemImage: "chevron.up") { search.move(-1) }
+                    .keyboardShortcut("g", modifiers: [.command, .shift])
+                    .disabled(search.occurrences.isEmpty)
+                    .help("Previous match (⇧⌘G)")
+                Button("Next match", systemImage: "chevron.down") { search.move(1) }
+                    .keyboardShortcut("g", modifiers: .command)
+                    .disabled(search.occurrences.isEmpty)
+                    .help("Next match (⌘G)")
+            }
+            Button("Close search", systemImage: "xmark.circle.fill") { search.dismiss() }
+                .help("Close search (Esc)")
+        }
+        .task(id: search.focusID) { isFocused = true }
+        .font(.body)
+        .buttonStyle(.plain)
+        .labelStyle(.iconOnly)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(minHeight: 38)
+        .frame(maxWidth: search.query.isEmpty ? 340 : 420)
+        .background(Color(nsColor: .controlBackgroundColor), in: .rect(cornerRadius: 8))
+        .overlay { RoundedRectangle(cornerRadius: 8).stroke(.secondary.opacity(0.35), lineWidth: 1) }
+        .help(search.error ?? "Search this conversation by words or phrases")
+    }
+}
+
+struct ChatSearchHighlight: Equatable {
+    let matches: [ChatSearchOccurrence]
+    let selected: ChatSearchOccurrence?
+    let revealID: UUID?
+
+}
+
+extension EnvironmentValues {
+    @Entry var chatSearchState: ChatSearchState? = nil
+    @Entry var chatSearchHighlight: ChatSearchHighlight? = nil
+}
+
+@MainActor
+extension MarkdownSurface {
+    func setSearchHighlight(_ value: ChatSearchHighlight?) {
+        guard searchHighlight != value else { return }
+        if value?.revealID != nil, value?.revealID != searchHighlight?.revealID, value?.selected != nil {
+            pendingSearchReveal = true
+        }
+        searchHighlight = value
+        if value?.selected == nil || value?.revealID == nil { pendingSearchReveal = false }
+        if value == nil {
+            for view in visibleTextViews { view.searchRanges = []; view.activeSearchRange = nil }
+        }
+        applySearchHighlights()
+        needsLayout = true
+    }
+
+    func applySearchHighlights() {
+        guard let searchHighlight else { return }
+        let fragments = Dictionary(grouping: searchHighlight.matches.flatMap(\.fragments), by: \.id)
+        for view in visibleTextViews {
+            let matches = fragments[view.fragmentID]?.filter { $0.text == view.string } ?? []
+            view.searchRanges = matches.map(\.range)
+            view.activeSearchRange = searchHighlight.selected?.fragments.first {
+                $0.id == view.fragmentID && $0.text == view.string
+            }?.range
+        }
+    }
+
+    func revealSearchMatchIfNeeded() {
+        guard pendingSearchReveal, window != nil, let selected = searchHighlight?.selected,
+              let snapshot, let scroll = enclosingScrollView else { return }
+        var target: CGRect?
+        var fragmentTargets: [(id: String, rect: CGRect)] = []
+        for block in snapshot.blocks {
+            for fragment in block.text {
+                let id = block.id + "/" + fragment.id
+                guard let match = selected.fragments.first(where: { $0.id == id && $0.text == fragment.text.string }) else { continue }
+                let system = visibleTextViews.first { $0.fragmentID == id }?.system
+                    ?? MarkdownTextSystem(fragment.text, width: fragment.frame.width)
+                guard let start = system.storage.location(system.storage.documentRange.location, offsetBy: match.range.location),
+                      let end = system.storage.location(start, offsetBy: match.range.length),
+                      let range = NSTextRange(location: start, end: end) else { return }
+                system.manager.ensureLayout(for: system.storage.documentRange)
+                var local: CGRect?
+                system.manager.enumerateTextSegments(in: range, type: .selection, options: []) { _, rect, _, _ in
+                    local = local.map { $0.union(rect) } ?? rect
+                    return true
+                }
+                guard let local else { return }
+                fragmentTargets.append((id, local))
+                let rect = local.offsetBy(dx: block.frame.minX + fragment.frame.minX,
+                                          dy: block.frame.minY + fragment.frame.minY)
+                target = target.map { $0.union(rect) } ?? rect
+            }
+        }
+        guard let target else { return }
+        pendingSearchReveal = false
+        scrollToVisible(target)
+        refreshVisibleBlocks()
+        for fragment in fragmentTargets {
+            visibleTextViews.first { $0.fragmentID == fragment.id }?.scrollToVisible(fragment.rect)
+        }
+        // Finish with the outer transcript's position, including when a code block
+        // has its own horizontal scroller or the finding was already visible.
+        let clip = scroll.contentView
+        var bounds = clip.bounds
+        bounds.origin.y = convert(target, to: clip).midY - bounds.height / 2
+        clip.scroll(to: clip.constrainBoundsRect(bounds).origin)
+        scroll.reflectScrolledClipView(clip)
+        refreshVisibleBlocks()
+        for view in visibleTextViews where view.activeSearchRange != nil {
+            if !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion { view.wantsLayer = true }
+            view.pendingSearchPulse = true
+            view.needsDisplay = true
+        }
+    }
+
+    static func searchPlainTextLayout(_ text: String, width: CGFloat, style: MarkdownStyle) -> MarkdownLayout {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = 2
+        let attributed = NSAttributedString(string: text, attributes: [
+            .font: NSFont.systemFont(ofSize: style.fontSize), .foregroundColor: style.foreground,
+            .paragraphStyle: paragraph,
+        ])
+        let compact = text.count <= 72 && !text.contains(where: \.isNewline)
+        let width = compact ? min(width, MarkdownTextSystem(attributed, width: .greatestFiniteMagnitude).measure().width) : width
+        let size = MarkdownTextSystem(attributed, width: width).measure()
+        let frame = CGRect(x: 0, y: 0, width: width, height: size.height)
+        return MarkdownLayout(blocks: [MarkdownBlock(id: "plain", frame: frame, contentSize: frame.size,
+            text: [MarkdownTextFragment(id: "text", text: attributed, frame: frame)])],
+            decorations: [], size: frame.size)
+    }
+}
+
+@MainActor
+extension MarkdownSelectableTextView {
+    func updateSearchFocus(previous: NSRange?) {
+        for (range, color) in [(previous, nil), (activeSearchRange, NSColor(calibratedWhite: 0.12, alpha: 1))] {
+            guard let range,
+                  let start = system.storage.location(system.storage.documentRange.location, offsetBy: range.location),
+                  let end = system.storage.location(start, offsetBy: range.length),
+                  let textRange = NSTextRange(location: start, end: end) else { continue }
+            if let color {
+                system.manager.addRenderingAttribute(.foregroundColor, value: color, for: textRange)
+            } else {
+                system.manager.removeRenderingAttribute(.foregroundColor, for: textRange)
+            }
+        }
+        searchPulseLayer?.removeFromSuperlayer()
+        searchPulseLayer = nil
+        pendingSearchPulse = false
+        needsDisplay = true
+    }
+
+    func drawSearchHighlights(in dirtyRect: CGRect) {
+        guard !searchRanges.isEmpty else { return }
+        let clip = dirtyRect.intersection(visibleRect)
+        guard !clip.isEmpty, !clip.isNull else { return }
+        system.manager.ensureLayout(for: clip)
+        guard let lower = lineBoundary(at: clip.minY, upper: false),
+              let upper = lineBoundary(at: clip.maxY.nextDown, upper: true) else { return }
+        let pulsePath = CGMutablePath()
+        for range in searchRanges {
+            if NSMaxRange(range) <= lower { continue }
+            if range.location >= upper { break }
+            let active = range == activeSearchRange
+            let fill = active ? NSColor(calibratedRed: 1, green: 0.74, blue: 0.18, alpha: 1)
+                : NSColor.systemYellow.withAlphaComponent(0.25)
+            fill.setFill()
+            for rect in selectionRects(for: range, clippedTo: clip) {
+                let padded = active ? rect.insetBy(dx: -3, dy: -1).intersection(bounds.insetBy(dx: 1, dy: 1)) : rect
+                let path = NSBezierPath(roundedRect: padded, xRadius: 3, yRadius: 3)
+                path.fill()
+                if active {
+                    NSColor(calibratedRed: 0.9, green: 0.36, blue: 0.02, alpha: 1).setStroke()
+                    path.lineWidth = 2
+                    path.stroke()
+                    pulsePath.addRoundedRect(in: padded, cornerWidth: 3, cornerHeight: 3)
+                }
+            }
+        }
+        if pendingSearchPulse, !pulsePath.isEmpty { pulseSearchFocus(path: pulsePath) }
+    }
+
+    private func pulseSearchFocus(path: CGPath) {
+        pendingSearchPulse = false
+        searchPulseLayer?.removeFromSuperlayer()
+        searchPulseLayer = nil
+        guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else { return }
+        let halo = CAShapeLayer()
+        halo.frame = bounds
+        halo.path = path
+        halo.fillColor = nil
+        halo.strokeColor = NSColor.systemOrange.cgColor
+        halo.lineWidth = 5
+        halo.shadowColor = NSColor.systemOrange.cgColor
+        halo.shadowPath = path
+        halo.shadowOpacity = 0.8
+        halo.shadowRadius = 6
+        halo.shadowOffset = .zero
+        halo.opacity = 0
+        layer?.addSublayer(halo)
+        searchPulseLayer = halo
+        let pulse = CAKeyframeAnimation(keyPath: "opacity")
+        pulse.values = [0, 0.85, 0]
+        pulse.keyTimes = [0, 0.18, 1]
+        pulse.duration = 0.55
+        halo.add(pulse, forKey: "searchFocus")
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatSearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatSearch.swift
@@ -1,10 +1,9 @@
 import AppKit
-import NaturalLanguage
 import Observation
 import QuartzCore
 import SwiftUI
 
-struct ChatSearchInput: Equatable, Sendable {
+struct ChatSearchInput: Codable, Equatable, Sendable {
     let messageID: UUID
     let rowID: UUID
     let text: String
@@ -52,7 +51,7 @@ struct ChatSearchOccurrence: Equatable, Sendable {
 }
 
 enum ChatSearchDocument {
-    struct Fragment: Equatable, Sendable {
+    struct Fragment: Codable, Equatable, Sendable {
         let id: String
         let text: String
     }
@@ -109,58 +108,187 @@ enum ChatSearchDocument {
     }
 }
 
-actor ChatSearchWorker {
-    struct Result: Sendable {
-        let occurrences: [ChatSearchOccurrence]
-        let hasMore: Bool
+struct ChatSearchIndex {
+    struct Key: Codable, Hashable, Sendable {
+        let sessionID: UUID?
+        let messageID: UUID
     }
 
-    private struct Entry {
+    struct Record: Codable {
+        let key: Key
         let input: ChatSearchInput
-        let fragments: [(ChatSearchDocument.Fragment, NSRange)]
+        let fragments: [ChatSearchDocument.Fragment]
         let message: ChatTextSearch.Message
-        let language: NLLanguage?
+        var alternatives: [String: ChatTextSearch.Message] = [:]
     }
 
-    private var entries: [UUID: Entry] = [:]
+    struct Entry {
+        let documentID: Int
+        let record: Record
+        let fragments: [(ChatSearchDocument.Fragment, NSRange)]
+        var position: Int
+        var input: ChatSearchInput { record.input }
+        var message: ChatTextSearch.Message { record.message }
+    }
 
-    func search(_ query: String, inputs: [ChatSearchInput], limit: Int = 10_000, firstMatchOnly: Bool = false) throws -> Result {
+    struct Changes {
+        var updated: Set<Key> = []
+        var removed: Set<Key> = []
+        var moved: Set<Key> = []
+    }
+
+    private struct SingleWords {
+        var index = ChatTextSearch.Index<Int>()
+        var messages: [Key: ChatTextSearch.Message] = [:]
+        var pending: Set<Key>
+    }
+
+    private(set) var entries: [Key: Entry] = [:]
+    private var sessions: [UUID?: Set<Key>] = [:]
+    private var index = ChatTextSearch.Index<Int>()
+    private var languages: [String: Int] = [:]
+    private var documents: [Int: Key] = [:]
+    private var nextDocumentID = 0
+    private var singleWords: Set<Key> = []
+    private var singleWordIndexes: [String: SingleWords] = [:]
+
+    private(set) var changes = Changes()
+
+    mutating func synchronize(_ inputs: [ChatSearchInput], sessionID: UUID? = nil) throws {
         try Task.checkCancellation()
-        guard limit > 0 else { return Result(occurrences: [], hasMore: false) }
-        let limit = min(limit, 10_000)
-        let ids = Set(inputs.map(\.messageID))
-        entries = entries.filter { ids.contains($0.key) }
-        var queries: [String: ChatTextSearch.Query] = [:]
-        var results: [ChatSearchOccurrence] = []
-        for input in inputs {
+        let keys = Set(inputs.map { Key(sessionID: sessionID, messageID: $0.messageID) })
+        for key in (sessions[sessionID] ?? []).subtracting(keys) {
+            remove(key)
+            changes.removed.insert(key)
+        }
+        sessions[sessionID] = keys
+        for (position, input) in inputs.enumerated() {
             try Task.checkCancellation()
-            let entry: Entry
-            if let cached = entries[input.messageID], cached.input == input {
-                entry = cached
-            } else {
-                let fragments = ChatSearchDocument.fragments(for: input)
-                let text = fragments.map(\.text).joined(separator: "\n\n")
-                let language = NLLanguageRecognizer.dominantLanguage(for: text)
-                var offset = 0
-                let positioned = fragments.map { fragment in
-                    let range = NSRange(location: offset, length: fragment.text.utf16.count)
-                    offset = NSMaxRange(range) + 2
-                    return (fragment, range)
+            let key = Key(sessionID: sessionID, messageID: input.messageID)
+            if entries[key]?.input == input {
+                if entries[key]?.position != position {
+                    entries[key]?.position = position
+                    changes.moved.insert(key)
                 }
-                entry = Entry(input: input, fragments: positioned,
-                              message: try ChatTextSearch.Message(id: input.messageID, text: text, language: language),
-                              language: language)
-                entries[input.messageID] = entry
+                continue
             }
-            let languageKey = entry.language?.rawValue ?? ""
-            let preparedQuery: ChatTextSearch.Query
-            if let cached = queries[languageKey] { preparedQuery = cached }
-            else {
-                preparedQuery = try ChatTextSearch.Query(query, language: entry.language)
-                queries[languageKey] = preparedQuery
+            let fragments = ChatSearchDocument.fragments(for: input)
+            let text = fragments.map(\.text).joined(separator: "\n\n")
+            let message = try ChatTextSearch.Message(id: input.messageID, text: text)
+            insert(Record(key: key, input: input, fragments: fragments, message: message), position: position)
+            changes.updated.insert(key)
+            changes.removed.remove(key)
+        }
+    }
+
+    mutating func insert(_ record: Record, position: Int) {
+        let key = record.key
+        let documentID = entries[key]?.documentID ?? nextDocumentID
+        if entries[key] == nil { nextDocumentID += 1 }
+        remove(key)
+        var offset = 0
+        let fragments = record.fragments.map { fragment in
+            let range = NSRange(location: offset, length: fragment.text.utf16.count)
+            offset = NSMaxRange(range) + 2
+            return (fragment, range)
+        }
+        documents[documentID] = key
+        entries[key] = Entry(documentID: documentID, record: record, fragments: fragments, position: position)
+        sessions[key.sessionID, default: []].insert(key)
+        index.insert(record.message, id: documentID)
+        languages[record.message.language?.rawValue ?? "", default: 0] += 1
+        if record.message.isSingleWord {
+            singleWords.insert(key)
+            for language in singleWordIndexes.keys { singleWordIndexes[language]?.pending.insert(key) }
+            for (language, message) in record.alternatives {
+                if singleWordIndexes[language] == nil { singleWordIndexes[language] = SingleWords(pending: singleWords) }
+                singleWordIndexes[language]?.pending.remove(key)
+                singleWordIndexes[language]?.messages[key] = message
+                singleWordIndexes[language]?.index.insert(message, id: documentID)
             }
-            let matches = try ChatTextSearch.matches(in: entry.message, query: preparedQuery,
-                                                    limit: firstMatchOnly ? 1 : max(1, limit + 1 - results.count))
+        }
+    }
+
+    func record(for key: Key) -> Record? {
+        guard var record = entries[key]?.record else { return nil }
+        record.alternatives = singleWordIndexes.compactMapValues { $0.messages[key] }
+        return record
+    }
+
+    mutating func didSave() { changes = Changes() }
+
+    mutating func removeSession(_ sessionID: UUID) {
+        for key in sessions.removeValue(forKey: sessionID) ?? [] {
+            remove(key)
+            changes.removed.insert(key)
+        }
+    }
+
+    private mutating func remove(_ key: Key) {
+        guard let entry = entries.removeValue(forKey: key) else { return }
+        documents[entry.documentID] = nil
+        index.remove(entry.message, id: entry.documentID)
+        let language = entry.message.language?.rawValue ?? ""
+        languages[language, default: 0] -= 1
+        if languages[language] == 0 { languages[language] = nil }
+        singleWords.remove(key)
+        for language in singleWordIndexes.keys {
+            singleWordIndexes[language]?.pending.remove(key)
+            if let message = singleWordIndexes[language]?.messages.removeValue(forKey: key) {
+                singleWordIndexes[language]?.index.remove(message, id: entry.documentID)
+            }
+        }
+    }
+
+    mutating func search(_ text: String, limit: Int, firstMatchOnly: Bool = false,
+                         sessionID: UUID? = nil,
+                         orderedBy: (Key, Entry, Key, Entry) -> Bool) throws -> [(Key, ChatSearchOccurrence)] {
+        try Task.checkCancellation()
+        guard limit > 0, !entries.isEmpty else { return [] }
+        let automatic = try ChatTextSearch.Query(text)
+        guard !automatic.text.isEmpty else { return [] }
+        var queries: [String: ChatTextSearch.Query] = [:]
+        var candidates: Set<Int> = []
+        for language in languages.keys {
+            let query = try ChatTextSearch.Query(text, languageCode: language)
+            queries[language] = query
+            candidates.formUnion(try index.candidates(for: query))
+        }
+        if let language = automatic.language, !singleWords.isEmpty {
+            let code = language.rawValue
+            if singleWordIndexes[code] == nil { singleWordIndexes[code] = SingleWords(pending: singleWords) }
+            for key in singleWordIndexes[code]?.pending ?? [] {
+                try Task.checkCancellation()
+                guard let entry = entries[key] else { continue }
+                if entry.message.language == language {
+                    singleWordIndexes[code]?.pending.remove(key)
+                    continue
+                }
+                let message = try ChatTextSearch.Message(id: key.messageID, text: entry.message.text,
+                                                         language: language)
+                singleWordIndexes[code]?.messages[key] = message
+                singleWordIndexes[code]?.index.insert(message, id: entry.documentID)
+                singleWordIndexes[code]?.pending.remove(key)
+                changes.updated.insert(key)
+            }
+            if let additional = try singleWordIndexes[code]?.index.candidates(for: automatic) {
+                candidates.formUnion(additional)
+            }
+        }
+        let ordered = candidates.compactMap { documents[$0] }.filter { sessionID == nil || $0.sessionID == sessionID }.sorted {
+            guard let left = entries[$0], let right = entries[$1] else { return false }
+            return orderedBy($0, left, $1, right)
+        }
+        var results: [(Key, ChatSearchOccurrence)] = []
+        for key in ordered {
+            try Task.checkCancellation()
+            guard let entry = entries[key], let query = queries[entry.message.language?.rawValue ?? ""] else { continue }
+            let matchLimit = firstMatchOnly ? 1 : limit - results.count
+            var matches = try ChatTextSearch.matches(in: entry.message, query: query, limit: matchLimit)
+            if matches.isEmpty, let code = automatic.language?.rawValue,
+               let message = singleWordIndexes[code]?.messages[key] {
+                matches = try ChatTextSearch.matches(in: message, query: automatic, limit: matchLimit)
+            }
             var firstFragment = 0
             for match in matches {
                 while firstFragment < entry.fragments.count,
@@ -176,14 +304,41 @@ actor ChatSearchWorker {
                     }
                 }
                 guard let first = parts.first else { continue }
-                results.append(ChatSearchOccurrence(messageID: input.messageID, rowID: input.rowID,
-                                                    fragment: first, continuations: Array(parts.dropFirst())))
-                if results.count > limit {
-                    return Result(occurrences: Array(results.prefix(limit)), hasMore: true)
-                }
+                results.append((key, ChatSearchOccurrence(messageID: key.messageID, rowID: entry.input.rowID,
+                                                          fragment: first, continuations: Array(parts.dropFirst()))))
+                if results.count == limit { return results }
             }
         }
-        return Result(occurrences: results, hasMore: false)
+        return results
+    }
+}
+
+actor ChatSearchWorker {
+    struct Result: Sendable {
+        let occurrences: [ChatSearchOccurrence]
+        let hasMore: Bool
+    }
+
+    private var index = ChatSearchIndex()
+
+    func synchronize(_ inputs: [ChatSearchInput]) throws {
+        try index.synchronize(inputs)
+        index.didSave()
+    }
+
+    func search(_ query: String, limit: Int = 10_000, firstMatchOnly: Bool = false) throws -> Result {
+        guard limit > 0 else { return Result(occurrences: [], hasMore: false) }
+        let limit = min(limit, 10_000)
+        let results = try index.search(query, limit: limit + 1, firstMatchOnly: firstMatchOnly) {
+            $1.position < $3.position
+        }
+        return Result(occurrences: results.prefix(limit).map { $0.1 }, hasMore: results.count > limit)
+    }
+
+    func search(_ query: String, inputs: [ChatSearchInput], limit: Int = 10_000,
+                firstMatchOnly: Bool = false) throws -> Result {
+        try synchronize(inputs)
+        return try search(query, limit: limit, firstMatchOnly: firstMatchOnly)
     }
 }
 
@@ -206,8 +361,11 @@ final class ChatSearchState {
     private(set) var revealID: UUID?
     private var matchesByMessage: [UUID: [ChatSearchOccurrence]] = [:]
     @ObservationIgnored private var worker = ChatSearchWorker()
+    @ObservationIgnored private var library: ChatSearchLibrary?
     @ObservationIgnored private var task: Task<Void, Never>?
     @ObservationIgnored private var inputs: [ChatSearchInput] = []
+    @ObservationIgnored private var snapshotRevision: Int?
+    @ObservationIgnored private var indexedRevision: Int?
     @ObservationIgnored private var sessionID: UUID?
     @ObservationIgnored private var generation = 0
     @ObservationIgnored private var revision = 0
@@ -246,7 +404,8 @@ final class ChatSearchState {
         reset(sessionID: sessionID)
     }
 
-    func reset(sessionID: UUID?) {
+    func reset(sessionID: UUID?, library: ChatSearchLibrary? = nil) {
+        if let library { self.library = library }
         self.sessionID = sessionID
         isPresented = false
         clear()
@@ -256,6 +415,8 @@ final class ChatSearchState {
         stop()
         query = ""
         inputs = []
+        snapshotRevision = nil
+        indexedRevision = nil
         occurrences = []
         matchesByMessage = [:]
         selectedIndex = 0
@@ -266,13 +427,17 @@ final class ChatSearchState {
         requestedMatch = nil
     }
 
-    func update(items: [ChatTranscriptItem], queryChanged: Bool = false) {
+    func update(items: @autoclosure () -> [ChatTranscriptItem], contentRevision: Int? = nil,
+                queryChanged: Bool = false) {
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             clear()
             return
         }
-        inputs = ChatSearchInput.snapshots(from: items)
-        revision &+= 1
+        if contentRevision == nil || snapshotRevision != contentRevision {
+            inputs = ChatSearchInput.snapshots(from: items())
+            snapshotRevision = contentRevision
+            revision &+= 1
+        }
         if queryChanged {
             stop()
             occurrences = []
@@ -321,7 +486,23 @@ final class ChatSearchState {
                 let previous = self.selected
                 let requested = self.requestedMatch.flatMap { $0.query == self.query ? $0.location : nil }
                 let location = requested ?? previous?.location
-                var result = try await self.worker.search(self.query, inputs: self.inputs)
+                let resultWorker = self.library?.worker
+                try await self.library?.ready()
+                if self.indexedRevision != revision {
+                    if let resultWorker, let sessionID = self.sessionID {
+                        try await resultWorker.synchronize(self.inputs, sessionID: sessionID)
+                    } else {
+                        try await self.worker.synchronize(self.inputs)
+                    }
+                    try Task.checkCancellation()
+                    self.indexedRevision = revision
+                }
+                var result: ChatSearchWorker.Result
+                if let resultWorker, let sessionID = self.sessionID {
+                    result = try await resultWorker.search(self.query, sessionID: sessionID)
+                } else {
+                    result = try await self.worker.search(self.query)
+                }
                 if result.hasMore, let location,
                    !result.occurrences.contains(where: { $0.messageID == location.messageID }),
                    let input = self.inputs.first(where: { $0.messageID == location.messageID }) {
@@ -344,7 +525,6 @@ final class ChatSearchState {
                 }
                 self.task = nil
                 self.isSearching = false
-                // Streaming updates are throttled, not endlessly postponed by a trailing debounce.
                 if self.revision != revision { self.schedule() }
             } catch is CancellationError {
             } catch {
@@ -493,8 +673,6 @@ extension MarkdownSurface {
         for fragment in fragmentTargets {
             visibleTextViews.first { $0.fragmentID == fragment.id }?.scrollToVisible(fragment.rect)
         }
-        // Finish with the outer transcript's position, including when a code block
-        // has its own horizontal scroller or the finding was already visible.
         let clip = scroll.contentView
         var bounds = clip.bounds
         bounds.origin.y = convert(target, to: clip).midY - bounds.height / 2

--- a/Sources/Nativ/Features/Chat/ChatSearchStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSearchStore.swift
@@ -1,0 +1,206 @@
+import Foundation
+import SQLite3
+
+final class ChatSearchStore {
+    struct Session: Codable, Equatable, Sendable {
+        let id: UUID
+        let title: String
+        let updatedAt: Date
+
+        init(_ summary: ChatSessionSummary) {
+            id = summary.id
+            title = summary.title
+            updatedAt = summary.updatedAt
+        }
+    }
+
+    struct Failure: Error {
+        let code: Int32
+        let message: String
+    }
+
+    static var defaultURL: URL {
+        URL.applicationSupportDirectory.appending(path: "Nativ/Chat/Search.sqlite")
+    }
+
+    private var database: OpaquePointer?
+    private let encoder: PropertyListEncoder = {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        return encoder
+    }()
+    private let decoder = PropertyListDecoder()
+    private let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    init(url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let code = sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX, nil)
+        guard code == SQLITE_OK else { throw failure(code) }
+        sqlite3_busy_timeout(database, 2_000)
+        do {
+            try configure()
+        } catch let error as Failure where error.code == SQLITE_CORRUPT || error.code == SQLITE_NOTADB {
+            sqlite3_close(database)
+            database = nil
+            for suffix in ["", "-wal", "-shm"] {
+                let path = url.path + suffix
+                if FileManager.default.fileExists(atPath: path) { try FileManager.default.removeItem(atPath: path) }
+            }
+            let code = sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX, nil)
+            guard code == SQLITE_OK else { throw failure(code) }
+            try configure()
+        }
+    }
+
+    deinit { sqlite3_close(database) }
+
+    private func configure() throws {
+        try execute("PRAGMA journal_mode=WAL")
+        try execute("PRAGMA synchronous=NORMAL")
+        try execute("PRAGMA secure_delete=ON")
+        try execute("CREATE TABLE IF NOT EXISTS metadata (version TEXT NOT NULL)")
+        let system = ProcessInfo.processInfo.operatingSystemVersion
+        let version = "1:\(system.majorVersion).\(system.minorVersion)"
+        var storedVersion: String?
+        try rows("SELECT version FROM metadata") { statement in
+            if let text = sqlite3_column_text(statement, 0) { storedVersion = String(cString: text) }
+        }
+        if storedVersion != version {
+            try transaction {
+                try execute("DROP TABLE IF EXISTS messages")
+                try execute("DROP TABLE IF EXISTS sessions")
+                try execute("DELETE FROM metadata")
+                try execute("INSERT INTO metadata VALUES (?)", strings: [version])
+            }
+        }
+        try execute("CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY, payload BLOB NOT NULL)")
+        try execute("CREATE TABLE IF NOT EXISTS messages (session_id TEXT NOT NULL, message_id TEXT NOT NULL, position INTEGER NOT NULL, payload BLOB NOT NULL, PRIMARY KEY (session_id, message_id))")
+    }
+
+    func restore(into index: inout ChatSearchIndex) throws -> [UUID: Session] {
+        var sessions: [UUID: Session] = [:]
+        do {
+            try rows("SELECT payload FROM sessions") { statement in
+                let session = try decoder.decode(Session.self, from: data(statement, column: 0))
+                sessions[session.id] = session
+            }
+            try rows("SELECT position, payload FROM messages") { statement in
+                try Task.checkCancellation()
+                let record = try decoder.decode(ChatSearchIndex.Record.self, from: data(statement, column: 1))
+                index.insert(record, position: Int(sqlite3_column_int64(statement, 0)))
+            }
+        } catch is DecodingError {
+            try transaction {
+                try execute("DELETE FROM messages")
+                try execute("DELETE FROM sessions")
+            }
+            index = ChatSearchIndex()
+            return [:]
+        }
+        return sessions
+    }
+
+    func save(_ index: ChatSearchIndex, sessions: [Session] = [], removedSessions: Set<UUID> = []) throws {
+        let changes = index.changes
+        guard !changes.updated.isEmpty || !changes.removed.isEmpty || !changes.moved.isEmpty
+                || !sessions.isEmpty || !removedSessions.isEmpty else { return }
+        try transaction {
+            for id in removedSessions {
+                try execute("DELETE FROM messages WHERE session_id = ?", strings: [id.uuidString])
+                try execute("DELETE FROM sessions WHERE id = ?", strings: [id.uuidString])
+            }
+            for session in sessions {
+                try execute("INSERT OR REPLACE INTO sessions VALUES (?, ?)", strings: [session.id.uuidString],
+                            payload: encoder.encode(session))
+            }
+            for key in changes.removed {
+                try execute("DELETE FROM messages WHERE session_id = ? AND message_id = ?", strings: identifiers(key))
+            }
+            for key in changes.updated {
+                guard let entry = index.entries[key], let record = index.record(for: key) else { continue }
+                try execute("INSERT OR REPLACE INTO messages VALUES (?, ?, ?, ?)", strings: identifiers(key),
+                            position: entry.position, payload: encoder.encode(record))
+            }
+            for key in changes.moved.subtracting(changes.updated) {
+                guard let entry = index.entries[key] else { continue }
+                try execute("UPDATE messages SET position = ? WHERE session_id = ? AND message_id = ?",
+                            strings: identifiers(key), position: entry.position, positionFirst: true)
+            }
+        }
+    }
+
+    func checkpoint() throws { try execute("PRAGMA wal_checkpoint(TRUNCATE)") }
+
+    private func identifiers(_ key: ChatSearchIndex.Key) -> [String] {
+        [key.sessionID?.uuidString ?? "", key.messageID.uuidString]
+    }
+
+    private func transaction(_ body: () throws -> Void) throws {
+        try execute("BEGIN IMMEDIATE")
+        do {
+            try body()
+            try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+    }
+
+    private func execute(_ sql: String, strings: [String] = [], position: Int? = nil,
+                         payload: Data? = nil, positionFirst: Bool = false) throws {
+        let statement = try prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        var parameter: Int32 = 1
+        if positionFirst, let position {
+            try check(sqlite3_bind_int64(statement, parameter, sqlite3_int64(position)))
+            parameter += 1
+        }
+        for string in strings {
+            try check(sqlite3_bind_text(statement, parameter, string, -1, transient))
+            parameter += 1
+        }
+        if !positionFirst, let position {
+            try check(sqlite3_bind_int64(statement, parameter, sqlite3_int64(position)))
+            parameter += 1
+        }
+        if let payload {
+            try payload.withUnsafeBytes { bytes in
+                try check(sqlite3_bind_blob(statement, parameter, bytes.baseAddress, Int32(bytes.count), transient))
+            }
+        }
+        var code = sqlite3_step(statement)
+        while code == SQLITE_ROW { code = sqlite3_step(statement) }
+        guard code == SQLITE_DONE else { throw failure(code) }
+    }
+
+    private func rows(_ sql: String, read: (OpaquePointer) throws -> Void) throws {
+        let statement = try prepare(sql)
+        defer { sqlite3_finalize(statement) }
+        var code = sqlite3_step(statement)
+        while code == SQLITE_ROW {
+            try read(statement)
+            code = sqlite3_step(statement)
+        }
+        guard code == SQLITE_DONE else { throw failure(code) }
+    }
+
+    private func prepare(_ sql: String) throws -> OpaquePointer {
+        var statement: OpaquePointer?
+        let code = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
+        guard code == SQLITE_OK, let statement else { throw failure(code) }
+        return statement
+    }
+
+    private func data(_ statement: OpaquePointer, column: Int32) -> Data {
+        guard let bytes = sqlite3_column_blob(statement, column) else { return Data() }
+        return Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, column)))
+    }
+
+    private func check(_ code: Int32) throws {
+        guard code == SQLITE_OK else { throw failure(code) }
+    }
+
+    private func failure(_ code: Int32) -> Failure {
+        Failure(code: code, message: database.map { String(cString: sqlite3_errmsg($0)) } ?? "Unable to open search cache")
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatSearchStore.swift
+++ b/Sources/Nativ/Features/Chat/ChatSearchStore.swift
@@ -35,8 +35,12 @@ final class ChatSearchStore {
     init(url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         let code = sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX, nil)
-        guard code == SQLITE_OK else { throw failure(code) }
-        sqlite3_busy_timeout(database, 2_000)
+        guard code == SQLITE_OK else {
+            let error = failure(code)
+            sqlite3_close(database)
+            database = nil
+            throw error
+        }
         do {
             try configure()
         } catch let error as Failure where error.code == SQLITE_CORRUPT || error.code == SQLITE_NOTADB {
@@ -47,14 +51,29 @@ final class ChatSearchStore {
                 if FileManager.default.fileExists(atPath: path) { try FileManager.default.removeItem(atPath: path) }
             }
             let code = sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX, nil)
-            guard code == SQLITE_OK else { throw failure(code) }
-            try configure()
+            guard code == SQLITE_OK else {
+                let error = failure(code)
+                sqlite3_close(database)
+                database = nil
+                throw error
+            }
+            do { try configure() }
+            catch {
+                sqlite3_close(database)
+                database = nil
+                throw error
+            }
+        } catch {
+            sqlite3_close(database)
+            database = nil
+            throw error
         }
     }
 
     deinit { sqlite3_close(database) }
 
     private func configure() throws {
+        sqlite3_busy_timeout(database, 2_000)
         try execute("PRAGMA journal_mode=WAL")
         try execute("PRAGMA synchronous=NORMAL")
         try execute("PRAGMA secure_delete=ON")

--- a/Sources/Nativ/Features/Chat/ChatTextSearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatTextSearch.swift
@@ -1,0 +1,225 @@
+import Foundation
+import NaturalLanguage
+
+enum ChatTextSearch {
+    enum MatchKind: Int, Sendable {
+        case exact
+        case wordForm
+        case typo
+    }
+ 
+    struct Match: Equatable, Sendable {
+        let messageID: UUID
+        let range: NSRange
+        let kind: MatchKind
+    }
+
+    struct Message: Sendable {
+        let id: UUID
+        let text: String
+        fileprivate let tokens: [Token]
+
+        init(id: UUID, text: String, language: NLLanguage? = nil) throws {
+            self.id = id
+            self.text = text
+            tokens = try tokenize(text, language: language)
+        }
+    }
+
+    struct Query: Sendable {
+        let text: String
+        fileprivate let tokens: [Token]
+
+        init(_ text: String, language: NLLanguage? = nil) throws {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let quoted = trimmed.count >= 2 && trimmed.first == "\"" && trimmed.last == "\""
+            self.text = quoted ? String(trimmed.dropFirst().dropLast()) : trimmed
+            let tokens = quoted ? [] : try tokenize(self.text, language: language)
+            // Paths, identifiers with punctuation, and symbols keep literal search semantics.
+            self.tokens = isWordPhrase(self.text, tokens: tokens) ? tokens : []
+        }   
+    }
+
+    static func matches(in message: Message, query: Query, limit: Int = 200) throws -> [Match] {
+        try Task.checkCancellation()
+        guard limit > 0, !query.text.isEmpty else { return [] }
+        var exact: [Range<String.Index>] = []
+        var start = message.text.startIndex
+        while start < message.text.endIndex, exact.count < limit {
+            try Task.checkCancellation()
+            guard let range = message.text.range(
+                of: query.text,
+                options: .caseInsensitive,
+                range: start..<message.text.endIndex
+            ) else { break }
+            exact.append(range)
+            start = range.upperBound
+        }
+
+        var occurrences = exact.map { ($0, MatchKind.exact) }
+        if !query.tokens.isEmpty, message.tokens.count >= query.tokens.count {
+            var decisions = Array(repeating: [Word: Decision](), count: query.tokens.count)
+            var exactIndex = 0
+            var variantCount = 0
+            for index in 0...(message.tokens.count - query.tokens.count) {
+                try Task.checkCancellation()
+                let window = message.tokens[index..<(index + query.tokens.count)]
+                guard let first = window.first, let last = window.last else { continue }
+                let range = first.range.lowerBound..<last.range.upperBound
+                if exact.count == limit, let lastExact = exact.last,
+                   range.lowerBound >= lastExact.lowerBound { break }
+                while exactIndex < exact.count, exact[exactIndex].upperBound <= range.lowerBound {
+                    exactIndex += 1
+                }
+                if exactIndex < exact.count, exact[exactIndex].overlaps(range) { continue }
+                var kind = MatchKind.exact
+                var matched = true
+                for (offset, token) in window.enumerated() {
+                    let decision: Decision
+                    if let cached = decisions[offset][token.word] {
+                        decision = cached
+                    } else {
+                        decision = Decision(kind: match(token.word, query: query.tokens[offset].word))
+                        decisions[offset][token.word] = decision
+                    }
+                    guard let tokenKind = decision.kind else {
+                        matched = false
+                        break
+                    }
+                    if tokenKind.rawValue > kind.rawValue { kind = tokenKind }
+                }
+                if matched, hasWhitespaceSeparators(message.text, tokens: window) {
+                    occurrences.append((range, kind))
+                    variantCount += 1
+                    if variantCount == limit { break }
+                }
+            }
+        }
+
+        return occurrences.sorted { $0.0.lowerBound < $1.0.lowerBound }.prefix(limit).map {
+            Match(messageID: message.id, range: NSRange($0.0, in: message.text), kind: $0.1)
+        }
+    }
+
+    fileprivate struct Token: Sendable {
+        let word: Word
+        let range: Range<String.Index>
+    }
+
+    fileprivate struct Word: Hashable, Sendable {
+        let text: String
+        let lemma: String?
+        let language: String?
+        let allowsVariants: Bool
+    }
+
+    private struct Decision {
+        let kind: MatchKind?
+    }
+
+    private static func tokenize(_ text: String, language: NLLanguage?) throws -> [Token] {
+        try Task.checkCancellation()
+        guard !text.isEmpty else { return [] }
+        let tagger = NLTagger(tagSchemes: [.lemma, .language])
+        tagger.string = text
+        if let language { tagger.setLanguage(language, range: text.startIndex..<text.endIndex) }
+        var tokens: [Token] = []
+        tagger.enumerateTags(
+            in: text.startIndex..<text.endIndex,
+            unit: .word,
+            scheme: .lemma,
+            options: [.omitWhitespace, .omitPunctuation, .omitOther]
+        ) { lemma, range in
+            guard !Task.isCancelled else { return false }
+            let source = String(text[range])
+            let tokenLanguage = language?.rawValue ?? tagger.tag(
+                at: range.lowerBound, unit: .word, scheme: .language
+            ).0?.rawValue
+            tokens.append(Token(
+                word: Word(
+                    text: normalize(source),
+                    lemma: lemma.map { normalize($0.rawValue) },
+                    language: tokenLanguage,
+                    allowsVariants: allowsVariants(source)
+                ),
+                range: range
+            ))
+            return true
+        }
+        try Task.checkCancellation()
+        return tokens
+    }
+
+    private static func normalize(_ text: String) -> String {
+        text.lowercased().precomposedStringWithCanonicalMapping
+    }
+
+    private static func allowsVariants(_ text: String) -> Bool {
+        text.allSatisfy(\.isLetter) && !text.dropFirst().contains(where: \.isUppercase)
+    }
+
+    private static func isWordPhrase(_ text: String, tokens: [Token]) -> Bool {
+        guard let first = tokens.first, let last = tokens.last,
+              first.range.lowerBound == text.startIndex,
+              last.range.upperBound == text.endIndex else { return false }
+        return hasWhitespaceSeparators(text, tokens: tokens[...])
+    }
+
+    private static func hasWhitespaceSeparators(_ text: String, tokens: ArraySlice<Token>) -> Bool {
+        for (left, right) in zip(tokens, tokens.dropFirst()) {
+            let separator = text[left.range.upperBound..<right.range.lowerBound]
+            guard !separator.isEmpty, separator.allSatisfy(\.isWhitespace) else { return false }
+        }
+        return true
+    }
+
+    private static func match(_ word: Word, query: Word) -> MatchKind? {
+        if word.text == query.text { return .exact }
+        guard word.allowsVariants, query.allowsVariants else { return nil }
+        let sameLanguage = word.language != nil && word.language == query.language
+        if sameLanguage, let lemma = word.lemma, lemma == query.lemma { return .wordForm }
+        if isSpellingVariant(word.text, query.text) { return .typo }
+        if sameLanguage {
+            if let lemma = word.lemma, isSpellingVariant(lemma, query.text) { return .typo }
+            if let lemma = query.lemma, isSpellingVariant(word.text, lemma) { return .typo }
+        }
+        return nil
+    }
+
+    private static func isSpellingVariant(_ lhs: String, _ rhs: String) -> Bool {
+        let shorter = min(lhs.count, rhs.count)
+        let longer = max(lhs.count, rhs.count)
+        // Bound both false positives for short words and work for unusually long tokens.
+        guard shorter >= 5, longer <= 64 else { return false }
+        let limit = shorter >= 9 ? 2 : 1
+        guard longer - shorter <= limit else { return false }
+        return editDistance(Array(lhs), Array(rhs), limit: limit) <= limit
+    }
+
+    private static func editDistance(_ lhs: [Character], _ rhs: [Character], limit: Int) -> Int {
+        let outside = limit + 1
+        var previous = Array(0...rhs.count)
+        var beforePrevious = previous
+        for row in 1...lhs.count {
+            var current = Array(repeating: outside, count: rhs.count + 1)
+            current[0] = row
+            let lower = max(1, row - limit)
+            let upper = min(rhs.count, row + limit)
+            guard lower <= upper else { return outside }
+            var minimum = outside
+            for column in lower...upper {
+                let replacement = previous[column - 1] + (lhs[row - 1] == rhs[column - 1] ? 0 : 1)
+                current[column] = min(previous[column] + 1, current[column - 1] + 1, replacement)
+                if row > 1, column > 1,
+                   lhs[row - 1] == rhs[column - 2], lhs[row - 2] == rhs[column - 1] {
+                    current[column] = min(current[column], beforePrevious[column - 2] + 1)
+                }
+                minimum = min(minimum, current[column])
+            }
+            if minimum > limit { return outside }
+            beforePrevious = previous
+            previous = current
+        }
+        return previous[rhs.count]
+    }
+}

--- a/Sources/Nativ/Features/Chat/ChatTextSearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatTextSearch.swift
@@ -193,12 +193,13 @@ enum ChatTextSearch {
             }
         }
 
-        func candidates(for query: Query) throws -> Set<ID> {
+        func candidates(for query: Query, within scope: Set<ID>? = nil) throws -> Set<ID> {
             try Task.checkCancellation()
             guard !query.text.isEmpty else { return [] }
             let grams = Self.fragments(query.text, longestOnly: true)
             let ordered = grams.sorted { (fragments[$0]?.count ?? 0) < (fragments[$1]?.count ?? 0) }
             var result = ordered.first.flatMap { fragments[$0] } ?? []
+            if let scope { result.formIntersection(scope) }
             for gram in ordered.dropFirst() {
                 if result.isEmpty { break }
                 try Task.checkCancellation()
@@ -206,7 +207,7 @@ enum ChatTextSearch {
             }
             var phrase: Set<ID>?
             for token in query.tokens {
-                let candidates = try candidates(for: token.word)
+                let candidates = try candidates(for: token.word, within: scope)
                 if phrase == nil { phrase = candidates }
                 else { phrase?.formIntersection(candidates) }
                 if phrase?.isEmpty == true { break }
@@ -215,7 +216,7 @@ enum ChatTextSearch {
             return result
         }
 
-        private func candidates(for query: Word) throws -> Set<ID> {
+        private func candidates(for query: Word, within scope: Set<ID>?) throws -> Set<ID> {
             var candidates = spellings[query.text] ?? []
             if query.allowsVariants {
                 for text in Set([query.text, query.lemma].compactMap { $0 }) {
@@ -241,7 +242,10 @@ enum ChatTextSearch {
             var result: Set<ID> = []
             for word in candidates {
                 try Task.checkCancellation()
-                if match(word, query: query) != nil { result.formUnion(words[word] ?? []) }
+                if match(word, query: query) != nil {
+                    let matches = words[word] ?? []
+                    result.formUnion(scope.map { matches.intersection($0) } ?? matches)
+                }
             }
             return result
         }

--- a/Sources/Nativ/Features/Chat/ChatTextSearch.swift
+++ b/Sources/Nativ/Features/Chat/ChatTextSearch.swift
@@ -7,22 +7,61 @@ enum ChatTextSearch {
         case wordForm
         case typo
     }
- 
+
     struct Match: Equatable, Sendable {
         let messageID: UUID
         let range: NSRange
         let kind: MatchKind
     }
 
-    struct Message: Sendable {
+    struct Message: Codable, Sendable {
         let id: UUID
         let text: String
         fileprivate let tokens: [Token]
+        fileprivate let fragments: Set<UInt64>
+
+        var language: NLLanguage? {
+            tokens.first?.word.language.map { NLLanguage(rawValue: $0) }
+        }
+
+        var isSingleWord: Bool { tokens.count == 1 }
 
         init(id: UUID, text: String, language: NLLanguage? = nil) throws {
             self.id = id
             self.text = text
             tokens = try tokenize(text, language: language)
+            fragments = Index<Int>.fragments(text)
+        }
+
+        private struct StoredToken: Codable {
+            let word: Word
+            let range: NSRange
+        }
+
+        private enum CodingKeys: CodingKey { case id, text, tokens, fragments }
+
+        init(from decoder: any Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            id = try values.decode(UUID.self, forKey: .id)
+            text = try values.decode(String.self, forKey: .text)
+            fragments = try values.decode(Set<UInt64>.self, forKey: .fragments)
+            let source = text
+            tokens = try values.decode([StoredToken].self, forKey: .tokens).map { token in
+                guard let range = Range(token.range, in: source) else {
+                    throw DecodingError.dataCorruptedError(forKey: .tokens, in: values,
+                                                           debugDescription: "Invalid token range")
+                }
+                return Token(word: token.word, range: range)
+            }
+        }
+
+        func encode(to encoder: any Encoder) throws {
+            var values = encoder.container(keyedBy: CodingKeys.self)
+            try values.encode(id, forKey: .id)
+            try values.encode(text, forKey: .text)
+            try values.encode(fragments, forKey: .fragments)
+            try values.encode(tokens.map { StoredToken(word: $0.word, range: NSRange($0.range, in: text)) },
+                              forKey: .tokens)
         }
     }
 
@@ -30,14 +69,21 @@ enum ChatTextSearch {
         let text: String
         fileprivate let tokens: [Token]
 
+        var language: NLLanguage? {
+            tokens.first?.word.language.map { NLLanguage(rawValue: $0) }
+        }
+
+        init(_ text: String, languageCode: String) throws {
+            try self.init(text, language: languageCode.isEmpty ? nil : NLLanguage(rawValue: languageCode))
+        }
+
         init(_ text: String, language: NLLanguage? = nil) throws {
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             let quoted = trimmed.count >= 2 && trimmed.first == "\"" && trimmed.last == "\""
             self.text = quoted ? String(trimmed.dropFirst().dropLast()) : trimmed
             let tokens = quoted ? [] : try tokenize(self.text, language: language)
-            // Paths, identifiers with punctuation, and symbols keep literal search semantics.
             self.tokens = isWordPhrase(self.text, tokens: tokens) ? tokens : []
-        }   
+        }
     }
 
     static func matches(in message: Message, query: Query, limit: Int = 200) throws -> [Match] {
@@ -101,12 +147,136 @@ enum ChatTextSearch {
         }
     }
 
+    struct Index<ID: Hashable & Sendable>: Sendable {
+        private var fragments: [UInt64: Set<ID>] = [:]
+        private var words: [Word: Set<ID>] = [:]
+        private var spellings: [String: Set<Word>] = [:]
+        private var pairs: [String: [String: Int]] = [:]
+
+        mutating func insert(_ message: Message, id: ID) {
+            for fragment in message.fragments {
+                fragments[fragment, default: []].insert(id)
+            }
+            for word in Set(message.tokens.map(\.word)) {
+                if words[word] == nil {
+                    for spelling in Set([word.text, word.lemma].compactMap { $0 }) {
+                        if spellings[spelling] == nil {
+                            for (pair, count) in Self.pairs(spelling) {
+                                pairs[pair, default: [:]][spelling] = count
+                            }
+                        }
+                        spellings[spelling, default: []].insert(word)
+                    }
+                }
+                words[word, default: []].insert(id)
+            }
+        }
+
+        mutating func remove(_ message: Message, id: ID) {
+            for fragment in message.fragments {
+                fragments[fragment]?.remove(id)
+                if fragments[fragment]?.isEmpty == true { fragments[fragment] = nil }
+            }
+            for word in Set(message.tokens.map(\.word)) {
+                words[word]?.remove(id)
+                guard words[word]?.isEmpty == true else { continue }
+                words[word] = nil
+                for spelling in Set([word.text, word.lemma].compactMap { $0 }) {
+                    spellings[spelling]?.remove(word)
+                    guard spellings[spelling]?.isEmpty == true else { continue }
+                    spellings[spelling] = nil
+                    for pair in Self.pairs(spelling).keys {
+                        pairs[pair]?[spelling] = nil
+                        if pairs[pair]?.isEmpty == true { pairs[pair] = nil }
+                    }
+                }
+            }
+        }
+
+        func candidates(for query: Query) throws -> Set<ID> {
+            try Task.checkCancellation()
+            guard !query.text.isEmpty else { return [] }
+            let grams = Self.fragments(query.text, longestOnly: true)
+            let ordered = grams.sorted { (fragments[$0]?.count ?? 0) < (fragments[$1]?.count ?? 0) }
+            var result = ordered.first.flatMap { fragments[$0] } ?? []
+            for gram in ordered.dropFirst() {
+                if result.isEmpty { break }
+                try Task.checkCancellation()
+                result.formIntersection(fragments[gram] ?? [])
+            }
+            var phrase: Set<ID>?
+            for token in query.tokens {
+                let candidates = try candidates(for: token.word)
+                if phrase == nil { phrase = candidates }
+                else { phrase?.formIntersection(candidates) }
+                if phrase?.isEmpty == true { break }
+            }
+            if let phrase { result.formUnion(phrase) }
+            return result
+        }
+
+        private func candidates(for query: Word) throws -> Set<ID> {
+            var candidates = spellings[query.text] ?? []
+            if query.allowsVariants {
+                for text in Set([query.text, query.lemma].compactMap { $0 }) {
+                    candidates.formUnion(spellings[text] ?? [])
+                    let length = text.count
+                    guard (5...64).contains(length) else { continue }
+                    let distance = length >= 9 ? 2 : 1
+                    let threshold = length - 1 - 3 * distance
+                    var overlap: [String: Int] = [:]
+                    for (pair, count) in Self.pairs(text) {
+                        try Task.checkCancellation()
+                        for (spelling, frequency) in pairs[pair] ?? [:] {
+                            overlap[spelling, default: 0] += min(count, frequency)
+                        }
+                    }
+                    for (spelling, count) in overlap where count >= threshold {
+                        if isSpellingVariant(spelling, text) {
+                            candidates.formUnion(spellings[spelling] ?? [])
+                        }
+                    }
+                }
+            }
+            var result: Set<ID> = []
+            for word in candidates {
+                try Task.checkCancellation()
+                if match(word, query: query) != nil { result.formUnion(words[word] ?? []) }
+            }
+            return result
+        }
+
+        private static func pairs(_ text: String) -> [String: Int] {
+            var result: [String: Int] = [:]
+            for (left, right) in zip(text, text.dropFirst()) {
+                result[String([left, right]), default: 0] += 1
+            }
+            return result
+        }
+
+        fileprivate static func fragments(_ text: String, longestOnly: Bool = false) -> Set<UInt64> {
+            let units = Array(text.folding(options: .caseInsensitive, locale: Locale(identifier: "en_US_POSIX"))
+                .decomposedStringWithCanonicalMapping.utf16)
+            guard !units.isEmpty else { return [] }
+            let maximum = min(3, units.count)
+            var result: Set<UInt64> = []
+            for length in (longestOnly ? maximum : 1)...maximum {
+                for start in 0...(units.count - length) {
+                    var key = UInt64(length) << 48
+                    for offset in 0..<length { key |= UInt64(units[start + offset]) << (offset * 16) }
+                    result.insert(key)
+                }
+            }
+            return result
+        }
+    }
+
     fileprivate struct Token: Sendable {
         let word: Word
         let range: Range<String.Index>
     }
 
-    fileprivate struct Word: Hashable, Sendable {
+    fileprivate struct Word: Codable, Hashable, Sendable {
         let text: String
         let lemma: String?
         let language: String?
@@ -189,7 +359,6 @@ enum ChatTextSearch {
     private static func isSpellingVariant(_ lhs: String, _ rhs: String) -> Bool {
         let shorter = min(lhs.count, rhs.count)
         let longer = max(lhs.count, rhs.count)
-        // Bound both false positives for short words and work for unusually long tokens.
         guard shorter >= 5, longer <= 64 else { return false }
         let limit = shorter >= 9 ? 2 : 1
         guard longer - shorter <= limit else { return false }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -162,6 +162,7 @@ private struct ChatTranscriptView: View {
     let onPreviewAttachment: (ChatImageAttachment) -> Void
     @State private var composerHeight: CGFloat = 0
     @State private var composerBackdropHeight: CGFloat = 0
+    @State private var search = ChatSearchState()
 
     private var selectedModelID: String? {
         model.settings.normalized().languageModelID
@@ -186,6 +187,14 @@ private struct ChatTranscriptView: View {
         .background(Color.nativMainContentBackground)
         .environment(\.chatAnnotationActions, chat.annotationActions)
         .environment(\.canAddChatAnnotation, chat.pendingAnnotations.count < ChatAnnotation.maximumCount)
+        .environment(\.chatSearchState, search)
+        .focusedSceneValue(\.chatSearch, search)
+        .onChange(of: chat.currentSessionID, initial: true) { _, id in search.reset(sessionID: id) }
+        .onChange(of: search.query) { _, _ in search.update(items: chat.visibleTranscriptItems, queryChanged: true) }
+        .onChange(of: chat.transcriptRevision.value) { _, _ in
+            if !search.query.isEmpty { search.update(items: chat.visibleTranscriptItems) }
+        }
+        .onDisappear { search.reset(sessionID: nil) }
     }
 
     private func transcript(
@@ -199,13 +208,26 @@ private struct ChatTranscriptView: View {
             submissionID: chat.transcriptSubmissionID,
             scrollTargetMessageID: $chat.scrollTargetMessageID,
             itemIDs: items.map(\.id),
+            searchNavigation: search.navigationRequest,
+            onSearchNavigation: search.finishNavigation,
             topInset: {
-                if let project {
-                    ChatProjectContextBanner(
-                        project: project,
-                        rootIsAvailable: projectRootIsAvailable,
-                        toolsEnabled: model.settings.projectToolsEnabled
-                    )
+                VStack(spacing: 0) {
+                    if search.isPresented {
+                        ChatSearchBar(search: search)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                            .padding(.leading, 16)
+                            .padding(.trailing, ControlPanelLayout.topControlsTrailingPadding
+                                     + ControlPanelLayout.topControlSize + 12)
+                            .padding(.vertical, 8)
+                            .background(Color.nativMainContentBackground)
+                    }
+                    if let project {
+                        ChatProjectContextBanner(
+                            project: project,
+                            rootIsAvailable: projectRootIsAvailable,
+                            toolsEnabled: model.settings.projectToolsEnabled
+                        )
+                    }
                 }
             }
         ) { attachedRange in
@@ -227,8 +249,6 @@ private struct ChatTranscriptView: View {
                     forkableAssistantResponseIDs: forkableAssistantResponseIDs
                 )
             } footer: {
-                // Keep the overlay clearance inside the scroll target so pinning lands
-                // above the composer rather than aligning hidden content behind it.
                 Color.clear
                     .frame(
                         height: max(
@@ -1964,13 +1984,23 @@ private struct ChatMessageText: View {
     let isStreaming: Bool
     var isUserPrompt = false
     @Environment(\.chatFontScale) private var chatFontScale
+    @Environment(\.chatSearchState) private var search
+    @Environment(\.colorScheme) private var colorScheme
 
     @ViewBuilder
     var body: some View {
+        let highlight = messageID.flatMap { search?.highlight(for: $0) }
         if isUserPrompt {
-            Text(verbatim: content)
-                .textSelection(.enabled)
-                .font(ChatFontMetrics.bodyFont(scale: chatFontScale))
+            if let highlight {
+                MarkdownView(content: content,
+                             style: MarkdownStyle(fontSize: ChatFontMetrics.baseBodyPointSize * chatFontScale,
+                                                  dark: colorScheme == .dark), plainText: true)
+                    .environment(\.chatSearchHighlight, highlight)
+            } else {
+                Text(verbatim: content)
+                    .textSelection(.enabled)
+                    .font(ChatFontMetrics.bodyFont(scale: chatFontScale))
+            }
         } else if rendersMarkdown {
             ChatMarkdownRenderer(
                 messageID: messageID,
@@ -1978,6 +2008,7 @@ private struct ChatMessageText: View {
                 isStreaming: isStreaming,
                 fontScale: chatFontScale
             )
+            .environment(\.chatSearchHighlight, highlight)
         } else {
             Text(verbatim: content)
                 .textSelection(.enabled)

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -190,10 +190,17 @@ private struct ChatTranscriptView: View {
         .environment(\.canAddChatAnnotation, chat.pendingAnnotations.count < ChatAnnotation.maximumCount)
         .environment(\.chatSearchState, search)
         .focusedSceneValue(\.chatSearch, search)
-        .onChange(of: chat.currentSessionID, initial: true) { _, id in search.reset(sessionID: id) }
-        .onChange(of: search.query) { _, _ in search.update(items: chat.visibleTranscriptItems, queryChanged: true) }
+        .onChange(of: chat.currentSessionID, initial: true) { _, id in
+            search.reset(sessionID: id, library: chat.searchLibrary)
+        }
+        .onChange(of: search.query) { _, _ in
+            search.update(items: chat.visibleTranscriptItems, contentRevision: chat.transcriptRevision.value,
+                          queryChanged: true)
+        }
         .onChange(of: chat.transcriptRevision.value) { _, _ in
-            if !search.query.isEmpty { search.update(items: chat.visibleTranscriptItems) }
+            if !search.query.isEmpty {
+                search.update(items: chat.visibleTranscriptItems, contentRevision: chat.transcriptRevision.value)
+            }
         }
         .task(id: librarySearch?.destination?.id) {
             guard let destination = librarySearch?.takeDestination(for: chat.currentSessionID) else { return }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -197,9 +197,9 @@ private struct ChatTranscriptView: View {
             search.update(items: chat.visibleTranscriptItems, contentRevision: chat.transcriptRevision.value,
                           queryChanged: true)
         }
-        .onChange(of: chat.transcriptRevision.value) { _, _ in
+        .onChange(of: search.query.isEmpty ? 0 : chat.searchLibrary.revision) { _, _ in
             if !search.query.isEmpty {
-                search.update(items: chat.visibleTranscriptItems, contentRevision: chat.transcriptRevision.value)
+                search.update(items: chat.visibleTranscriptItems, contentRevision: chat.searchLibrary.revision)
             }
         }
         .task(id: librarySearch?.destination?.id) {

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -163,6 +163,7 @@ private struct ChatTranscriptView: View {
     @State private var composerHeight: CGFloat = 0
     @State private var composerBackdropHeight: CGFloat = 0
     @State private var search = ChatSearchState()
+    @Environment(\.chatLibrarySearch) private var librarySearch
 
     private var selectedModelID: String? {
         model.settings.normalized().languageModelID
@@ -193,6 +194,11 @@ private struct ChatTranscriptView: View {
         .onChange(of: search.query) { _, _ in search.update(items: chat.visibleTranscriptItems, queryChanged: true) }
         .onChange(of: chat.transcriptRevision.value) { _, _ in
             if !search.query.isEmpty { search.update(items: chat.visibleTranscriptItems) }
+        }
+        .task(id: librarySearch?.destination?.id) {
+            guard let destination = librarySearch?.takeDestination(for: chat.currentSessionID) else { return }
+            search.reveal(destination.result.occurrence, query: destination.query,
+                          sessionID: destination.result.sessionID, items: chat.visibleTranscriptItems)
         }
         .onDisappear { search.reset(sessionID: nil) }
     }

--- a/Sources/Nativ/Features/Chat/ChatView.swift
+++ b/Sources/Nativ/Features/Chat/ChatView.swift
@@ -164,6 +164,7 @@ private struct ChatTranscriptView: View {
     @State private var composerBackdropHeight: CGFloat = 0
     @State private var search = ChatSearchState()
     @Environment(\.chatLibrarySearch) private var librarySearch
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var selectedModelID: String? {
         model.settings.normalized().languageModelID
@@ -224,23 +225,12 @@ private struct ChatTranscriptView: View {
             searchNavigation: search.navigationRequest,
             onSearchNavigation: search.finishNavigation,
             topInset: {
-                VStack(spacing: 0) {
-                    if search.isPresented {
-                        ChatSearchBar(search: search)
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                            .padding(.leading, 16)
-                            .padding(.trailing, ControlPanelLayout.topControlsTrailingPadding
-                                     + ControlPanelLayout.topControlSize + 12)
-                            .padding(.vertical, 8)
-                            .background(Color.nativMainContentBackground)
-                    }
-                    if let project {
-                        ChatProjectContextBanner(
-                            project: project,
-                            rootIsAvailable: projectRootIsAvailable,
-                            toolsEnabled: model.settings.projectToolsEnabled
-                        )
-                    }
+                if let project {
+                    ChatProjectContextBanner(
+                        project: project,
+                        rootIsAvailable: projectRootIsAvailable,
+                        toolsEnabled: model.settings.projectToolsEnabled
+                    )
                 }
             }
         ) { attachedRange in
@@ -282,6 +272,19 @@ private struct ChatTranscriptView: View {
                     + ChatTranscriptLayout.messageHorizontalInset
             )
             .padding(.top, 18)
+        }
+        .overlay(alignment: .topTrailing) {
+            ZStack(alignment: .topTrailing) {
+                if search.isPresented {
+                    ChatSearchBar(search: search)
+                        .padding(.leading, 16)
+                        .padding(.trailing, ControlPanelLayout.topControlsTrailingPadding
+                                 + ControlPanelLayout.topControlSize + 12)
+                        .padding(.top, 8)
+                        .transition(reduceMotion ? .opacity : .opacity.combined(with: .offset(y: -6)))
+                }
+            }
+            .animation(.easeInOut(duration: 0.18), value: search.isPresented)
         }
     }
 

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -81,7 +81,9 @@ final class ChatViewModel: ObservableObject {
     @Published private(set) var folders: [ChatFolder] = []
     @Published private(set) var currentSessionID: UUID?
     @Published private(set) var currentProjectID: UUID?
-    @Published private(set) var messages: [ChatTranscriptMessage] = []
+    @Published private(set) var messages: [ChatTranscriptMessage] = [] {
+        didSet { searchLibrary.invalidate(currentSessionID) }
+    }
     @Published private(set) var pendingImageAttachments: [ChatImageAttachment] = [] {
         didSet {
             if pendingImageAttachments.isEmpty {
@@ -107,6 +109,7 @@ final class ChatViewModel: ObservableObject {
     @Published private(set) var activeRequestSessionID: UUID?
     @Published private(set) var sendingStartedAt: Date?
     let transcriptRevision = ChatTranscriptRevision()
+    let searchLibrary: ChatSearchLibrary
     @Published private(set) var transcriptSubmissionID: UUID?
     @Published var scrollTargetMessageID: UUID?
     @Published private(set) var isLoadingSessions = true
@@ -123,7 +126,13 @@ final class ChatViewModel: ObservableObject {
     private var activeTask: Task<Void, Never>?
     private var activeRequestID: UUID?
     private var activeAssistantMessageID: UUID?
-    @Published private var requestQueue: [QueuedChatRequest] = []
+    @Published private var requestQueue: [QueuedChatRequest] = [] {
+        didSet {
+            for id in Set(oldValue.map(\.sessionID) + requestQueue.map(\.sessionID)) {
+                searchLibrary.invalidate(id)
+            }
+        }
+    }
     private var storedSessions: [ChatSession] = []
     private var currentSession: ChatSession?
     private var liveDecodeRateRefreshDates: [UUID: Date] = [:]
@@ -143,12 +152,14 @@ final class ChatViewModel: ObservableObject {
         windowID: UUID = UUID(),
         persistedDataChanges: PersistedDataChangeHub = .init(),
         inferenceActivity: InferenceActivityCoordinator = .init(),
-        projectStore: ChatProjectStore = .init()
+        projectStore: ChatProjectStore = .init(),
+        searchLibrary: ChatSearchLibrary = .init()
     ) {
         self.windowID = windowID
         self.persistedDataChanges = persistedDataChanges
         self.inferenceActivity = inferenceActivity
         self.projectStore = projectStore
+        self.searchLibrary = searchLibrary
         let documentExtractionCache = ChatDocumentExtractionCache()
         documentContextBuilder = ChatDocumentContextBuilder(
             extractionCache: documentExtractionCache
@@ -2356,6 +2367,7 @@ final class ChatViewModel: ObservableObject {
             return false
         }
         storedSessions[sessionIndex].messages.insert(message, at: anchorIndex + 1)
+        searchLibrary.invalidate(sessionID)
         return true
     }
 
@@ -2553,6 +2565,7 @@ final class ChatViewModel: ObservableObject {
             return
         }
         storedSessions[sessionIndex].messages.removeAll { $0.id == messageID }
+        searchLibrary.invalidate(sessionID)
     }
 
     private func append(event: MLXChatStreamDelta, to id: UUID, in sessionID: UUID) {
@@ -2698,6 +2711,7 @@ final class ChatViewModel: ObservableObject {
         }
 
         mutate(&storedSessions[sessionIndex].messages[messageIndex])
+        searchLibrary.invalidate(sessionID)
         return true
     }
 
@@ -2720,6 +2734,7 @@ final class ChatViewModel: ObservableObject {
 
     private func finishLoadingSessions(_ bootstrap: ChatSessionBootstrap) {
         defer {
+            searchLibrary.start(storedSessions)
             if needsPersistedSessionReload {
                 needsPersistedSessionReload = false
                 reloadPersistedSessions(preservingCurrentIfMissing: false)
@@ -2736,6 +2751,7 @@ final class ChatViewModel: ObservableObject {
             } == true
 
         storedSessions = bootstrap.sessions
+        searchLibrary.reset()
         if localSessionHasWork, let localSession {
             upsertStoredSession(localSession)
         }
@@ -2854,6 +2870,7 @@ final class ChatViewModel: ObservableObject {
             return
         }
         storedSessions = sessionStore.loadSessions()
+        searchLibrary.reset()
         if let currentSession {
             if let fresh = storedSessions.first(where: { $0.id == currentSession.id }) {
                 if activeRequestSessionID != currentSession.id, fresh != currentSession {
@@ -2899,6 +2916,7 @@ final class ChatViewModel: ObservableObject {
 
     @discardableResult
     private func saveSession(_ session: ChatSession) -> Bool {
+        searchLibrary.invalidate(session.id)
         guard canModifySession(session.id) else {
             return false
         }

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -245,6 +245,13 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
+    func searchableTranscriptItems(in sessionID: UUID) -> [ChatTranscriptItem] {
+        if sessionID == currentSessionID { return visibleTranscriptItems }
+        let queuedIDs = Set(requestQueue.lazy.filter { $0.sessionID == sessionID }.map(\.userMessageID))
+        let messages = (sessionMessages(for: sessionID) ?? []).filter { !queuedIDs.contains($0.id) }
+        return ChatTranscriptPresentation.items(from: messages)
+    }
+
     var visibleTranscriptItems: [ChatTranscriptItem] {
         ChatTranscriptPresentation.items(from: visibleUnqueuedMessages)
     }

--- a/Sources/Nativ/Features/Chat/ChatViewModel.swift
+++ b/Sources/Nativ/Features/Chat/ChatViewModel.swift
@@ -82,7 +82,7 @@ final class ChatViewModel: ObservableObject {
     @Published private(set) var currentSessionID: UUID?
     @Published private(set) var currentProjectID: UUID?
     @Published private(set) var messages: [ChatTranscriptMessage] = [] {
-        didSet { searchLibrary.invalidate(currentSessionID) }
+        didSet { searchLibrary.invalidate(currentSessionID, from: self) }
     }
     @Published private(set) var pendingImageAttachments: [ChatImageAttachment] = [] {
         didSet {
@@ -129,7 +129,7 @@ final class ChatViewModel: ObservableObject {
     @Published private var requestQueue: [QueuedChatRequest] = [] {
         didSet {
             for id in Set(oldValue.map(\.sessionID) + requestQueue.map(\.sessionID)) {
-                searchLibrary.invalidate(id)
+                searchLibrary.invalidate(id, from: self)
             }
         }
     }
@@ -254,6 +254,13 @@ final class ChatViewModel: ObservableObject {
                 && $0.reasoningContent.isEmpty
                 && !$0.toolCalls.isEmpty)
         }
+    }
+
+    func searchSnapshot(in sessionID: UUID) -> ChatLibrarySearchSession? {
+        let session = sessionID == currentSessionID
+            ? currentSessionSnapshot : storedSessions.first { $0.id == sessionID }
+        guard let session else { return nil }
+        return ChatLibrarySearchSession(summary: session.summary, items: searchableTranscriptItems(in: sessionID))
     }
 
     func searchableTranscriptItems(in sessionID: UUID) -> [ChatTranscriptItem] {
@@ -2367,7 +2374,7 @@ final class ChatViewModel: ObservableObject {
             return false
         }
         storedSessions[sessionIndex].messages.insert(message, at: anchorIndex + 1)
-        searchLibrary.invalidate(sessionID)
+        searchLibrary.invalidate(sessionID, from: self)
         return true
     }
 
@@ -2565,7 +2572,7 @@ final class ChatViewModel: ObservableObject {
             return
         }
         storedSessions[sessionIndex].messages.removeAll { $0.id == messageID }
-        searchLibrary.invalidate(sessionID)
+        searchLibrary.invalidate(sessionID, from: self)
     }
 
     private func append(event: MLXChatStreamDelta, to id: UUID, in sessionID: UUID) {
@@ -2711,7 +2718,7 @@ final class ChatViewModel: ObservableObject {
         }
 
         mutate(&storedSessions[sessionIndex].messages[messageIndex])
-        searchLibrary.invalidate(sessionID)
+        searchLibrary.invalidate(sessionID, from: self)
         return true
     }
 
@@ -2735,6 +2742,7 @@ final class ChatViewModel: ObservableObject {
     private func finishLoadingSessions(_ bootstrap: ChatSessionBootstrap) {
         defer {
             searchLibrary.start(storedSessions)
+            searchLibrary.invalidate(currentSessionID, from: self)
             if needsPersistedSessionReload {
                 needsPersistedSessionReload = false
                 reloadPersistedSessions(preservingCurrentIfMissing: false)
@@ -2751,7 +2759,6 @@ final class ChatViewModel: ObservableObject {
             } == true
 
         storedSessions = bootstrap.sessions
-        searchLibrary.reset()
         if localSessionHasWork, let localSession {
             upsertStoredSession(localSession)
         }
@@ -2870,7 +2877,7 @@ final class ChatViewModel: ObservableObject {
             return
         }
         storedSessions = sessionStore.loadSessions()
-        searchLibrary.reset()
+        defer { searchLibrary.reconcile(sessions, from: self) }
         if let currentSession {
             if let fresh = storedSessions.first(where: { $0.id == currentSession.id }) {
                 if activeRequestSessionID != currentSession.id, fresh != currentSession {
@@ -2916,7 +2923,7 @@ final class ChatViewModel: ObservableObject {
 
     @discardableResult
     private func saveSession(_ session: ChatSession) -> Bool {
-        searchLibrary.invalidate(session.id)
+        searchLibrary.invalidate(session.id, from: self)
         guard canModifySession(session.id) else {
             return false
         }
@@ -2936,6 +2943,7 @@ final class ChatViewModel: ObservableObject {
 
     private func deletePersistedSession(_ sessionID: UUID) {
         sessionStore.deleteSession(id: sessionID)
+        searchLibrary.remove(sessionID)
         persistedDataChanges.send(.chatSession(sessionID), originWindowID: windowID)
     }
 

--- a/Sources/Nativ/Features/Chat/Rendering/ChatTranscriptScroller.swift
+++ b/Sources/Nativ/Features/Chat/Rendering/ChatTranscriptScroller.swift
@@ -6,6 +6,8 @@ struct ChatTranscriptScroller<Content: View, TopInset: View>: View {
     let submissionID: UUID?
     @Binding var scrollTargetMessageID: UUID?
     let itemIDs: [UUID]
+    let searchNavigation: ChatSearchNavigationRequest?
+    let onSearchNavigation: (UUID) -> Void
     let topInset: TopInset
     let content: (Range<Int>) -> Content
     @State private var contentHeight: CGFloat = 0
@@ -23,6 +25,8 @@ struct ChatTranscriptScroller<Content: View, TopInset: View>: View {
         submissionID: UUID?,
         scrollTargetMessageID: Binding<UUID?>,
         itemIDs: [UUID],
+        searchNavigation: ChatSearchNavigationRequest? = nil,
+        onSearchNavigation: @escaping (UUID) -> Void = { _ in },
         @ViewBuilder topInset: () -> TopInset,
         @ViewBuilder content: @escaping (Range<Int>) -> Content
     ) {
@@ -31,13 +35,19 @@ struct ChatTranscriptScroller<Content: View, TopInset: View>: View {
         self.submissionID = submissionID
         _scrollTargetMessageID = scrollTargetMessageID
         self.itemIDs = itemIDs
+        self.searchNavigation = searchNavigation
+        self.onSearchNavigation = onSearchNavigation
         self.topInset = topInset()
         self.content = content
     }
 
     var body: some View {
         ScrollViewReader { proxy in
-            ScrollView { content(paging.attachedRange(in: itemIDs)) }
+            ScrollView {
+                content(paging.attachedRange(in: itemIDs))
+                    // Leave room to center findings at either end of the conversation.
+                    .padding(.vertical, searchNavigation == nil ? 0 : viewportHeight / 2)
+            }
                 .scrollPosition($readingPosition)
                 // Content-size changes are handled by the single pinner below.
                 // Applying the default anchor to them as well competes with that scroll.
@@ -119,6 +129,16 @@ struct ChatTranscriptScroller<Content: View, TopInset: View>: View {
                         proxy.scrollTo(target, anchor: .center)
                         scrollTargetMessageID = nil
                     }
+                }
+                .task(id: searchNavigation) {
+                    guard let request = searchNavigation else { return }
+                    followState.pause()
+                    pendingPrepend = nil
+                    paging.reveal(request.rowID, in: itemIDs)
+                    initialPositionEstablished = true
+                    await Task.yield()
+                    guard !Task.isCancelled else { return }
+                    onSearchNavigation(request.id)
                 }
                 .background {
                     ChatTranscriptScrollPinner(

--- a/Sources/Nativ/Features/Chat/Rendering/ChatTranscriptScroller.swift
+++ b/Sources/Nativ/Features/Chat/Rendering/ChatTranscriptScroller.swift
@@ -45,8 +45,6 @@ struct ChatTranscriptScroller<Content: View, TopInset: View>: View {
         ScrollViewReader { proxy in
             ScrollView {
                 content(paging.attachedRange(in: itemIDs))
-                    // Leave room to center findings at either end of the conversation.
-                    .padding(.vertical, searchNavigation == nil ? 0 : viewportHeight / 2)
             }
                 .scrollPosition($readingPosition)
                 // Content-size changes are handled by the single pinner below.

--- a/Sources/Nativ/Features/Chat/Rendering/MarkdownView.swift
+++ b/Sources/Nativ/Features/Chat/Rendering/MarkdownView.swift
@@ -1,24 +1,32 @@
 import AppKit
+import QuartzCore
 import SwiftUI
 
 /// A cheap document shell. Its height comes from preflight; only nearby blocks create text views.
 struct MarkdownView: NSViewRepresentable {
     let content: String
     let style: MarkdownStyle
+    var plainText = false
+    @Environment(\.chatSearchHighlight) private var searchHighlight
 
     func makeNSView(context: Context) -> MarkdownSurface {
         let view = MarkdownSurface()
-        view.configure(content: content, style: style)
+        view.configure(content: content, style: style, plainText: plainText)
+        view.setSearchHighlight(searchHighlight)
         return view
     }
 
     func updateNSView(_ nsView: MarkdownSurface, context: Context) {
-        nsView.configure(content: content, style: style)
+        nsView.configure(content: content, style: style, plainText: plainText)
+        nsView.setSearchHighlight(searchHighlight)
     }
 
     func sizeThatFits(_ proposal: ProposedViewSize, nsView: MarkdownSurface, context: Context)
         -> CGSize?
     {
+        if proposal.width == nil, plainText, content.count <= 72, !content.contains(where: \.isNewline) {
+            return nsView.preflight(width: .greatestFiniteMagnitude).size
+        }
         guard let width = proposal.width, width.isFinite, width > 0 else { return nil }
         return nsView.preflight(width: width).size
     }
@@ -30,6 +38,9 @@ final class MarkdownSurface: NSView {
     var visibleTextViews: [MarkdownSelectableTextView] { mounted.values.flatMap { $0.content.textViews } }
     private var content: String?
     private var style = MarkdownStyle()
+    private var plainText = false
+    var searchHighlight: ChatSearchHighlight?
+    var pendingSearchReveal = false
     private var mounted: [String: MarkdownBlockView] = [:]
     private var measuredWidth: CGFloat = -1
     private(set) var snapshot: MarkdownLayout?
@@ -73,11 +84,12 @@ final class MarkdownSurface: NSView {
     convenience init() { self.init(frame: .zero) }
     required init?(coder: NSCoder) { fatalError("Not a serialized view") }
 
-    func configure(content: String, style: MarkdownStyle) {
-        guard self.content != content || self.style != style else { return }
+    func configure(content: String, style: MarkdownStyle, plainText: Bool = false) {
+        guard self.content != content || self.style != style || self.plainText != plainText else { return }
         selection.invalidate(contentChanged: self.content != content)
         self.content = content
         self.style = style
+        self.plainText = plainText
         measuredWidth = -1
         invalidateIntrinsicContentSize()
         needsLayout = true
@@ -85,8 +97,9 @@ final class MarkdownSurface: NSView {
 
     func preflight(width: CGFloat) -> MarkdownLayout {
         if let snapshot, measuredWidth == width { return snapshot }
-        let result = MarkdownLayoutCache.shared.layout(
-            content ?? "", width: width, style: style)
+        let result = plainText
+            ? Self.searchPlainTextLayout(content ?? "", width: width, style: style)
+            : MarkdownLayoutCache.shared.layout(content ?? "", width: width, style: style)
         setSnapshot(result)
         measuredWidth = width
         return result
@@ -110,6 +123,7 @@ final class MarkdownSurface: NSView {
         super.layout()
         if content != nil && bounds.width > 0 { _ = preflight(width: bounds.width) }
         refreshVisibleBlocks()
+        revealSearchMatchIfNeeded()
     }
 
     override func viewWillDraw() {
@@ -170,6 +184,7 @@ final class MarkdownSurface: NSView {
             view.removeFromSuperview()
             mounted.removeValue(forKey: id)
         }
+        applySearchHighlights()
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -303,6 +318,14 @@ final class MarkdownSelectableTextView: NSTextView {
     var documentSelection: NSRange? {
         didSet { if oldValue != documentSelection { needsDisplay = true } }
     }
+    var searchRanges: [NSRange] = [] {
+        didSet { if oldValue != searchRanges { needsDisplay = true } }
+    }
+    var activeSearchRange: NSRange? {
+        didSet { if oldValue != activeSearchRange { updateSearchFocus(previous: oldValue) } }
+    }
+    var pendingSearchPulse = false
+    var searchPulseLayer: CAShapeLayer?
     let system: MarkdownTextSystem
     private let original: NSAttributedString
     private let measuredWidth: CGFloat
@@ -399,7 +422,7 @@ final class MarkdownSelectableTextView: NSTextView {
 
     /// Find whole visible lines before enumerating selection geometry. Using line
     /// boundaries also preserves RTL text and wrapped paragraphs when clipping.
-    private func lineBoundary(at y: CGFloat, upper: Bool) -> Int? {
+    func lineBoundary(at y: CGFloat, upper: Bool) -> Int? {
         guard original.length > 0 else { return nil }
         let last = system.storage.location(system.storage.documentRange.location, offsetBy: original.length - 1)
         guard let fragment = system.manager.textLayoutFragment(for: CGPoint(x: bounds.minX, y: y))
@@ -419,6 +442,7 @@ final class MarkdownSelectableTextView: NSTextView {
                 NSBezierPath(rect: rect).fill()
             }
         }
+        drawSearchHighlights(in: dirtyRect)
         super.draw(dirtyRect)
     }
 

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
@@ -8,6 +8,7 @@ final class ControlPanelSharedDependencies {
     let persistedDataChanges = PersistedDataChangeHub()
     let inferenceActivity = InferenceActivityCoordinator()
     let projects = ChatProjectStore()
+    let chatSearch = ChatSearchLibrary(storageURL: ChatSearchStore.defaultURL)
 }
 
 @MainActor
@@ -19,12 +20,14 @@ final class ControlPanelDependencies: ObservableObject {
     let persistedDataChanges: PersistedDataChangeHub
     let inferenceActivity: InferenceActivityCoordinator
     let projects: ChatProjectStore
+    let chatSearch: ChatSearchLibrary
 
     lazy var chat = ChatViewModel(
         windowID: windowID,
         persistedDataChanges: persistedDataChanges,
         inferenceActivity: inferenceActivity,
-        projectStore: projects
+        projectStore: projects,
+        searchLibrary: chatSearch
     )
     lazy var imageGeneration = ImageGenerationViewModel(
         windowID: windowID,
@@ -66,5 +69,6 @@ final class ControlPanelDependencies: ObservableObject {
         persistedDataChanges = shared.persistedDataChanges
         inferenceActivity = shared.inferenceActivity
         projects = shared.projects
+        chatSearch = shared.chatSearch
     }
 }

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarActions.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarActions.swift
@@ -6,6 +6,18 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 extension ControlPanelView {
+    func openChatSearchResult(_ result: ChatLibrarySearchResult) {
+        guard chat.sessions.contains(where: { $0.id == result.sessionID }),
+              result.isCurrent(in: chat.searchableTranscriptItems(in: result.sessionID)) else {
+            chatLibrarySearch.refresh(from: chat, queryChanged: true)
+            return
+        }
+        chat.selectSession(result.sessionID)
+        guard chat.currentSessionID == result.sessionID else { return }
+        applySidebarSelection(.chat(result.sessionID))
+        chatLibrarySearch.select(result)
+    }
+
     @ViewBuilder
     func recentSessionRow(
         _ recent: ControlPanelRecentSession,

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelSidebarView.swift
@@ -27,6 +27,14 @@ extension ControlPanelView {
                 Text("Nativ")
                     .legacyTextStyle(.brandTitle)
                     .foregroundStyle(.primary)
+                Spacer(minLength: 0)
+                Button("Search chats", systemImage: "magnifyingglass") { chatLibrarySearch.present() }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .font(.system(size: 15))
+                    .frame(width: 28, height: 28)
+                    .contentShape(.rect)
+                    .help("Search all chats")
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .frame(height: ControlPanelLayout.sidebarBrandHeight)

--- a/Sources/Nativ/Features/ControlPanel/ControlPanelView.swift
+++ b/Sources/Nativ/Features/ControlPanel/ControlPanelView.swift
@@ -58,6 +58,7 @@ struct ControlPanelView: View {
     @State var projectErrorMessage: String?
     @State var isConfirmingBulkDelete = false
     @State var chatImportAlert: ChatImportAlert?
+    @State var chatLibrarySearch = ChatLibrarySearchState()
 
     var chat: ChatViewModel { dependencies.chat }
     var mcpHost: MCPHostManager { dependencies.mcpHost }
@@ -154,6 +155,10 @@ struct ControlPanelView: View {
         .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .toolbar(removing: .title)
         .frame(minWidth: 1040, minHeight: 600)
+        .environment(\.chatLibrarySearch, chatLibrarySearch)
+        .sheet(isPresented: $chatLibrarySearch.isPresented) {
+            ChatLibrarySearchPopup(search: chatLibrarySearch, chat: chat, onSelect: openChatSearchResult)
+        }
         .environment(\.controlPanelIsFullScreen, isFullScreen)
         .environment(\.controlPanelIsSidebarVisible, isSidebarVisible)
         .environment(\.openExtensionsHubSection) { section in

--- a/Sources/Nativ/Main.swift
+++ b/Sources/Nativ/Main.swift
@@ -130,6 +130,7 @@ private struct NativApplication: App {
         .windowBackgroundDragBehavior(.disabled)
         .commands {
             NativApplicationCommands(appDelegate: appDelegate)
+            ChatSearchCommands()
         }
     }
 }

--- a/Tests/NativTests/ChatLibrarySearchTests.swift
+++ b/Tests/NativTests/ChatLibrarySearchTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import SwiftUI
+import XCTest
+
+@MainActor
+final class ChatLibrarySearchTests: XCTestCase {
+    func testSearchesMessagesAcrossChatsWithTyposAndWordForms() async throws {
+        let first = session("One", messages: [message("Notification permissions were updated.")])
+        let second = session("Two", messages: [message("A notification permission was requested.")])
+        let worker = ChatLibrarySearchWorker()
+        let result = try await worker.search("notificaiton permission", sessions: [first, second])
+        XCTAssertEqual(Set(result.messages.map(\.sessionID)), [first.id, second.id])
+        XCTAssertTrue(result.messages.allSatisfy { $0.occurrence.range.length > 0 })
+        let semantic = try await worker.search("authorization", sessions: [first, second])
+        XCTAssertTrue(semantic.messages.isEmpty)
+    }
+
+    func testResultsBelongToMessagesAndGroupedResponsesKeepTheirRow() async throws {
+        let user = message("notification notification")
+        let tool = ChatTranscriptMessage(role: .tool, content: "notification tool internals")
+        let assistant = ChatTranscriptMessage(role: .assistant, content: "Final **notification** response.")
+        let input = session("Chat", messages: [user, tool, assistant])
+        let result = try await ChatLibrarySearchWorker().search("notification", sessions: [input])
+        XCTAssertEqual(result.messages.count, 2)
+        let answer = try XCTUnwrap(result.messages.first { $0.isAssistant })
+        XCTAssertEqual(answer.occurrence.messageID, assistant.id)
+        XCTAssertEqual(answer.occurrence.rowID, tool.id)
+        XCTAssertEqual(result.messages.filter { $0.occurrence.messageID == user.id }.count, 1)
+    }
+
+    func testForkedChatsCanShareMessageIDsWithoutSharingCachedContents() async throws {
+        let id = UUID()
+        let first = session("Original", messages: [message("notification", id: id)])
+        let second = session("Fork", messages: [message("permission", id: id)])
+        let worker = ChatLibrarySearchWorker()
+        for _ in 0..<2 {
+            let result = try await worker.search("notification", sessions: [first, second])
+            XCTAssertEqual(result.messages.map(\.sessionID), [first.id])
+            let other = try await worker.search("permission", sessions: [first, second])
+            XCTAssertEqual(other.messages.map(\.sessionID), [second.id])
+        }
+        let shared = session("Fork", id: second.id, messages: [message("notification", id: id)])
+        let both = try await worker.search("notification", sessions: [first, shared])
+        XCTAssertEqual(Set(both.messages.map(\.id)).count, 2)
+    }
+
+    func testEditsDeletionsAndRenamesRefreshResults() async throws {
+        let original = session("Old title", messages: [message("notification")])
+        let worker = ChatLibrarySearchWorker()
+        _ = try await worker.search("notification", sessions: [original])
+        let edited = session("New title", id: original.id,
+                             messages: [message("permission", id: original.inputs[0].messageID)])
+        let oldQuery = try await worker.search("notification", sessions: [edited])
+        XCTAssertTrue(oldQuery.messages.isEmpty)
+        let newQuery = try await worker.search("permission", sessions: [edited])
+        XCTAssertEqual(newQuery.messages.first?.title, "New title")
+        let deleted = try await worker.search("permission", sessions: [])
+        XCTAssertTrue(deleted.messages.isEmpty)
+    }
+
+    func testChangedOrDeletedMessagesCannotOpenAStaleResult() async throws {
+        let message = message("notification")
+        let input = session("Chat", messages: [message])
+        let result = try await ChatLibrarySearchWorker().search("notification", sessions: [input])
+        let match = try XCTUnwrap(result.messages.first)
+        XCTAssertTrue(match.isCurrent(in: [.message(message)]))
+        var edited = message
+        edited.content = "unrelated replacement"
+        XCTAssertFalse(match.isCurrent(in: [.message(edited)]))
+        XCTAssertFalse(match.isCurrent(in: []))
+    }
+
+    func testLimitCountsMessagesAndStillSearchesOldChats() async throws {
+        let old = session("Old", updatedAt: .distantPast, messages: [message("unique notification")])
+        let recent = (0..<205).map { session("Recent \($0)", messages: [message("notification notification")]) }
+        let worker = ChatLibrarySearchWorker()
+        let common = try await worker.search("notification", sessions: recent + [old])
+        XCTAssertEqual(common.messages.count, 200)
+        XCTAssertTrue(common.hasMore)
+        let rare = try await worker.search("unique notification", sessions: recent + [old])
+        XCTAssertEqual(rare.messages.map(\.sessionID), [old.id])
+        XCTAssertFalse(rare.hasMore)
+    }
+
+    func testExcerptPreservesUnicodeAndHighlightsTheMatchedWord() async throws {
+        let content = String(repeating: "👩🏽‍💻 Background. ", count: 80) + "notification\nsettings"
+        let result = try await ChatLibrarySearchWorker().search("notificaiton", sessions: [session("Unicode", messages: [message(content)])])
+        let excerpt = try XCTUnwrap(result.messages.first).excerpt
+        let text = String(excerpt.characters)
+        XCTAssertTrue(text.contains("notification settings"))
+        XCTAssertFalse(text.contains("\u{FFFD}"))
+        XCTAssertLessThan(text.count, 245)
+        XCTAssertTrue(excerpt.runs.contains { $0.backgroundColor != nil })
+    }
+
+    func testCancelledSearchDoesNotReturnResults() async throws {
+        let worker = ChatLibrarySearchWorker()
+        let sessions = [session("Chat", messages: [message("notification")])]
+        let task = Task { try await worker.search("notification", sessions: sessions) }
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {}
+    }
+
+    func testDestinationIsConsumedOnlyByItsChatAndPreservesTheQuery() async throws {
+        let input = session("Target", messages: [message("notification")])
+        let results = try await ChatLibrarySearchWorker().search("notificaiton", sessions: [input])
+        let result = try XCTUnwrap(results.messages.first)
+        let state = ChatLibrarySearchState()
+        state.present()
+        state.query = "notificaiton"
+        state.select(result)
+        XCTAssertFalse(state.isPresented)
+        XCTAssertNil(state.takeDestination(for: UUID()))
+        let destination = try XCTUnwrap(state.takeDestination(for: input.id))
+        XCTAssertEqual(destination.query, "notificaiton")
+        XCTAssertEqual(destination.result.occurrence, result.occurrence)
+        XCTAssertNil(state.takeDestination(for: input.id))
+    }
+
+    func testOpeningResultSelectsItsMessageInsteadOfFirstMatchInChat() async throws {
+        let messages = [message("notification earlier"), message("notification target")]
+        let input = session("Target", messages: messages)
+        let result = try await ChatLibrarySearchWorker().search("notification", sessions: [input])
+        let target = try XCTUnwrap(result.messages.first)
+        let state = ChatSearchState()
+        state.reveal(target.occurrence, query: "notification", sessionID: input.id,
+                     items: ChatTranscriptPresentation.items(from: messages))
+        // The view also observes the query change when the destination opens.
+        state.update(items: ChatTranscriptPresentation.items(from: messages), queryChanged: true)
+        try await waitForSearch(state)
+        XCTAssertEqual(state.selected?.messageID, messages.last?.id)
+        XCTAssertTrue(state.isPresented)
+    }
+
+    func testOpeningResultBeyondInChatResultLimitStillSelectsIt() async throws {
+        let messages = [message(String(repeating: "notification ", count: 10_010)), message("notification target")]
+        let input = session("Long chat", messages: messages)
+        let result = try await ChatLibrarySearchWorker().search("notification", sessions: [input])
+        let target = try XCTUnwrap(result.messages.first)
+        let state = ChatSearchState()
+        state.reveal(target.occurrence, query: "notification", sessionID: input.id,
+                     items: ChatTranscriptPresentation.items(from: messages))
+        try await waitForSearch(state)
+        XCTAssertEqual(state.selected?.messageID, messages.last?.id)
+        XCTAssertTrue(state.hasMore)
+        let navigation = state.navigationID
+        state.update(items: ChatTranscriptPresentation.items(from: messages + [message("New background message")]))
+        try await waitForSearch(state)
+        XCTAssertEqual(state.selected?.messageID, messages.last?.id)
+        XCTAssertEqual(state.navigationID, navigation)
+    }
+
+    private func waitForSearch(_ state: ChatSearchState) async throws {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(10))
+        while state.isSearching, ContinuousClock.now < deadline { try await Task.sleep(for: .milliseconds(20)) }
+        XCTAssertFalse(state.isSearching)
+        XCTAssertNil(state.error)
+    }
+
+    private func message(_ text: String, id: UUID = UUID()) -> ChatTranscriptMessage {
+        ChatTranscriptMessage(id: id, role: .user, content: text)
+    }
+
+    private func session(_ title: String, id: UUID = UUID(), updatedAt: Date = Date(),
+                         messages: [ChatTranscriptMessage]) -> ChatLibrarySearchSession {
+        let session = ChatSession(id: id, title: title, customTitle: title, createdAt: updatedAt,
+                                  updatedAt: updatedAt, messages: messages)
+        return ChatLibrarySearchSession(summary: session.summary, items: ChatTranscriptPresentation.items(from: messages))
+    }
+}

--- a/Tests/NativTests/ChatLibrarySearchTests.swift
+++ b/Tests/NativTests/ChatLibrarySearchTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import SwiftUI
 import XCTest
 
@@ -151,6 +152,121 @@ final class ChatLibrarySearchTests: XCTestCase {
         try await waitForSearch(state)
         XCTAssertEqual(state.selected?.messageID, messages.last?.id)
         XCTAssertEqual(state.navigationID, navigation)
+    }
+
+    func testIncrementalSynchronizationKeepsUnchangedChatsAndUpdatesOrdering() async throws {
+        let older = session("Older", updatedAt: .distantPast, messages: [message("notification")])
+        let newer = session("Newer", messages: [message("notification")])
+        let worker = ChatLibrarySearchWorker()
+        try await worker.synchronize([older, newer], summaries: [older.summary, newer.summary])
+        let initial = try await worker.search("notification")
+        XCTAssertEqual(initial.messages.map(\.sessionID), [newer.id, older.id])
+        let edited = session("Renamed", id: older.id, updatedAt: .distantFuture,
+                             messages: [message("notification permissions")])
+        try await worker.synchronize([edited], summaries: [edited.summary, newer.summary])
+        let updated = try await worker.search("notification")
+        XCTAssertEqual(updated.messages.map(\.sessionID), [older.id, newer.id])
+        XCTAssertEqual(updated.messages.first?.title, "Renamed")
+        try await worker.synchronize([], summaries: [newer.summary])
+        let deleted = try await worker.search("notification")
+        XCTAssertEqual(deleted.messages.map(\.sessionID), [newer.id])
+    }
+
+    func testPersistentIndexRestoresGlobalAndInChatResults() async throws {
+        let url = try databaseURL()
+        let messages = [message("👋 cafe\u{301} notification"), message("We ran yesterday."), message("mice")]
+        let chat = session("Stored", messages: messages)
+        let worker = ChatLibrarySearchWorker(storageURL: url)
+        try await worker.synchronize([chat], summaries: [chat.summary])
+        for query in ["café", "notificaiton", "running", "mouse"] {
+            let before = try await worker.search(query)
+            let restored = ChatLibrarySearchWorker(storageURL: url)
+            let after = try await restored.search(query)
+            XCTAssertEqual(after.messages, before.messages, query)
+            let local = try await restored.search(query, sessionID: chat.id)
+            XCTAssertEqual(Set(local.occurrences.map(\.messageID)), Set(before.messages.map { $0.occurrence.messageID }))
+        }
+    }
+
+    func testPersistentIndexReconcilesEditsDeletionsAndNewMessages() async throws {
+        let url = try databaseURL()
+        let first = session("First", messages: [message("notification")])
+        let removed = session("Removed", messages: [message("obsolete")])
+        let worker = ChatLibrarySearchWorker(storageURL: url)
+        try await worker.synchronize([first, removed], summaries: [first.summary, removed.summary])
+        let updated = session("Renamed", id: first.id, messages: [
+            message("permission", id: first.inputs[0].messageID), message("notification newest"),
+        ])
+        let relaunched = ChatLibrarySearchWorker(storageURL: url)
+        try await relaunched.synchronize([updated], summaries: [updated.summary])
+        let restored = ChatLibrarySearchWorker(storageURL: url)
+        let obsolete = try await restored.search("obsolete")
+        XCTAssertTrue(obsolete.messages.isEmpty)
+        let notification = try await restored.search("notification")
+        XCTAssertEqual(notification.messages.map { $0.occurrence.messageID }, [updated.inputs[1].messageID])
+        XCTAssertEqual(notification.messages.first?.title, "Renamed")
+        let permission = try await restored.search("permission")
+        XCTAssertEqual(permission.messages.map { $0.occurrence.messageID }, [updated.inputs[0].messageID])
+    }
+
+    func testPersistentIndexPreservesForkNamespacesAndMessageOrder() async throws {
+        let url = try databaseURL()
+        let sharedID = UUID()
+        let first = session("Original", messages: [message("notification", id: sharedID), message("notification later")])
+        let fork = session("Fork", messages: [message("permissions", id: sharedID)])
+        let worker = ChatLibrarySearchWorker(storageURL: url)
+        try await worker.synchronize([first, fork], summaries: [first.summary, fork.summary])
+        let restored = ChatLibrarySearchWorker(storageURL: url)
+        let global = try await restored.search("notification")
+        XCTAssertEqual(global.messages.map { $0.occurrence.messageID }, first.inputs.reversed().map(\.messageID))
+        let local = try await restored.search("notification", sessionID: first.id)
+        XCTAssertEqual(local.occurrences.map(\.messageID), first.inputs.map(\.messageID))
+        let other = try await restored.search("permission", sessionID: fork.id)
+        XCTAssertEqual(other.occurrences.map(\.messageID), [sharedID])
+    }
+
+    func testSharedIndexSurvivesSearchDismissalAndQueryClearing() async throws {
+        let url = try databaseURL()
+        let library = ChatSearchLibrary(storageURL: url)
+        let chat = session("Shared", messages: [message("notification")])
+        try await library.worker.synchronize([chat], summaries: [chat.summary])
+        let local = ChatSearchState()
+        local.reset(sessionID: chat.id, library: library)
+        local.query = "notification"
+        local.update(items: [.message(message("notification", id: chat.inputs[0].messageID))])
+        try await waitForSearch(local)
+        local.dismiss()
+        let popup = ChatLibrarySearchState()
+        popup.present()
+        popup.dismiss()
+        let remaining = try await library.worker.search("notification")
+        XCTAssertEqual(remaining.messages.count, 1)
+    }
+
+    func testDamagedAndIncompatibleCachesAreRebuilt() async throws {
+        let url = try databaseURL()
+        try Data("damaged cache".utf8).write(to: url)
+        let chat = session("Rebuilt", messages: [message("notification")])
+        var worker: ChatLibrarySearchWorker? = ChatLibrarySearchWorker(storageURL: url)
+        try await worker?.synchronize([chat], summaries: [chat.summary])
+        let first = try await worker?.search("notification")
+        XCTAssertEqual(first?.messages.count, 1)
+        worker = nil
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &database), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(database, "UPDATE metadata SET version = 'obsolete'", nil, nil, nil), SQLITE_OK)
+        sqlite3_close(database)
+        let rebuilt = ChatLibrarySearchWorker(storageURL: url)
+        try await rebuilt.synchronize([chat], summaries: [chat.summary])
+        let result = try await rebuilt.search("notification")
+        XCTAssertEqual(result.messages.count, 1)
+    }
+
+    private func databaseURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "ChatSearchTests-" + UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try FileManager.default.removeItem(at: directory) }
+        return directory.appending(path: "Search.sqlite")
     }
 
     private func waitForSearch(_ state: ChatSearchState) async throws {

--- a/Tests/NativTests/ChatLibrarySearchTests.swift
+++ b/Tests/NativTests/ChatLibrarySearchTests.swift
@@ -262,6 +262,140 @@ final class ChatLibrarySearchTests: XCTestCase {
         XCTAssertEqual(result.messages.count, 1)
     }
 
+    func testMessageEventsUpdateThePersistentIndexWithoutOpeningSearch() async throws {
+        let url = try databaseURL()
+        let library = ChatSearchLibrary(storageURL: url)
+        library.start([])
+        let id = UUID()
+        var snapshot = session("Live", id: id, messages: [message("notification")])
+        library.enqueue(id) { snapshot }
+        try await library.ready()
+        let initial = try await library.worker.search("notification")
+        XCTAssertEqual(initial.messages.count, 1)
+        snapshot = session("Edited", id: id, messages: [message("permission", id: snapshot.inputs[0].messageID)])
+        library.enqueue(id) { snapshot }
+        try await library.ready()
+        let restored = ChatLibrarySearchWorker(storageURL: url)
+        let old = try await restored.search("notification")
+        XCTAssertTrue(old.messages.isEmpty)
+        let updated = try await restored.search("permission")
+        XCTAssertEqual(updated.messages.first?.title, "Edited")
+        library.remove(id)
+        try await library.ready()
+        let deleted = try await ChatLibrarySearchWorker(storageURL: url).search("permission")
+        XCTAssertTrue(deleted.messages.isEmpty)
+    }
+
+    func testBurstUpdatesReadOnlyTheLatestSnapshot() async throws {
+        let library = ChatSearchLibrary(storageURL: try databaseURL())
+        library.start([])
+        let id = UUID()
+        var reads = 0
+        var snapshot = session("Streaming", id: id, messages: [message("Initial")])
+        for index in 0..<100 {
+            snapshot = session("Streaming", id: id, messages: [message("notification revision \(index)")])
+            library.enqueue(id) { reads += 1; return snapshot }
+        }
+        try await library.ready()
+        XCTAssertEqual(reads, 1)
+        let result = try await library.worker.search("\"revision 99\"")
+        XCTAssertEqual(result.messages.count, 1)
+    }
+
+    func testStreamingUpdatesMakeProgressAndPersistTheFinalMessage() async throws {
+        let url = try databaseURL()
+        let library = ChatSearchLibrary(storageURL: url)
+        library.start([])
+        let id = UUID()
+        let messageID = UUID()
+        var reads = 0
+        var text = "notification"
+        for index in 0..<12 {
+            text += " update\(index)"
+            library.enqueue(id) {
+                reads += 1
+                return self.session("Streaming", id: id, messages: [self.message(text, id: messageID)])
+            }
+            try await Task.sleep(for: .milliseconds(30))
+        }
+        XCTAssertGreaterThan(reads, 0)
+        try await library.ready()
+        XCTAssertLessThan(reads, 12)
+        let restored = ChatLibrarySearchWorker(storageURL: url)
+        let result = try await restored.search("\"update11\"")
+        XCTAssertEqual(result.messages.map { $0.occurrence.messageID }, [messageID])
+    }
+
+    func testDeletionSupersedesAnUnprocessedSnapshot() async throws {
+        let url = try databaseURL()
+        let library = ChatSearchLibrary(storageURL: url)
+        library.start([])
+        let chat = session("Deleted", messages: [message("notification")])
+        library.enqueue(chat.id) { chat }
+        library.remove(chat.id)
+        try await library.ready()
+        let result = try await ChatLibrarySearchWorker(storageURL: url).search("notification")
+        XCTAssertTrue(result.messages.isEmpty)
+    }
+
+    func testSharedInChatSearchDoesNotRequestTranscriptSnapshots() async throws {
+        let library = ChatSearchLibrary(storageURL: try databaseURL())
+        library.start([])
+        let chat = session("Shared", messages: [message("notification permission")])
+        library.enqueue(chat.id) { chat }
+        try await library.ready()
+        let state = ChatSearchState()
+        state.reset(sessionID: chat.id, library: library)
+        var reads = 0
+        func items() -> [ChatTranscriptItem] { reads += 1; return [] }
+        for query in ["notification", "permission"] {
+            state.query = query
+            state.update(items: items(), queryChanged: true)
+            try await waitForSearch(state)
+            XCTAssertEqual(state.occurrences.count, 1)
+        }
+        XCTAssertEqual(reads, 0)
+    }
+
+    func testTwoSearchViewsShareMessageUpdates() async throws {
+        let library = ChatSearchLibrary(storageURL: try databaseURL())
+        library.start([])
+        let id = UUID()
+        let messageID = UUID()
+        var snapshot = session("Shared", id: id, messages: [message("notification", id: messageID)])
+        library.enqueue(id) { snapshot }
+        try await library.ready()
+        let views = [ChatSearchState(), ChatSearchState()]
+        for view in views {
+            view.reset(sessionID: id, library: library)
+            view.query = "notification"
+            view.update(items: [], queryChanged: true)
+            try await waitForSearch(view)
+            XCTAssertEqual(view.occurrences.count, 1)
+        }
+        snapshot = session("Shared", id: id, messages: [message("replacement", id: messageID)])
+        library.enqueue(id) { snapshot }
+        try await library.ready()
+        for view in views {
+            view.update(items: [])
+            try await waitForSearch(view)
+            XCTAssertTrue(view.occurrences.isEmpty)
+        }
+    }
+
+    func testStartupStorageFailureIsReported() async throws {
+        let url = try databaseURL().deletingLastPathComponent()
+        let library = ChatSearchLibrary(storageURL: url)
+        library.start([])
+        do {
+            try await library.ready()
+            XCTFail("Expected the directory to be rejected as a database")
+        } catch {
+            XCTAssertNotNil(library.error)
+            XCTAssertGreaterThan(library.revision, 0)
+        }
+    }
+
     private func databaseURL() throws -> URL {
         let directory = FileManager.default.temporaryDirectory.appending(path: "ChatSearchTests-" + UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/Tests/NativTests/ChatSearchTests.swift
+++ b/Tests/NativTests/ChatSearchTests.swift
@@ -410,9 +410,9 @@ final class ChatSearchTests: XCTestCase {
         window.orderBack(nil)
         defer { search.stop(); window.close() }
         try await settle(host)
+        try await beforeSearch(host)
         search.present()
         try await settle(host)
-        try await beforeSearch(host)
         search.query = query
         search.update(items: items, queryChanged: true)
         try await waitForSearch(search)
@@ -472,9 +472,7 @@ private struct SearchNavigationFixture: View {
         ChatTranscriptScroller(currentSessionID: nil, revision: revision, submissionID: nil,
                                scrollTargetMessageID: $target, itemIDs: items.map(\.id),
                                searchNavigation: search.navigationRequest, onSearchNavigation: search.finishNavigation,
-                               topInset: {
-                                   if search.isPresented { ChatSearchBar(search: search).padding(8) }
-                               }) { attached in
+                               topInset: { EmptyView() }) { attached in
             VStack(alignment: .leading, spacing: 20) {
                 ForEach(Array(items[attached])) { item in
                     if case .message(let message) = item {
@@ -493,6 +491,9 @@ private struct SearchNavigationFixture: View {
                 Color.clear.frame(height: 100).id(ChatTranscriptScrollTarget.bottom)
             }
             .padding(20)
+        }
+        .overlay(alignment: .topTrailing) {
+            if search.isPresented { ChatSearchBar(search: search).padding(8) }
         }
     }
 }

--- a/Tests/NativTests/ChatSearchTests.swift
+++ b/Tests/NativTests/ChatSearchTests.swift
@@ -211,11 +211,11 @@ final class ChatSearchTests: XCTestCase {
             for offset in [0, 1, 75, -60, 83, 1, -1] {
                 if offset != 0 { search.move(offset) }
                 try await settle(host)
-                try assertSelectedOccurrenceCentered(search, in: host)
+                try assertSelectedOccurrencePositioned(search, in: host)
             }
             for _ in 0..<55 { search.move(1) }
             try await settle(host)
-            try assertSelectedOccurrenceCentered(search, in: host)
+            try assertSelectedOccurrencePositioned(search, in: host)
         }
     }
 
@@ -229,7 +229,7 @@ final class ChatSearchTests: XCTestCase {
             for offset in [0, 1, 89, 1, 89, 1, -1, -90, -90] {
                 if offset != 0 { search.move(offset) }
                 try await settle(host)
-                try assertSelectedOccurrenceCentered(search, in: host)
+                try assertSelectedOccurrencePositioned(search, in: host)
             }
         }
     }
@@ -251,32 +251,69 @@ final class ChatSearchTests: XCTestCase {
             try await waitForSearch(search)
             try await settle(host)
             XCTAssertEqual(search.selected?.messageID, messages[35].id)
-            try assertSelectedOccurrenceCentered(search, in: host)
+            try assertSelectedOccurrencePositioned(search, in: host)
         }
     }
 
-    func testFirstAndLastFindingsCanBeCenteredInAShortChat() async throws {
+    func testSearchingShortChatsDoesNotExpandScrollBounds() async throws {
+        for messages in [
+            [ChatTranscriptMessage(role: .user, content: "notification")],
+            [ChatTranscriptMessage(role: .assistant, content: "notification")],
+            [ChatTranscriptMessage(role: .user, content: "notification"),
+             ChatTranscriptMessage(role: .assistant, content: "Last notification.")],
+        ] {
+            var originalHeight: CGFloat = 0
+            var originalLimits: ClosedRange<CGFloat> = 0...0
+            try await withSearchTranscript(messages, beforeSearch: { host in
+                let scroll = try XCTUnwrap(descendants(host).compactMap { $0 as? NSScrollView }.first)
+                originalHeight = try XCTUnwrap(scroll.documentView).frame.height
+                originalLimits = scrollLimits(scroll.contentView)
+            }) { search, host in
+                for offset in [0, 1, -1] {
+                    if offset != 0 { search.move(offset) }
+                    try await settle(host)
+                    let scroll = try XCTUnwrap(descendants(host).compactMap { $0 as? NSScrollView }.first)
+                    XCTAssertEqual(try XCTUnwrap(scroll.documentView).frame.height, originalHeight, accuracy: 1,
+                                   "Searching must not add blank space to a short transcript")
+                    let limits = scrollLimits(scroll.contentView)
+                    XCTAssertEqual(limits.lowerBound, originalLimits.lowerBound, accuracy: 1)
+                    XCTAssertEqual(limits.upperBound, originalLimits.upperBound, accuracy: 1)
+                    try assertSelectedOccurrencePositioned(search, in: host)
+                }
+            }
+        }
+    }
+
+    private func scrollLimits(_ clip: NSClipView) -> ClosedRange<CGFloat> {
+        var bounds = clip.bounds
+        bounds.origin.y = -1_000_000
+        let top = clip.constrainBoundsRect(bounds).minY
+        bounds.origin.y = 1_000_000
+        return top...clip.constrainBoundsRect(bounds).minY
+    }
+
+    func testFirstAndLastFindingsStayVisibleInAShortChat() async throws {
         let messages = [ChatTranscriptMessage(role: .user, content: "notification"),
                         ChatTranscriptMessage(role: .assistant, content: "Last notification.")]
         try await withSearchTranscript(messages) { search, host in
             for offset in [0, 1, -1] {
                 if offset != 0 { search.move(offset) }
                 try await settle(host)
-                try assertSelectedOccurrenceCentered(search, in: host)
+                try assertSelectedOccurrencePositioned(search, in: host)
             }
         }
     }
 
-    func testPhraseSpanningParagraphsCentersTheWholeFinding() async throws {
+    func testPhraseSpanningParagraphsPositionsTheWholeFinding() async throws {
         let messages = [ChatTranscriptMessage(role: .assistant, content: "notification\n\npermissions")]
         try await withSearchTranscript(messages, query: "notification permissions") { search, host in
             try await settle(host)
             XCTAssertEqual(search.selected?.fragments.count, 2)
-            try assertSelectedOccurrenceCentered(search, in: host)
+            try assertSelectedOccurrencePositioned(search, in: host)
         }
     }
 
-    private func assertSelectedOccurrenceCentered(_ search: ChatSearchState, in host: NSView) throws {
+    private func assertSelectedOccurrencePositioned(_ search: ChatSearchState, in host: NSView) throws {
         let selected = try XCTUnwrap(search.selected)
         let surface = try XCTUnwrap(descendants(host).compactMap { $0 as? MarkdownSurface }.first {
             $0.searchHighlight?.selected?.location == selected.location
@@ -294,11 +331,19 @@ final class ChatSearchTests: XCTestCase {
                 bounds = bounds.map { $0.union(converted) } ?? converted
             }
         }
-        XCTAssertEqual(try XCTUnwrap(bounds).midY, clip.bounds.midY, accuracy: 1,
-                       "Occurrence \(search.selectedIndex) must be vertically centered")
+        let finding = try XCTUnwrap(bounds)
+        XCTAssertTrue(clip.bounds.intersects(finding), "The selected finding must be visible")
+        let delta = finding.midY - clip.bounds.midY
+        if abs(delta) > 1 {
+            var boundary = clip.bounds
+            boundary.origin.y = delta < 0 ? -1_000_000 : 1_000_000
+            XCTAssertEqual(clip.bounds.minY, clip.constrainBoundsRect(boundary).minY, accuracy: 1,
+                           "A finding must be centered unless the transcript's scroll limit prevents it")
+        }
     }
 
     private func withSearchTranscript(_ messages: [ChatTranscriptMessage], query: String = "notification",
+                                      beforeSearch: (NSView) async throws -> Void = { _ in },
                                       body: (ChatSearchState, NSView) async throws -> Void) async throws {
         let search = ChatSearchState()
         let items = ChatTranscriptPresentation.items(from: messages)
@@ -311,6 +356,8 @@ final class ChatSearchTests: XCTestCase {
         defer { search.stop(); window.close() }
         try await settle(host)
         search.present()
+        try await settle(host)
+        try await beforeSearch(host)
         search.query = query
         search.update(items: items, queryChanged: true)
         try await waitForSearch(search)

--- a/Tests/NativTests/ChatSearchTests.swift
+++ b/Tests/NativTests/ChatSearchTests.swift
@@ -68,6 +68,61 @@ final class ChatSearchTests: XCTestCase {
         XCTAssertTrue(afterDelete.occurrences.isEmpty)
     }
 
+    func testWorkerPreservesWordFormsAndTyposWithoutExplicitLanguageDetection() async throws {
+        for (query, text) in [("running", "We ran yesterday."), ("mouse", "mice"),
+                              ("mouse", "The mice ate cheese."),
+                              ("child", "children"), ("conect", "We connected yesterday."),
+                              ("notificaiton", "notification")] {
+            for markdown in [false, true] {
+                let message = input(markdown ? "**\(text)**" : text, markdown: markdown)
+                let result = try await ChatSearchWorker().search(query, inputs: [message])
+                XCTAssertEqual(result.occurrences.map(\.messageID), [message.messageID], query)
+            }
+        }
+    }
+
+    func testIndexedQueriesReuseSnapshotsUntilContentChanges() async throws {
+        let state = ChatSearchState()
+        var reads = 0
+        var messages = [ChatTranscriptMessage(role: .user, content: "notification permissions")]
+        func items() -> [ChatTranscriptItem] {
+            reads += 1
+            return ChatTranscriptPresentation.items(from: messages)
+        }
+        state.query = "notification"
+        state.update(items: items(), contentRevision: 1, queryChanged: true)
+        try await waitForSearch(state)
+        state.query = "permission"
+        state.update(items: items(), contentRevision: 1, queryChanged: true)
+        try await waitForSearch(state)
+        XCTAssertEqual(reads, 1)
+        XCTAssertEqual(state.occurrences.count, 1)
+        messages[0].content = "changed content"
+        state.update(items: items(), contentRevision: 2)
+        try await waitForSearch(state)
+        XCTAssertEqual(reads, 2)
+        XCTAssertTrue(state.occurrences.isEmpty)
+    }
+
+    func testSingleWordIndexRefreshesAfterEditsAndDeletions() async throws {
+        let worker = ChatSearchWorker()
+        let first = input("mice")
+        try await worker.synchronize([first])
+        for query in ["mouse", "mouse"] {
+            let result = try await worker.search(query)
+            XCTAssertEqual(result.occurrences.map(\.messageID), [first.messageID])
+        }
+        let edited = ChatSearchInput(messageID: first.messageID, rowID: first.rowID, text: "children", markdown: false)
+        try await worker.synchronize([edited])
+        let old = try await worker.search("mouse")
+        XCTAssertTrue(old.occurrences.isEmpty)
+        let new = try await worker.search("child")
+        XCTAssertEqual(new.occurrences.map(\.messageID), [first.messageID])
+        try await worker.synchronize([])
+        let deleted = try await worker.search("child")
+        XCTAssertTrue(deleted.occurrences.isEmpty)
+    }
+
     func testPhraseCanSpanMarkdownParagraphs() async throws {
         let result = try await ChatSearchWorker().search("notification permission", inputs: [
             input("notification\n\n**permissions**", markdown: true),

--- a/Tests/NativTests/ChatSearchTests.swift
+++ b/Tests/NativTests/ChatSearchTests.swift
@@ -1,0 +1,375 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@MainActor
+final class ChatSearchTests: XCTestCase {
+    func testSearchProjectionMatchesRenderedMarkdownFragments() throws {
+        let source = """
+        # A heading
+
+        A **bold** paragraph with [a link](https://example.com/hidden), `code` and a soft
+        break. 🌙
+
+        - First item
+        - Second *item*
+
+        > Quoted text
+
+        | Name | Value |
+        | --- | --- |
+        | Alpha | Beta |
+
+        ```swift
+        let answer = 42
+        ```
+
+        Inline $x+y$ math and ![image label](https://example.com/image.png).
+        """
+        let input = input(source, markdown: true)
+        let fragments = ChatSearchDocument.fragments(for: input)
+        let layout = MarkdownLayouter.layout(MathPreprocessor.preprocess(source), width: 500, style: MarkdownStyle())
+        let rendered = Dictionary(uniqueKeysWithValues: layout.blocks.flatMap { block in
+            block.text.map { (block.id + "/" + $0.id, $0.text.string) }
+        })
+        for fragment in fragments { XCTAssertEqual(fragment.text, rendered[fragment.id], fragment.id) }
+        XCTAssertFalse(fragments.map(\.text).joined().contains("example.com/hidden"))
+    }
+
+    func testSearchIncludesRenderedMessagesAndMapsGroupedResponsesToTheirRow() {
+        let user = ChatTranscriptMessage(role: .user, content: "Question")
+        let tool = ChatTranscriptMessage(role: .tool, content: "Hidden tool output")
+        let assistant = ChatTranscriptMessage(role: .assistant, content: "Final answer")
+        let items = ChatTranscriptPresentation.items(from: [user, tool, assistant])
+        let snapshots = ChatSearchInput.snapshots(from: items)
+        XCTAssertEqual(snapshots.map(\.messageID), [user.id, assistant.id])
+        XCTAssertEqual(snapshots.last?.rowID, tool.id)
+    }
+
+    func testWorkerSearchesVisibleMarkdownAndPreservesPlainUserText() async throws {
+        let worker = ChatSearchWorker()
+        let messages = [input("notification **permissions**", markdown: true), input("literal **permissions**")]
+        let result = try await worker.search("notification permission", inputs: messages)
+        XCTAssertEqual(result.occurrences.count, 1)
+        XCTAssertEqual(result.occurrences.first?.text, "notification permissions")
+        let literal = try await worker.search("\"**permissions**\"", inputs: messages)
+        XCTAssertEqual(literal.occurrences.map(\.messageID), [messages[1].messageID])
+    }
+
+    func testWorkerRefreshesEditedMessagesAndRemovesDeletedMessages() async throws {
+        let worker = ChatSearchWorker()
+        let original = input("notification")
+        let initial = try await worker.search("notification", inputs: [original])
+        XCTAssertEqual(initial.occurrences.count, 1)
+        let edited = ChatSearchInput(messageID: original.messageID, rowID: original.rowID, text: "different text", markdown: false)
+        let afterEdit = try await worker.search("notification", inputs: [edited])
+        XCTAssertTrue(afterEdit.occurrences.isEmpty)
+        let afterDelete = try await worker.search("notification", inputs: [])
+        XCTAssertTrue(afterDelete.occurrences.isEmpty)
+    }
+
+    func testPhraseCanSpanMarkdownParagraphs() async throws {
+        let result = try await ChatSearchWorker().search("notification permission", inputs: [
+            input("notification\n\n**permissions**", markdown: true),
+        ])
+        let occurrence = try XCTUnwrap(result.occurrences.first)
+        XCTAssertEqual(result.occurrences.count, 1)
+        XCTAssertEqual(occurrence.fragments.map(\.text), ["notification", "permissions"])
+    }
+
+    func testWorkerReportsTruncationAndSearchesOlderMessages() async throws {
+        let worker = ChatSearchWorker()
+        let messages = (0..<250).map { _ in input("notification") }
+        let result = try await worker.search("notificaiton", inputs: messages, limit: 2)
+        XCTAssertEqual(result.occurrences.map(\.messageID), Array(messages.prefix(2).map(\.messageID)))
+        XCTAssertTrue(result.hasMore)
+    }
+
+    func testNavigationWrapsAndChatSwitchClearsState() async throws {
+        let state = ChatSearchState()
+        state.reset(sessionID: UUID())
+        XCTAssertFalse(state.isPresented)
+        state.present()
+        XCTAssertTrue(state.isPresented)
+        let focus = state.focusID
+        state.present()
+        XCTAssertNotEqual(state.focusID, focus)
+        state.query = "notification"
+        state.update(items: [.message(ChatTranscriptMessage(role: .user, content: "notification notification"))], queryChanged: true)
+        try await waitForSearch(state)
+        XCTAssertEqual(state.countLabel, "1/2")
+        state.move(-1)
+        XCTAssertEqual(state.countLabel, "2/2")
+        state.move(1)
+        XCTAssertEqual(state.countLabel, "1/2")
+        let previousNavigation = state.navigationID
+        state.move(1)
+        state.finishNavigation(previousNavigation)
+        XCTAssertNil(state.revealID)
+        state.finishNavigation(state.navigationID)
+        XCTAssertEqual(state.revealID, state.navigationID)
+        state.dismiss()
+        XCTAssertFalse(state.isPresented)
+        XCTAssertEqual(state.query, "")
+        XCTAssertNil(state.selected)
+        XCTAssertTrue(state.occurrences.isEmpty)
+    }
+
+    func testSupersededQueriesAndSessionResetsCannotPublishOldResults() async throws {
+        let state = ChatSearchState()
+        let items = [ChatTranscriptItem.message(ChatTranscriptMessage(role: .user, content: "notification permission"))]
+        state.query = "notification"
+        state.update(items: items, queryChanged: true)
+        state.query = "permission"
+        state.update(items: items, queryChanged: true)
+        try await waitForSearch(state)
+        let match = try XCTUnwrap(state.selected)
+        XCTAssertEqual((match.text as NSString).substring(with: match.range), "permission")
+        state.query = "notification"
+        state.update(items: items, queryChanged: true)
+        state.reset(sessionID: UUID())
+        try await Task.sleep(for: .milliseconds(250))
+        XCTAssertTrue(state.occurrences.isEmpty)
+        XCTAssertFalse(state.isSearching)
+    }
+
+    func testStreamingUpdatesAreNotStarvedByDebouncing() async throws {
+        let state = ChatSearchState()
+        state.query = "notification"
+        let id = UUID()
+        for index in 0..<12 {
+            state.update(items: [.message(ChatTranscriptMessage(id: id, role: .user,
+                                                               content: "notification \(index)"))])
+            try await Task.sleep(for: .milliseconds(40))
+        }
+        XCTAssertFalse(state.occurrences.isEmpty)
+        try await waitForSearch(state)
+        XCTAssertEqual(state.selected?.text, "notification 11")
+        state.stop()
+    }
+
+    func testStreamingDoesNotRepeatedlyNavigateToAnUnchangedMatch() async throws {
+        let state = ChatSearchState()
+        state.query = "notification"
+        let id = UUID()
+        state.update(items: [.message(ChatTranscriptMessage(id: id, role: .user, content: "notification"))])
+        try await waitForSearch(state)
+        let navigation = state.navigationID
+        state.update(items: [.message(ChatTranscriptMessage(id: id, role: .user, content: "notification continued"))])
+        try await waitForSearch(state)
+        XCTAssertEqual(state.navigationID, navigation)
+    }
+
+    func testHighlightsPreserveLayoutAndRevealAnOffscreenOccurrence() async throws {
+        let source = (0..<120).map { "Paragraph \($0) with notification text." }.joined(separator: "\n\n")
+        let worker = ChatSearchWorker()
+        let result = try await worker.search("notification", inputs: [input(source, markdown: true)])
+        let selected = try XCTUnwrap(result.occurrences.last)
+        let (window, scroll, surface) = fixture(source)
+        defer { window.close() }
+        let size = surface.snapshot?.size
+        surface.setSearchHighlight(ChatSearchHighlight(matches: result.occurrences, selected: selected, revealID: UUID()))
+        surface.layoutSubtreeIfNeeded()
+        surface.revealSearchMatchIfNeeded()
+        XCTAssertGreaterThan(scroll.contentView.bounds.minY, 1000)
+        surface.refreshVisibleBlocks()
+        let view = try XCTUnwrap(surface.visibleTextViews.first { $0.fragmentID == selected.fragmentID })
+        XCTAssertEqual(view.activeSearchRange, selected.range)
+        let original = try XCTUnwrap(surface.snapshot?.blocks.flatMap(\.text).first { $0.text.string == selected.text }?.text)
+        XCTAssertTrue(view.textStorage?.isEqual(to: original) == true, "Focus styling must not change the stored text or its attributes")
+        XCTAssertEqual(surface.snapshot?.size, size)
+        surface.setSearchHighlight(nil)
+        XCTAssertTrue(surface.visibleTextViews.allSatisfy { $0.searchRanges.isEmpty && $0.activeSearchRange == nil && $0.searchPulseLayer == nil })
+        XCTAssertTrue(view.textStorage?.isEqual(to: original) == true)
+    }
+
+    func testPlainTextSearchPreservesMarkdownCharactersAndUnicodeRanges() async throws {
+        let text = "🌙 **literal** " + String(repeating: "content ", count: 100) + "notification"
+        let worker = ChatSearchWorker()
+        let result = try await worker.search("notification", inputs: [input(text)])
+        let (window, _, surface) = fixture(text, plainText: true)
+        defer { window.close() }
+        surface.setSearchHighlight(ChatSearchHighlight(matches: result.occurrences, selected: result.occurrences.first, revealID: UUID()))
+        surface.layoutSubtreeIfNeeded()
+        XCTAssertEqual(surface.snapshot?.blocks.first?.text.first?.text.string, text)
+        XCTAssertEqual(surface.visibleTextViews.first?.activeSearchRange, result.occurrences.first?.range)
+    }
+
+    func testCompactUserSearchKeepsItsIntrinsicWidth() {
+        let layout = MarkdownSurface.searchPlainTextLayout("notification", width: 500, style: MarkdownStyle())
+        XCTAssertGreaterThan(layout.size.width, 0)
+        XCTAssertLessThan(layout.size.width, 150)
+    }
+
+    func testArrowNavigationRevealsEachOccurrenceInsidePagedSwiftUITranscript() async throws {
+        let longText = (0..<100).map { "Finding \($0): notification settings.\n" + String(repeating: "Background text. ", count: 20) }
+            .joined(separator: "\n\n")
+        let messages = (0..<40).map { index in
+            ChatTranscriptMessage(role: .assistant, content: index == 5 ? longText : "Message \(index) without a match.")
+        }
+        try await withSearchTranscript(messages) { search, host in
+            for offset in [0, 1, 75, -60, 83, 1, -1] {
+                if offset != 0 { search.move(offset) }
+                try await settle(host)
+                try assertSelectedOccurrenceCentered(search, in: host)
+            }
+            for _ in 0..<55 { search.move(1) }
+            try await settle(host)
+            try assertSelectedOccurrenceCentered(search, in: host)
+        }
+    }
+
+    func testNavigationAcrossRowsAndWithinLongCodeAndUserText() async throws {
+        let lines = (0..<90).map { "Line \($0): notification settings." }.joined(separator: "\n")
+        var messages = (0..<40).map { ChatTranscriptMessage(role: .assistant, content: "Message \($0).") }
+        messages[2] = ChatTranscriptMessage(role: .user, content: "notification")
+        messages[8] = ChatTranscriptMessage(role: .assistant, content: "```\n" + lines + "\n```")
+        messages[30] = ChatTranscriptMessage(role: .user, content: lines)
+        try await withSearchTranscript(messages) { search, host in
+            for offset in [0, 1, 89, 1, 89, 1, -1, -90, -90] {
+                if offset != 0 { search.move(offset) }
+                try await settle(host)
+                try assertSelectedOccurrenceCentered(search, in: host)
+            }
+        }
+    }
+
+    func testFirstAndLastFindingsCanBeCenteredInAShortChat() async throws {
+        let messages = [ChatTranscriptMessage(role: .user, content: "notification"),
+                        ChatTranscriptMessage(role: .assistant, content: "Last notification.")]
+        try await withSearchTranscript(messages) { search, host in
+            for offset in [0, 1, -1] {
+                if offset != 0 { search.move(offset) }
+                try await settle(host)
+                try assertSelectedOccurrenceCentered(search, in: host)
+            }
+        }
+    }
+
+    func testPhraseSpanningParagraphsCentersTheWholeFinding() async throws {
+        let messages = [ChatTranscriptMessage(role: .assistant, content: "notification\n\npermissions")]
+        try await withSearchTranscript(messages, query: "notification permissions") { search, host in
+            try await settle(host)
+            XCTAssertEqual(search.selected?.fragments.count, 2)
+            try assertSelectedOccurrenceCentered(search, in: host)
+        }
+    }
+
+    private func assertSelectedOccurrenceCentered(_ search: ChatSearchState, in host: NSView) throws {
+        let selected = try XCTUnwrap(search.selected)
+        let surface = try XCTUnwrap(descendants(host).compactMap { $0 as? MarkdownSurface }.first {
+            $0.searchHighlight?.selected?.location == selected.location
+        })
+        let clip = try XCTUnwrap(surface.enclosingScrollView?.contentView)
+        var bounds: CGRect?
+        for fragment in selected.fragments {
+            let text = try XCTUnwrap(surface.visibleTextViews.first { $0.fragmentID == fragment.id },
+                                    "Selected occurrence \(search.selectedIndex) must be mounted")
+            XCTAssertEqual(text.activeSearchRange, fragment.range)
+            // Measure the reference without TextKit's estimates for offscreen lines.
+            text.system.manager.ensureLayout(for: text.system.storage.documentRange)
+            for rect in text.selectionRects(for: fragment.range) {
+                let converted = text.convert(rect, to: clip)
+                bounds = bounds.map { $0.union(converted) } ?? converted
+            }
+        }
+        XCTAssertEqual(try XCTUnwrap(bounds).midY, clip.bounds.midY, accuracy: 1,
+                       "Occurrence \(search.selectedIndex) must be vertically centered")
+    }
+
+    private func withSearchTranscript(_ messages: [ChatTranscriptMessage], query: String = "notification",
+                                      body: (ChatSearchState, NSView) async throws -> Void) async throws {
+        let search = ChatSearchState()
+        let items = ChatTranscriptPresentation.items(from: messages)
+        let host = NSHostingView(rootView: SearchNavigationFixture(search: search, items: items))
+        let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 600, height: 360),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentView = host
+        window.orderBack(nil)
+        defer { search.stop(); window.close() }
+        try await settle(host)
+        search.present()
+        search.query = query
+        search.update(items: items, queryChanged: true)
+        try await waitForSearch(search)
+        try await body(search, host)
+    }
+
+    private func settle(_ host: NSView) async throws {
+        let bitmap = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+        for _ in 0..<5 {
+            try await Task.sleep(for: .milliseconds(40))
+            host.layoutSubtreeIfNeeded()
+            host.cacheDisplay(in: host.bounds, to: bitmap)
+        }
+    }
+
+    private func descendants(_ view: NSView) -> [NSView] {
+        [view] + view.subviews.flatMap { descendants($0) }
+    }
+
+    private func input(_ text: String, markdown: Bool = false) -> ChatSearchInput {
+        let id = UUID()
+        return ChatSearchInput(messageID: id, rowID: id, text: text, markdown: markdown)
+    }
+
+    private func waitForSearch(_ state: ChatSearchState) async throws {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while state.isSearching && ContinuousClock.now < deadline { try await Task.sleep(for: .milliseconds(20)) }
+        XCTAssertFalse(state.isSearching, "Search did not finish")
+        XCTAssertNil(state.error)
+    }
+
+    private func fixture(_ source: String, plainText: Bool = false) -> (NSWindow, NSScrollView, MarkdownSurface) {
+        let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 500, height: 250),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        let scroll = NSScrollView(frame: CGRect(x: 0, y: 0, width: 500, height: 250))
+        scroll.hasVerticalScroller = true
+        let surface = MarkdownSurface()
+        surface.configure(content: source, style: MarkdownStyle(), plainText: plainText)
+        surface.frame = CGRect(origin: .zero, size: surface.preflight(width: 480).size)
+        scroll.documentView = surface
+        window.contentView = scroll
+        window.orderFront(nil)
+        window.contentView?.layoutSubtreeIfNeeded()
+        surface.refreshVisibleBlocks()
+        return (window, scroll, surface)
+    }
+}
+
+private struct SearchNavigationFixture: View {
+    let search: ChatSearchState
+    let items: [ChatTranscriptItem]
+    @State private var target: UUID?
+    @State private var revision = ChatTranscriptRevision()
+
+    var body: some View {
+        ChatTranscriptScroller(currentSessionID: nil, revision: revision, submissionID: nil,
+                               scrollTargetMessageID: $target, itemIDs: items.map(\.id),
+                               searchNavigation: search.navigationRequest, onSearchNavigation: search.finishNavigation,
+                               topInset: {
+                                   if search.isPresented { ChatSearchBar(search: search).padding(8) }
+                               }) { attached in
+            VStack(alignment: .leading, spacing: 20) {
+                ForEach(Array(items[attached])) { item in
+                    if case .message(let message) = item {
+                        Group {
+                            if message.role == .user {
+                                MarkdownView(content: message.content, style: MarkdownStyle(fontSize: 14), plainText: true)
+                                    .fixedSize(horizontal: message.content.count <= 72 && !message.content.contains(where: \.isNewline), vertical: false)
+                            } else {
+                                MarkdownRenderer(content: message.content, fontSize: 14)
+                            }
+                        }
+                        .environment(\.chatSearchHighlight, search.highlight(for: message.id))
+                        .id(item.id)
+                    }
+                }
+                Color.clear.frame(height: 100).id(ChatTranscriptScrollTarget.bottom)
+            }
+            .padding(20)
+        }
+    }
+}

--- a/Tests/NativTests/ChatSearchTests.swift
+++ b/Tests/NativTests/ChatSearchTests.swift
@@ -234,6 +234,27 @@ final class ChatSearchTests: XCTestCase {
         }
     }
 
+    func testLibraryResultCentersItsMessageInTheRealTranscript() async throws {
+        let messages = (0..<40).map { index in
+            ChatTranscriptMessage(role: .assistant,
+                                  content: index == 5 || index == 35 ? "notification \(index)" : "Background message \(index)")
+        }
+        let session = ChatSession(id: UUID(), title: "Target", createdAt: Date(), updatedAt: Date(), messages: messages)
+        let items = ChatTranscriptPresentation.items(from: messages)
+        let results = try await ChatLibrarySearchWorker().search("notification", sessions: [
+            ChatLibrarySearchSession(summary: session.summary, items: items)
+        ])
+        let target = try XCTUnwrap(results.messages.first)
+        try await withSearchTranscript(messages) { search, host in
+            search.reveal(target.occurrence, query: "notification", sessionID: session.id, items: items)
+            search.update(items: items, queryChanged: true)
+            try await waitForSearch(search)
+            try await settle(host)
+            XCTAssertEqual(search.selected?.messageID, messages[35].id)
+            try assertSelectedOccurrenceCentered(search, in: host)
+        }
+    }
+
     func testFirstAndLastFindingsCanBeCenteredInAShortChat() async throws {
         let messages = [ChatTranscriptMessage(role: .user, content: "notification"),
                         ChatTranscriptMessage(role: .assistant, content: "Last notification.")]

--- a/Tests/NativTests/ChatTextSearchTests.swift
+++ b/Tests/NativTests/ChatTextSearchTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import NaturalLanguage
+import XCTest
+
+final class ChatTextSearchTests: XCTestCase {
+    func testLiteralMatchesPreserveCaseInsensitiveSubstringBehavior() throws {
+        let results = try search("NOTIFICATION notifications notification", for: "notification")
+        XCTAssertEqual(results.texts, ["NOTIFICATION", "notification", "notification"])
+        XCTAssertEqual(results.matches.map(\.kind), [.exact, .exact, .exact])
+    }
+
+    func testFindsInsertionDeletionReplacementAndTransposition() throws {
+        for query in ["notifcation", "notiffication", "notificxtion", "notificaiton"] {
+            let results = try search("notification", for: query)
+            XCTAssertEqual(results.texts, ["notification"], query)
+            XCTAssertEqual(results.matches.first?.kind, .typo, query)
+        }
+    }
+
+    func testWordFormsIncludeInflectionsAndIrregularForms() throws {
+        for (query, text) in [("connect", "connected"), ("run", "running"), ("child", "children"), ("mouse", "mice")] {
+            let results = try search(text, for: query)
+            XCTAssertFalse(results.matches.isEmpty, "\(query) → \(text)")
+            // Literal substrings still win over grammatical alternatives.
+            XCTAssertEqual(results.matches.first?.kind, text.contains(query) ? .exact : .wordForm)
+        }
+        XCTAssertEqual(try search("We ran yesterday.", for: "running").matches.first?.kind, .wordForm)
+    }
+
+    func testTypoCanMatchAnInflectedWordThroughItsLemma() throws {
+        XCTAssertEqual(try search("We connected yesterday.", for: "conect").texts, ["connected"])
+    }
+
+    func testPhrasesRequireAdjacentWordsInTheSameOrder() throws {
+        let text = "notificaiton permission; notification other permissions; permissions notification"
+        XCTAssertEqual(try search(text, for: "notification permissions").texts, ["notificaiton permission"])
+        XCTAssertTrue(try search("notification. Permissions", for: "notification permissions").matches.isEmpty)
+    }
+
+    func testPhraseAllowsWhitespaceChanges() throws {
+        let results = try search("Notification\n\tpermissions", for: "notification permissions")
+        XCTAssertEqual(results.texts, ["Notification\n\tpermissions"])
+    }
+
+    func testQuotedQueriesAreLiteral() throws {
+        let text = "notification permissions; notificaiton permissions; notification\npermissions"
+        XCTAssertEqual(try search(text, for: "\"notification permissions\"").texts, ["notification permissions"])
+        XCTAssertTrue(try search("We ran.", for: "\"running\"").matches.isEmpty)
+    }
+
+    func testPunctuationAndCodeQueriesStayLiteral() throws {
+        XCTAssertEqual(try search("Use foo_bar() and foo_baz().", for: "foo_bar()").texts, ["foo_bar()"])
+        XCTAssertTrue(try search("chat_session", for: "chat_sesion").matches.isEmpty)
+        XCTAssertTrue(try search("notificationManager", for: "notificaitonManager").matches.isEmpty)
+        XCTAssertTrue(try search("notification-manager", for: "notificaiton-manager").matches.isEmpty)
+        XCTAssertEqual(try search("Use **bold** here.", for: "**bold**").texts, ["**bold**"])
+    }
+
+    func testShortWordsNumbersAndAcronymsDoNotReceiveTypoExpansion() throws {
+        for (query, text) in [("car", "cat"), ("port", "part"), ("12345", "12346"), ("HTTPS", "HTTPX")] {
+            XCTAssertTrue(try search(text, for: query).matches.isEmpty, query)
+        }
+    }
+
+    func testTypoDistanceIsBoundedByWordLength() throws {
+        XCTAssertTrue(try search("planet", for: "plxxet").matches.isEmpty)
+        XCTAssertEqual(try search("notification", for: "notificxtixn").texts, ["notification"])
+        XCTAssertTrue(try search("notification", for: "notixixxtion").matches.isEmpty)
+        XCTAssertTrue(try search(String(repeating: "a", count: 80), for: String(repeating: "a", count: 79) + "b").matches.isEmpty)
+    }
+
+    func testDoesNotExpandSynonyms() throws {
+        XCTAssertTrue(try search("automobile bicycle vehicle", for: "car").matches.isEmpty)
+    }
+
+    func testRangesReferToOriginalUnicodeText() throws {
+        let text = "👩🏽‍💻 cafe\u{301} — NOTIFICATION; notificaiton ✅"
+        let results = try search(text, for: "notification")
+        XCTAssertEqual(results.texts, ["NOTIFICATION", "notificaiton"])
+        for match in results.matches {
+            XCTAssertNotNil(Range(match.range, in: text))
+        }
+        XCTAssertEqual(try search("👋 cafe\u{301}", for: "café").texts, ["cafe\u{301}"])
+    }
+
+    func testExactMatchesAreNotDuplicatedByWordMatching() throws {
+        let results = try search("connected connected", for: "connect")
+        XCTAssertEqual(results.texts, ["connect", "connect"])
+    }
+
+    func testLimitsPreserveTextOrderAcrossMatchKinds() throws {
+        let results = try search("notificaiton notification notificxtion notification", for: "notification", limit: 2)
+        XCTAssertEqual(results.texts, ["notificaiton", "notification"])
+        XCTAssertEqual(results.matches.map(\.kind), [.typo, .exact])
+    }
+
+    func testEmptyQueriesAndNonpositiveLimitsHaveNoMatches() throws {
+        for query in ["", " \n\t", "\"\""] {
+            XCTAssertTrue(try search("notification", for: query).matches.isEmpty)
+        }
+        XCTAssertTrue(try search("notification", for: "notification", limit: 0).matches.isEmpty)
+        XCTAssertTrue(try search("notification", for: "notification", limit: -1).matches.isEmpty)
+    }
+
+    func testPreparedMessageCanBeReusedAndRetainsItsID() throws {
+        let id = UUID()
+        let message = try ChatTextSearch.Message(id: id, text: "notification permissions", language: .english)
+        for query in ["notification", "permission", "notificaiton"] {
+            let results = try ChatTextSearch.matches(in: message, query: ChatTextSearch.Query(query, language: .english))
+            XCTAssertEqual(results.map(\.messageID), [id])
+        }
+    }
+
+    func testMessagesDoNotSharePhraseMatches() throws {
+        let query = try ChatTextSearch.Query("notification permissions", language: .english)
+        for text in ["notification", "permissions"] {
+            let message = try ChatTextSearch.Message(id: UUID(), text: text, language: .english)
+            XCTAssertTrue(try ChatTextSearch.matches(in: message, query: query).isEmpty)
+        }
+    }
+
+    func testUnknownLanguageRetainsLiteralAndTypoMatching() throws {
+        let message = try ChatTextSearch.Message(id: UUID(), text: "notification", language: .undetermined)
+        for text in ["notification", "notificaiton"] {
+            let query = try ChatTextSearch.Query(text, language: .undetermined)
+            XCTAssertEqual(try ChatTextSearch.matches(in: message, query: query).count, 1)
+        }
+    }
+
+    func testAutomaticLanguageDetectionSupportsWordForms() throws {
+        let message = try ChatTextSearch.Message(id: UUID(), text: "We ran yesterday.")
+        let query = try ChatTextSearch.Query("running")
+        let matches = try ChatTextSearch.matches(in: message, query: query)
+        XCTAssertEqual(matches.map(\.kind), [.wordForm])
+    }
+
+    func testNonLatinLiteralRangesAndCaseFolding() throws {
+        XCTAssertEqual(try search("👋 连接数据库", for: "数据库").texts, ["数据库"])
+        XCTAssertEqual(try search("👋 Straße", for: "STRASSE").texts, ["Straße"])
+    }
+
+    func testCancellationIsPropagated() async throws {
+        let message = try ChatTextSearch.Message(id: UUID(), text: "notification", language: .english)
+        let query = try ChatTextSearch.Query("notification", language: .english)
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try ChatTextSearch.matches(in: message, query: query)
+        }
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+        }
+    }
+
+    private func search(_ text: String, for query: String, limit: Int = 200) throws -> (texts: [String], matches: [ChatTextSearch.Match]) {
+        let message = try ChatTextSearch.Message(id: UUID(), text: text, language: .english)
+        let query = try ChatTextSearch.Query(query, language: .english)
+        let matches = try ChatTextSearch.matches(in: message, query: query, limit: limit)
+        let texts = try matches.map { match in
+            String(text[try XCTUnwrap(Range(match.range, in: text))])
+        }
+        return (texts, matches)
+    }
+}

--- a/Tests/NativTests/ChatTextSearchTests.swift
+++ b/Tests/NativTests/ChatTextSearchTests.swift
@@ -237,6 +237,20 @@ final class ChatTextSearchTests: XCTestCase {
         XCTAssertTrue(try index.candidates(for: ChatTextSearch.Query("xylophone", language: .english)).isEmpty)
     }
 
+    func testCandidateLookupCanBeRestrictedToAChatOrMessage() throws {
+        var index = ChatTextSearch.Index<Int>()
+        for id in 0..<10 {
+            let message = try ChatTextSearch.Message(id: UUID(), text: "Notification permissions", language: .english)
+            index.insert(message, id: id)
+        }
+        for text in ["ficat", "notificaiton", "permission"] {
+            let query = try ChatTextSearch.Query(text, language: .english)
+            XCTAssertEqual(try index.candidates(for: query, within: [2, 5]), [2, 5])
+            XCTAssertEqual(try index.candidates(for: query, within: [4]), [4])
+            XCTAssertTrue(try index.candidates(for: query, within: []).isEmpty)
+        }
+    }
+
     private func search(_ text: String, for query: String, limit: Int = 200) throws -> (texts: [String], matches: [ChatTextSearch.Match]) {
         let message = try ChatTextSearch.Message(id: UUID(), text: text, language: .english)
         let query = try ChatTextSearch.Query(query, language: .english)

--- a/Tests/NativTests/ChatTextSearchTests.swift
+++ b/Tests/NativTests/ChatTextSearchTests.swift
@@ -153,6 +153,90 @@ final class ChatTextSearchTests: XCTestCase {
         }
     }
 
+    func testIndexPreservesLiteralUnicodeAndSubstringMatches() throws {
+        let texts = ["NOTIFICATION notifications", "👋 Straße", "cafe\u{301} CAFÉ",
+                     "👩🏽‍💻 连接数据库", "foo_bar() notificationManager", "İstanbul Σίσυφος",
+                     "A **bold** phrase", "\n", "ﬃ ffi", "a\u{301}\u{323}"]
+        let queries = ["n", "on", "fic", "NOTIFICATION", "STRASSE", "ss", "café", "fé",
+                       "数据库", "👩🏽‍💻", "🏽", "foo_bar()", "**bold**", "İ", "σ", "ffi", "a\u{323}\u{301}"]
+        let messages = try texts.map { try ChatTextSearch.Message(id: UUID(), text: $0, language: .english) }
+        var index = ChatTextSearch.Index<UUID>()
+        for message in messages { index.insert(message, id: message.id) }
+        for text in queries {
+            let query = try ChatTextSearch.Query("\"\(text)\"", language: .english)
+            let candidates = try index.candidates(for: query)
+            for message in messages where try !ChatTextSearch.matches(in: message, query: query).isEmpty {
+                XCTAssertTrue(candidates.contains(message.id), "\(text) in \(message.text)")
+            }
+        }
+    }
+
+    func testIndexPreservesTypoCandidatesIncludingTwoTranspositions() throws {
+        for text in ["abcde", "planet", "abcdefgh", "abcdefghi", "notification", "aaaaaaaaab"] {
+            let message = try ChatTextSearch.Message(id: UUID(), text: text, language: .english)
+            var index = ChatTextSearch.Index<UUID>()
+            index.insert(message, id: message.id)
+            let characters = Array(text)
+            var queries: Set<String> = []
+            for offset in characters.indices {
+                var edited = characters
+                edited[offset] = "x"
+                queries.insert(String(edited))
+                edited = characters
+                edited.remove(at: offset)
+                queries.insert(String(edited))
+                edited = characters
+                edited.insert("x", at: offset)
+                queries.insert(String(edited))
+                if offset + 1 < characters.count {
+                    edited = characters
+                    edited.swapAt(offset, offset + 1)
+                    queries.insert(String(edited))
+                    for other in characters.indices.dropLast() {
+                        var twice = edited
+                        twice.swapAt(other, other + 1)
+                        queries.insert(String(twice))
+                    }
+                }
+            }
+            for text in queries {
+                let query = try ChatTextSearch.Query(text, language: .english)
+                if try !ChatTextSearch.matches(in: message, query: query).isEmpty {
+                    XCTAssertTrue(try index.candidates(for: query).contains(message.id), text)
+                }
+            }
+        }
+    }
+
+    func testIndexRemovesPostingsWithoutLosingSharedWords() throws {
+        let first = try ChatTextSearch.Message(id: UUID(), text: "We ran yesterday.", language: .english)
+        let second = try ChatTextSearch.Message(id: UUID(), text: "We ran yesterday.", language: .english)
+        var index = ChatTextSearch.Index<UUID>()
+        index.insert(first, id: first.id)
+        index.insert(second, id: second.id)
+        index.remove(first, id: first.id)
+        for text in ["running", "ran", "yesterdya"] {
+            let query = try ChatTextSearch.Query(text, language: .english)
+            XCTAssertEqual(try index.candidates(for: query), [second.id])
+        }
+        index.remove(second, id: second.id)
+        XCTAssertTrue(try index.candidates(for: ChatTextSearch.Query("running", language: .english)).isEmpty)
+    }
+
+    func testSelectiveIndexLookupDoesNotReturnUnrelatedMessages() throws {
+        var index = ChatTextSearch.Index<UUID>()
+        for _ in 0..<200 {
+            let message = try ChatTextSearch.Message(id: UUID(), text: "Ordinary background conversation.", language: .english)
+            index.insert(message, id: message.id)
+        }
+        let target = try ChatTextSearch.Message(id: UUID(), text: "Notification permissions were updated.", language: .english)
+        index.insert(target, id: target.id)
+        for text in ["notification", "notificaiton", "permission", "ficat"] {
+            XCTAssertEqual(try index.candidates(for: ChatTextSearch.Query(text, language: .english)), [target.id])
+        }
+        XCTAssertTrue(try index.candidates(for: ChatTextSearch.Query("xylophone", language: .english)).isEmpty)
+    }
+
     private func search(_ text: String, for query: String, limit: Int = 200) throws -> (texts: [String], matches: [ChatTextSearch.Match]) {
         let message = try ChatTextSearch.Message(id: UUID(), text: text, language: .english)
         let query = try ChatTextSearch.Query(query, language: .english)

--- a/project.yml
+++ b/project.yml
@@ -284,6 +284,7 @@ targets:
       - path: Sources/Nativ/Features/Chat/ChatDocumentContextBuilder.swift
       - path: Sources/Nativ/Features/Chat/ChatTextSearch.swift
       - path: Sources/Nativ/Features/Chat/ChatSearch.swift
+      - path: Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
       - path: Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
       - path: Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
       - path: Sources/Nativ/Features/ControlPanel/ControlPanelNavigation.swift

--- a/project.yml
+++ b/project.yml
@@ -284,6 +284,7 @@ targets:
       - path: Sources/Nativ/Features/Chat/ChatDocumentContextBuilder.swift
       - path: Sources/Nativ/Features/Chat/ChatTextSearch.swift
       - path: Sources/Nativ/Features/Chat/ChatSearch.swift
+      - path: Sources/Nativ/Features/Chat/ChatSearchStore.swift
       - path: Sources/Nativ/Features/Chat/ChatLibrarySearch.swift
       - path: Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
       - path: Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift

--- a/project.yml
+++ b/project.yml
@@ -282,6 +282,8 @@ targets:
       - path: Sources/Nativ/Features/Chat/ChatAttachmentValidator.swift
       - path: Sources/Nativ/Features/Chat/ChatDocumentExtractionCache.swift
       - path: Sources/Nativ/Features/Chat/ChatDocumentContextBuilder.swift
+      - path: Sources/Nativ/Features/Chat/ChatTextSearch.swift
+      - path: Sources/Nativ/Features/Chat/ChatSearch.swift
       - path: Sources/Nativ/Features/ImageGeneration/ImageGenerationViewModel.swift
       - path: Sources/Nativ/Features/ControlPanel/ControlPanelDependencies.swift
       - path: Sources/Nativ/Features/ControlPanel/ControlPanelNavigation.swift


### PR DESCRIPTION
<html><head></head><body><p>Adds search within the current chat and across saved chats, with exact matching, typo tolerance, and word-form matching. Search runs locally using native APIs, without semantic search or new third-party dependencies.</p><ul><li>Press Cmd+F to search within a chat. Navigate matches using the arrows, with a stronger highlight for the focused match. Scrolling centers the match where the available content allows, without adding empty space.</li><li>Open global search from the search icon beside the sidebar logo. The popup displays matching message excerpts linked to their chats. Clicking a result opens the conversation and focuses the match.</li></ul><p>Both interfaces use a shared index that maps searchable words, word forms, and character fragments to messages. Searches retrieve candidate messages from these lookup structures and verify matches within them. This avoids scanning the entire conversation history for selective queries, while preserving typo tolerance and accurate highlight locations. Broad queries can still inspect many messages.</p><p>Initial indexing runs in the background after chat history loads. Prepared search records are saved in SQLite and restored on subsequent launches, avoiding repeated text preparation. The searchable structures remain in memory and are shared across windows; opening or closing search does not rebuild or discard them.</p><p>New messages, edits, and deletions update the index automatically. Updates inspect the affected chat, prepare changed messages, and persist the changes without rewriting the entire library. Streaming changes are grouped with a 250 ms batching delay.</p><p>Benchmarks used 10,000 synthetic messages of approximately 1 KB each on an Apple M5 Max with 48 GiB RAM. Search code was compiled with optimization enabled in the test target; these are not packaged Release-app measurements.</p><div><div><div>
<table>
  <thead>
    <tr>
      <th>Operation</th>
      <th>Median elapsed time</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Initial indexing and persistence</td>
      <td>20.06 s</td>
    </tr>
    <tr>
      <td>Restore saved index and reconcile</td>
      <td>9.42 s</td>
    </tr>
    <tr>
      <td>Add one message</td>
      <td>2.75 ms</td>
    </tr>
    <tr>
      <td>Edit one message</td>
      <td>1.72 ms</td>
    </tr>
    <tr>
      <td>Delete the last message</td>
      <td>0.33 ms</td>
    </tr>
    <tr>
      <td>Global search: rare or missing term</td>
      <td>0.44–0.64 ms</td>
    </tr>
    <tr>
      <td>Global search: common term, typo, or word form</td>
      <td>26–27 ms</td>
    </tr>
    <tr>
      <td>In-chat search in a 50-message chat</td>
      <td>0.24–0.78 ms</td>
    </tr>
    <tr>
      <td>Popup results, including debounce and first draw</td>
      <td>166–210 ms</td>
    </tr>
  </tbody>
</table>

</div></div></div><p>Message-update timings include snapshot creation, indexing, and persistence in a 50–80-message chat, excluding the batching delay. Popup timings include the 150 ms search debounce and use a rendering fixture matching the production layout.</p><p>Restoring 9,950 messages increased process memory by approximately 351 MiB. Adding another 1,000 messages averaged 36.6 KiB of additional RAM per message. The SQLite cache occupied approximately 182 MiB after checkpointing. During a streaming benchmark, 60 updates produced 12 indexing batches, averaging approximately 4% of one CPU core.</p><p>Startup restoration and memory usage remain significant. Updates still inspect the affected chat: appending to a single 10,000-message chat took approximately 15 ms, while deleting its first message took 317 ms because subsequent positions changed.</p><p>Validation: 79 tests passed, covering matching, Unicode ranges, highlights and navigation, persistence, cache recovery, edits, deletions, shared search state, and update batching.</p><p>  </p></body></html>