### PR TITLE
Add LWC MCP catalog entry

### DIFF
--- a/Sources/Nativ/Resources/MCPCatalog.json
+++ b/Sources/Nativ/Resources/MCPCatalog.json
@@ -58,6 +58,16 @@
     "sourceURL": "https://github.com/modelcontextprotocol/servers/tree/main/src/memory"
   },
   {
+    "id": "lwc",
+    "name": "LWC",
+    "summary": "Explore source-grounded project memory and code context with bounded read-only MCP tools.",
+    "command": "npx",
+    "args": ["-y", "@i-xor/lwc@0.18.5", "serve", "--mcp"],
+    "symbol": "brain.head.profile",
+    "tint": "purple",
+    "sourceURL": "https://github.com/JanYork/llm-wiki-cli"
+  },
+  {
     "id": "sqlite",
     "name": "sqlite",
     "summary": "Query and edit a local SQLite database.",


### PR DESCRIPTION
## Summary

Adds LWC to Nativ's built-in MCP catalog.

LWC is a local-first, source-grounded project-memory CLI with a read-only stdio MCP server. The entry pins the published `@i-xor/lwc@0.18.5` package.

## Validation

- Ran `python scripts/verify_mcp_catalog.py --only lwc`.
- The verifier completed the MCP initialize handshake and `tools/list`, returning 4 tools.
- Rechecked current catalog and LWC, llm-wiki-cli, and JanYork issue/PR history for duplicates.

Affiliation: I maintain LWC.
